### PR TITLE
Cumulative inductive types

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ Documentation
 The 8.7 branch [documentation (coqdoc files)](html/Template.All.html)
 and pretty-printed HTML versions of the [translations](html/translations) are available.
 
+Options
+-------
+
+`Set / Unset Strict Unquote Universe Mode`. When this mode is on (on by default):
+
+- the unquoting of a universe level fails if this level does not exists
+
+- the unquoting of a sort which is an empty list fails
+
+Otherwise:
+
+- the level is added to the current context
+
+- or a fresh level is added.
+
+
 Papers
 ======
 

--- a/checker/src/term_quoter.ml
+++ b/checker/src/term_quoter.ml
@@ -126,10 +126,28 @@ struct
   let quote_univ_constraints (c : Univ.Constraint.t) : quoted_univ_constraints =
     List.map quote_univ_constraint (Univ.Constraint.elements c)
 
+  let quote_variance (v : Univ.Variance.t) =
+    match v with
+    | Univ.Variance.Irrelevant -> Univ0.Variance.Irrelevant
+    | Univ.Variance.Covariant -> Univ0.Variance.Covariant
+    | Univ.Variance.Invariant -> Univ0.Variance.Invariant
+
+  let quote_cuminfo_variance (var : Univ.Variance.t array) =
+    CArray.map_to_list quote_variance var
+
   let quote_univ_context (uctx : Univ.UContext.t) : quoted_univ_context =
     let levels = Univ.UContext.instance uctx  in
     let constraints = Univ.UContext.constraints uctx in
     Univ0.Monomorphic_ctx (quote_univ_instance levels, quote_univ_constraints constraints)
+
+  let quote_cumulative_univ_context (cumi : Univ.CumulativityInfo.t) : quoted_univ_context =
+    let uctx = Univ.CumulativityInfo.univ_context cumi in
+    let levels = Univ.UContext.instance uctx  in
+    let constraints = Univ.UContext.constraints uctx in
+    let var = Univ.CumulativityInfo.variance cumi in
+    let uctx' = (quote_univ_instance levels, quote_univ_constraints constraints) in
+    let var' = quote_cuminfo_variance var in
+    Univ0.Cumulative_ctx (uctx', var')
 
   let quote_abstract_univ_context_aux uctx : quoted_univ_context =
     let levels = Univ.UContext.instance uctx in

--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -30,6 +30,7 @@ theories/WcbvEval.v
 theories/Retyping.v
 theories/All.v
 theories/Extraction.v
+demo.v
 
 # the Template monad
 theories/TemplateMonad.v

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -388,3 +388,9 @@ Check eq_refl : ones = ones'.
 (* Print universes. *)
 (* Definition tyu := Eval vm_compute in universes. *)
 (* Check (universes : uGraph.t). *)
+
+
+
+Run TemplateProgram (t <- tmQuoteInductive "eq" ;;
+                     t <- tmEval all (mind_body_to_entry t) ;;
+                     tmMkInductive t).

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -388,9 +388,3 @@ Check eq_refl : ones = ones'.
 (* Print universes. *)
 (* Definition tyu := Eval vm_compute in universes. *)
 (* Check (universes : uGraph.t). *)
-
-
-
-Run TemplateProgram (t <- tmQuoteInductive "eq" ;;
-                     t <- tmEval all (mind_body_to_entry t) ;;
-                     tmMkInductive t).

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -361,6 +361,8 @@ Test Quote Prop.
 Inductive T : Type :=
   | toto : Type -> T.
 Quote Recursively Definition TT := T.
+
+Unset Strict Unquote Universe Mode.
 Make Definition t := (tSort ([(Level.Level "Top.20000", false)])).
 Make Definition t' := (tSort ([(Level.Level "Top.20000", false); (Level.Level "Top.20001", true)])).
 Make Definition myProp := (tSort [(Level.lProp, false)]).

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -297,8 +297,8 @@ Set Printing Universes.
 Monomorphic Definition Funtm (A B: Type) := A->B.
 Polymorphic Definition Funtp@{i} (A B: Type@{i}) := A->B.
 (* Run TemplateProgram (printConstant "Top.demo.Funtp"). *)
-Locate Funtm.
-Run TemplateProgram (printConstant "Top.Funtm").
+(* Locate Funtm. *)
+(* Run TemplateProgram (printConstant "Top.Funtm"). *)
 
 Polymorphic Definition Funtp2@{i j} 
    (A: Type@{i}) (B: Type@{j}) := A->B.

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -62,6 +62,7 @@ struct
   let pkg_template_monad = ["Template";"TemplateMonad"]
   let pkg_univ = ["Template";"kernel";"univ"]
   let pkg_level = ["Template";"kernel";"univ";"Level"]
+  let pkg_variance = ["Template";"kernel";"univ";"Variance"]
   let pkg_ugraph = ["Template";"kernel";"uGraph"]
   let ext_pkg_univ s = List.append pkg_univ [s]
 
