### PR TITLE
Optional reduction argument for tmDefinition (Coq 8.8)

### DIFF
--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -159,10 +159,10 @@ struct
 
   let (tglobal_reference, tConstRef, tIndRef, tConstructRef) = (r_reify "global_reference", r_reify "ConstRef", r_reify "IndRef", r_reify "ConstructRef")
 
-  let (tmReturn, tmBind, tmQuote, tmQuoteRec, tmEval, tmDefinition, tmAxiom, tmLemma, tmFreshName, tmAbout, tmCurrentModPath,
+  let (tmReturn, tmBind, tmQuote, tmQuoteRec, tmEval, tmDefinitionRed, tmAxiomRed, tmLemmaRed, tmFreshName, tmAbout, tmCurrentModPath,
        tmMkDefinition, tmMkInductive, tmPrint, tmFail, tmQuoteInductive, tmQuoteConstant, tmQuoteUniverses, tmUnquote, tmUnquoteTyped, tmInferInstance, tmExistingInstance) =
-    (r_template_monad_p "tmReturn", r_template_monad_p "tmBind", r_template_monad_p "tmQuote", r_template_monad_p "tmQuoteRec", r_template_monad_p "tmEval", r_template_monad_p "tmDefinition",
-     r_template_monad_p "tmAxiom", r_template_monad_p "tmLemma", r_template_monad_p "tmFreshName", r_template_monad_p "tmAbout", r_template_monad_p "tmCurrentModPath",
+    (r_template_monad_p "tmReturn", r_template_monad_p "tmBind", r_template_monad_p "tmQuote", r_template_monad_p "tmQuoteRec", r_template_monad_p "tmEval", r_template_monad_p "tmDefinitionRed",
+     r_template_monad_p "tmAxiomRed", r_template_monad_p "tmLemmaRed", r_template_monad_p "tmFreshName", r_template_monad_p "tmAbout", r_template_monad_p "tmCurrentModPath",
      r_template_monad_p "tmMkDefinition", r_template_monad_p "tmMkInductive", r_template_monad_p "tmPrint", r_template_monad_p "tmFail", r_template_monad_p "tmQuoteInductive", r_template_monad_p "tmQuoteConstant",
      r_template_monad_p "tmQuoteUniverses", r_template_monad_p "tmUnquote", r_template_monad_p "tmUnquoteTyped", r_template_monad_p "tmInferInstance", r_template_monad_p "tmExistingInstance")
 

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -213,9 +213,10 @@ let reduce env evm red trm =
   let evm, red = red env evm (EConstr.of_constr trm) in
   (evm, EConstr.to_constr evm red)
 
-let reduce_all env evm trm =
-  EConstr.to_constr evm (Reductionops.nf_all env evm (EConstr.of_constr trm))
-
+let reduce_all env evm ?(red=Genredexpr.Cbv Redops.all_flags) trm =
+  let red, _ = Redexpr.reduction_of_red_expr env red in
+  let evm, red = red env evm (EConstr.of_constr trm) in
+  EConstr.to_constr evm red
 
 module Reify (Q : Quoter) =
 struct

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -213,10 +213,9 @@ let reduce env evm red trm =
   let evm, red = red env evm (EConstr.of_constr trm) in
   (evm, EConstr.to_constr evm red)
 
-let reduce_all env evm ?(red=Genredexpr.Cbv Redops.all_flags) trm =
-  let red, _ = Redexpr.reduction_of_red_expr env red in
-  let evm, red = red env evm (EConstr.of_constr trm) in
-  EConstr.to_constr evm red
+let reduce_all env evm trm =
+  EConstr.to_constr evm (Reductionops.nf_all env evm (EConstr.of_constr trm))
+
 
 module Reify (Q : Quoter) =
 struct

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -40,7 +40,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
 | tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
 | tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 
-                                                                 
+
 (* Return the defined constant *)
 | tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 | tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -40,10 +40,11 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
 | tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
 | tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 
+                                                                 
 (* Return the defined constant *)
-| tmDefinition : ident -> forall {A:Type@{t}}, A -> TemplateMonad A
-| tmAxiom : ident -> forall A : Type@{t}, TemplateMonad A
-| tmLemma : ident -> forall A : Type@{t}, TemplateMonad A
+| tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
+| tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
+| tmLemmaRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
 
 (* Guaranteed to not cause "... already declared" error *)
 | tmFreshName : ident -> TemplateMonad ident
@@ -80,3 +81,7 @@ Definition fail_nf {A} (msg : string) : TemplateMonad A
 
 Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
   := tmMkInductive (mind_body_to_entry mind).
+
+Definition tmLemma (i : ident) := tmLemmaRed i (Some hnf).
+Definition tmAxiom (i : ident) := tmAxiomRed i (Some hnf).
+Definition tmDefinition (i : ident) {A : Type} := @tmDefinitionRed i (Some hnf) A.


### PR DESCRIPTION
This is #42 for the 8.8 branch.

Currently, `tmLemma` always uses `hnf` reduction for the body. We have some use cases where we need to control this more, and there was already a comment that this should be customisable.

I introduced `tmLemmaRed` (same for `tmAxiom` and `tmDefinition`) and redefined `tmLemma` to be `tmLemmaRed` with `hnf` reduction. That's now compatible with the test-suite again.