### PR TITLE
[to check before merge] correct isConstruct in checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ Documentation
 The 8.7 branch [documentation (coqdoc files)](html/Template.All.html)
 and pretty-printed HTML versions of the [translations](html/translations) are available.
 
+Options
+-------
+
+`Set / Unset Strict Unquote Universe Mode`. When this mode is on (on by default):
+
+- the unquoting of a universe level fails if this level does not exists
+
+- the unquoting of a sort which is an empty list fails
+
+Otherwise:
+
+- the level is added to the current context
+
+- or a fresh level is added.
+
+
 Papers
 ======
 

--- a/checker/src/term_quoter.ml
+++ b/checker/src/term_quoter.ml
@@ -126,10 +126,28 @@ struct
   let quote_univ_constraints (c : Univ.Constraint.t) : quoted_univ_constraints =
     List.map quote_univ_constraint (Univ.Constraint.elements c)
 
+  let quote_variance (v : Univ.Variance.t) =
+    match v with
+    | Univ.Variance.Irrelevant -> Univ0.Variance.Irrelevant
+    | Univ.Variance.Covariant -> Univ0.Variance.Covariant
+    | Univ.Variance.Invariant -> Univ0.Variance.Invariant
+
+  let quote_cuminfo_variance (var : Univ.Variance.t array) =
+    CArray.map_to_list quote_variance var
+
   let quote_univ_context (uctx : Univ.UContext.t) : quoted_univ_context =
     let levels = Univ.UContext.instance uctx  in
     let constraints = Univ.UContext.constraints uctx in
     Univ0.Monomorphic_ctx (quote_univ_instance levels, quote_univ_constraints constraints)
+
+  let quote_cumulative_univ_context (cumi : Univ.CumulativityInfo.t) : quoted_univ_context =
+    let uctx = Univ.CumulativityInfo.univ_context cumi in
+    let levels = Univ.UContext.instance uctx  in
+    let constraints = Univ.UContext.constraints uctx in
+    let var = Univ.CumulativityInfo.variance cumi in
+    let uctx' = (quote_univ_instance levels, quote_univ_constraints constraints) in
+    let var' = quote_cuminfo_variance var in
+    Univ0.Cumulative_ctx (uctx', var')
 
   let quote_abstract_univ_context_aux uctx : quoted_univ_context =
     let levels = Univ.UContext.instance uctx in

--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -29,6 +29,7 @@ theories/WcbvEval.v
 theories/Retyping.v
 theories/All.v
 theories/Extraction.v
+demo.v
 
 # the Template monad
 theories/TemplateMonad.v

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -388,3 +388,9 @@ Check eq_refl : ones = ones'.
 (* Print universes. *)
 (* Definition tyu := Eval vm_compute in universes. *)
 (* Check (universes : uGraph.t). *)
+
+
+
+Run TemplateProgram (t <- tmQuoteInductive "eq" ;;
+                     t <- tmEval all (mind_body_to_entry t) ;;
+                     tmMkInductive t).

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -388,9 +388,3 @@ Check eq_refl : ones = ones'.
 (* Print universes. *)
 (* Definition tyu := Eval vm_compute in universes. *)
 (* Check (universes : uGraph.t). *)
-
-
-
-Run TemplateProgram (t <- tmQuoteInductive "eq" ;;
-                     t <- tmEval all (mind_body_to_entry t) ;;
-                     tmMkInductive t).

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -361,6 +361,8 @@ Test Quote Prop.
 Inductive T : Type :=
   | toto : Type -> T.
 Quote Recursively Definition TT := T.
+
+Unset Strict Unquote Universe Mode.
 Make Definition t := (tSort ([(Level.Level "Top.20000", false)])).
 Make Definition t' := (tSort ([(Level.Level "Top.20000", false); (Level.Level "Top.20001", true)])).
 Make Definition myProp := (tSort [(Level.lProp, false)]).

--- a/template-coq/demo.v
+++ b/template-coq/demo.v
@@ -297,8 +297,8 @@ Set Printing Universes.
 Monomorphic Definition Funtm (A B: Type) := A->B.
 Polymorphic Definition Funtp@{i} (A B: Type@{i}) := A->B.
 (* Run TemplateProgram (printConstant "Top.demo.Funtp"). *)
-Locate Funtm.
-Run TemplateProgram (printConstant "Top.Funtm").
+(* Locate Funtm. *)
+(* Run TemplateProgram (printConstant "Top.Funtm"). *)
 
 Polymorphic Definition Funtp2@{i j} 
    (A: Type@{i}) (B: Type@{j}) := A->B.

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -262,6 +262,7 @@ struct
     to_string (Univ.Level.to_string s)
 
   let quote_level l =
+    debug (fun () -> str"quote_level " ++ Level.pr l);
     if Level.is_prop l then lProp
     else if Level.is_set l then lSet
     else match Level.var_index l with
@@ -269,14 +270,7 @@ struct
          | None -> Constr.mkApp (tLevel, [| string_of_level l|])
 
   let quote_universe s =
-    (* hack because we can't recover the list of level*int *)
-    (* todo : map on LSet is now exposed in Coq trunk, we should use it to remove this hack *)
-    let levels = LSet.elements (Universe.levels s) in
-    let levels = List.map (fun l -> let l' = quote_level l in
-                                    (* is indeed i always 0 or 1 ? *)
-                                    let b' = quote_bool (Universe.exists (fun (l2,i) -> Level.equal l l2 && i = 1) s) in
-                                    pair tlevel bool_type l' b')
-                          levels in
+    let levels = Universe.map (fun (l,i) -> pair tlevel bool_type (quote_level l) (if i > 0 then ttrue else tfalse)) s in
     to_coq_list (prod tlevel bool_type) levels
 
   (* todo : can be deduced from quote_level, hence shoud be in the Reify module *)

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -211,37 +211,6 @@ let unquote_name trm =
     not_supported_verb trm "unquote_name"
 
 
-  (* FIXME CHANGES: This code was taken from (old version of) Pretyping, because it is not exposed globally *)
-  (* the case for strict universe declarations was removed *)
-
- (* It seems that the way to work with global universe declarations has changed.
-    See: https://github.com/coq/coq/commit/20c98eab851210702b39e1c66e005acfc351d8dd
-    Also, instead of strings, new level manupulation functions
-    use [qualid]. Maybe it's worth considering to make corresponding changes to template-coq representations as well.
-  *)
-
-(* let get_level evd s = *)
-(*   if CString.string_contains ~where:s ~what:"." then *)
-(*     match List.rev (CString.split '.' s) with *)
-(*     | [] -> CErrors.anomaly (str"Invalid universe name " ++ str s ++ str".") *)
-(*     | n :: dp -> *)
-(*        let num = int_of_string n in *)
-(*        let dp = DirPath.make (List.map Id.of_string dp) in *)
-(*        let level = Univ.Level.make dp num in *)
-(*        let evd = *)
-(*          try Evd.add_global_univ evd level *)
-(*          with UGraph.AlreadyDeclared -> evd *)
-(*        in evd, level *)
-(*   else *)
-(*     try *)
-(*       let level = Evd.universe_of_name evd (Id.of_string s) in *)
-(*       evd, level *)
-(*     with Not_found -> *)
-(*       user_err  ~hdr:"interp_universe_level_name" *)
-(*                 (Pp.(str "Undeclared universe: " ++ Id.print (Id.of_string s))) *)
-(* (\* end of code from Pretyping *\) *)
-
-
 (* If strict unquote universe mode is on then fail when unquoting a non *)
 (* declared universe / an empty list of level expressions. *)
 (* Otherwise, add it / a fresh level the global environnment. *)
@@ -273,20 +242,23 @@ let get_level evm s =
        let l = Univ.Level.make dp num in
        try
          let evm = Evd.add_global_univ evm l in
-         (* ignore (UGraph.add_universe l false evm); *)
          if !strict_unquote_universe_mode then
            CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level and you are in Strict Unquote Universe Mode."))
-         else (
-           (* Global.push_context false (Univ.UContext.make (Univ.Instance.of_array [|l|], Univ.Constraint.empty)); *)
-           Feedback.msg_info (str"Fresh universe " ++ Level.pr l ++ str" was added to the context.");
-           evm, l)
+         else (Feedback.msg_info (str"Fresh universe " ++ Level.pr l ++ str" was added to the context.");
+               evm, l)
        with
        | UGraph.AlreadyDeclared -> evm, l
   else
     try
       evm, Evd.universe_of_name evm (Id.of_string s)
     with Not_found ->
-      CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level."))
+         try
+           let univ, k = Nametab.locate_universe (Libnames.qualid_of_string s) in
+           evm, Univ.Level.make univ k
+         with Not_found ->
+           CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level."))
+
+
 
 
 
@@ -326,7 +298,6 @@ let unquote_universe evm trm (* of type universe *) =
           else
             let evm, u = Evd.new_univ_variable (Evd.UnivFlexible false) evm in
             Feedback.msg_info (str"Fresh universe " ++ Universe.pr u ++ str" was added to the context.");
-            (* Global.push_context false (Evd.to_universe_context evm); *)
             evm, u
   | (l,b)::q -> List.fold_left (fun (evm,u) (l,b) -> let evm, u' = unquote_level_expr evm l b
                                                      in evm, Univ.Universe.sup u u')
@@ -636,7 +607,7 @@ let monad_failure_full s k prg =
        str "While trying to run: " ++ fnl () ++ print_term prg ++ fnl () ++
        str "Please file a bug with Template-Coq.")
 
-let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t -> unit) env ((evm, pgm) : Evd.evar_map * Constr.t) : unit =
+let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_map * Constr.t -> unit) env ((evm, pgm) : Evd.evar_map * Constr.t) : unit =
   let pgm = Reduction.whd_all env pgm in
   let (coConstr, args) = app_full pgm [] in
   let (glob_ref, universes) =
@@ -653,41 +624,43 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
   in
   if Globnames.eq_gr glob_ref tmReturn then
     match args with
-    | _::h::[] -> k (evm, h)
+    | _::h::[] -> k (env, evm, h)
     | _ -> monad_failure "tmReturn" 2
   else if Globnames.eq_gr glob_ref tmBind then
     match args with
     | _::_::a::f::[] ->
