### PR TITLE
Fix bugs when running in tactic

### DIFF
--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -543,7 +543,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
   else if Globnames.eq_gr glob_ref tmBind then
     match args with
     | _::_::a::f::[] ->
-       run_template_program_rec ~intactic:intactic (fun (evm, ar) -> run_template_program_rec k (evm, Constr.mkApp (f, [|ar|]))) (evm, a)
+       run_template_program_rec ~intactic:intactic (fun (evm, ar) -> run_template_program_rec ~intactic:intactic k (evm, Constr.mkApp (f, [|ar|]))) (evm, a)
     | _ -> monad_failure_full "tmBind" 4 pgm
   else if Globnames.eq_gr glob_ref tmDefinition then
     if intactic then not_in_tactic "tmDefinition" else

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -520,8 +520,7 @@ let monad_failure_full s k prg =
        str "While trying to run: " ++ fnl () ++ print_term prg ++ fnl () ++
        str "Please file a bug with Template-Coq.")
 
-let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t -> unit)  ((evm, pgm) : Evd.evar_map * Constr.t) : unit =
-  let env = Global.env () in
+let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t -> unit) env ((evm, pgm) : Evd.evar_map * Constr.t) : unit =
   let pgm = Reduction.whd_all env pgm in
   let (coConstr, args) = app_full pgm [] in
   let (glob_ref, universes) =
@@ -543,7 +542,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
   else if Globnames.eq_gr glob_ref tmBind then
     match args with
     | _::_::a::f::[] ->
-       run_template_program_rec ~intactic:intactic (fun (evm, ar) -> run_template_program_rec ~intactic:intactic k (evm, Constr.mkApp (f, [|ar|]))) (evm, a)
+       run_template_program_rec ~intactic:intactic (fun (evm, ar) -> run_template_program_rec ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
     | _ -> monad_failure_full "tmBind" 4 pgm
   else if Globnames.eq_gr glob_ref tmDefinition then
     if intactic then not_in_tactic "tmDefinition" else

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -147,15 +147,16 @@ VERNAC COMMAND EXTEND Run_program CLASSIFIED AS SIDEFF
       [ let (evm, env) = Pfedit.get_current_context () in
         let (def, _) = Constrintern.interp_constr env evm def in
         (* todo : uctx ? *)
-        Denote.run_template_program_rec (fun _ -> ()) (evm, (EConstr.to_constr evm def)) ]
+        Denote.run_template_program_rec (fun _ -> ()) (Global.env ()) (evm, (EConstr.to_constr evm def)) ]
 END;;
 
 TACTIC EXTEND run_program
     | [ "run_template_program" constr(c) tactic(tac) ] ->
       [ Proofview.Goal.enter (begin fun gl ->
          let evm = Proofview.Goal.sigma gl in
+         let env = Proofview.Goal.env gl in
          let ret = ref None in
-         Denote.run_template_program_rec ~intactic:true (fun (evm, t) -> ret := Some t) (evm, EConstr.to_constr evm c);
+         Denote.run_template_program_rec ~intactic:true (fun (evm, t) -> ret := Some t) env (evm, EConstr.to_constr evm c);
          match !ret with
            Some c ->
            ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c])


### PR DESCRIPTION
`run_template_program` did not use the environment of the proof, but the global environment. 

Also, `intactic` was not passed correctly in the `tmBind` case, allowing `tmLemmaRed` to be used in a tactic once a bind was used before.

Both problems are fixed now.