### PR TITLE
Ast.term, ErastedTerm.v: use pi-types with names instead of comments

### DIFF
--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -71,24 +71,24 @@ Definition mfixpoint (term : Set) : Set :=
   list (def term).
 
 Inductive term : Set :=
-| tRel       : nat -> term
-| tVar       : ident -> term (* For free variables (e.g. in a goal) *)
-| tMeta      : nat -> term   (* NOTE: this will go away *)
-| tEvar      : nat -> list term -> term
-| tSort      : universe -> term
-| tCast      : term -> cast_kind -> term -> term
-| tProd      : forall (_:name) (type:term) (body:term), term
-| tLambda    : forall (_:name) (type:term) (body:term), term
-| tLetIn     : forall (_:name) (def:term) (type:term) (body:term), term
-| tApp       : term -> list term -> term
-| tConst     : kername -> universe_instance -> term
-| tInd       : inductive -> universe_instance -> term
-| tConstruct : inductive -> nat -> universe_instance -> term
-| tCase      : forall (inductive_and_nb_params:inductive*nat) (type_info:term)
-                      (discriminee:term) (branches : list (nat * term)), term
-| tProj      : projection -> term -> term
-| tFix       : mfixpoint term -> nat -> term
-| tCoFix     : mfixpoint term -> nat -> term.
+| tRel (n : nat)
+| tVar (id : ident) (* For free variables (e.g. in a goal) *)
+| tMeta (meta : nat) (* NOTE: this will go away *)
+| tEvar (ev : nat) (args : list term)
+| tSort (s : universe)
+| tCast (t : term) (kind : cast_kind) (v : term)
+| tProd (na : name) (ty : term) (body : term)
+| tLambda (na : name) (ty : term) (body : term)
+| tLetIn (na : name) (def : term) (def_ty : term) (body : term)
+| tApp (f : term) (args : list term)
+| tConst (c : kername) (u : universe_instance)
+| tInd (ind : inductive) (u : universe_instance)
+| tConstruct (ind : inductive) (idx : nat) (u : universe_instance)
+| tCase (ind_and_nbparams: inductive*nat) (type_info:term)
+        (discr:term) (branches : list (nat * term))
+| tProj (proj : projection) (t : term)
+| tFix (mfix : mfixpoint term) (idx : nat)
+| tCoFix (mfix : mfixpoint term) (idx : nat).
 
 Definition mkApps t us :=
   match us with

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -77,19 +77,18 @@ Inductive term : Set :=
 | tEvar      : nat -> list term -> term
 | tSort      : universe -> term
 | tCast      : term -> cast_kind -> term -> term
-| tProd      : name -> term (* the type *) -> term -> term
-| tLambda    : name -> term (* the type *) -> term -> term
-| tLetIn     : name -> term (* the term *) -> term (* the type *) -> term -> term
+| tProd      : forall (_:name) (type:term) (body:term), term
+| tLambda    : forall (_:name) (type:term) (body:term), term
+| tLetIn     : forall (_:name) (def:term) (type:term) (body:term), term
 | tApp       : term -> list term -> term
 | tConst     : kername -> universe_instance -> term
 | tInd       : inductive -> universe_instance -> term
 | tConstruct : inductive -> nat -> universe_instance -> term