-       run_template_program_rec ~intactic:intactic (fun (evm, ar) -> run_template_program_rec ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
+       run_template_program_rec ~intactic:intactic (fun (env, evm, ar) -> run_template_program_rec ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
     | _ -> monad_failure_full "tmBind" 4 pgm
   else if Globnames.eq_gr glob_ref tmDefinitionRed then
     if intactic then not_in_tactic "tmDefinitionRed" else
     match args with
     | name::s::typ::body::[] ->
        let name = reduce_all env evm name in
-       let evm, typ = (match denote_option s with Some s -> let red = denote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+       let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
        let univs =
          if Flags.is_universe_polymorphism () then Polymorphic_const_entry (Evd.to_universe_context evm)
          else Monomorphic_const_entry (Evd.universe_context_set evm) in
        let n = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) ~types:typ (body, univs) in
-       k (evm, Constr.mkConst n)
+       let env = Global.env () in
+       k (env, evm, Constr.mkConst n)
     | _ -> monad_failure "tmDefinitionRed" 4
   else if Globnames.eq_gr glob_ref tmAxiomRed then
     if intactic then not_in_tactic "tmAxiomRed" else
     match args with
     | name::s::typ::[] ->
        let name = reduce_all env evm name in
-       let evm, typ = (match denote_option s with Some s -> let red = denote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+       let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
        let param = Entries.ParameterEntry (None, (typ, Monomorphic_const_entry (Evd.universe_context_set evm)), None) in
        let n = Declare.declare_constant (unquote_ident name) (param, Decl_kinds.IsDefinition Decl_kinds.Definition) in
-       k (evm, Constr.mkConst n)
+       let env = Global.env () in
+       k (env, evm, Constr.mkConst n)
     | _ -> monad_failure "tmAxiomRed" 3
   else if Globnames.eq_gr glob_ref tmLemmaRed then
     if intactic then not_in_tactic "tmLemmaRed" else
     match args with
     | name::s::typ::[] ->
        let name = reduce_all env evm name in
-       let evm, typ = (match denote_option s with Some s -> let red = denote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+       let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
        let poly = Flags.is_universe_polymorphism () in
        let kind = (Decl_kinds.Global, poly, Decl_kinds.Definition) in
        let hole = CAst.make (Constrexpr.CHole (None, Misctypes.IntroAnonymous, None)) in
@@ -699,7 +672,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
        let ctx = Evd.evar_universe_context evm in
        let hook = Lemmas.mk_hook (fun _ gr _ -> let env = Global.env () in
                                                 let evm = Evd.from_env env in
-                                                let evm, t = Evd.fresh_global env evm gr in k (evm, t)) in
+                                                let evm, t = Evd.fresh_global env evm gr in k (env, evm, t)) in  (* todo better *)
        ignore (Obligations.add_definition ident ~term:c cty ctx ~kind ~hook obls)
     (* let kind = Decl_kinds.(Global, Flags.use_polymorphic_flag (), DefinitionBody Definition) in *)
     (* Lemmas.start_proof (unquote_ident name) kind evm (EConstr.of_constr typ) *)
@@ -717,17 +690,18 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
        let evm, trm = denote_term evm body in
        let (evm, _) = Typing.type_of env evm (EConstr.of_constr trm) in
        let _ = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) (trm, Monomorphic_const_entry (Evd.universe_context_set evm)) in
-       k (evm, unit_tt)
+       let env = Global.env () in
+       k (env, evm, unit_tt)
     | _ -> monad_failure "tmMkDefinition" 2
   else if Globnames.eq_gr glob_ref tmQuote then
     match args with
     | _::trm::[] -> let qt = TermReify.quote_term env trm (* user should do the reduction (using tmEval) if they want *)
-                    in k (evm, qt)
+                    in k (env, evm, qt)
     | _ -> monad_failure "tmQuote" 2
   else if Globnames.eq_gr glob_ref tmQuoteRec then
     match args with
     | _::trm::[] -> let qt = TermReify.quote_term_rec env trm in
-                    k (evm, qt)
+                    k (env, evm, qt)
     | _ -> monad_failure "tmQuoteRec" 2
   else if Globnames.eq_gr glob_ref tmQuoteInductive then
     match args with
@@ -741,7 +715,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
            let _, args = Constr.destApp t in
            (match args with
             | [|kn; decl|] ->
-               k (evm, decl)
+               k (env, evm, decl)
             | _ -> bad_term_verb t "anomaly in quoting of inductive types")
         (* quote_mut_ind produce an entry rather than a decl *)
         (* let c = Environ.lookup_mind (fst ni) env in (\* FIX: For efficienctly, we should also export (snd ni)*\) *)
@@ -763,17 +737,17 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
          | Some (Right _) -> CErrors.user_err (str name ++ str " refers to an inductive")
          | None -> bad_term_verb coConstr "anomaly in QuoteConstant"
        in
-       k (evm, entry)
+       k (env, evm, entry)
     | _ -> monad_failure "tmQuoteConstant" 2
   else if Globnames.eq_gr glob_ref tmQuoteUniverses then
     match args with
     | _::[] -> let univs = Environ.universes env in
-               k (evm, quote_ugraph univs)
+               k (env, evm, quote_ugraph univs)
     | _ -> monad_failure "tmQuoteUniverses" 1
   else if Globnames.eq_gr glob_ref tmPrint then
     match args with
     | _::trm::[] -> Feedback.msg_info (pr_constr trm);
-                    k (evm, unit_tt)
+                    k (env, evm, unit_tt)
     | _ -> monad_failure "tmPrint" 2
   else if Globnames.eq_gr glob_ref tmFail then
     match args with
@@ -785,28 +759,29 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
                 (try
                    let gr = Smartlocate.locate_global_with_alias (CAst.make (Libnames.qualid_of_string id)) in
                    let opt = Constr.mkApp (cSome , [|tglobal_reference ; quote_global_reference gr|]) in
-                   k (evm, opt)
+                   k (env, evm, opt)
                  with
-                 | Not_found -> k (evm, Constr.mkApp (cNone, [|tglobal_reference|])))
+                 | Not_found -> k (env, evm, Constr.mkApp (cNone, [|tglobal_reference|])))
     | _ -> monad_failure "tmAbout" 1
   else if Globnames.eq_gr glob_ref tmCurrentModPath then
     match args with
     | _::[] -> let mp = Lib.current_mp () in
                (* let dp' = Lib.cwd () in (* different on sections ? *) *)
                let s = quote_string (Names.ModPath.to_string mp) in
-               k (evm, s)
+               k (env, evm, s)
     | _ -> monad_failure "tmCurrentModPath" 1
   else if Globnames.eq_gr glob_ref tmEval then
     match args with
     | s(*reduction strategy*)::_(*type*)::trm::[] ->
        let red = unquote_reduction_strategy env evm s in
        let (evm, trm) = reduce env evm red trm
-       in k (evm, trm)
+       in k (env, evm, trm)
     | _ -> monad_failure "tmEval" 3
   else if Globnames.eq_gr glob_ref tmMkInductive then
     match args with
     | mind::[] -> declare_inductive env evm mind;
-                  k (evm, unit_tt)
+                  let env = Global.env () in
+                  k (env, evm, unit_tt)
     | _ -> monad_failure "tmMkInductive" 1
   else if Globnames.eq_gr glob_ref tmUnquote then
     match args with
@@ -823,7 +798,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
              let term = Constr.mkApp
                (Constr.mkConstructU (ctor, Univ.Instance.of_array [|u|]), [|typ; t'|]) in
              let evm, _ = Typing.type_of env evm (EConstr.of_constr term) in
-               (evm, term)
+               (env, evm, term)
            | _ -> anomaly (str "texistT_typed_term does not refer to a constructor")
          in
            k (make_typed_term (EConstr.to_constr evm typ) t' evm)
@@ -835,15 +810,16 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
        let t = reduce_all env evm t in
        let evm, t' = denote_term evm t in
        let evdref = ref evm in
-       let t' = Typing.e_solve_evars env evdref (EConstr.of_constr t') in
-       Typing.e_check env evdref t' (EConstr.of_constr typ);
+       (* let t' = Typing.e_solve_evars env evdref (EConstr.of_constr t') in *)
+       Feedback.msg_debug (Printer.pr_constr typ);
+       Typing.e_check env evdref (EConstr.of_constr t') (EConstr.of_constr typ);
        let evm = !evdref in
-       k (evm, EConstr.to_constr evm t')
+       k (env, evm, t')
     | _ -> monad_failure "tmUnquoteTyped" 2
   else if Globnames.eq_gr glob_ref tmFreshName then
     match args with
     | name::[] -> let name' = Namegen.next_ident_away_from (unquote_ident name) (fun id -> Nametab.exists_cci (Lib.make_path id)) in
-                  k (evm, quote_ident name')
+                  k (env, evm, quote_ident name')
     | _ -> monad_failure "tmFreshName" 1
   else if Globnames.eq_gr glob_ref tmExistingInstance then
     match args with
@@ -852,12 +828,12 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
   else if Globnames.eq_gr glob_ref tmInferInstance then
     match args with
     | s :: typ :: [] ->
-       let evm, typ = (match denote_option s with Some s -> let red = denote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
+       let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
        (try
           let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
-          k (evm, Constr.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
+          k (env, evm, Constr.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
         with
-          Not_found -> k (evm, Constr.mkApp (cNone, [|typ|]))
+          Not_found -> k (env, evm, Constr.mkApp (cNone, [|typ|]))
        )
     | _ -> monad_failure "tmInferInstance" 2
   else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -385,7 +385,7 @@ let denote_term evdref (trm: Constr.t) : Constr.t =
     | _ ->  not_supported_verb trm "big_case"
   in aux trm
 
-let denote_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexpr.red_expr =
+let quoted_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexpr.red_expr =
   let trm = Reduction.whd_all env trm in
   let (trm, args) = app_full trm [] in
   (* from g_tactic.ml4 *)
@@ -691,7 +691,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
   else if Globnames.eq_gr glob_ref tmEval then
     match args with
     | s(*reduction strategy*)::_(*type*)::trm::[] ->
-       let red = denote_reduction_strategy env evm s in
+       let red = quoted_reduction_strategy env evm s in
        let (evm, trm) = reduce env evm red trm
        in k (evm, trm)
     | _ -> monad_failure "tmEval" 3

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -604,7 +604,7 @@ let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) 
        let evm, params = map_evm (fun evm p -> let (l,r) = unquote_pair p in
                                                let evm, e = denote_local_entry evm r in
                                                evm, (unquote_ident l, e))
-                                 evm (List.rev (unquote_list params)) in (* TODO: rev ?? *)
+                                 evm (unquote_list params) in
        let evm, inds = map_evm unquote_one_inductive_entry evm (unquote_list inds) in
        let evm, univs = denote_universe_context evm univs in
        let priv = unquote_map_option unquote_bool priv in

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -505,18 +505,33 @@ let unquote_constraint_type trm (* of type constraint_type *) : constraint_type 
     else not_supported_verb trm "unquote_constraint_type"
   | _ -> bad_term_verb trm "unquote_constraint_type"
 
-let unquote_univ_constraint evm c (* of type univ_constraint *) : univ_constraint =
+let unquote_univ_constraint evm c (* of type univ_constraint *) : _ * univ_constraint =
   let c, l2 = unquote_pair c in
   let l1, c = unquote_pair c in
   let evm, l1 = unquote_level evm l1 in
   let evm, l2 = unquote_level evm l2 in
   let c = unquote_constraint_type c in
-  (l1, c, l2)
+  evm, (l1, c, l2)
+
+(* set given by MSets.MSetWeakList.Make *)
+let unquote_set trm =
+  let (h, args) = app_full trm [] in
+  (* h supposed to be Mkt, the constructor of the record *)
+  match args with
+  | list :: ok :: [] -> unquote_list list
+  | _ -> not_supported_verb trm "unquote_set"
 
 let unquote_constraints evm c (* of type constraints *) : _ * Constraint.t =
-  (* TODO *)
-  evm, Constraint.empty
+  let c = unquote_set c in
+  List.fold_left (fun (evm, set) c -> let evm, c = unquote_univ_constraint evm c in evm, Constraint.add c set)
+                 (evm, Constraint.empty) c 
 
+
+let denote_variance trm (* of type Variance *) : Variance.t =
+  if Constr.equal trm cIrrelevant then Variance.Irrelevant
+  else if Constr.equal trm cCovariant then Variance.Covariant
+  else if Constr.equal trm cInvariant then Variance.Invariant
+  else not_supported_verb trm "denote_variance"
 
 let denote_ucontext evm trm (* of type UContext.t *) : _ * UContext.t =
   let i, c = unquote_pair trm in
@@ -524,25 +539,40 @@ let denote_ucontext evm trm (* of type UContext.t *) : _ * UContext.t =
   let evm, c = unquote_constraints evm c in
   evm, Univ.UContext.make (i, c)
 
-(* todo : stick to Coq implem *)
-type universe_context_type = Mono | Poly | Cumul
+let denote_cumulativity_info evm trm (* of type CumulativityInfo *) : _ * CumulativityInfo.t =
+  let uctx, variances = unquote_pair trm in
+  let evm, uctx = denote_ucontext evm uctx in
+  let variances = List.map denote_variance (unquote_list variances) in
+  evm, CumulativityInfo.make (uctx, Array.of_list variances)
 
-let denote_universe_context evm trm (* of type universe_context *) : _ * (universe_context_type * UContext.t) =
+
+(* todo : stick to Coq implem *)
+type universe_context_type =
+  | Monomorphic_uctx of Univ.UContext.t
+  | Polymorphic_uctx of Univ.UContext.t
+  | Cumulative_uctx of Univ.CumulativityInfo.t
+
+let to_entry_inductive_universes = function
+  | Monomorphic_uctx ctx -> Monomorphic_ind_entry (ContextSet.of_context ctx)
+  | Polymorphic_uctx ctx -> Polymorphic_ind_entry ctx
+  | Cumulative_uctx ctx -> Cumulative_ind_entry ctx
+
+let denote_universe_context evm trm (* of type universe_context *) : _ * universe_context_type =
   let (h, args) = app_full trm [] in
-  let b = if Constr.equal h cMonomorphic_ctx then Mono
-          else if Constr.equal h cPolymorphic_ctx then Poly
-          else if Constr.equal h cCumulative_ctx then Cumul
-          else not_supported_verb trm "denote_universe_context" in
   match args with
-  | ctx :: [] -> let evm, ctx = denote_ucontext evm ctx in
-                 evm, (b, ctx)
+  | ctx :: [] -> if Constr.equal h cMonomorphic_ctx then
+                   let evm, ctx = denote_ucontext evm ctx in
+                   evm, Monomorphic_uctx ctx
+                 else if Constr.equal h cPolymorphic_ctx then
+                   let evm, ctx = denote_ucontext evm ctx in
+                   evm, Polymorphic_uctx ctx
+                 else if Constr.equal h cCumulative_ctx then
+                   let evm, ctx = denote_cumulativity_info evm ctx in
+                   evm, Cumulative_uctx ctx
+                 else
+                   not_supported_verb trm "denote_universe_context"
   | _ -> bad_term_verb trm "denote_universe_context"
 
-let denote_mind_entry_universes evm trm =
-  match denote_universe_context evm trm with
-  | evm, (Mono, ctx) -> evm, Monomorphic_ind_entry (Univ.ContextSet.of_context ctx)
-  | evm, (Poly, ctx) -> evm, Polymorphic_ind_entry ctx
-  | evm, (Cumul, ctx) -> not_supported_verb trm "denote_mind_entry_universes"
 
 
 let unquote_one_inductive_entry evm trm (* of type one_inductive_entry *) : _ * Entries.one_inductive_entry =
@@ -576,13 +606,13 @@ let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) 
                                                evm, (unquote_ident l, e))
                                  evm (List.rev (unquote_list params)) in (* TODO: rev ?? *)
        let evm, inds = map_evm unquote_one_inductive_entry evm (unquote_list inds) in
-       let evm, univs = denote_mind_entry_universes evm univs in
+       let evm, univs = denote_universe_context evm univs in
        let priv = unquote_map_option unquote_bool priv in
        evm, { mind_entry_record = record;
               mind_entry_finite = finite;
               mind_entry_params = params;
               mind_entry_inds = inds;
-              mind_entry_universes = univs;
+              mind_entry_universes = to_entry_inductive_universes univs;
               mind_entry_private = priv }
     | _ -> bad_term_verb trm "unquote_mutual_inductive_entry"
   else

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -257,8 +257,13 @@ let _ =
       optread  = (fun () -> !strict_unquote_universe_mode);
       optwrite = (fun b -> strict_unquote_universe_mode := b) }
 
+let map_evm (f : 'a -> 'b -> 'a * 'c) (evm : 'a) (l : 'b list) : 'a * ('c list) =
+  let evm, res = List.fold_left (fun (evm, l) b -> let evm, c = f evm b in evm, c :: l) (evm, []) l in
+  evm, List.rev res
 
-let get_level s =
+
+
+let get_level evm s =
   if CString.string_contains ~where:s ~what:"." then
     match List.rev (CString.split '.' s) with
     | [] -> CErrors.anomaly (str"Invalid universe name " ++ str s ++ str".")
@@ -267,62 +272,71 @@ let get_level s =
        let dp = DirPath.make (List.map Id.of_string dp) in
        let l = Univ.Level.make dp num in
        try
-         ignore (UGraph.add_universe l false (Environ.universes(Global.env ())));
+         let evm = Evd.add_global_univ evm l in
+         (* ignore (UGraph.add_universe l false evm); *)
          if !strict_unquote_universe_mode then
            CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level and you are in Strict Unquote Universe Mode."))
          else (
-           Global.push_context false (Univ.UContext.make (Univ.Instance.of_array [|l|], Univ.Constraint.empty));
-           Feedback.msg_info (str"Fresh universe " ++ Level.pr l ++ str" was added to the global context.");
-           l)
+           (* Global.push_context false (Univ.UContext.make (Univ.Instance.of_array [|l|], Univ.Constraint.empty)); *)
+           Feedback.msg_info (str"Fresh universe " ++ Level.pr l ++ str" was added to the context.");
+           evm, l)
        with
-       | UGraph.AlreadyDeclared -> l
+       | UGraph.AlreadyDeclared -> evm, l
   else
     try
-      Evd.universe_of_name (Evd.from_env (Global.env ())) (Id.of_string s)
+      evm, Evd.universe_of_name evm (Id.of_string s)
     with Not_found ->
       CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level."))
 
 
 
-let unquote_level trm (* of type level *) : Univ.Level.t =
+let unquote_level evm trm (* of type level *) : Evd.evar_map * Univ.Level.t =
   let (h,args) = app_full trm [] in
   if Constr.equal h lProp then
     match args with
-    | [] -> Univ.Level.prop
+    | [] -> evm, Univ.Level.prop
     | _ -> bad_term_verb trm "unquote_level"
   else if Constr.equal h lSet then
     match args with
-    | [] -> Univ.Level.set
+    | [] -> evm, Univ.Level.set
     | _ -> bad_term_verb trm "unquote_level"
   else if Constr.equal h tLevel then
     match args with
     | s :: [] -> debug (fun () -> str "Unquoting level " ++ pr_constr trm);
-                 get_level (unquote_string s)
+                 get_level evm (unquote_string s)
     | _ -> bad_term_verb trm "unquote_level"
   else if Constr.equal h tLevelVar then
     match args with
-    | l :: [] -> Univ.Level.var (unquote_nat l)
+    | l :: [] -> evm, Univ.Level.var (unquote_nat l)
     | _ -> bad_term_verb trm "unquote_level"
   else
     not_supported_verb trm "unquote_level"
 
-let unquote_level_expr trm (* of type level *) b (* of type bool *) : Univ.Universe.t=
-  let u = Univ.Universe.make (unquote_level trm) in
-  if unquote_bool b then Univ.Universe.super u else u
+let unquote_level_expr evm trm (* of type level *) b (* of type bool *) : Evd.evar_map * Univ.Universe.t =
+  let evm, l = unquote_level evm trm in
+  let u = Univ.Universe.make l in
+  evm, if unquote_bool b then Univ.Universe.super u else u
 
 
-let unquote_universe trm (* of type universe *) =
+let unquote_universe evm trm (* of type universe *) =
   let levels = List.map unquote_pair (unquote_list trm) in
   match levels with
   | [] -> if !strict_unquote_universe_mode then
             CErrors.user_err ~hdr:"unquote_universe" (str "It is not possible to unquote an empty universe in Strict Unquote Universe Mode.")
           else
-            let evm, u = Evd.new_univ_variable (Evd.UnivFlexible false) (Evd.from_env (Global.env ())) in
-            Feedback.msg_info (str"Fresh universe " ++ Universe.pr u ++ str" was added to the global context.");
-            Global.push_context false (Evd.to_universe_context evm);
-            u
-  | (l,b)::q -> List.fold_left (fun u (l,b) -> Univ.Universe.sup u (unquote_level_expr l b))
-                               (unquote_level_expr l b) q
+            let evm, u = Evd.new_univ_variable (Evd.UnivFlexible false) evm in
+            Feedback.msg_info (str"Fresh universe " ++ Universe.pr u ++ str" was added to the context.");
+            (* Global.push_context false (Evd.to_universe_context evm); *)
+            evm, u
+  | (l,b)::q -> List.fold_left (fun (evm,u) (l,b) -> let evm, u' = unquote_level_expr evm l b
+                                                     in evm, Univ.Universe.sup u u')
+                               (unquote_level_expr evm l b) q
+
+let unquote_universe_instance evm trm (* of type universe_instance *) =
+  let l = unquote_list trm in
+  let evm, l = map_evm unquote_level evm l in
+  evm, Univ.Instance.of_array (Array.of_list l)
+
 
 
 let unquote_kn (k : quoted_kernel_name) : Libnames.qualid =
@@ -366,69 +380,84 @@ let rec app_full_abs (trm: Constr.t) (acc: Constr.t list) =
   | _ -> (trm, acc)
 
 
-let denote_term (trm: Constr.t) : Constr.t =
-  let rec aux (trm: Constr.t) : Constr.t =
-    (*debug (fun () -> Pp.(str "denote_term" ++ spc () ++ pr_constr trm)) ; *)
+let denote_term evm (trm: Constr.t) : Evd.evar_map * Constr.t =
+  let rec aux evm (trm: Constr.t) : _ * Constr.t =
+    debug (fun () -> Pp.(str "denote_term" ++ spc () ++ pr_constr trm)) ;
     match (inspectTerm trm) with
-    | ACoq_tRel x -> Constr.mkRel (unquote_nat x + 1)
-    | ACoq_tVar x -> Constr.mkVar (unquote_ident x)
-    | ACoq_tSort x -> Constr.mkType (unquote_universe x)
-    | ACoq_tCast (t,c,ty) -> Constr.mkCast (aux t, unquote_cast_kind c, aux ty)
-    | ACoq_tProd (n,t,b) -> Constr.mkProd (unquote_name n, aux t, aux b)
-    | ACoq_tLambda (n,t,b) -> Constr.mkLambda (unquote_name n, aux t, aux b)
-    | ACoq_tLetIn (n,e,t,b) -> Constr.mkLetIn (unquote_name n, aux e, aux t, aux b)
-    | ACoq_tApp (f,xs) ->
-       Constr.mkApp (aux f, Array.of_list (List.map aux  xs))
-    | ACoq_tConst (s,_) ->
-       (* TODO: unquote universes *)
-       let s = (unquote_kn s) in
+    | ACoq_tRel x -> evm, Constr.mkRel (unquote_nat x + 1)
+    | ACoq_tVar x -> evm, Constr.mkVar (unquote_ident x)
+    | ACoq_tSort x -> let evm, u = unquote_universe evm x in evm, Constr.mkType u
+    | ACoq_tCast (t,c,ty) -> let evm, t = aux evm t in
+                             let evm, ty = aux evm ty in
+                             evm, Constr.mkCast (t, unquote_cast_kind c, ty)
+    | ACoq_tProd (n,t,b) -> let evm, t = aux evm t in
+                            let evm, b = aux evm b in
+                            evm, Constr.mkProd (unquote_name n, t, b)
+    | ACoq_tLambda (n,t,b) -> let evm, t = aux evm t in
+                              let evm, b = aux evm b in
+                              evm, Constr.mkLambda (unquote_name n, t, b)
+    | ACoq_tLetIn (n,e,t,b) -> let evm, e = aux evm e in
+                               let evm, t = aux evm t in
+                               let evm, b = aux evm b in
+                               evm, Constr.mkLetIn (unquote_name n, e, t, b)
+    | ACoq_tApp (f,xs) -> let evm, f = aux evm f in
+                          let evm, xs = map_evm aux evm xs in
+                          evm, Constr.mkApp (f, Array.of_list xs)
+    | ACoq_tConst (s,u) ->
+       let s = unquote_kn s in
+       let evm, u = unquote_universe_instance evm u in
        (try
           match Nametab.locate s with
-          | Globnames.ConstRef c -> Universes.constr_of_global (Globnames.ConstRef c)
-          | Globnames.IndRef _ -> CErrors.user_err (str "the constant is an inductive. use tInd : "
-                                                    ++  Pp.str (Libnames.string_of_qualid s))
-          | Globnames.VarRef _ -> CErrors.user_err (str "the constant is a variable. use tVar : " ++ Pp.str (Libnames.string_of_qualid s))
-          | Globnames.ConstructRef _ -> CErrors.user_err (str "the constant is a consructor. use tConstructor : "++ Pp.str (Libnames.string_of_qualid s))
+          | Globnames.ConstRef c -> evm, Constr.mkConstU (c, u)
+          | Globnames.IndRef _ -> CErrors.user_err (str"The constant " ++ Libnames.pr_qualid s ++ str" is an inductive, use tInd.")
+          | Globnames.VarRef _ -> CErrors.user_err (str"The constant " ++ Libnames.pr_qualid s ++ str" is a variable, use tVar.")
+          | Globnames.ConstructRef _ -> CErrors.user_err (str"The constant " ++ Libnames.pr_qualid s ++ str" is a constructor, use tConstructor.")
         with
-          Not_found -> CErrors.user_err (str "Constant not found : " ++ Pp.str (Libnames.string_of_qualid s)))
-    | ACoq_tConstruct (i,idx,_) ->
+          Not_found -> CErrors.user_err (str"Constant not found: " ++ Libnames.pr_qualid s))
+    | ACoq_tConstruct (i,idx,u) ->
        let ind = unquote_inductive i in
-       Constr.mkConstruct (ind, unquote_nat idx + 1)
-    | ACoq_tInd (i, _) ->
+       let evm, u = unquote_universe_instance evm u in
+       evm, Constr.mkConstructU ((ind, unquote_nat idx + 1), u)
+    | ACoq_tInd (i, u) ->
        let i = unquote_inductive i in
-       Constr.mkInd i
-    | ACoq_tCase (info, ty, d, brs) ->
-       let i, _ = info in
+       let evm, u = unquote_universe_instance evm u in
+       evm, Constr.mkIndU (i, u)
+    | ACoq_tCase ((i, _), ty, d, brs) ->
        let ind = unquote_inductive i in
+       let evm, ty = aux evm ty in
+       let evm, d = aux evm d in
+       let evm, brs = map_evm aux evm (List.map snd brs) in
+       (* todo: reify better case_info *)
        let ci = Inductiveops.make_case_info (Global.env ()) ind Constr.RegularStyle in
-       let denote_branch br =
-         let _, br = br in
-         aux br
-       in
-       Constr.mkCase (ci, aux ty, aux d, Array.of_list (List.map denote_branch (brs)))
+       evm, Constr.mkCase (ci, ty, d, Array.of_list brs)
     | ACoq_tFix (lbd, i) ->
        let (names,types,bodies,rargs) = (List.map (fun p->p.adname) lbd,  List.map (fun p->p.adtype) lbd, List.map (fun p->p.adbody) lbd,
                                          List.map (fun p->p.rarg) lbd) in
-       let (types,bodies) = (List.map aux types, List.map aux bodies) in
+       let evm, types = map_evm aux evm types in
+       let evm, bodies = map_evm aux evm bodies in
        let (names,rargs) = (List.map unquote_name names, List.map unquote_nat rargs) in
        let la = Array.of_list in
-       Constr.mkFix ((la rargs,unquote_nat i), (la names, la types, la bodies))
+       evm, Constr.mkFix ((la rargs,unquote_nat i), (la names, la types, la bodies))
     | ACoq_tCoFix (lbd, i) ->
        let (names,types,bodies,rargs) = (List.map (fun p->p.adname) lbd,  List.map (fun p->p.adtype) lbd, List.map (fun p->p.adbody) lbd,
                                          List.map (fun p->p.rarg) lbd) in
-       let (types,bodies) = (List.map aux types, List.map aux bodies) in
+       let evm, types = map_evm aux evm types in
+       let evm, bodies = map_evm aux evm bodies in
        let (names,rargs) = (List.map unquote_name names, List.map unquote_nat rargs) in
        let la = Array.of_list in
-       Constr.mkCoFix (unquote_nat i, (la names, la types, la bodies))
+       evm, Constr.mkCoFix (unquote_nat i, (la names, la types, la bodies))
     | ACoq_tProj (proj,t) ->
-       let (ind, _, narg) = unquote_proj proj in (* is narg the correct projection? *)
+       let (ind, _, narg) = unquote_proj proj in (* todo: is narg the correct projection? *)
        let ind' = unquote_inductive ind in
        let projs = Recordops.lookup_projections ind' in
+       let evm, t = aux evm t in
        (match List.nth projs (unquote_nat narg) with
-        | Some p -> Constr.mkProj (Names.Projection.make p false, aux t)
+        | Some p -> evm, Constr.mkProj (Names.Projection.make p false, t)
         | None -> bad_term trm)
     | _ ->  not_supported_verb trm "big_case"
-  in aux trm
+  in aux evm trm
+
+
 
 let quoted_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexpr.red_expr =
   let trm = Reduction.whd_all env trm in
@@ -453,13 +482,19 @@ let quoted_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexp
 
 
 
-let denote_local_entry trm =
+let denote_local_entry evm trm =
   let (h,args) = app_full trm [] in
   match args with
     x :: [] ->
-    if Constr.equal h tLocalDef then Entries.LocalDefEntry (denote_term x)
-    else (if  Constr.equal h tLocalAssum then Entries.LocalAssumEntry (denote_term x) else bad_term trm)
-  | _ -> bad_term trm
+    if Constr.equal h tLocalDef then
+      let evm, x = denote_term evm x in
+      evm, Entries.LocalDefEntry x
+    else if  Constr.equal h tLocalAssum then
+      let evm, x = denote_term evm x in
+      evm, Entries.LocalAssumEntry x
+    else
+      not_supported_verb trm "denote_local_entry"
+  | _ -> bad_term_verb trm "denote_local_entry"
 
 let denote_mind_entry_finite trm =
   let (h,args) = app_full trm [] in
@@ -468,8 +503,8 @@ let denote_mind_entry_finite trm =
     if Constr.equal h cFinite then Declarations.Finite
     else if  Constr.equal h cCoFinite then Declarations.CoFinite
     else if  Constr.equal h cBiFinite then Declarations.BiFinite
-    else bad_term trm
-  | _ -> bad_term trm
+    else not_supported_verb trm "denote_mind_entry_finite"
+  | _ -> bad_term_verb trm "denote_mind_entry_finite"
 
 
 
@@ -489,76 +524,106 @@ let unquote_map_option f trm =
 let denote_option = unquote_map_option (fun x -> x)
 
 
-let denote_ucontext (trm : Constr.t) : UContext.t =
-  Univ.UContext.empty (* FIXME *)
 
-let denote_universe_context (trm : Constr.t) : bool * UContext.t =
-  let (h, args) = app_full trm [] in
-  let b =
-    if Constr.equal h cMonomorphic_ctx then Some false
-    else if Constr.equal h cPolymorphic_ctx then Some true
-    else None
-  in
-  match b, args with
-  | Some poly, ctx :: [] ->
-     poly, denote_ucontext ctx
-  | _, _ -> bad_term trm
-
-let denote_mind_entry_universes trm =
-  match denote_universe_context trm with
-  | false, ctx -> Monomorphic_ind_entry (Univ.ContextSet.of_context ctx)
-  | true, ctx -> Polymorphic_ind_entry ctx
-
-(* let denote_inductive_first trm =
- *   let (h,args) = app_full trm [] in
- *   if Constr.equal h tmkInd then
- *     match args with
- *       nm :: num :: _ ->
- *       let s = (unquote_string nm) in
- *       let (dp, nm) = split_name s in
- *       (try
- *         match Nametab.locate (Libnames.make_qualid dp nm) with
- *         | Globnames.ConstRef c ->  CErrors.user_err (str "this not an inductive constant. use tConst instead of tInd : " ++ str s)
- *         | Globnames.IndRef i -> (fst i, unquote_nat  num)
- *         | Globnames.VarRef _ -> CErrors.user_err (str "the constant is a variable. use tVar : " ++ str s)
- *         | Globnames.ConstructRef _ -> CErrors.user_err (str "the constant is a consructor. use tConstructor : " ++ str s)
- *       with
- *       Not_found ->   CErrors.user_err (str "Constant not found : " ++ str s))
- *     | _ -> assert false
- *   else
- *     bad_term_verb trm "non-constructor" *)
-
-let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (body: Constr.t) : unit =
-  let body = reduce_all env evm body in
-  let (_,args) = app_full body [] in (* check that the first component is Build_mut_ind .. *)
-  let one_ind b1 : Entries.one_inductive_entry =
-    let (_,args) = app_full b1 [] in (* check that the first component is Build_one_ind .. *)
-    match args with
-    | mt::ma::mtemp::mcn::mct::[] ->
-       {
-         mind_entry_typename = unquote_ident mt;
-         mind_entry_arity = denote_term ma;
-         mind_entry_template = unquote_bool mtemp;
-         mind_entry_consnames = List.map unquote_ident (unquote_list mcn);
-         mind_entry_lc = List.map denote_term (unquote_list mct)
-       }
-    | _ -> raise (Failure "ill-typed one_inductive_entry")
-  in
-  let mut_ind mr mf mp mi uctx mpr : Entries.mutual_inductive_entry =
-    {
-      mind_entry_record = unquote_map_option (unquote_map_option unquote_ident) mr;
-      mind_entry_finite = denote_mind_entry_finite mf; (* inductive *)
-      mind_entry_params = List.map (fun p -> let (l,r) = (unquote_pair p) in (unquote_ident l, denote_local_entry r))
-                                   (List.rev (unquote_list mp));
-      mind_entry_inds = List.map one_ind (unquote_list mi);
-      mind_entry_universes = denote_mind_entry_universes uctx;
-      mind_entry_private = unquote_map_option unquote_bool mpr (*mpr*)
-    } in
+let unquote_constraint_type trm (* of type constraint_type *) : constraint_type =
+  let (h,args) = app_full trm [] in
   match args with
-    mr::mf::mp::mi::univs::mpr::[] ->
-    ignore(ComInductive.declare_mutual_inductive_with_eliminations (mut_ind mr mf mp mi univs mpr) Names.Id.Map.empty [])
-  | _ -> raise (Failure "ill-typed mutual_inductive_entry")
+    [] ->
+    if Constr.equal h tunivLt then Univ.Lt
+    else if Constr.equal h tunivLe then Univ.Le
+    else if Constr.equal h tunivEq then Univ.Eq
+    else not_supported_verb trm "unquote_constraint_type"
+  | _ -> bad_term_verb trm "unquote_constraint_type"
 
+let unquote_univ_constraint evm c (* of type univ_constraint *) : univ_constraint =
+  let c, l2 = unquote_pair c in
+  let l1, c = unquote_pair c in
+  let evm, l1 = unquote_level evm l1 in
+  let evm, l2 = unquote_level evm l2 in
+  let c = unquote_constraint_type c in
+  (l1, c, l2)
+
+let unquote_constraints evm c (* of type constraints *) : _ * Constraint.t =
+  (* TODO *)
+  evm, Constraint.empty
+
+
+let denote_ucontext evm trm (* of type UContext.t *) : _ * UContext.t =
+  let i, c = unquote_pair trm in
+  let evm, i = unquote_universe_instance evm i in
+  let evm, c = unquote_constraints evm c in
+  evm, Univ.UContext.make (i, c)
+
+(* todo : stick to Coq implem *)
+type universe_context_type = Mono | Poly | Cumul
+
+let denote_universe_context evm trm (* of type universe_context *) : _ * (universe_context_type * UContext.t) =
+  let (h, args) = app_full trm [] in
+  let b = if Constr.equal h cMonomorphic_ctx then Mono
+          else if Constr.equal h cPolymorphic_ctx then Poly
+          else if Constr.equal h cCumulative_ctx then Cumul
+          else not_supported_verb trm "denote_universe_context" in
+  match args with
+  | ctx :: [] -> let evm, ctx = denote_ucontext evm ctx in
+                 evm, (b, ctx)
+  | _ -> bad_term_verb trm "denote_universe_context"
+
+let denote_mind_entry_universes evm trm =
+  match denote_universe_context evm trm with
+  | evm, (Mono, ctx) -> evm, Monomorphic_ind_entry (Univ.ContextSet.of_context ctx)
+  | evm, (Poly, ctx) -> evm, Polymorphic_ind_entry ctx
+  | evm, (Cumul, ctx) -> not_supported_verb trm "denote_mind_entry_universes"
+
+
+let unquote_one_inductive_entry evm trm (* of type one_inductive_entry *) : _ * Entries.one_inductive_entry =
+  let (h,args) = app_full trm [] in
+  if Constr.equal h tBuild_one_inductive_entry then
+    match args with
+    | id::ar::template::cnames::ctms::[] ->
+       let id = unquote_ident id in
+       let evm, ar = denote_term evm ar in
+       let template = unquote_bool template in
+       let cnames = List.map unquote_ident (unquote_list cnames) in
+       let evm, ctms = map_evm denote_term evm (unquote_list ctms) in
+       evm, { mind_entry_typename = id ;
+              mind_entry_arity = ar;
+              mind_entry_template = template;
+              mind_entry_consnames = cnames;
+              mind_entry_lc = ctms }
+    | _ -> bad_term_verb trm "unquote_one_inductive_entry"
+  else
+    not_supported_verb trm "unquote_one_inductive_entry"
+
+let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) : _ * Entries.mutual_inductive_entry =
+  let (h,args) = app_full trm [] in
+  if Constr.equal h tBuild_mutual_inductive_entry then
+    match args with
+    | record::finite::params::inds::univs::priv::[] ->
+       let record = unquote_map_option (unquote_map_option unquote_ident) record in
+       let finite = denote_mind_entry_finite finite in
+       let evm, params = map_evm (fun evm p -> let (l,r) = unquote_pair p in
+                                               let evm, e = denote_local_entry evm r in
+                                               evm, (unquote_ident l, e))
+                                 evm (List.rev (unquote_list params)) in (* TODO: rev ?? *)
+       let evm, inds = map_evm unquote_one_inductive_entry evm (unquote_list inds) in
+       let evm, univs = denote_mind_entry_universes evm univs in
+       let priv = unquote_map_option unquote_bool priv in
+       evm, { mind_entry_record = record;
+              mind_entry_finite = finite;
+              mind_entry_params = params;
+              mind_entry_inds = inds;
+              mind_entry_universes = univs;
+              mind_entry_private = priv }
+    | _ -> bad_term_verb trm "unquote_mutual_inductive_entry"
+  else
+    not_supported_verb trm "unquote_mutual_inductive_entry"
+
+
+let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (mind: Constr.t) : unit =
+  let mind = reduce_all env evm mind in
+  debug (fun () -> str"declare_inductive: " ++ pr_constr mind);
+  let evm, mind = unquote_mutual_inductive_entry evm mind in
+  ignore (ComInductive.declare_mutual_inductive_with_eliminations mind Names.Id.Map.empty [])
 
 let monad_failure s k =
   CErrors.user_err  (str (s ^ " must take " ^ (string_of_int k) ^ " argument" ^ (if k > 0 then "s" else "") ^ ".")
@@ -649,7 +714,8 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     match args with
     | name::body::[] ->
        let name = reduce_all env evm name in
-       let trm = denote_term body in
+       let body = reduce_all env evm body in
+       let evm, trm = denote_term evm body in
        let (evm, _) = Typing.type_of env evm (EConstr.of_constr trm) in
        let _ = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) (trm, Monomorphic_const_entry (Evd.universe_context_set evm)) in
        k (evm, unit_tt)
@@ -748,9 +814,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     | t::[] ->
        (try
          let t = reduce_all env evm t in
-         let evdref = ref evm in
-         let t' = denote_term t in
-         let evm = !evdref in
+         let evm, t' = denote_term evm t in
          let typ = Retyping.get_type_of env evm (EConstr.of_constr t') in
          let evm, typ = Evarsolve.refresh_universes (Some false) env evm typ in
          let make_typed_term typ term evm =
@@ -770,8 +834,8 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     match args with
     | typ::t::[] ->
        let t = reduce_all env evm t in
+       let evm, t' = denote_term evm t in
        let evdref = ref evm in
-       let t' = denote_term t in
        let t' = Typing.e_solve_evars env evdref (EConstr.of_constr t') in
        Typing.e_check env evdref t' (EConstr.of_constr typ);
        let evm = !evdref in

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -220,64 +220,110 @@ let unquote_name trm =
     use [qualid]. Maybe it's worth considering to make corresponding changes to template-coq representations as well.
   *)
 
-let get_level evd s =
+(* let get_level evd s = *)
+(*   if CString.string_contains ~where:s ~what:"." then *)
+(*     match List.rev (CString.split '.' s) with *)
+(*     | [] -> CErrors.anomaly (str"Invalid universe name " ++ str s ++ str".") *)
+(*     | n :: dp -> *)
+(*        let num = int_of_string n in *)
+(*        let dp = DirPath.make (List.map Id.of_string dp) in *)
+(*        let level = Univ.Level.make dp num in *)
+(*        let evd = *)
+(*          try Evd.add_global_univ evd level *)
+(*          with UGraph.AlreadyDeclared -> evd *)
+(*        in evd, level *)
+(*   else *)
+(*     try *)
+(*       let level = Evd.universe_of_name evd (Id.of_string s) in *)
+(*       evd, level *)
+(*     with Not_found -> *)
+(*       user_err  ~hdr:"interp_universe_level_name" *)
+(*                 (Pp.(str "Undeclared universe: " ++ Id.print (Id.of_string s))) *)
+(* (\* end of code from Pretyping *\) *)
+
+
+(* If strict unquote universe mode is on then fail when unquoting a non *)
+(* declared universe / an empty list of level expressions. *)
+(* Otherwise, add it / a fresh level the global environnment. *)
+
+let strict_unquote_universe_mode = ref true
+
+let _ =
+  let open Goptions in
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "strict unquote universe mode";
+      optkey   = ["Strict"; "Unquote"; "Universe"; "Mode"];
+      optread  = (fun () -> !strict_unquote_universe_mode);
+      optwrite = (fun b -> strict_unquote_universe_mode := b) }
+
+
+let get_level s =
   if CString.string_contains ~where:s ~what:"." then
     match List.rev (CString.split '.' s) with
     | [] -> CErrors.anomaly (str"Invalid universe name " ++ str s ++ str".")
     | n :: dp ->
        let num = int_of_string n in
        let dp = DirPath.make (List.map Id.of_string dp) in
-       let level = Univ.Level.make dp num in
-       let evd =
-         try Evd.add_global_univ evd level
-         with UGraph.AlreadyDeclared -> evd
-       in evd, level
+       let l = Univ.Level.make dp num in
+       try
+         ignore (UGraph.add_universe l false (Environ.universes(Global.env ())));
+         if !strict_unquote_universe_mode then
+           CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level and you are in Strict Unquote Universe Mode."))
+         else (
+           Global.push_context false (Univ.UContext.make (Univ.Instance.of_array [|l|], Univ.Constraint.empty));
+           Feedback.msg_info (str"Fresh universe " ++ Level.pr l ++ str" was added to the global context.");
+           l)
+       with
+       | UGraph.AlreadyDeclared -> l
   else
     try
-      let level = Evd.universe_of_name evd (Id.of_string s) in
-      evd, level
+      Evd.universe_of_name (Evd.from_env (Global.env ())) (Id.of_string s)
     with Not_found ->
-      user_err  ~hdr:"interp_universe_level_name"
-                (Pp.(str "Undeclared universe: " ++ Id.print (Id.of_string s)))
-(* end of code from Pretyping *)
+      CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level."))
 
 
 
-let unquote_level evd trm (* of type level *) : Evd.evar_map * Univ.Level.t =
+let unquote_level trm (* of type level *) : Univ.Level.t =
   let (h,args) = app_full trm [] in
   if Constr.equal h lProp then
     match args with
-    | [] -> evd, Univ.Level.prop
+    | [] -> Univ.Level.prop
     | _ -> bad_term_verb trm "unquote_level"
   else if Constr.equal h lSet then
     match args with
-    | [] -> evd, Univ.Level.set
+    | [] -> Univ.Level.set
     | _ -> bad_term_verb trm "unquote_level"
   else if Constr.equal h tLevel then
     match args with
-    | s :: [] -> get_level evd (unquote_string s)
+    | s :: [] -> debug (fun () -> str "Unquoting level " ++ pr_constr trm);
+                 get_level (unquote_string s)
     | _ -> bad_term_verb trm "unquote_level"
   else if Constr.equal h tLevelVar then
     match args with
-    | l :: [] -> evd, Univ.Level.var (unquote_nat l)
+    | l :: [] -> Univ.Level.var (unquote_nat l)
     | _ -> bad_term_verb trm "unquote_level"
   else
     not_supported_verb trm "unquote_level"
 
-let unquote_level_expr evd trm (* of type level *) b (* of type bool *) : Evd.evar_map * Univ.Universe.t=
-  let evd, l = unquote_level evd trm in
-  let u = Univ.Universe.make l in
-  if unquote_bool b then evd, Univ.Universe.super u
-  else evd, u
+let unquote_level_expr trm (* of type level *) b (* of type bool *) : Univ.Universe.t=
+  let u = Univ.Universe.make (unquote_level trm) in
+  if unquote_bool b then Univ.Universe.super u else u
 
-let unquote_universe evd trm (* of type universe *) =
+
+let unquote_universe trm (* of type universe *) =
   let levels = List.map unquote_pair (unquote_list trm) in
-  let evd, u = match levels with
-    | [] -> Evd.new_univ_variable (Evd.UnivFlexible false) evd
-    | (l,b)::q -> List.fold_left (fun (evd,u) (l,b) -> let evd, u' = unquote_level_expr evd l b
-                                                       in evd, Univ.Universe.sup u u')
-                                 (unquote_level_expr evd l b) q
-  in evd, u
+  match levels with
+  | [] -> if !strict_unquote_universe_mode then
+            CErrors.user_err ~hdr:"unquote_universe" (str "It is not possible to unquote an empty universe in Strict Unquote Universe Mode.")
+          else
+            let evm, u = Evd.new_univ_variable (Evd.UnivFlexible false) (Evd.from_env (Global.env ())) in
+            Feedback.msg_info (str"Fresh universe " ++ Universe.pr u ++ str" was added to the global context.");
+            Global.push_context false (Evd.to_universe_context evm);
+            u
+  | (l,b)::q -> List.fold_left (fun u (l,b) -> Univ.Universe.sup u (unquote_level_expr l b))
+                               (unquote_level_expr l b) q
+
 
 let unquote_kn (k : quoted_kernel_name) : Libnames.qualid =
   Libnames.qualid_of_string (clean_name (unquote_string k))
@@ -320,14 +366,13 @@ let rec app_full_abs (trm: Constr.t) (acc: Constr.t list) =
   | _ -> (trm, acc)
 
 
-let denote_term evdref (trm: Constr.t) : Constr.t =
+let denote_term (trm: Constr.t) : Constr.t =
   let rec aux (trm: Constr.t) : Constr.t =
     (*debug (fun () -> Pp.(str "denote_term" ++ spc () ++ pr_constr trm)) ; *)
     match (inspectTerm trm) with
     | ACoq_tRel x -> Constr.mkRel (unquote_nat x + 1)
     | ACoq_tVar x -> Constr.mkVar (unquote_ident x)
-    | ACoq_tSort x ->
-       let evd, u = unquote_universe !evdref x in evdref := evd; Constr.mkType u
+    | ACoq_tSort x -> Constr.mkType (unquote_universe x)
     | ACoq_tCast (t,c,ty) -> Constr.mkCast (aux t, unquote_cast_kind c, aux ty)
     | ACoq_tProd (n,t,b) -> Constr.mkProd (unquote_name n, aux t, aux b)
     | ACoq_tLambda (n,t,b) -> Constr.mkLambda (unquote_name n, aux t, aux b)
@@ -408,12 +453,12 @@ let quoted_reduction_strategy env evm (trm : quoted_reduction_strategy) : Redexp
 
 
 
-let denote_local_entry evdref trm =
+let denote_local_entry trm =
   let (h,args) = app_full trm [] in
   match args with
     x :: [] ->
-    if Constr.equal h tLocalDef then Entries.LocalDefEntry (denote_term evdref x)
-    else (if  Constr.equal h tLocalAssum then Entries.LocalAssumEntry (denote_term evdref x) else bad_term trm)
+    if Constr.equal h tLocalDef then Entries.LocalDefEntry (denote_term x)
+    else (if  Constr.equal h tLocalAssum then Entries.LocalAssumEntry (denote_term x) else bad_term trm)
   | _ -> bad_term trm
 
 let denote_mind_entry_finite trm =
@@ -486,17 +531,16 @@ let denote_mind_entry_universes trm =
 let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (body: Constr.t) : unit =
   let body = reduce_all env evm body in
   let (_,args) = app_full body [] in (* check that the first component is Build_mut_ind .. *)
-  let evdref = ref evm in
   let one_ind b1 : Entries.one_inductive_entry =
     let (_,args) = app_full b1 [] in (* check that the first component is Build_one_ind .. *)
     match args with
     | mt::ma::mtemp::mcn::mct::[] ->
        {
          mind_entry_typename = unquote_ident mt;
-         mind_entry_arity = denote_term evdref ma;
+         mind_entry_arity = denote_term ma;
          mind_entry_template = unquote_bool mtemp;
          mind_entry_consnames = List.map unquote_ident (unquote_list mcn);
-         mind_entry_lc = List.map (denote_term evdref) (unquote_list mct)
+         mind_entry_lc = List.map denote_term (unquote_list mct)
        }
     | _ -> raise (Failure "ill-typed one_inductive_entry")
   in
@@ -504,7 +548,7 @@ let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (body: Constr.t) : 
     {
       mind_entry_record = unquote_map_option (unquote_map_option unquote_ident) mr;
       mind_entry_finite = denote_mind_entry_finite mf; (* inductive *)
-      mind_entry_params = List.map (fun p -> let (l,r) = (unquote_pair p) in (unquote_ident l, (denote_local_entry evdref r)))
+      mind_entry_params = List.map (fun p -> let (l,r) = (unquote_pair p) in (unquote_ident l, denote_local_entry r))
                                    (List.rev (unquote_list mp));
       mind_entry_inds = List.map one_ind (unquote_list mi);
       mind_entry_universes = denote_mind_entry_universes uctx;
@@ -601,13 +645,12 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     (* )); *)
     | _ -> monad_failure "tmLemmaRed" 3
   else if Globnames.eq_gr glob_ref tmMkDefinition then
-    if intactic then not_in_tactic "tmExistingInstance" else
+    if intactic then not_in_tactic "tmMkDefinition" else
     match args with
     | name::body::[] ->
        let name = reduce_all env evm name in
-       let evdref = ref evm in
-       let trm = denote_term evdref body in
-       let (evm, _) = Typing.type_of env !evdref (EConstr.of_constr trm) in
+       let trm = denote_term body in
+       let (evm, _) = Typing.type_of env evm (EConstr.of_constr trm) in
        let _ = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) (trm, Monomorphic_const_entry (Evd.universe_context_set evm)) in
        k (evm, unit_tt)
     | _ -> monad_failure "tmMkDefinition" 2
@@ -706,7 +749,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
        (try
          let t = reduce_all env evm t in
          let evdref = ref evm in
-         let t' = denote_term evdref t in
+         let t' = denote_term t in
          let evm = !evdref in
          let typ = Retyping.get_type_of env evm (EConstr.of_constr t') in
          let evm, typ = Evarsolve.refresh_universes (Some false) env evm typ in
@@ -728,7 +771,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Evd.evar_map * Constr.t 
     | typ::t::[] ->
        let t = reduce_all env evm t in
        let evdref = ref evm in
-       let t' = denote_term evdref t in
+       let t' = denote_term t in
        let t' = Typing.e_solve_evars env evdref (EConstr.of_constr t') in
        Typing.e_check env evdref t' (EConstr.of_constr typ);
        let evm = !evdref in

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -142,9 +142,8 @@ END;;
 VERNAC COMMAND EXTEND Run_program CLASSIFIED AS SIDEFF
     | [ "Run" "TemplateProgram" constr(def) ] ->
       [ let (evm, env) = Pfedit.get_current_context () in
-        let (def, _) = Constrintern.interp_constr env evm def in
-        (* todo : uctx ? *)
-        Denote.run_template_program_rec (fun _ -> ()) (Global.env ()) (evm, (EConstr.to_constr evm def)) ]
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        Denote.run_template_program_rec (fun _ -> ()) env (evm, (EConstr.to_constr evm def)) ]
 END;;
 
 TACTIC EXTEND run_program

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -64,9 +64,6 @@ TACTIC EXTEND denote_term
          let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let evm, c = Denote.denote_term evm (EConstr.to_constr evm c) in
-         (* TODO : not the right way of retype things *)
-         (* let def' = Constrextern.extern_constr true env evm (EConstr.of_constr c) in *)
-         (* let def = Constrintern.interp_constr env evm def' in *)
          Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm)
 	   (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c]))
       end) ]

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -65,10 +65,10 @@ TACTIC EXTEND denote_term
          let evm = Proofview.Goal.sigma gl in
          let evm, c = Denote.denote_term evm (EConstr.to_constr evm c) in
          (* TODO : not the right way of retype things *)
