### PR TITLE
Optional reduction argument for tmInferInstance

### DIFF
--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -735,12 +735,13 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     | _ -> monad_failure "tmExistingInstance" 1
   else if Globnames.eq_gr glob_ref tmInferInstance then
     match args with
-    | typ :: [] ->
+    | s :: typ :: [] ->
+       let typ = (match denote_option s with Some s -> let red = denote_reduction_strategy env evm s in reduce_all ~red env evm typ | None -> typ) in
        (try
           let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
           k (evm, Constr.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
         with
           Not_found -> k (evm, Constr.mkApp (cNone, [|typ|]))
        )
-    | _ -> monad_failure "tmInferInstance" 1
+    | _ -> monad_failure "tmInferInstance" 2
   else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -69,7 +69,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
 
 (* Typeclass registration and querying for an instance *)
 | tmExistingInstance : ident -> TemplateMonad unit
-| tmInferInstance : forall A : Type@{t}, TemplateMonad (option A)
+| tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
 .
 
 Definition print_nf {A} (msg : A) : TemplateMonad unit

--- a/test-suite/tmInferInstance.v
+++ b/test-suite/tmInferInstance.v
@@ -6,5 +6,5 @@ Import MonadNotation.
 Existing Class True.
 Existing Instance I.
 
-Run TemplateProgram (tmInferInstance True >>= tmPrint).
-Run TemplateProgram (tmInferInstance False >>= tmPrint).
+Run TemplateProgram (tmInferInstance None True >>= tmPrint).
+Run TemplateProgram (tmInferInstance None False >>= tmPrint).


### PR DESCRIPTION
The following program is not well-typed:

```
Definition tmInferHnf (A : Type) : TemplateMonad A :=
  tmBind (tmEval hnf A) tmInferInstance.
```

The issue is that Coq can not see that `A` and the result of `tmEval hnf A` are judgmentally equal (and I don't think we have any way of exposing this information). 

We have a use case were we want to normalise a type before we want to run typeclass inference (and I think that will be a more common use case once Template Coq is more commonly used).

So this pull request adds an optional reduction argument to `tmInferInstance`. Note that this will break existing code using `tmInferInstance`. If somebody sees good reason we could use the same route as for `tmDefinition`, i.e. rename `tmInferInstance` into `tmInferInstanceRed` and then make `tmInferInstance` an alias for `tmInferInstanceRed None`.