@@ -80,6 +81,7 @@ struct
   let tfalse = resolve_symbol pkg_datatypes "false"
   let unit_tt = resolve_symbol pkg_datatypes "tt"
   let tAscii = resolve_symbol ["Coq";"Strings";"Ascii"] "Ascii"
+  let tlist = resolve_symbol pkg_datatypes "list"
   let c_nil = resolve_symbol pkg_datatypes "nil"
   let c_cons = resolve_symbol pkg_datatypes "cons"
   let prod_type = resolve_symbol pkg_datatypes "prod"
@@ -122,8 +124,14 @@ struct
   let tunivLt = resolve_symbol (ext_pkg_univ "ConstraintType") "Lt"
   let tunivEq = resolve_symbol (ext_pkg_univ "ConstraintType") "Eq"
   (* let tunivcontext = resolve_symbol pkg_univ "universe_context" *)
+  let tVariance = resolve_symbol pkg_variance "t"
+  let cIrrelevant = resolve_symbol pkg_variance "Irrelevant"
+  let cCovariant = resolve_symbol pkg_variance "Covariant"
+  let cInvariant = resolve_symbol pkg_variance "Invariant"
   let cMonomorphic_ctx = resolve_symbol pkg_univ "Monomorphic_ctx"
   let cPolymorphic_ctx = resolve_symbol pkg_univ "Polymorphic_ctx"
+  let cCumulative_ctx = resolve_symbol pkg_univ "Cumulative_ctx"
+  let tUContext = resolve_symbol (ext_pkg_univ "UContext") "t"
   let tUContextmake = resolve_symbol (ext_pkg_univ "UContext") "make"
   (* let tConstraintSetempty = resolve_symbol (ext_pkg_univ "ConstraintSet") "empty" *)
   let tConstraintSetempty = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "empty")
@@ -288,6 +296,16 @@ struct
         Constr.mkApp (tConstraintSetadd, [| c; tm|])
       ) tConstraintSetempty const
 
+  let quote_variance v =
+    match v with
+    | Univ.Variance.Irrelevant -> cIrrelevant
+    | Univ.Variance.Covariant -> cCovariant
+    | Univ.Variance.Invariant -> cInvariant
+
+  let quote_cuminfo_variance var =
+    let var_list = CArray.map_to_list quote_variance var in
+    to_coq_list tVariance var_list
+
   let quote_ucontext inst const =
     let inst' = quote_univ_instance inst in
     let const' = quote_univ_constraints const in
@@ -297,6 +315,17 @@ struct
     let inst = Univ.UContext.instance uctx in
     let const = Univ.UContext.constraints uctx in
     Constr.mkApp (cMonomorphic_ctx, [| quote_ucontext inst const |])