-         let def' = Constrextern.extern_constr true env evm (EConstr.of_constr c) in
-         let def = Constrintern.interp_constr env evm def' in
+         (* let def' = Constrextern.extern_constr true env evm (EConstr.of_constr c) in *)
+         (* let def = Constrintern.interp_constr env evm def' in *)
          Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm)
-	   (ltac_apply tac (List.map to_ltac_val [fst def]))
+	   (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c]))
       end) ]
 END;;
 
@@ -150,10 +150,11 @@ END;;
 TACTIC EXTEND run_program
     | [ "run_template_program" constr(c) tactic(tac) ] ->
       [ Proofview.Goal.enter (begin fun gl ->
+         let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let env = Proofview.Goal.env gl in
          let ret = ref None in
-         Denote.run_template_program_rec ~intactic:true (fun (evm, t) -> ret := Some t) env (evm, EConstr.to_constr evm c);
+         Denote.run_template_program_rec ~intactic:true (fun (env, evm, t) -> ret := Some t) env (evm, EConstr.to_constr evm c);
          match !ret with
            Some c ->
            ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c])

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -64,7 +64,7 @@ TACTIC EXTEND denote_term
          let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let evdref = ref evm in
-         let c = Denote.denote_term evdref (EConstr.to_constr evm c) in
+         let c = Denote.denote_term (EConstr.to_constr evm c) in
          (* TODO : not the right way of retype things *)
          let def' = Constrextern.extern_constr true env !evdref (EConstr.of_constr c) in
          let def = Constrintern.interp_constr env !evdref def' in