-| tCase      : (inductive * nat) (* # of parameters *) -> term (* type info *)
-               -> term (* discriminee *) -> list (nat * term) (* branches *) -> term
+| tCase      : forall (inductive_and_nb_params:inductive*nat) (type_info:term)
+                      (discriminee:term) (branches : list (nat * term)), term
 | tProj      : projection -> term -> term
 | tFix       : mfixpoint term -> nat -> term
 | tCoFix     : mfixpoint term -> nat -> term.
-
 
 Definition mkApps t us :=
   match us with

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -1023,7 +1023,7 @@ Section Typecheck2.
     - (* Construct *) admit.
 
     - (* Case *)
-      destruct p.
+      match goal with H : inductive * nat |- _ => destruct H end.
       infers.
       destruct reduce_to_ind eqn:?; try discriminate. simpl.
       destruct a0 as [[ind' u] args].

--- a/template-coq/theories/ErasedTerm.v
+++ b/template-coq/theories/ErasedTerm.v
@@ -12,23 +12,22 @@ From Template Require Export univ uGraph Ast.
   compared to kernel terms, all proofs are translated to [tBox] and
   casts are removed.
 *)
-
 Inductive term : Set :=
-| tBox       : term (* Represents all proofs *)
-| tRel       : nat -> term
-| tVar       : ident -> term (* For free variables (e.g. in a goal) *)
-| tMeta      : nat -> term   (* NOTE: this will go away *)
-| tEvar      : nat -> list term -> term
-| tSort      : universe -> term
-| tProd      : forall (_:name) (type:term) (body:term), term
-| tLambda    : name -> term -> term -> term
-| tLetIn     : forall (_:name) (term_:term) (type:term) (body:term), term
-| tApp       : term -> list term -> term
-| tConst     : kername -> universe_instance -> term
-| tInd       : inductive -> universe_instance -> term
-| tConstruct : inductive -> nat -> universe_instance -> term
-| tCase      : forall (inductive_and_nb_params:inductive*nat) (type_info:term)
-                      (discriminee:term) (branches : list (nat * term)), term
-| tProj      : projection -> term -> term
-| tFix       : mfixpoint term -> nat -> term
-| tCoFix     : mfixpoint term -> nat -> term.
+| tBox (t : term) (* Represents all proofs *)
+| tRel (n : nat)
+| tVar (id : ident) (* For free variables (e.g. in a goal) *)
+| tMeta (meta : nat) (* NOTE: this will go away *)
+| tEvar (ev : nat) (args : list term)
+| tSort (s : universe)
+| tProd (na : name) (ty : term) (body : term)
+| tLambda (na : name) (ty : term) (body : term)
+| tLetIn (na : name) (def : term) (def_ty : term) (body : term)
+| tApp (f : term) (args : list term)
+| tConst (c : kername) (u : universe_instance)
+| tInd (ind : inductive) (u : universe_instance)
+| tConstruct (ind : inductive) (idx : nat) (u : universe_instance)
+| tCase (ind_and_nbparams: inductive*nat) (type_info:term)
+        (discr:term) (branches : list (nat * term))
+| tProj (proj : projection) (t : term)
+| tFix (mfix : mfixpoint term) (idx : nat)
+| tCoFix (mfix : mfixpoint term) (idx : nat).

--- a/template-coq/theories/ErasedTerm.v
+++ b/template-coq/theories/ErasedTerm.v
@@ -20,15 +20,15 @@ Inductive term : Set :=
 | tMeta      : nat -> term   (* NOTE: this will go away *)
 | tEvar      : nat -> list term -> term
 | tSort      : universe -> term
-| tProd      : name -> term (* the type *) -> term -> term
+| tProd      : forall (_:name) (type:term) (body:term), term
 | tLambda    : name -> term -> term -> term
-| tLetIn     : name -> term (* the term *) -> term -> term -> term
+| tLetIn     : forall (_:name) (term_:term) (type:term) (body:term), term
 | tApp       : term -> list term -> term
 | tConst     : kername -> universe_instance -> term
 | tInd       : inductive -> universe_instance -> term
 | tConstruct : inductive -> nat -> universe_instance -> term
-| tCase      : (inductive * nat) (* # of parameters *) -> term (* type info *)
-               -> term (* discriminee *) -> list (nat * term) (* branches *) -> term
+| tCase      : forall (inductive_and_nb_params:inductive*nat) (type_info:term)
+                      (discriminee:term) (branches : list (nat * term)), term
 | tProj      : projection -> term -> term
 | tFix       : mfixpoint term -> nat -> term
 | tCoFix     : mfixpoint term -> nat -> term.

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -113,30 +113,16 @@ Proof.
   intros until t. revert t.
   fix auxt 1.
   move auxt at top. 
-  destruct t; match goal with
-                 H : _ |- _ => apply H
-              end; auto.
-  revert l.
-  fix auxl' 1.
-  destruct l; constructor; [|apply auxl'].
-  apply auxt.
-  revert l.
-  fix auxl' 1.
-  destruct l; constructor; [|apply auxl'].
-  apply auxt.
-  revert l.
-  fix auxl' 1.
-  destruct l; constructor; [|apply auxl'].
-  apply auxt.
-
-  revert m.
-  fix auxm 1.
-  destruct m; constructor; [|apply auxm].
-  split; apply auxt.
-  revert m.
-  fix auxm 1.
-  destruct m; constructor; [|apply auxm].
-  split; apply auxt.
+  destruct t;
+    match goal with
+      H : _ |- _ => apply H; auto
+    end;
+    match goal with
+      |- _ P ?arg =>
+      revert arg; fix aux_arg 1; intro arg;
+        destruct arg; constructor; [|apply aux_arg];
+          try split; apply auxt
+    end.
 Defined.
 
 Lemma forall_map_spec {A} {P : A -> Prop} {l} {f g : A -> A} :

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -818,30 +818,16 @@ Proof.
   revert t.
   fix auxt 1.
   move auxt at top.
-  destruct t; match goal with
-                 H : _ |- _ => apply H
-              end; auto.
-  revert l.
-  fix auxl' 1.
-  destruct l; constructor; [|apply auxl'].
-  apply auxt.
-  revert l.
-  fix auxl' 1.
-  destruct l; constructor; [|apply auxl'].
-  apply auxt.
-  revert l.
-  fix auxl' 1.
-  destruct l; constructor; [|apply auxl'].
-  apply auxt.
-
-  revert m.
-  fix auxm 1.
-  destruct m; constructor; [|apply auxm].
-  split; apply auxt.
-  revert m.
-  fix auxm 1.
-  destruct m; constructor; [|apply auxm].
-  split; apply auxt.
+  destruct t;
+    match goal with
+      H : _ |- _ => apply H
+    end; auto;
+    match goal with
+      |- _ (P Σ) ?arg =>
+      revert arg; fix aux_arg 1; intro arg;
+        destruct arg; constructor; [|apply aux_arg];
+          try split; apply auxt
+    end.
 Defined.
 
 Lemma term_env_ind' :


### PR DESCRIPTION
This PR was suggested by @silene during a talk by @mattam82 today.

(I'm not sure it compiles, I haven't checked.)