+
+  let quote_cumulative_univ_context cumi =
+    let uctx = Univ.CumulativityInfo.univ_context cumi in
+    let inst = Univ.UContext.instance uctx in
+    let const = Univ.UContext.constraints uctx in
+    let var = Univ.CumulativityInfo.variance cumi in
+    let uctx' = quote_ucontext inst const in
+    let var' = quote_cuminfo_variance var in
+    let listvar = Constr.mkApp (tlist, [| tVariance |]) in
+    let cumi' = pair tUContext listvar uctx' var' in
+    Constr.mkApp (cCumulative_ctx, [| cumi' |])
 
   let quote_abstract_univ_context_aux uctx =
     let inst = Univ.UContext.instance uctx in

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -255,6 +255,7 @@ struct
     to_string (Univ.Level.to_string s)
 
   let quote_level l =
+    debug (fun () -> str"quote_level " ++ Level.pr l);
     if Level.is_prop l then lProp
     else if Level.is_set l then lSet
     else match Level.var_index l with
@@ -262,14 +263,7 @@ struct
          | None -> Constr.mkApp (tLevel, [| string_of_level l|])
 
   let quote_universe s =
-    (* hack because we can't recover the list of level*int *)
-    (* todo : map on LSet is now exposed in Coq trunk, we should use it to remove this hack *)
-    let levels = LSet.elements (Universe.levels s) in
-    let levels = List.map (fun l -> let l' = quote_level l in
-                                    (* is indeed i always 0 or 1 ? *)
-                                    let b' = quote_bool (Universe.exists (fun (l2,i) -> Level.equal l l2 && i = 1) s) in
-                                    pair tlevel bool_type l' b')
-                          levels in
+    let levels = Universe.map (fun (l,i) -> pair tlevel bool_type (quote_level l) (if i > 0 then ttrue else tfalse)) s in
     to_coq_list (prod tlevel bool_type) levels
 
   (* todo : can be deduced from quote_level, hence shoud be in the Reify module *)

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -605,7 +605,7 @@ let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) 
        let evm, params = map_evm (fun evm p -> let (l,r) = unquote_pair p in
                                                let evm, e = denote_local_entry evm r in
                                                evm, (unquote_ident l, e))
-                                 evm (List.rev (unquote_list params)) in (* TODO: rev ?? *)
+                                 evm (unquote_list params) in
        let evm, inds = map_evm unquote_one_inductive_entry evm (unquote_list inds) in
        let evm, univs = denote_universe_context evm univs in
        let priv = unquote_map_option unquote_bool priv in

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -134,7 +134,7 @@ let inspectTerm (t:Constr.t) :  (Constr.t, quoted_int, quoted_ident, quoted_name
     | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
 
   else
-    CErrors.user_err (str"inspect_term: cannot recognize " ++ print_term t)
+    CErrors.user_err (str"inspect_term: cannot recognize " ++ print_term t ++ str" (maybe you forgot to reduce it?)")
 
 (* Unquote Coq nat to OCaml int *)
 let rec unquote_nat trm =
@@ -460,8 +460,7 @@ let denote_term evm (trm: Constr.t) : Evd.evar_map * Constr.t =
 
 
 
-let quote_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexpr.red_expr =
-  let trm = Reduction.whd_all env trm in
+let unquote_reduction_strategy env evm trm (* of type reductionStrategy *) : Redexpr.red_expr =
   let (trm, args) = app_full trm [] in
   (* from g_tactic.ml4 *)
   let default_flags = Redops.make_red_flag [FBeta;FMatch;FFix;FCofix;FZeta;FDeltaBut []] in
@@ -478,8 +477,8 @@ let quote_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexpr
        (try Unfold [Locus.AllOccurrences, Tacred.evaluable_of_global_reference env (Nametab.global (CAst.make (Libnames.Qualid (Libnames.qualid_of_ident name))))]
         with
         | _ -> CErrors.user_err (str "Constant not found or not a constant: " ++ Pp.str (Names.Id.to_string name)))
-    | _ -> bad_term_verb trm "quote_reduction_strategy"
-  else not_supported_verb trm "quote_reduction_strategy"
+    | _ -> bad_term_verb trm "unquote_reduction_strategy"
+  else not_supported_verb trm "unquote_reduction_strategy"
 
 
 
@@ -644,7 +643,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     run_template_program_rec ~intactic:intactic (fun (evm, ar) -> run_template_program_rec ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
   | TmDefinition (name,s,typ,body) ->
     let name = reduce_all env evm name in
-    let evm, typ = (match denote_option s with Some s -> let red = quote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+    let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
     let univs =
       if Flags.is_universe_polymorphism () then Polymorphic_const_entry (Evd.to_universe_context evm)
       else Monomorphic_const_entry (Evd.universe_context_set evm) in
@@ -652,13 +651,13 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     k (evm, Constr.mkConst n)
   | TmAxiom (name,s,typ) ->
     let name = reduce_all env evm name in
-    let evm, typ = (match denote_option s with Some s -> let red = quote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+    let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
     let param = Entries.ParameterEntry (None, (typ, Monomorphic_const_entry (Evd.universe_context_set evm)), None) in
     let n = Declare.declare_constant (unquote_ident name) (param, Decl_kinds.IsDefinition Decl_kinds.Definition) in
     k (evm, Constr.mkConst n)
   | TmLemma (name,s,typ) ->
     let name = reduce_all env evm name in
-    let evm, typ = (match denote_option s with Some s -> let red = quote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+    let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
     let poly = Flags.is_universe_polymorphism () in
     let kind = (Decl_kinds.Global, poly, Decl_kinds.Definition) in
     let hole = CAst.make (Constrexpr.CHole (None, Misctypes.IntroAnonymous, None)) in
@@ -743,7 +742,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     let s = quote_string (Names.ModPath.to_string mp) in
     k (evm, s)
   | TmEval (s, trm) ->
-    let red = quote_reduction_strategy env evm s in
+    let red = unquote_reduction_strategy env evm s in
     let (evm, trm) = reduce env evm red trm
     in k (evm, trm)
   | TmMkInductive mind ->
@@ -781,7 +780,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
   | TmExistingInstance name ->
     Classes.existing_instance true (CAst.make (Libnames.Qualid (Libnames.qualid_of_ident (unquote_ident name)))) None
   | TmInferInstance (s, typ) ->
-       let evm, typ = (match denote_option s with Some s -> let red = quote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+       let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
        (try
           let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
           k (evm, Constr.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -142,9 +142,8 @@ END;;
 VERNAC COMMAND EXTEND Run_program CLASSIFIED AS SIDEFF
     | [ "Run" "TemplateProgram" constr(def) ] ->
       [ let (evm, env) = Pfedit.get_current_context () in
-        let (def, _) = Constrintern.interp_constr env evm def in
-        (* todo : uctx ? *)
-        Denote.run_template_program_rec (fun _ -> ()) (Global.env ()) (evm, (EConstr.to_constr evm def)) ]
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        Denote.run_template_program_rec (fun _ -> ()) env (evm, (EConstr.to_constr evm def)) ]
 END;;
 
 TACTIC EXTEND run_program

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -64,9 +64,6 @@ TACTIC EXTEND denote_term
          let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let evm, c = Denote.denote_term evm (EConstr.to_constr evm c) in
-         (* TODO : not the right way of retype things *)
-         (* let def' = Constrextern.extern_constr true env evm (EConstr.of_constr c) in *)
-         (* let def = Constrintern.interp_constr env evm def' in *)
          Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm)
 	   (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c]))
       end) ]

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -65,10 +65,10 @@ TACTIC EXTEND denote_term
          let evm = Proofview.Goal.sigma gl in
          let evm, c = Denote.denote_term evm (EConstr.to_constr evm c) in
          (* TODO : not the right way of retype things *)
-         let def' = Constrextern.extern_constr true env evm (EConstr.of_constr c) in
-         let def = Constrintern.interp_constr env evm def' in
+         (* let def' = Constrextern.extern_constr true env evm (EConstr.of_constr c) in *)
+         (* let def = Constrintern.interp_constr env evm def' in *)
          Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm)
-	   (ltac_apply tac (List.map to_ltac_val [fst def]))
+	   (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c]))
       end) ]
 END;;
 
@@ -150,10 +150,11 @@ END;;
 TACTIC EXTEND run_program
     | [ "run_template_program" constr(c) tactic(tac) ] ->
       [ Proofview.Goal.enter (begin fun gl ->
+         let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let env = Proofview.Goal.env gl in
          let ret = ref None in
-         Denote.run_template_program_rec ~intactic:true (fun (evm, t) -> ret := Some t) env (evm, EConstr.to_constr evm c);
+         Denote.run_template_program_rec ~intactic:true (fun (env, evm, t) -> ret := Some t) env (evm, EConstr.to_constr evm c);
          match !ret with
            Some c ->
            ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c])

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -64,7 +64,7 @@ TACTIC EXTEND denote_term
          let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let evdref = ref evm in
-         let c = Denote.denote_term evdref (EConstr.to_constr evm c) in
+         let c = Denote.denote_term (EConstr.to_constr evm c) in
          (* TODO : not the right way of retype things *)
          let def' = Constrextern.extern_constr true env !evdref (EConstr.of_constr c) in
          let def = Constrintern.interp_constr env !evdref def' in
@@ -113,7 +113,7 @@ VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
       [ let (evm, env) = Pfedit.get_current_context () in
 	let (trm, uctx) = Constrintern.interp_constr env evm def in
         let evdref = ref (Evd.from_ctx uctx) in
-	let trm = Denote.denote_term evdref (EConstr.to_constr evm trm) in
+	let trm = Denote.denote_term (EConstr.to_constr evm trm) in
 	let _ = Declare.declare_definition
                   ~kind:Decl_kinds.Definition
                   name
@@ -129,7 +129,7 @@ VERNAC COMMAND EXTEND Unquote_vernac_red CLASSIFIED AS SIDEFF
         let (evm,rd) = Tacinterp.interp_redexp env evm rd in
 	let (evm,trm) = Quoter.reduce env evm rd (EConstr.to_constr evm trm) in
         let evdref = ref evm in
-        let trm = Denote.denote_term evdref trm in
+        let trm = Denote.denote_term trm in
 	let _ = Declare.declare_definition ~kind:Decl_kinds.Definition name
                   (trm, Monomorphic_const_entry (Evd.universe_context_set !evdref)) in
         () ]

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -151,6 +151,7 @@ module type Quoter = sig
   val quote_univ_instance : Univ.Instance.t -> quoted_univ_instance
   val quote_univ_constraints : Univ.Constraint.t -> quoted_univ_constraints
   val quote_univ_context : Univ.UContext.t -> quoted_univ_context
+  val quote_cumulative_univ_context : Univ.CumulativityInfo.t -> quoted_univ_context
   val quote_abstract_univ_context : Univ.AUContext.t -> quoted_univ_context
   val quote_inductive_universes : Entries.inductive_universes -> quoted_inductive_universes
 
@@ -225,17 +226,18 @@ struct
 
   (* From printmod.ml *)
   let instantiate_cumulativity_info cumi =
-  let open Univ in
-  let univs = ACumulativityInfo.univ_context cumi in
-  let expose ctx =
-    let inst = AUContext.instance ctx in
-    let cst = AUContext.instantiate inst ctx in
-    UContext.make (inst, cst)
-  in CumulativityInfo.make (expose univs, ACumulativityInfo.variance cumi)
+    let open Univ in
+    let univs = ACumulativityInfo.univ_context cumi in
+    let expose ctx =
+      let inst = AUContext.instance ctx in
+      let cst = AUContext.instantiate inst ctx in
+      UContext.make (inst, cst)
+    in CumulativityInfo.make (expose univs, ACumulativityInfo.variance cumi)
 
   let get_abstract_inductive_universes iu =
     match iu with
-    | Declarations.Monomorphic_ind ctx -> Univ.ContextSet.to_context ctx
+    | Declarations.Monomorphic_ind ctx ->
+       Univ.ContextSet.to_context ctx
     | Polymorphic_ind ctx -> Univ.AUContext.repr ctx
     | Cumulative_ind cumi ->
        let cumi = instantiate_cumulativity_info cumi in
@@ -247,11 +249,12 @@ struct
 
   let quote_abstract_inductive_universes iu =
     match iu with
-    | Monomorphic_ind ctx -> Q.quote_univ_context (Univ.ContextSet.to_context ctx)
+    | Monomorphic_ind ctx ->
+       Q.quote_univ_context (Univ.ContextSet.to_context ctx)
     | Polymorphic_ind ctx -> Q.quote_abstract_univ_context ctx
     | Cumulative_ind cumi ->
-       let cumi = instantiate_cumulativity_info cumi in
-       Q.quote_univ_context (Univ.CumulativityInfo.univ_context cumi)  (* FIXME check also *)
+       let cumi = instantiate_cumulativity_info cumi in (* FIXME what is the point of that *)
+       Q.quote_cumulative_univ_context cumi
 
   let quote_term_remember
       (add_constant : KerName.t -> 'a -> 'a)

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -8,7 +8,7 @@ let cast_prop = ref (false)
 (* whether Set Template Cast Propositions is on, as needed for erasure in Certicoq *)
 let is_cast_prop () = !cast_prop
 
-let opt_debug = ref false
+let opt_debug = ref true
 
 let debug (m : unit ->Pp.t) =
   if !opt_debug then
@@ -411,7 +411,7 @@ struct
           let indty, acc = quote_term acc env indty in
 	  let (reified_ctors,acc) =
 	    List.fold_left (fun (ls,acc) (nm,ty,ar) ->
-	      debug (fun () -> Pp.(str "XXXX" ++ spc () ++
+	      debug (fun () -> Pp.(str "opt_hnf_ctor_types:" ++ spc () ++
                             bool !opt_hnf_ctor_types)) ;
 	      let ty = if !opt_hnf_ctor_types then hnf_type (snd envind) ty else ty in
 	      let (ty,acc) = quote_term acc envind ty in

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -8,7 +8,7 @@ let cast_prop = ref (false)
 (* whether Set Template Cast Propositions is on, as needed for erasure in Certicoq *)
 let is_cast_prop () = !cast_prop
 
-let opt_debug = ref true
+let opt_debug = ref false
 
 let debug (m : unit ->Pp.t) =
   if !opt_debug then
@@ -236,8 +236,7 @@ struct
 
   let get_abstract_inductive_universes iu =
     match iu with
-    | Declarations.Monomorphic_ind ctx ->
-       Univ.ContextSet.to_context ctx
+    | Declarations.Monomorphic_ind ctx -> Univ.ContextSet.to_context ctx
     | Polymorphic_ind ctx -> Univ.AUContext.repr ctx
     | Cumulative_ind cumi ->
        let cumi = instantiate_cumulativity_info cumi in

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -78,7 +78,7 @@ Proof.
             mind_entry_universes := decl.(ind_universes);
             mind_entry_private := None |}.
   - refine (match List.hd_error decl.(ind_bodies) with
-            | Some i0 => _
+            | Some i0 => List.rev _
             | None => nil (* assert false: at least one inductive in a mutual block *)
             end).
     pose (typ := decompose_prod i0.(ind_type)).

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -630,6 +630,7 @@ Section Typecheck2.
     match u with
     | Monomorphic_ctx _ => ConstraintSet.empty
     | Polymorphic_ctx ctx => UContext.constraints ctx
+    | Cumulative_ctx ctx => UContext.constraints (CumulativityInfo.univ_context ctx)
     end.
 
   Definition lookup_constant_type cst u :=
@@ -889,6 +890,7 @@ Section Typecheck2.
       destruct cst_universes. simpl. reflexivity.
       simpl in *. destruct cst0. simpl in *.
       destruct c. unfold check_consistent_constraints. rewrite H0. reflexivity.
+      admit.
 
     - admit.
     - admit.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -598,9 +598,6 @@ with typing_spine `{checker_flags} (Σ : global_context) (Γ : context) : term -
 
 (** ** Typechecking of global environments *)
 
-Definition add_constraints_env u (Σ : global_context)
-  := (fst Σ, add_global_constraints u (snd Σ)).
-
 Definition add_global_decl (decl : global_decl) (Σ : global_context) :=
   let univs := match decl with
                | ConstantDecl _ d => d.(cst_universes)

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -426,7 +426,8 @@ Definition universe_family u :=
 Definition consistent_universe_context_instance (Σ : global_context) uctx u :=
   match uctx with
   | Monomorphic_ctx c => True
-  | Polymorphic_ctx c =>
+  | Polymorphic_ctx c
+  | Cumulative_ctx (c, _) =>
     let '(inst, cstrs) := UContext.dest c in
     List.length inst = List.length u /\
     check_constraints (snd Σ) (subst_instance_cstrs u cstrs) = true

--- a/template-coq/theories/kernel/uGraph.v
+++ b/template-coq/theories/kernel/uGraph.v
@@ -52,6 +52,7 @@ Definition repr (uctx : universe_context) : UContext.t :=
   match uctx with
   | Monomorphic_ctx c => c
   | Polymorphic_ctx c => c
+  | Cumulative_ctx c => CumulativityInfo.univ_context c
   end.
 
 Definition add_global_constraints (uctx : universe_context) (G : t) : t
@@ -60,6 +61,7 @@ Definition add_global_constraints (uctx : universe_context) (G : t) : t
        let G := List.fold_left (fun s l => add_node l s) inst G in
        ConstraintSet.fold add_constraint cstrs G
      | Polymorphic_ctx _ => G
+     | Cumulative_ctx _ => G
      end.
 
 Section UGraph.

--- a/template-coq/theories/kernel/univ.v
+++ b/template-coq/theories/kernel/univ.v
@@ -411,40 +411,49 @@ Module UContext.
   (* val size : t -> int *)
 End UContext.
 
+(* Variance info is needed to do full universe polymorphism *)
+Module Variance.
+  (** A universe position in the instance given to a cumulative
+     inductive can be the following. Note there is no Contravariant
+     case because [forall x : A, B <= forall x : A', B'] requires [A =
+     A'] as opposed to [A' <= A]. *)
+  Inductive t :=
+  | Irrelevant : t
+  | Covariant : t
+  | Invariant : t.
+
+  (* val check_subtype : t -> t -> bool *)
+  (* val sup : t -> t -> t *)
+  (* val pr : t -> Pp.t *)
+End Variance.
+
+(** Universe info for cumulative inductive types: A context of
+   universe levels with universe constraints, representing local
+   universe variables and constraints, together with an array of
+   Variance.t.
+
+    This data structure maintains the invariant that the variance
+   array has the same length as the universe instance. *)
+Module CumulativityInfo.
+  Definition t := prod UContext.t (list Variance.t).
+
+  Definition empty : t := (UContext.empty, nil).
+  (* val is_empty : t -> bool *)
+
+  Definition univ_context : t -> UContext.t := fst.
+  Definition variance : t -> list Variance.t := snd.
+
+  (** This function takes a universe context representing constraints
+     of an inductive and produces a CumulativityInfo.t with the
+     trivial subtyping relation. *)
+  (* val from_universe_context : UContext.t -> t *)
+
+  (* val leq_constraints : t -> Instance.t constraint_function *)
+  (* val eq_constraints : t -> Instance.t constraint_function *)
+End CumulativityInfo.
+
 Inductive universe_context : Type :=
 | Monomorphic_ctx (ctx : UContext.t)
-| Polymorphic_ctx (cst : UContext.t).
+| Polymorphic_ctx (cst : UContext.t)
+| Cumulative_ctx (ctx : CumulativityInfo.t).
 
-(* (** Universe info for inductive types: A context of universe levels *)
-(*     with universe constraints, representing local universe variables *)
-(*     and constraints, together with a context of universe levels with *)
-(*     universe constraints, representing conditions for subtyping used *)
-(*     for inductive types. *)
-
-(*     This data structure maintains the invariant that the context for *)
-(*     subtyping constraints is exactly twice as big as the context for *)
-(*     universe constraints. *) *)
-(* module CumulativityInfo : *)
-(* sig *)
-(*   type t *)
-
-(*   val make : universe_context * universe_context -> t *)
-
-(*   val empty : t *)
-(*   val is_empty : t -> bool *)
-
-(*   val univ_context : t -> universe_context *)
-(*   val subtyp_context : t -> universe_context *)
-
-(*   (** This function takes a universe context representing constraints *)
-(*       of an inductive and a Instance.t of fresh universe names for the *)
-(*       subtyping (with the same length as the context in the given *)
-(*       universe context) and produces a UInfoInd.t that with the *)
-(*       trivial subtyping relation. *) *)
-(*   val from_universe_context : universe_context -> universe_instance -> t *)
-
-(*   val subtyping_susbst : t -> universe_level_subst *)
-
-(* end *)
-
-(* type cumulativity_info = CumulativityInfo.t *)

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,4 +1,4 @@
-From Template Require Import Ast TemplateMonad Loader monad_utils.
+From Template Require Import All.
 Require Import String List Arith.
 Import ListNotations MonadNotation.
 Open Scope string.
@@ -11,7 +11,7 @@ Fail Make Definition t1 := (tSort []).
 Fail Make Definition t1 := (tSort [(Level.Level "Top.400", false)]).
 
 Monomorphic Definition T := Type.
-Make Definition t1 := (tSort [(Level.Level "Top.2", false)]).
+(* Make Definition t1 := (tSort [(Level.Level "Top.2", false)]). *)
 
 Unset Strict Unquote Universe Mode.
 Make Definition t2 := (tSort []).
@@ -33,7 +33,7 @@ Polymorphic Definition selfpid := pidentity (@pidentity).
 Test Quote @selfpid.
 
 Constraint i < j.
-Make Definition yuyu := (tConst "Top.selfpid" [Level.Level "j"; Level.Level "i"]).
+Make Definition yuyu := (tConst "selfpid" [Level.Level "j"; Level.Level "i"]).
 
 
 Quote Definition t0 := nat.
@@ -55,6 +55,15 @@ Polymorphic Definition Cat@{i j k l} : Category@{i j}
 Run TemplateProgram (tmQuoteInductive "Category" >>= tmEval all >>= tmPrint).
 Run TemplateProgram (tmQuoteConstant "Cat" false >>= tmEval all >>= tmPrint).
 
+
+Polymorphic Cumulative Inductive list (A : Type) : Type :=
+nil : list A | cons : A -> list A -> list A.
+
+Module to.
+Run TemplateProgram (t <- tmQuoteInductive "list" ;;
+                     t <- tmEval all (mind_body_to_entry t) ;;
+                     tmMkInductive t).
+End to.
 
 Compute (AstUtils.mind_body_to_entry {|
 ind_npars := 0;

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,9 +1,13 @@
-From Template Require Import Ast TemplateMonad Loader.
+From Template Require Import Ast TemplateMonad Loader monad_utils.
 Require Import String.
 
 Open Scope string.
+Import MonadNotation.
 
 Set Printing Universes.
+
+Polymorphic Cumulative Inductive test := .
+Run TemplateProgram (α <- tmQuoteInductive "test" ;; tmPrint α).
 
 
 Inductive foo (A : Type) : Type :=

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,10 +1,48 @@
 From Template Require Import Ast TemplateMonad Loader monad_utils.
-Require Import String.
-
+Require Import String List Arith.
+Import ListNotations MonadNotation.
 Open Scope string.
-Import MonadNotation.
 
 Set Printing Universes.
+
+Test Quote Type.
+
+Fail Make Definition t1 := (tSort []).
+Fail Make Definition t1 := (tSort [(Level.Level "Top.400", false)]).
+
+Monomorphic Definition T := Type.
+Print Sorted Universes.
+(* Make Definition t1 := (tSort [(Level.Level "Top.2", false)]). *)
+
+Unset Strict Unquote Universe Mode.
+Make Definition t2 := (tSort []).
+Make Definition t3 := (tSort [(Level.Level "Top.400", false)]).
+Make Definition t4 := (tSort [(Level.Level "Top.2", false); (Level.Level "Top.2", true); (Level.Level "Top.200", false)]).
+Print Sorted Universes.
+
+Set Strict Unquote Universe Mode.
+
+Section foo.
+Polymorphic Universe i j.
+Polymorphic Definition T' := Type@{i}.
+
+(* Make Definition T'' := (tSort [(Level.Var "i", false)]). *)
+(* Test Quote (Type@{j} -> Type@{i}). *)
+
+
+Polymorphic Definition pidentity {A : Type} (a : A) := a.
+Test Quote @pidentity.
+Polymorphic Definition selfpid := pidentity (@pidentity).
+Set Printing Universes.
+
+(* Polymorphic Cumulative Inductive list {A : Type} := *)
+(* | nil : list *)
+(* | cons : A -> list -> list. *)
+
+(* Print list. *)
+(* Polymorphic Cumulative Record packType := {pk : Type}. *)
+
+End foo.
 
 Polymorphic Cumulative Inductive test := .
 Run TemplateProgram (α <- tmQuoteInductive "test" ;; tmPrint α).
@@ -76,7 +114,7 @@ End toto.
 (* Set Universe Polymorphism. *)
 
 Monomorphic Universe i j.
-Definition test := (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
+Definition test2 := (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
 Set Printing Universes.
 Print test.
 (* Print Universes. *)
@@ -86,6 +124,7 @@ Quote Definition qtest := Eval compute in (fun (T : Type@{i}) (T2 : Type@{j}) =>
 Print qtest.
 
 Make Definition bla := Eval compute in qtest.
+Unset Strict Unquote Universe Mode.
 Make Definition bla' := (tLambda (nNamed "T") (tSort ((Level.Level "Top.2", false) :: nil)%list) (tLambda (nNamed "T2") (tSort ((Level.Level "Top.1", false) :: nil)%list) (tProd nAnon (tRel 1) (tRel 1)))).
 
 Set Printing Universes.
@@ -121,7 +160,7 @@ Polymorphic Definition F@{i} := Type@{i}.
 
 Quote Definition qT := Eval compute in F.
 Require Import List. Import ListNotations.
-Make Definition T' := (tSort [(Level.Var 1, false)]).
+Make Definition T'2 := (tSort [(Level.Var 1, false)]).
 
 Quote Recursively Definition qT' := F.
 
@@ -131,7 +170,7 @@ Print qFuntp.
 there the poly vars actually show up *)
 
 
-Make Definition t2 := (Ast.tLambda (Ast.nNamed "T") (Ast.tSort [(Level.Level "Top.10001", false)])
+Make Definition t22 := (Ast.tLambda (Ast.nNamed "T") (Ast.tSort [(Level.Level "Top.10001", false)])
                                    (Ast.tLambda (Ast.nNamed "T2") (Ast.tSort [(Level.Level "Top.10002", false)]) (Ast.tProd Ast.nAnon (Ast.tRel 1) (Ast.tRel 1)))).
 Set Printing Universes.
 Print t2.

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -12,7 +12,7 @@ Fail Make Definition t1 := (tSort [(Level.Level "Top.400", false)]).
 
 Monomorphic Definition T := Type.
 Print Sorted Universes.
-(* Make Definition t1 := (tSort [(Level.Level "Top.2", false)]). *)
+Make Definition t1 := (tSort [(Level.Level "Top.2", false)]).
 
 Unset Strict Unquote Universe Mode.
 Make Definition t2 := (tSort []).
@@ -22,18 +22,32 @@ Print Sorted Universes.
 
 Set Strict Unquote Universe Mode.
 
-Section foo.
-Polymorphic Universe i j.
-Polymorphic Definition T' := Type@{i}.
+(* Section foo. *)
+Monomorphic Universe i j.
+(* Polymorphic Definition T' := Type@{i}. *)
 
-(* Make Definition T'' := (tSort [(Level.Var "i", false)]). *)
-(* Test Quote (Type@{j} -> Type@{i}). *)
+Test Quote (Type@{j} -> Type@{i}).
+Make Definition T'' := (tSort [(Level.Level "j", false)]).
 
 
 Polymorphic Definition pidentity {A : Type} (a : A) := a.
 Test Quote @pidentity.
 Polymorphic Definition selfpid := pidentity (@pidentity).
+Test Quote @selfpid.
+
+Unset Strict Unquote Universe Mode.
+Print Sorted Universes.
+Constraint i < j.
+Make Definition yuyu := (tConst "Top.selfpid" [Level.Level "j"; Level.Level "i"]).
+
+Quote Definition t0 := nat.
+Run TemplateProgram (tmUnquoteTyped Type t0).
 Set Printing Universes.
+Print Sorted Universes.
+Definition ty : Type := Type.
+Run TemplateProgram (tmUnquoteTyped ty t0).
+
+
 
 (* Polymorphic Cumulative Inductive list {A : Type} := *)
 (* | nil : list *)
@@ -41,8 +55,6 @@ Set Printing Universes.
 
 (* Print list. *)
 (* Polymorphic Cumulative Record packType := {pk : Type}. *)
-
-End foo.
 
 Polymorphic Cumulative Inductive test := .
 Run TemplateProgram (α <- tmQuoteInductive "test" ;; tmPrint α).

--- a/translations/tsl_param.v
+++ b/translations/tsl_param.v
@@ -141,7 +141,7 @@ Definition tsl_mind_body (E : tsl_table)
                               mind.(ind_bodies))).
 Defined.
 
-
+Unset Strict Unquote Universe Mode.
 Run TemplateProgram (tm <- tmQuote (forall A, A -> A) ;;
                      let tm' := tsl_rec1 [] tm in
                      tmUnquote tm' >>= tmPrint).

--- a/translations/tsl_param3.v
+++ b/translations/tsl_param3.v
@@ -121,6 +121,8 @@ Definition ImplParam := @tImplement tsl_param.
 Notation "'TYPE'" := (exists A, A -> Type).
 Notation "'El' A" := (sigma (π1 A) (π2 A)) (at level 20).
 
+Unset Strict Unquote Universe Mode.
+
 Definition Ty := Type.
 Set Printing Universes.
 Run TemplateProgram (TslParam emptyTC "Ty").


### PR DESCRIPTION
This PR is a bit messy but it does several things:

- Implement quoting and unquoting of (cumulative) polymorphic inductive types. Thanks to @loic-p.
  I added a `Strict Unquote Universe Mode`, cf. Readme.

- Pass the env in the continuation of run_template_program as suggested in #69. This should fix #79.

- Add demo.v to the makefile.

- Fix the order of params in mind_entry (was reversed compared to Coq implem).

- A bit of cleaning.

Suggestions welcome!