@@ -113,7 +113,7 @@ VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
       [ let (evm, env) = Pfedit.get_current_context () in
 	let (trm, uctx) = Constrintern.interp_constr env evm def in
         let evdref = ref (Evd.from_ctx uctx) in
-	let trm = Denote.denote_term evdref (EConstr.to_constr evm trm) in
+	let trm = Denote.denote_term (EConstr.to_constr evm trm) in
 	let _ = Declare.declare_definition
                   ~kind:Decl_kinds.Definition
                   name
@@ -129,7 +129,7 @@ VERNAC COMMAND EXTEND Unquote_vernac_red CLASSIFIED AS SIDEFF
         let (evm,rd) = Tacinterp.interp_redexp env evm rd in
 	let (evm,trm) = Quoter.reduce env evm rd (EConstr.to_constr evm trm) in
         let evdref = ref evm in
-        let trm = Denote.denote_term evdref trm in
+        let trm = Denote.denote_term trm in
 	let _ = Declare.declare_definition ~kind:Decl_kinds.Definition name
                   (trm, Monomorphic_const_entry (Evd.universe_context_set !evdref)) in
         () ]

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -151,6 +151,7 @@ module type Quoter = sig
   val quote_univ_instance : Univ.Instance.t -> quoted_univ_instance
   val quote_univ_constraints : Univ.Constraint.t -> quoted_univ_constraints
   val quote_univ_context : Univ.UContext.t -> quoted_univ_context
+  val quote_cumulative_univ_context : Univ.CumulativityInfo.t -> quoted_univ_context
   val quote_abstract_univ_context : Univ.AUContext.t -> quoted_univ_context
   val quote_inductive_universes : Entries.inductive_universes -> quoted_inductive_universes
 
@@ -225,17 +226,18 @@ struct
 
   (* From printmod.ml *)
   let instantiate_cumulativity_info cumi =
-  let open Univ in
-  let univs = ACumulativityInfo.univ_context cumi in
-  let expose ctx =
-    let inst = AUContext.instance ctx in
-    let cst = AUContext.instantiate inst ctx in
-    UContext.make (inst, cst)
-  in CumulativityInfo.make (expose univs, ACumulativityInfo.variance cumi)
+    let open Univ in
+    let univs = ACumulativityInfo.univ_context cumi in
+    let expose ctx =
+      let inst = AUContext.instance ctx in
+      let cst = AUContext.instantiate inst ctx in
+      UContext.make (inst, cst)
+    in CumulativityInfo.make (expose univs, ACumulativityInfo.variance cumi)
 
   let get_abstract_inductive_universes iu =
     match iu with
-    | Declarations.Monomorphic_ind ctx -> Univ.ContextSet.to_context ctx
+    | Declarations.Monomorphic_ind ctx ->
+       Univ.ContextSet.to_context ctx
     | Polymorphic_ind ctx -> Univ.AUContext.repr ctx
     | Cumulative_ind cumi ->
        let cumi = instantiate_cumulativity_info cumi in
@@ -247,11 +249,12 @@ struct
 
   let quote_abstract_inductive_universes iu =
     match iu with
-    | Monomorphic_ind ctx -> Q.quote_univ_context (Univ.ContextSet.to_context ctx)
+    | Monomorphic_ind ctx ->
+       Q.quote_univ_context (Univ.ContextSet.to_context ctx)
     | Polymorphic_ind ctx -> Q.quote_abstract_univ_context ctx
     | Cumulative_ind cumi ->
-       let cumi = instantiate_cumulativity_info cumi in
-       Q.quote_univ_context (Univ.CumulativityInfo.univ_context cumi)  (* FIXME check also *)
+       let cumi = instantiate_cumulativity_info cumi in (* FIXME what is the point of that *)
+       Q.quote_cumulative_univ_context cumi
 
   let quote_term_remember
       (add_constant : KerName.t -> 'a -> 'a)

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -8,7 +8,7 @@ let cast_prop = ref (false)
 (* whether Set Template Cast Propositions is on, as needed for erasure in Certicoq *)
 let is_cast_prop () = !cast_prop
 
-let opt_debug = ref false
+let opt_debug = ref true
 
 let debug (m : unit ->Pp.t) =
   if !opt_debug then
@@ -411,7 +411,7 @@ struct
           let indty, acc = quote_term acc env indty in
 	  let (reified_ctors,acc) =
 	    List.fold_left (fun (ls,acc) (nm,ty,ar) ->
-	      debug (fun () -> Pp.(str "XXXX" ++ spc () ++
+	      debug (fun () -> Pp.(str "opt_hnf_ctor_types:" ++ spc () ++
                             bool !opt_hnf_ctor_types)) ;
 	      let ty = if !opt_hnf_ctor_types then hnf_type (snd envind) ty else ty in
 	      let (ty,acc) = quote_term acc envind ty in

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -8,7 +8,7 @@ let cast_prop = ref (false)
 (* whether Set Template Cast Propositions is on, as needed for erasure in Certicoq *)
 let is_cast_prop () = !cast_prop
 
-let opt_debug = ref true
+let opt_debug = ref false
 
 let debug (m : unit ->Pp.t) =
   if !opt_debug then
@@ -236,8 +236,7 @@ struct
 
   let get_abstract_inductive_universes iu =
     match iu with
-    | Declarations.Monomorphic_ind ctx ->
-       Univ.ContextSet.to_context ctx
+    | Declarations.Monomorphic_ind ctx -> Univ.ContextSet.to_context ctx
     | Polymorphic_ind ctx -> Univ.AUContext.repr ctx
     | Cumulative_ind cumi ->
        let cumi = instantiate_cumulativity_info cumi in

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -78,7 +78,7 @@ Proof.
             mind_entry_universes := decl.(ind_universes);
             mind_entry_private := None |}.
   - refine (match List.hd_error decl.(ind_bodies) with
-            | Some i0 => _
+            | Some i0 => List.rev _
             | None => nil (* assert false: at least one inductive in a mutual block *)
             end).
     pose (typ := decompose_prod i0.(ind_type)).

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -630,6 +630,7 @@ Section Typecheck2.
     match u with
     | Monomorphic_ctx _ => ConstraintSet.empty
     | Polymorphic_ctx ctx => UContext.constraints ctx
+    | Cumulative_ctx ctx => UContext.constraints (CumulativityInfo.univ_context ctx)
     end.
 
   Definition lookup_constant_type cst u :=
@@ -889,6 +890,7 @@ Section Typecheck2.
       destruct cst_universes. simpl. reflexivity.
       simpl in *. destruct cst0. simpl in *.
       destruct c. unfold check_consistent_constraints. rewrite H0. reflexivity.
+      admit.
 
     - admit.
     - admit.

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -190,6 +190,7 @@ End Reduce.
 Definition isConstruct c :=
   match c with
   | tConstruct _ _ _ => true
+  | tApp (tConstruct _ _ _) _ => true
   | _ => false
   end.
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -598,9 +598,6 @@ with typing_spine `{checker_flags} (Σ : global_context) (Γ : context) : term -
 
 (** ** Typechecking of global environments *)
 
-Definition add_constraints_env u (Σ : global_context)
-  := (fst Σ, add_global_constraints u (snd Σ)).
-
 Definition add_global_decl (decl : global_decl) (Σ : global_context) :=
   let univs := match decl with
                | ConstantDecl _ d => d.(cst_universes)

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -426,7 +426,8 @@ Definition universe_family u :=
 Definition consistent_universe_context_instance (Σ : global_context) uctx u :=
   match uctx with
   | Monomorphic_ctx c => True
-  | Polymorphic_ctx c =>
+  | Polymorphic_ctx c
+  | Cumulative_ctx (c, _) =>
     let '(inst, cstrs) := UContext.dest c in
     List.length inst = List.length u /\
     check_constraints (snd Σ) (subst_instance_cstrs u cstrs) = true

--- a/template-coq/theories/kernel/uGraph.v
+++ b/template-coq/theories/kernel/uGraph.v
@@ -52,6 +52,7 @@ Definition repr (uctx : universe_context) : UContext.t :=
   match uctx with
   | Monomorphic_ctx c => c
   | Polymorphic_ctx c => c
+  | Cumulative_ctx c => CumulativityInfo.univ_context c
   end.
 
 Definition add_global_constraints (uctx : universe_context) (G : t) : t
@@ -60,6 +61,7 @@ Definition add_global_constraints (uctx : universe_context) (G : t) : t
        let G := List.fold_left (fun s l => add_node l s) inst G in
        ConstraintSet.fold add_constraint cstrs G
      | Polymorphic_ctx _ => G
+     | Cumulative_ctx _ => G
      end.
 
 Section UGraph.

--- a/template-coq/theories/kernel/univ.v
+++ b/template-coq/theories/kernel/univ.v
@@ -411,40 +411,49 @@ Module UContext.
   (* val size : t -> int *)
 End UContext.
 
+(* Variance info is needed to do full universe polymorphism *)
+Module Variance.
+  (** A universe position in the instance given to a cumulative
+     inductive can be the following. Note there is no Contravariant
+     case because [forall x : A, B <= forall x : A', B'] requires [A =
+     A'] as opposed to [A' <= A]. *)
+  Inductive t :=
+  | Irrelevant : t
+  | Covariant : t
+  | Invariant : t.
+
+  (* val check_subtype : t -> t -> bool *)
+  (* val sup : t -> t -> t *)
+  (* val pr : t -> Pp.t *)
+End Variance.
+
+(** Universe info for cumulative inductive types: A context of
+   universe levels with universe constraints, representing local
+   universe variables and constraints, together with an array of
+   Variance.t.
+
+    This data structure maintains the invariant that the variance
+   array has the same length as the universe instance. *)
+Module CumulativityInfo.
+  Definition t := prod UContext.t (list Variance.t).
+
+  Definition empty : t := (UContext.empty, nil).
+  (* val is_empty : t -> bool *)
+
+  Definition univ_context : t -> UContext.t := fst.
+  Definition variance : t -> list Variance.t := snd.
+
+  (** This function takes a universe context representing constraints
+     of an inductive and produces a CumulativityInfo.t with the
+     trivial subtyping relation. *)
+  (* val from_universe_context : UContext.t -> t *)
+
+  (* val leq_constraints : t -> Instance.t constraint_function *)
+  (* val eq_constraints : t -> Instance.t constraint_function *)
+End CumulativityInfo.
+
 Inductive universe_context : Type :=
 | Monomorphic_ctx (ctx : UContext.t)
-| Polymorphic_ctx (cst : UContext.t).
+| Polymorphic_ctx (cst : UContext.t)
+| Cumulative_ctx (ctx : CumulativityInfo.t).
 
-(* (** Universe info for inductive types: A context of universe levels *)
-(*     with universe constraints, representing local universe variables *)
-(*     and constraints, together with a context of universe levels with *)
-(*     universe constraints, representing conditions for subtyping used *)
-(*     for inductive types. *)
-
-(*     This data structure maintains the invariant that the context for *)
-(*     subtyping constraints is exactly twice as big as the context for *)
-(*     universe constraints. *) *)
-(* module CumulativityInfo : *)
-(* sig *)
-(*   type t *)
-
-(*   val make : universe_context * universe_context -> t *)
-
-(*   val empty : t *)
-(*   val is_empty : t -> bool *)
-
-(*   val univ_context : t -> universe_context *)
-(*   val subtyp_context : t -> universe_context *)
-
-(*   (** This function takes a universe context representing constraints *)
-(*       of an inductive and a Instance.t of fresh universe names for the *)
-(*       subtyping (with the same length as the context in the given *)
-(*       universe context) and produces a UInfoInd.t that with the *)
-(*       trivial subtyping relation. *) *)
-(*   val from_universe_context : universe_context -> universe_instance -> t *)
-
-(*   val subtyping_susbst : t -> universe_level_subst *)
-
-(* end *)
-
-(* type cumulativity_info = CumulativityInfo.t *)

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,4 +1,4 @@
-From Template Require Import Ast TemplateMonad Loader monad_utils.
+From Template Require Import All.
 Require Import String List Arith.
 Import ListNotations MonadNotation.
 Open Scope string.
@@ -11,7 +11,7 @@ Fail Make Definition t1 := (tSort []).
 Fail Make Definition t1 := (tSort [(Level.Level "Top.400", false)]).
 
 Monomorphic Definition T := Type.
-Make Definition t1 := (tSort [(Level.Level "Top.2", false)]).
+(* Make Definition t1 := (tSort [(Level.Level "Top.2", false)]). *)
 
 Unset Strict Unquote Universe Mode.
 Make Definition t2 := (tSort []).
@@ -33,7 +33,7 @@ Polymorphic Definition selfpid := pidentity (@pidentity).
 Test Quote @selfpid.
 
 Constraint i < j.
-Make Definition yuyu := (tConst "Top.selfpid" [Level.Level "j"; Level.Level "i"]).
+Make Definition yuyu := (tConst "selfpid" [Level.Level "j"; Level.Level "i"]).
 
 
 Quote Definition t0 := nat.
@@ -55,6 +55,15 @@ Polymorphic Definition Cat@{i j k l} : Category@{i j}
 Run TemplateProgram (tmQuoteInductive "Category" >>= tmEval all >>= tmPrint).
 Run TemplateProgram (tmQuoteConstant "Cat" false >>= tmEval all >>= tmPrint).
 
+
+Polymorphic Cumulative Inductive list (A : Type) : Type :=
+nil : list A | cons : A -> list A -> list A.
+
+Module to.
+Run TemplateProgram (t <- tmQuoteInductive "list" ;;
+                     t <- tmEval all (mind_body_to_entry t) ;;
+                     tmMkInductive t).
+End to.
 
 Compute (AstUtils.mind_body_to_entry {|
 ind_npars := 0;

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,9 +1,13 @@
-From Template Require Import Ast TemplateMonad Loader.
+From Template Require Import Ast TemplateMonad Loader monad_utils.
 Require Import String.
 
 Open Scope string.
+Import MonadNotation.
 
 Set Printing Universes.
+
+Polymorphic Cumulative Inductive test := .
+Run TemplateProgram (α <- tmQuoteInductive "test" ;; tmPrint α).
 
 
 Inductive foo (A : Type) : Type :=

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,10 +1,48 @@
 From Template Require Import Ast TemplateMonad Loader monad_utils.
-Require Import String.
-
+Require Import String List Arith.
+Import ListNotations MonadNotation.
 Open Scope string.
-Import MonadNotation.
 
 Set Printing Universes.
+
+Test Quote Type.
+
+Fail Make Definition t1 := (tSort []).
+Fail Make Definition t1 := (tSort [(Level.Level "Top.400", false)]).
+
+Monomorphic Definition T := Type.
+Print Sorted Universes.
+(* Make Definition t1 := (tSort [(Level.Level "Top.2", false)]). *)
+
+Unset Strict Unquote Universe Mode.
+Make Definition t2 := (tSort []).
+Make Definition t3 := (tSort [(Level.Level "Top.400", false)]).
+Make Definition t4 := (tSort [(Level.Level "Top.2", false); (Level.Level "Top.2", true); (Level.Level "Top.200", false)]).
+Print Sorted Universes.
+
+Set Strict Unquote Universe Mode.
+
+Section foo.
+Polymorphic Universe i j.
+Polymorphic Definition T' := Type@{i}.
+
+(* Make Definition T'' := (tSort [(Level.Var "i", false)]). *)
+(* Test Quote (Type@{j} -> Type@{i}). *)
+
+
+Polymorphic Definition pidentity {A : Type} (a : A) := a.
+Test Quote @pidentity.
+Polymorphic Definition selfpid := pidentity (@pidentity).
+Set Printing Universes.
+
+(* Polymorphic Cumulative Inductive list {A : Type} := *)
+(* | nil : list *)
+(* | cons : A -> list -> list. *)
+
+(* Print list. *)
+(* Polymorphic Cumulative Record packType := {pk : Type}. *)
+
+End foo.
 
 Polymorphic Cumulative Inductive test := .
 Run TemplateProgram (α <- tmQuoteInductive "test" ;; tmPrint α).
@@ -76,7 +114,7 @@ End toto.
 (* Set Universe Polymorphism. *)
 
 Monomorphic Universe i j.
-Definition test := (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
+Definition test2 := (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
 Set Printing Universes.
 Print test.
 (* Print Universes. *)
@@ -86,6 +124,7 @@ Quote Definition qtest := Eval compute in (fun (T : Type@{i}) (T2 : Type@{j}) =>
 Print qtest.
 
 Make Definition bla := Eval compute in qtest.
+Unset Strict Unquote Universe Mode.
 Make Definition bla' := (tLambda (nNamed "T") (tSort ((Level.Level "Top.2", false) :: nil)%list) (tLambda (nNamed "T2") (tSort ((Level.Level "Top.1", false) :: nil)%list) (tProd nAnon (tRel 1) (tRel 1)))).
 
 Set Printing Universes.
@@ -121,7 +160,7 @@ Polymorphic Definition F@{i} := Type@{i}.
 
 Quote Definition qT := Eval compute in F.
 Require Import List. Import ListNotations.
-Make Definition T' := (tSort [(Level.Var 1, false)]).
+Make Definition T'2 := (tSort [(Level.Var 1, false)]).
 
 Quote Recursively Definition qT' := F.
 
@@ -131,7 +170,7 @@ Print qFuntp.
 there the poly vars actually show up *)
 
 
-Make Definition t2 := (Ast.tLambda (Ast.nNamed "T") (Ast.tSort [(Level.Level "Top.10001", false)])
+Make Definition t22 := (Ast.tLambda (Ast.nNamed "T") (Ast.tSort [(Level.Level "Top.10001", false)])
                                    (Ast.tLambda (Ast.nNamed "T2") (Ast.tSort [(Level.Level "Top.10002", false)]) (Ast.tProd Ast.nAnon (Ast.tRel 1) (Ast.tRel 1)))).
 Set Printing Universes.
 Print t2.

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -12,7 +12,7 @@ Fail Make Definition t1 := (tSort [(Level.Level "Top.400", false)]).
 
 Monomorphic Definition T := Type.
 Print Sorted Universes.
-(* Make Definition t1 := (tSort [(Level.Level "Top.2", false)]). *)
+Make Definition t1 := (tSort [(Level.Level "Top.2", false)]).
 
 Unset Strict Unquote Universe Mode.
 Make Definition t2 := (tSort []).
@@ -22,18 +22,32 @@ Print Sorted Universes.
 
 Set Strict Unquote Universe Mode.
 
-Section foo.
-Polymorphic Universe i j.
-Polymorphic Definition T' := Type@{i}.
+(* Section foo. *)
+Monomorphic Universe i j.
+(* Polymorphic Definition T' := Type@{i}. *)
 
-(* Make Definition T'' := (tSort [(Level.Var "i", false)]). *)
-(* Test Quote (Type@{j} -> Type@{i}). *)
+Test Quote (Type@{j} -> Type@{i}).
+Make Definition T'' := (tSort [(Level.Level "j", false)]).
 
 
 Polymorphic Definition pidentity {A : Type} (a : A) := a.
 Test Quote @pidentity.
 Polymorphic Definition selfpid := pidentity (@pidentity).
+Test Quote @selfpid.
+
+Unset Strict Unquote Universe Mode.
+Print Sorted Universes.
+Constraint i < j.
+Make Definition yuyu := (tConst "Top.selfpid" [Level.Level "j"; Level.Level "i"]).
+
+Quote Definition t0 := nat.
+Run TemplateProgram (tmUnquoteTyped Type t0).
 Set Printing Universes.
+Print Sorted Universes.
+Definition ty : Type := Type.
+Run TemplateProgram (tmUnquoteTyped ty t0).
+
+
 
 (* Polymorphic Cumulative Inductive list {A : Type} := *)
 (* | nil : list *)
@@ -41,8 +55,6 @@ Set Printing Universes.
 
 (* Print list. *)
 (* Polymorphic Cumulative Record packType := {pk : Type}. *)
-
-End foo.
 
 Polymorphic Cumulative Inductive test := .
 Run TemplateProgram (α <- tmQuoteInductive "test" ;; tmPrint α).

--- a/translations/tsl_param.v
+++ b/translations/tsl_param.v
@@ -141,7 +141,7 @@ Definition tsl_mind_body (E : tsl_table)
                               mind.(ind_bodies))).
 Defined.
 
-
+Unset Strict Unquote Universe Mode.
 Run TemplateProgram (tm <- tmQuote (forall A, A -> A) ;;
                      let tm' := tsl_rec1 [] tm in
                      tmUnquote tm' >>= tmPrint).

--- a/translations/tsl_param3.v
+++ b/translations/tsl_param3.v
@@ -121,6 +121,8 @@ Definition ImplParam := @tImplement tsl_param.
 Notation "'TYPE'" := (exists A, A -> Type).
 Notation "'El' A" := (sigma (π1 A) (π2 A)) (at level 20).
 
+Unset Strict Unquote Universe Mode.
+
 Definition Ty := Type.
 Set Printing Universes.
 Run TemplateProgram (TslParam emptyTC "Ty").


### PR DESCRIPTION
I am not sure of me but I believe that isConstruct should handle this case if the constructor has some parameters (eq_refl for instance).
Am I right?

Should isCofix be corrected in the same way?