### PR TITLE
Drop quote in `InType`

### DIFF
--- a/template-coq/Makefile.coq.local
+++ b/template-coq/Makefile.coq.local
@@ -1,1 +1,0 @@
-COQDOCFLAGS=--no-index --interpolate --parse-comments --utf8 $(COQLIBS_NOML)

--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -33,6 +33,8 @@ theories/Extraction.v
 
 # the Template monad
 theories/TemplateMonad.v
+theories/TemplateMonad/Common.v
 theories/TemplateMonad/Core.v
+theories/TemplateMonad/Extractable.v
 theories/TemplateMonad/Monad.v
 theories/monad_utils.v

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -739,7 +739,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
     let ctx = Evd.evar_universe_context evm in
     let hook = Lemmas.mk_hook (fun _ gr _ -> let env = Global.env () in
                                 let evm = Evd.from_env env in
-                                let evm, t = Evd.fresh_global env evm gr in k (env, evm, EConstr.to_constr evm t)) in
+                                let evm, t = Evd.fresh_global env evm gr in k (env, evm, t)) in
     ignore (Obligations.add_definition ident ~term:c cty ctx ~kind ~hook obls)
   (* let kind = Decl_kinds.(Global, Flags.use_polymorphic_flag (), DefinitionBody Definition) in *)
   (* Lemmas.start_proof (unquote_ident name) kind evm (EConstr.of_constr typ) *)

--- a/template-coq/src/pluginCore.ml
+++ b/template-coq/src/pluginCore.ml
@@ -1,0 +1,57 @@
+(* this file is the interface that extracted plugins will use.
+ *)
+
+type ident   (* Template.Ast.ident *)
+type kername (* Template.Ast.kername *)
+type reductionStrategy (* Template.TemplateMonad.Common.reductionStrategy *)
+type global_reference (* Template.Ast.global_reference *)
+type term = Constr.t  (* Ast.term *)
+
+type 'a tm = 'a
+
+let not_implemented (s : string) : 'a tm =
+  assert false
+
+let tmReturn (x : 'a) : 'a tm = x
+let tmBind (x : 'a) (k : 'a -> 'b tm) : 'b tm =
+  k x
+
+let tmPrint (t : term) : unit tm =
+  not_implemented "tmPrint"
+let tmMsg  (s : string) : unit tm =
+  not_implemented "tmMsg"
+
+let tmFail (s : string) : 'a tm =
+  not_implemented "tmFail"
+let tmEval (rd : reductionStrategy) (t : term) : term tm =
+  not_implemented "tmEval"
+
+let tmDefinition (nm : ident) (typ : term option) (trm : term) : kername tm =
+  not_implemented "tmDefinition"
+let tmAxiom (nm : ident) (trm : term) : kername tm =
+  not_implemented "tmAxiom"
+let tmLemma (nm : ident) (ty : term option) (trm : term) : kername tm =
+  not_implemented "tmLemma"
+
+let tmFreshName (nm : ident) : ident tm =
+  not_implemented "tmFreshName"
+
+let tmAbout (nm : ident) : global_reference option tm =
+  not_implemented "tmAbout"
+let tmCurrentModPath (_ : unit) : string tm =
+  not_implemented "tmCurrentModPath"
+
+let tmQuoteInductive (kn : kername) : _ tm =
+  not_implemented "tmQuoteInductive"
+let tmQuoteUniverses : _ tm =
+  not_implemented "tmQuoteUniverses"
+let tmQuoteConstant (kn : kername) (bypass : bool) : _ tm =
+  not_implemented "tmQuoteConstant"
+
+let tmMkInductive : _ -> _ tm =
+  not_implemented "tmMkInductive"
+
+let tmExistingInstance (kn : kername) : unit tm =
+  not_implemented "tmExistingInstance"
+let tmInferInstance (tm : term) : term option tm =
+  not_implemented "tmInferInstance"

--- a/template-coq/src/pluginCore.mli
+++ b/template-coq/src/pluginCore.mli
@@ -1,0 +1,37 @@
+(* this file is the interface that extracted plugins will use.
+ *)
+
+type ident   (* Template.Ast.ident *)
+type kername (* Template.Ast.kername *)
+type reductionStrategy (* Template.TemplateMonad.Common.reductionStrategy *)
+type global_reference (* Template.Ast.global_reference *)
+type term = Constr.t  (* Ast.term *)
+
+type 'a tm
+
+val tmReturn : 'a -> 'a tm
+val tmBind : 'a tm -> ('a -> 'b tm) -> 'b tm
+
+val tmPrint : term -> unit tm
+val tmMsg  : string -> unit tm
+
+val tmFail : string -> 'a tm
+val tmEval : reductionStrategy -> term -> term tm
+
+val tmDefinition : ident -> term option -> term -> kername tm
+val tmAxiom : ident -> term -> kername tm
+val tmLemma : ident -> term option -> term -> kername tm
+
+val tmFreshName : ident -> ident tm
+
+val tmAbout : ident -> global_reference option tm
+val tmCurrentModPath : unit -> string tm
+
+val tmQuoteInductive : kername -> _ tm
+val tmQuoteUniverses : _ tm
+val tmQuoteConstant : kername -> bool -> _ tm
+
+val tmMkInductive : _ -> _ tm
+
+val tmExistingInstance : kername -> unit tm
+val tmInferInstance : term -> term option tm

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -111,14 +111,14 @@ struct
        ttmFreshName,
        ttmAbout,
        ttmCurrentModPath,
-       ttmMkDefinition,
+(*       ttmMkDefinition, *)
        ttmMkInductive,
        ttmFail,
        ttmQuoteInductive,
        ttmQuoteConstant,
        ttmQuoteUniverses,
-       ttmUnquote,
-       ttmUnquoteTyped,
+(*       ttmUnquote,
+       ttmUnquoteTyped, *)
        ttmInferInstance,
        ttmExistingInstance) =
     (r_template_monad_type_p "tmReturn",
@@ -130,14 +130,14 @@ struct
      r_template_monad_type_p "tmFreshName",
      r_template_monad_type_p "tmAbout",
      r_template_monad_type_p "tmCurrentModPath",
-     r_template_monad_type_p "tmMkDefinition",
+(*     r_template_monad_type_p "tmMkDefinition", *)
      r_template_monad_type_p "tmMkInductive",
      r_template_monad_type_p "tmFail",
      r_template_monad_type_p "tmQuoteInductive",
      r_template_monad_type_p "tmQuoteConstant",
      r_template_monad_type_p "tmQuoteUniverses",
-     r_template_monad_type_p "tmUnquote",
-     r_template_monad_type_p "tmUnquoteTyped",
+(*     r_template_monad_type_p "tmUnquote",
+     r_template_monad_type_p "tmUnquoteTyped", *)
      r_template_monad_type_p "tmInferInstance",
      r_template_monad_type_p "tmExistingInstance")
 
@@ -225,7 +225,7 @@ struct
       | name::s::typ::[] ->
         (TmLemma (name,s,typ), universes)
       | _ -> monad_failure "tmLemmaRed" 3
-    else if Globnames.eq_gr glob_ref ptmMkDefinition || Globnames.eq_gr glob_ref ttmMkDefinition then
+    else if Globnames.eq_gr glob_ref ptmMkDefinition then
       match args with
       | name::body::[] ->
         (TmMkDefinition (name, body), universes)
@@ -252,9 +252,9 @@ struct
       | _ -> monad_failure "tmQuoteConstant" 2
     else if Globnames.eq_gr glob_ref ptmQuoteUniverses || Globnames.eq_gr glob_ref ttmQuoteUniverses then
       match args with
-      | _::[] ->
+      | [] ->
         (TmQuoteUnivs, universes)
-      | _ -> monad_failure "tmQuoteUniverses" 1
+      | _ -> monad_failure "tmQuoteUniverses" 0
     else if Globnames.eq_gr glob_ref ptmPrint then
       match args with
       | _::trm::[] ->
@@ -284,12 +284,12 @@ struct
       match args with
       | mind::[] -> (TmMkInductive mind, universes)
       | _ -> monad_failure "tmMkInductive" 1
-    else if Globnames.eq_gr glob_ref ptmUnquote || Globnames.eq_gr glob_ref ttmUnquote then
+    else if Globnames.eq_gr glob_ref ptmUnquote then
       match args with
       | t::[] ->
         (TmUnquote t, universes)
       | _ -> monad_failure "tmUnquote" 1
-    else if Globnames.eq_gr glob_ref ptmUnquoteTyped || Globnames.eq_gr glob_ref ttmUnquoteTyped then
+    else if Globnames.eq_gr glob_ref ptmUnquoteTyped then
       match args with
       | typ::t::[] ->
         (TmUnquoteTyped (typ, t), universes)

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -1,4 +1,3 @@
-open CErrors
 open Univ
 open Names
 open Constr_quoter
@@ -8,29 +7,51 @@ open Quoter
 
 module TemplateMonad :
 sig
+  type defn_kind = Definition | Lemma
+
   type template_monad =
       TmReturn of Constr.t
     | TmBind  of Constr.t * Constr.t
-    | TmPrint of Constr.t
+
+      (* printing *)
+    | TmPrint of Constr.t      (* only Prop *)
+    | TmPrintTerm of Constr.t  (* only Extractable *)
+    | TmMsg of Constr.t
     | TmFail of Constr.t
-    | TmEval of Constr.t * Constr.t
+
+      (* evaluation *)
+    | TmEval of Constr.t * Constr.t      (* only Prop *)
+    | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
+
+    | TmResolve of Constr.t
+
+      (* creating definitions *)
     | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
-    | TmAxiom of Constr.t * Constr.t * Constr.t
+    | TmDefinitionTerm of defn_kind * Constr.t * Constr.t * Constr.t * Constr.t
     | TmLemma of Constr.t * Constr.t * Constr.t
-    | TmFreshName of Constr.t
-    | TmAbout of Constr.t
-    | TmCurrentModPath
-    | TmQuote of Constr.t
-    | TmQuoteRec of Constr.t
-    | TmQuoteInd of Constr.t
-    | TmQuoteUnivs
-    | TmQuoteConst of Constr.t * Constr.t
+    | TmAxiom of Constr.t * Constr.t * Constr.t
+    | TmAxiomTerm of Constr.t * Constr.t * Constr.t
     | TmMkDefinition of Constr.t * Constr.t
     | TmMkInductive of Constr.t
-    | TmUnquote of Constr.t
-    | TmUnquoteTyped of Constr.t * Constr.t
+
+    | TmFreshName of Constr.t
+
+    | TmAbout of Constr.t
+    | TmCurrentModPath
+
+      (* quoting *)
+    | TmQuote of bool * Constr.t  (* only Prop *)
+    | TmQuoteInd of Constr.t
+    | TmQuoteConst of Constr.t * Constr.t
+    | TmQuoteUnivs
+
+    | TmUnquote of Constr.t                   (* only Prop *)
+    | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
+
+      (* typeclass resolution *)
     | TmExistingInstance of Constr.t
-    | TmInferInstance of Constr.t * Constr.t
+    | TmInferInstance of Constr.t * Constr.t     (* only Prop *)
+    | TmInferInstanceTerm of Constr.t * Constr.t (* only Extractable *)
 
   val next_action
     : Environ.env -> Constr.t -> (template_monad * Univ.Instance.t)
@@ -38,134 +59,180 @@ sig
 end =
 struct
 
-  let resolve_symbol (path : string list) (tm : string) : Constr.t =
-    gen_constant_in_modules contrib_name [path] tm
-
   let resolve_symbol_p (path : string list) (tm : string) : global_reference =
     Coqlib.gen_reference_in_modules contrib_name [path] tm
 
-  let pkg_reify = ["Template";"Ast"]
-  let pkg_template_monad = ["Template";"TemplateMonad"]
   let pkg_template_monad_prop = ["Template";"TemplateMonad";"Core"]
   let pkg_template_monad_type = ["Template";"TemplateMonad";"Extractable"]
 
-  let r_reify = resolve_symbol pkg_reify
-  let r_template_monad = resolve_symbol pkg_template_monad
   let r_template_monad_prop_p = resolve_symbol_p pkg_template_monad_prop
   let r_template_monad_type_p = resolve_symbol_p pkg_template_monad_type
 
 
-  (* for "InProp" *)
+  (* for "Core" *)
   let (ptmReturn,
        ptmBind,
-       ptmQuote,
-       ptmQuoteRec,
+
+       ptmPrint,
+       ptmMsg,
+       ptmFail,
+
        ptmEval,
+
+       ptmResolve,
+
        ptmDefinitionRed,
-       ptmAxiomRed,
        ptmLemmaRed,
-       ptmFreshName,
-       ptmAbout,
-       ptmCurrentModPath,
+       ptmAxiomRed,
        ptmMkDefinition,
        ptmMkInductive,
-       ptmPrint,
-       ptmFail,
+
+       ptmFreshName,
+
+       ptmAbout,
+       ptmCurrentModPath,
+
+       ptmQuote,
+       ptmQuoteRec,
        ptmQuoteInductive,
        ptmQuoteConstant,
        ptmQuoteUniverses,
+
        ptmUnquote,
        ptmUnquoteTyped,
+
        ptmInferInstance,
        ptmExistingInstance) =
     (r_template_monad_prop_p "tmReturn",
      r_template_monad_prop_p "tmBind",
-     r_template_monad_prop_p "tmQuote",
-     r_template_monad_prop_p "tmQuoteRec",
+
+     r_template_monad_prop_p "tmPrint",
+     r_template_monad_prop_p "tmMsg",
+     r_template_monad_prop_p "tmFail",
+
      r_template_monad_prop_p "tmEval",
+
+     r_template_monad_prop_p "tmResolve",
+
      r_template_monad_prop_p "tmDefinitionRed",
-     r_template_monad_prop_p "tmAxiomRed",
      r_template_monad_prop_p "tmLemmaRed",
-     r_template_monad_prop_p "tmFreshName",
-     r_template_monad_prop_p "tmAbout",
-     r_template_monad_prop_p "tmCurrentModPath",
+     r_template_monad_prop_p "tmAxiomRed",
      r_template_monad_prop_p "tmMkDefinition",
      r_template_monad_prop_p "tmMkInductive",
-     r_template_monad_prop_p "tmPrint",
-     r_template_monad_prop_p "tmFail",
+
+     r_template_monad_prop_p "tmFreshName",
+
+     r_template_monad_prop_p "tmAbout",
+     r_template_monad_prop_p "tmCurrentModPath",
+
+     r_template_monad_prop_p "tmQuote",
+     r_template_monad_prop_p "tmQuoteRec",
      r_template_monad_prop_p "tmQuoteInductive",
      r_template_monad_prop_p "tmQuoteConstant",
      r_template_monad_prop_p "tmQuoteUniverses",
+
      r_template_monad_prop_p "tmUnquote",
      r_template_monad_prop_p "tmUnquoteTyped",
-     r_template_monad_prop_p "tmInferInstance",
-     r_template_monad_prop_p "tmExistingInstance")
 
-  (* for "InType" *)
+     r_template_monad_prop_p "tmExistingInstance",
+     r_template_monad_prop_p "tmInferInstance")
+
+  (* for "Extractable" *)
   let (ttmReturn,
        ttmBind,
+       ttmPrintTerm,
+       ttmMsg,
+       ttmFail,
        ttmEval,
+       ttmResolve,
+
        ttmDefinitionRed,
        ttmAxiomRed,
        ttmLemmaRed,
        ttmFreshName,
        ttmAbout,
        ttmCurrentModPath,
-(*       ttmMkDefinition, *)
-       ttmMkInductive,
-       ttmFail,
        ttmQuoteInductive,
        ttmQuoteConstant,
        ttmQuoteUniverses,
-(*       ttmUnquote,
-       ttmUnquoteTyped, *)
-       ttmInferInstance,
-       ttmExistingInstance) =
+       ttmMkInductive,
+       ttmExistingInstance,
+       ttmInferInstance) =
     (r_template_monad_type_p "tmReturn",
      r_template_monad_type_p "tmBind",
+
+     r_template_monad_type_p "tmPrint",
+     r_template_monad_type_p "tmMsg",
+     r_template_monad_type_p "tmFail",
      r_template_monad_type_p "tmEval",
+
+     r_template_monad_type_p "tmResolve",
+
      r_template_monad_type_p "tmDefinitionRed",
      r_template_monad_type_p "tmAxiomRed",
      r_template_monad_type_p "tmLemmaRed",
+
      r_template_monad_type_p "tmFreshName",
+
      r_template_monad_type_p "tmAbout",
      r_template_monad_type_p "tmCurrentModPath",
-(*     r_template_monad_type_p "tmMkDefinition", *)
-     r_template_monad_type_p "tmMkInductive",
-     r_template_monad_type_p "tmFail",
+
      r_template_monad_type_p "tmQuoteInductive",
-     r_template_monad_type_p "tmQuoteConstant",
      r_template_monad_type_p "tmQuoteUniverses",
-(*     r_template_monad_type_p "tmUnquote",
-     r_template_monad_type_p "tmUnquoteTyped", *)
-     r_template_monad_type_p "tmInferInstance",
-     r_template_monad_type_p "tmExistingInstance")
+     r_template_monad_type_p "tmQuoteConstant",
+
+     r_template_monad_type_p "tmMkInductive",
+
+     r_template_monad_type_p "tmExistingInstance",
+     r_template_monad_type_p "tmInferInstance")
 
   type constr = Constr.t
+
+  type defn_kind = Definition | Lemma
 
   type template_monad =
       TmReturn of Constr.t
     | TmBind  of Constr.t * Constr.t
-    | TmPrint of Constr.t
+
+      (* printing *)
+    | TmPrint of Constr.t      (* only Prop *)
+    | TmPrintTerm of Constr.t  (* only Extractable *)
+    | TmMsg of Constr.t
     | TmFail of Constr.t
-    | TmEval of Constr.t * Constr.t
+
+      (* evaluation *)
+    | TmEval of Constr.t * Constr.t      (* only Prop *)
+    | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
+
+    | TmResolve of Constr.t
+
+      (* creating definitions *)
     | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
-    | TmAxiom of Constr.t * Constr.t * Constr.t
+    | TmDefinitionTerm of defn_kind * Constr.t * Constr.t * Constr.t * Constr.t
     | TmLemma of Constr.t * Constr.t * Constr.t
-    | TmFreshName of Constr.t
-    | TmAbout of Constr.t
-    | TmCurrentModPath
-    | TmQuote of Constr.t
-    | TmQuoteRec of Constr.t
-    | TmQuoteInd of Constr.t
-    | TmQuoteUnivs
-    | TmQuoteConst of Constr.t * Constr.t
+    | TmAxiom of Constr.t * Constr.t * Constr.t
+    | TmAxiomTerm of Constr.t * Constr.t * Constr.t
     | TmMkDefinition of Constr.t * Constr.t
     | TmMkInductive of Constr.t
-    | TmUnquote of Constr.t
-    | TmUnquoteTyped of Constr.t * Constr.t
+
+    | TmFreshName of Constr.t
+
+    | TmAbout of Constr.t
+    | TmCurrentModPath
+
+      (* quoting *)
+    | TmQuote of bool * Constr.t  (* only Prop *)
+    | TmQuoteInd of Constr.t
+    | TmQuoteConst of Constr.t * Constr.t
+    | TmQuoteUnivs
+
+    | TmUnquote of Constr.t                   (* only Prop *)
+    | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
+
+      (* typeclass resolution *)
     | TmExistingInstance of Constr.t
-    | TmInferInstance of Constr.t * Constr.t
+    | TmInferInstance of Constr.t * Constr.t     (* only Prop *)
+    | TmInferInstanceTerm of Constr.t * Constr.t (* only Extractable *)
 
   (* todo: the recursive call is uneeded provided we call it on well formed terms *)
   let rec app_full trm acc =
@@ -210,61 +277,79 @@ struct
       | _::_::a::f::[] ->
         (TmBind (a, f), universes)
       | _ -> monad_failure_full "tmBind" 4 pgm
-    else if Globnames.eq_gr glob_ref ptmDefinitionRed || Globnames.eq_gr glob_ref ttmDefinitionRed then
-      match args with
-      | name::s::typ::body::[] ->
-        (TmDefinition (name,s,typ,body), universes)
-      | _ -> monad_failure "tmDefinitionRed" 4
-    else if Globnames.eq_gr glob_ref ptmAxiomRed || Globnames.eq_gr glob_ref ttmAxiomRed then
-      match args with
-      | name::s::typ::[] ->
-        (TmAxiom (name,s,typ), universes)
-      | _ -> monad_failure "tmAxiomRed" 3
-    else if Globnames.eq_gr glob_ref ptmLemmaRed || Globnames.eq_gr glob_ref ttmLemmaRed then
-      match args with
-      | name::s::typ::[] ->
-        (TmLemma (name,s,typ), universes)
-      | _ -> monad_failure "tmLemmaRed" 3
-    else if Globnames.eq_gr glob_ref ptmMkDefinition then
-      match args with
-      | name::body::[] ->
-        (TmMkDefinition (name, body), universes)
-      | _ -> monad_failure "tmMkDefinition" 2
-    else if Globnames.eq_gr glob_ref ptmQuote then
-      match args with
-      | _::trm::[] ->
-        (TmQuote trm, universes)
-      | _ -> monad_failure "tmQuote" 2
-    else if Globnames.eq_gr glob_ref ptmQuoteRec then
-      match args with
-      | _::trm::[] ->
-        (TmQuoteRec trm, universes)
-      | _ -> monad_failure "tmQuoteRec" 2
-    else if Globnames.eq_gr glob_ref ptmQuoteInductive || Globnames.eq_gr glob_ref ttmQuoteInductive then
-      match args with
-      | name::[] ->
-        (TmQuoteInd name, universes)
-      | _ -> monad_failure "tmQuoteInductive" 1
-    else if Globnames.eq_gr glob_ref ptmQuoteConstant || Globnames.eq_gr glob_ref ttmQuoteConstant then
-      match args with
-      | name::bypass::[] ->
-        (TmQuoteConst (name, bypass), universes)
-      | _ -> monad_failure "tmQuoteConstant" 2
-    else if Globnames.eq_gr glob_ref ptmQuoteUniverses || Globnames.eq_gr glob_ref ttmQuoteUniverses then
-      match args with
-      | [] ->
-        (TmQuoteUnivs, universes)
-      | _ -> monad_failure "tmQuoteUniverses" 0
     else if Globnames.eq_gr glob_ref ptmPrint then
       match args with
       | _::trm::[] ->
         (TmPrint trm, universes)
       | _ -> monad_failure "tmPrint" 2
+    else if Globnames.eq_gr glob_ref ttmPrintTerm then
+      match args with
+      | trm::[] ->
+        (TmPrintTerm trm, universes)
+      | _ -> monad_failure "tmPrint" 1
+    else if Globnames.eq_gr glob_ref ttmMsg then
+      match args with
+      | trm::[] ->
+        (TmMsg trm, universes)
+      | _ -> monad_failure "tmMsg" 2
     else if Globnames.eq_gr glob_ref ptmFail || Globnames.eq_gr glob_ref ttmFail then
       match args with
       | _::trm::[] ->
         (TmFail trm, universes)
       | _ -> monad_failure "tmFail" 2
+    else if Globnames.eq_gr glob_ref ptmEval then
+      match args with
+      | strat::_::trm::[] -> (TmEval (strat, trm), universes)
+      | _ -> monad_failure "tmEval" 3
+    else if Globnames.eq_gr glob_ref ttmEval then
+      match args with
+      | strat::trm::[] -> (TmEvalTerm (strat, trm), universes)
+      | _ -> monad_failure "tmEval" 2
+
+    else if Globnames.eq_gr glob_ref ttmResolve || Globnames.eq_gr glob_ref ptmResolve then
+      match args with
+      | [s] -> (TmResolve s, universes)
+      | _ -> monad_failure "tmResolve" 1
+
+    else if Globnames.eq_gr glob_ref ptmDefinitionRed then
+      match args with
+      | name::s::typ::body::[] ->
+        (TmDefinition (name, s, typ, body), universes)
+      | _ -> monad_failure "tmDefinitionRed" 4
+    else if Globnames.eq_gr glob_ref ttmDefinitionRed then
+      match args with
+      | name::s::typ::body::[] ->
+        (TmDefinitionTerm (Definition, name, s, typ, body), universes)
+      | _ -> monad_failure "tmDefinitionRed" 4
+
+    else if Globnames.eq_gr glob_ref ptmLemmaRed then
+      match args with
+      | name::s::typ::[] ->
+        (TmLemma (name,s,typ), universes)
+      | _ -> monad_failure "tmLemmaRed" 3
+    else if Globnames.eq_gr glob_ref ttmLemmaRed then
+      match args with
+      | name::s::typ::term::[] ->
+        (TmDefinitionTerm (Lemma, name, s, typ, term), universes)
+      | _ -> monad_failure "tmLemmaRed" 3
+
+    else if Globnames.eq_gr glob_ref ptmAxiomRed then
+      match args with
+      | name::s::typ::[] ->
+        (TmAxiom (name,s,typ), universes)
+      | _ -> monad_failure "tmAxiomRed" 3
+    else if Globnames.eq_gr glob_ref ttmAxiomRed then
+      match args with
+      | name::s::typ::[] ->
+        (TmAxiomTerm (name, s, typ), universes)
+      | _ -> monad_failure "tmAxiomRed" 3
+
+    else if Globnames.eq_gr glob_ref ptmFreshName || Globnames.eq_gr glob_ref ttmFreshName then
+      match args with
+      | name::[] ->
+        (TmFreshName name, universes)
+      | _ -> monad_failure "tmFreshName" 1
+
     else if Globnames.eq_gr glob_ref ptmAbout || Globnames.eq_gr glob_ref ttmAbout then
       match args with
       | id::[] ->
@@ -275,15 +360,45 @@ struct
       | _::[] ->
         (TmCurrentModPath, universes)
       | _ -> monad_failure "tmCurrentModPath" 1
-    else if Globnames.eq_gr glob_ref ptmEval || Globnames.eq_gr glob_ref ttmEval then
+
+    else if Globnames.eq_gr glob_ref ptmMkDefinition then
       match args with
-      | s(*reduction strategy*)::_(*type*)::trm::[] ->
-        (TmEval (s, trm), universes)
-      | _ -> monad_failure "tmEval" 3
+      | name::body::[] ->
+        (TmMkDefinition (name, body), universes)
+      | _ -> monad_failure "tmMkDefinition" 2
+
+    else if Globnames.eq_gr glob_ref ptmQuote then
+      match args with
+      | _::trm::[] ->
+        (TmQuote (false,trm), universes)
+      | _ -> monad_failure "tmQuote" 2
+    else if Globnames.eq_gr glob_ref ptmQuoteRec then
+      match args with
+      | _::trm::[] ->
+        (TmQuote (true,trm), universes)
+      | _ -> monad_failure "tmQuoteRec" 2
+
+    else if Globnames.eq_gr glob_ref ptmQuoteInductive || Globnames.eq_gr glob_ref ttmQuoteInductive then
+      match args with
+      | name::[] ->
+        (TmQuoteInd name, universes)
+      | _ -> monad_failure "tmQuoteInductive" 1
+    else if Globnames.eq_gr glob_ref ptmQuoteUniverses || Globnames.eq_gr glob_ref ttmQuoteUniverses then
+      match args with
+      | [] ->
+        (TmQuoteUnivs, universes)
+      | _ -> monad_failure "tmQuoteUniverses" 0
+    else if Globnames.eq_gr glob_ref ptmQuoteConstant || Globnames.eq_gr glob_ref ttmQuoteConstant then
+      match args with
+      | name::bypass::[] ->
+        (TmQuoteConst (name, bypass), universes)
+      | _ -> monad_failure "tmQuoteConstant" 2
+
     else if Globnames.eq_gr glob_ref ptmMkInductive || Globnames.eq_gr glob_ref ttmMkInductive then
       match args with
       | mind::[] -> (TmMkInductive mind, universes)
       | _ -> monad_failure "tmMkInductive" 1
+
     else if Globnames.eq_gr glob_ref ptmUnquote then
       match args with
       | t::[] ->
@@ -294,21 +409,23 @@ struct
       | typ::t::[] ->
         (TmUnquoteTyped (typ, t), universes)
       | _ -> monad_failure "tmUnquoteTyped" 2
-    else if Globnames.eq_gr glob_ref ptmFreshName || Globnames.eq_gr glob_ref ttmFreshName then
-      match args with
-      | name::[] ->
-        (TmFreshName name, universes)
-      | _ -> monad_failure "tmFreshName" 1
+
     else if Globnames.eq_gr glob_ref ptmExistingInstance || Globnames.eq_gr glob_ref ttmExistingInstance then
       match args with
       | name :: [] ->
         (TmExistingInstance name, universes)
       | _ -> monad_failure "tmExistingInstance" 1
-    else if Globnames.eq_gr glob_ref ptmInferInstance || Globnames.eq_gr glob_ref ttmInferInstance then
+    else if Globnames.eq_gr glob_ref ptmInferInstance then
       match args with
       | s :: typ :: [] ->
         (TmInferInstance (s, typ), universes)
       | _ -> monad_failure "tmInferInstance" 2
+    else if Globnames.eq_gr glob_ref ttmInferInstance then
+      match args with
+      | s :: typ :: [] ->
+        (TmInferInstanceTerm (s, typ), universes)
+      | _ -> monad_failure "tmInferInstance" 2
+
     else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)
 
 end

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -46,8 +46,8 @@ struct
 
   let pkg_reify = ["Template";"Ast"]
   let pkg_template_monad = ["Template";"TemplateMonad"]
-  let pkg_template_monad_prop = ["Template";"TemplateMonad";"Core";"InProp"]
-  let pkg_template_monad_type = ["Template";"TemplateMonad";"Core";"InType"]
+  let pkg_template_monad_prop = ["Template";"TemplateMonad";"Core"]
+  let pkg_template_monad_type = ["Template";"TemplateMonad";"Extractable"]
 
   let r_reify = resolve_symbol pkg_reify
   let r_template_monad = resolve_symbol pkg_template_monad

--- a/template-coq/theories/All.v
+++ b/template-coq/theories/All.v
@@ -14,3 +14,6 @@ From Template Require Export
      Typing        (* Typing judgment *)
      Checker       (* Partial typechecker implementation *)
      Retyping      (* Fast retyping judgment *).
+
+(* note(gmm): i'm not exactly sure where this should go. *)
+Notation "<% x %>" := (ltac:(let p y := exact y in quote_term x p)).

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -31,13 +31,7 @@ From Template Require Export univ uGraph.
     ** Environments of declarations
 
       The global environment [global_context]: a list of [global_decl] and
-    a universe graph [uGraph.t].
-
-    ** The Template Monad
-
-      A monad for programming with template-coq operations. Use [Run
-    TemplateProgram] on a monad action to produce its side-effects.
-    Uses a reduction strategy specifier [reductionStrategy].  *)
+    a universe graph [uGraph.t].  *)
 
 Definition ident := string. (* e.g. nat *)
 Definition kername := string. (* e.g. Coq.Init.Datatypes.nat *)

--- a/template-coq/theories/Loader.v
+++ b/template-coq/theories/Loader.v
@@ -1,4 +1,4 @@
-Require Import Template.Ast.
-Require Import Template.TemplateMonad.
+Require Template.TemplateMonad.Core.
+Require Template.TemplateMonad.Extractable.
 
 Declare ML Module "template_coq".

--- a/template-coq/theories/TemplateMonad.v
+++ b/template-coq/theories/TemplateMonad.v
@@ -1,2 +1,2 @@
-Require Export Template.TemplateMonad.Core.
-Require Export Template.TemplateMonad.Monad.
+From Template.TemplateMonad Require Export
+     Common Core Monad.

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -1,0 +1,44 @@
+From Coq Require Import Strings.String.
+From Template Require Import Ast.
+
+Set Universe Polymorphism.
+Set Universe Minimization ToSet.
+Set Primitive Projections.
+Set Printing Universes.
+
+(** Reduction strategy to apply, beware [cbv], [cbn] and [lazy] are _strong_. *)
+
+Inductive reductionStrategy : Set :=
+  cbv | cbn | hnf | all | lazy | unfold (i : ident).
+
+Record typed_term : Type := existT_typed_term
+{ my_projT1 : Type
+; my_projT2 : my_projT1
+}.
+
+
+Record TMInstance@{t u r} :=
+{ TemplateMonad : Type@{t} -> Type@{r}
+; tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
+; tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
+                                   -> TemplateMonad B
+
+(* General commands *)
+; tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
+
+(* Guaranteed to not cause "... already declared" error *)
+; tmFreshName : ident -> TemplateMonad ident
+
+; tmAbout : ident -> TemplateMonad (option global_reference)
+; tmCurrentModPath : unit -> TemplateMonad string
+
+(* Quote the body of a definition or inductive. Its name need not be fully quaified *)
+; tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
+; tmQuoteUniverses : TemplateMonad uGraph.t
+; tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
+(* unquote before making the definition *)
+(* FIXME take an optional universe context as well *)
+; tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
+(* Typeclass registration and querying for an instance *)
+; tmExistingInstance : ident -> TemplateMonad unit
+}.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -72,5 +72,5 @@ Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
 
 Definition tmLemma (i : ident) := tmLemmaRed i (Some hnf).
 Definition tmAxiom (i : ident) := tmAxiomRed i (Some hnf).
-Definition tmDefinition (i : ident) :=
-  @tmDefinitionRed i (Some hnf).
+Definition tmDefinition (i : ident) {T} (t : T) :=
+  @tmDefinitionRed i (Some hnf) T t.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -1,230 +1,64 @@
 From Coq Require Import Strings.String.
-From Template Require Import Ast AstUtils.
+From Template Require Import
+     Ast AstUtils Common.
 
 Set Universe Polymorphism.
+Set Universe Minimization ToSet.
 Set Primitive Projections.
 Set Printing Universes.
 
 (** ** The Template Monad
 
-  A monad for programming with Template Coq structures. *)
+  A monad for programming with Template Coq structures. Use [Run
+  TemplateProgram] on a monad action to produce its side-effects.
 
-(** Reduction strategy to apply, beware [cbv], [cbn] and [lazy] are _strong_. *)
-
-Inductive reductionStrategy : Set :=
-  cbv | cbn | hnf | all | lazy | unfold (i : ident).
-
-Record typed_term : Type := existT_typed_term
-{ my_projT1 : Type
-; my_projT2 : my_projT1
-}.
-(*
-Polymorphic Definition typed_term@{t} := {T : Type@{t} & T}.
-Polymorphic Definition existT_typed_term a t : typed_term :=
-  @existT Type (fun T => T) a t. (* todo: need to fix this *)
-
-Definition my_projT1 (t : typed_term) : Type := @projT1 Type (fun T => T) t.
-Definition my_projT2 (t : typed_term) : my_projT1 t := @projT2 Type (fun T => T) t.
-*)
+  Uses a reduction strategy specifier [reductionStrategy]. *)
 
 (** *** The TemplateMonad type *)
+Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
+(* Monadic operations *)
+| tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
+| tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
+                               -> TemplateMonad B
 
-Module InProp.
-  Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
-  (* Monadic operations *)
-  | tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
-  | tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
-                                 -> TemplateMonad B
+(* General commands *)
+| tmPrint : forall {A:Type@{t}}, A -> TemplateMonad unit
+| tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
+| tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 
-  (* General commands *)
-  | tmPrint : forall {A:Type@{t}}, A -> TemplateMonad unit
-  | tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
-  | tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
+| tmResolve : string -> TemplateMonad Ast.term
 
+(* Return the defined constant *)
+| tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
+| tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
+| tmLemmaRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
 
-  (* Return the defined constant *)
-  | tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
-  | tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
-  | tmLemmaRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
+(* Guaranteed to not cause "... already declared" error *)
+| tmFreshName : ident -> TemplateMonad ident
 
-  (* Guaranteed to not cause "... already declared" error *)
-  | tmFreshName : ident -> TemplateMonad ident
+| tmAbout : ident -> TemplateMonad (option global_reference)
+| tmCurrentModPath : unit -> TemplateMonad string
 
-  | tmAbout : ident -> TemplateMonad (option global_reference)
-  | tmCurrentModPath : unit -> TemplateMonad string
+(* Quoting and unquoting commands *)
+(* Similar to Quote Definition ... := ... *)
+| tmQuote : forall {A:Type@{t}}, A  -> TemplateMonad Ast.term
+(* Similar to Quote Recursively Definition ... := ...*)
+| tmQuoteRec : forall {A:Type@{t}}, A  -> TemplateMonad program
+(* Quote the body of a definition or inductive. Its name need not be fully qualified *)
+| tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
+| tmQuoteUniverses : TemplateMonad uGraph.t
+| tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
+| tmMkDefinition : ident -> Ast.term -> TemplateMonad unit
+(* unquote before making the definition *)
+(* FIXME take an optional universe context as well *)
+| tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
+| tmUnquote : Ast.term  -> TemplateMonad typed_term@{u}
+| tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
 
-  (* Quoting and unquoting commands *)
-  (* Similar to Quote Definition ... := ... *)
-  | tmQuote : forall {A:Type@{t}}, A  -> TemplateMonad Ast.term
-  (* Similar to Quote Recursively Definition ... := ...*)
-  | tmQuoteRec : forall {A:Type@{t}}, A  -> TemplateMonad program
-  (* Quote the body of a definition or inductive. Its name need not be fully qualified *)
-  | tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
-  | tmQuoteUniverses : TemplateMonad uGraph.t
-  | tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
-  | tmMkDefinition : ident -> Ast.term -> TemplateMonad unit
-  (* unquote before making the definition *)
-  (* FIXME take an optional universe context as well *)
-  | tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
-  | tmUnquote : Ast.term  -> TemplateMonad typed_term@{u}
-  | tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
-
-  (* Typeclass registration and querying for an instance *)
-  | tmExistingInstance : ident -> TemplateMonad unit
-  | tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
-  .
-End InProp.
-
-Module InType.
-  Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Type :=
-  (* Monadic operations *)
-  | tmReturn {A:Type@{t}}
-    : A -> TemplateMonad A
-  | tmBind {A B : Type@{t}}
-    : TemplateMonad A -> (A -> TemplateMonad B) -> TemplateMonad B
-
-  (* General commands *)
-  | tmPrint : Ast.term -> TemplateMonad unit
-  | tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
-  | tmEval (red : reductionStrategy) (tm : Ast.term)
-    : TemplateMonad Ast.term
-
-  (* Return the defined constant *)
-  | tmDefinitionRed (nm : ident) (red : option reductionStrategy)
-                    (type : option Ast.term) (term : Ast.term)
-    : TemplateMonad kername
-  | tmAxiomRed (nm : ident) (red : option reductionStrategy)
-               (type : Ast.term)
-    : TemplateMonad kername
-  | tmLemmaRed (nm : ident) (red : option reductionStrategy)
-               (type : option Ast.term) (term : Ast.term)
-    : TemplateMonad kername
-
-  (* Guaranteed to not cause "... already declared" error *)
-  | tmFreshName : ident -> TemplateMonad ident
-
-  | tmAbout : ident -> TemplateMonad (option global_reference)
-  | tmCurrentModPath : unit -> TemplateMonad string
-
-  (* Quote the body of a definition or inductive. Its name need not be fully qualified *)
-  (* note(gmm): quoting requires universes for polymorphic kernel names *)
-  | tmQuoteInductive (nm : kername)
-    : TemplateMonad mutual_inductive_body
-  | tmQuoteUniverses : TemplateMonad uGraph.t
-  | tmQuoteConstant (nm : kername) (bypass_opacity : bool)
-    : TemplateMonad constant_entry
-
-  (* unquote before making the definition *)
-  (* FIXME take an optional universe context as well *)
-  | tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
-
-  (* Typeclass registration and querying for an instance *)
-  | tmExistingInstance : ident -> TemplateMonad unit
-  | tmInferInstance (red : option reductionStrategy)
-                    (type : Ast.term)
-    : TemplateMonad (option Ast.term)
-  .
-End InType.
-
-Module TMAbs.
-  Record TMInstance@{t u r} :=
-  { TemplateMonad : Type@{t} -> Type@{r}
-  ; tmReturn : forall {A:Type@{t}}, A -> TemplateMonad A
-  ; tmBind : forall {A B : Type@{t}}, TemplateMonad A -> (A -> TemplateMonad B)
-                                 -> TemplateMonad B
-
-  (* General commands *)
-  ; tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
-(*  ; tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A *)
-
-  (* Return the defined constant *)
-(*
-  ; tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
-  ; tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
-  ; tmLemmaRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
-*)
-
-  (* Guaranteed to not cause "... already declared" error *)
-  ; tmFreshName : ident -> TemplateMonad ident
-
-  ; tmAbout : ident -> TemplateMonad (option global_reference)
-  ; tmCurrentModPath : unit -> TemplateMonad string
-
-  (* Quote the body of a definition or inductive. Its name need not be fully qualified *)
-  ; tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
-  ; tmQuoteUniverses : TemplateMonad uGraph.t
-  ; tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
-(*  ; tmMkDefinition : ident -> Ast.term -> TemplateMonad unit *)
-  (* unquote before making the definition *)
-  (* FIXME take an optional universe context as well *)
-  ; tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
-(*
-  ; tmUnquote : Ast.term  -> TemplateMonad typed_term@{u}
-  ; tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
-*)
-  (* Typeclass registration and querying for an instance *)
-  ; tmExistingInstance : ident -> TemplateMonad unit
-(*
-  ; tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
-*)
-  }.
-
-End TMAbs.
-
-  Definition PropInstance@{t u r}: TMAbs.TMInstance@{t u r} :=
-    {| TMAbs.TemplateMonad := InProp.TemplateMonad@{t u}
-     ; TMAbs.tmReturn:=@InProp.tmReturn
-     ; TMAbs.tmBind:=@InProp.tmBind
-     ; TMAbs.tmFail:=@InProp.tmFail
-(*     ; TMAbs.tmEval:=@InProp.tmEval
-     ; TMAbs.tmDefinitionRed:=@InProp.tmDefinitionRed
-     ; TMAbs.tmAxiomRed:=@InProp.tmAxiomRed
-     ; TMAbs.tmLemmaRed:=@InProp.tmLemmaRed
-*)
-     ; TMAbs.tmFreshName:=@InProp.tmFreshName
-     ; TMAbs.tmAbout:=@InProp.tmAbout
-     ; TMAbs.tmCurrentModPath:=@InProp.tmCurrentModPath
-     ; TMAbs.tmQuoteInductive:=@InProp.tmQuoteInductive
-     ; TMAbs.tmQuoteUniverses:=@InProp.tmQuoteUniverses
-     ; TMAbs.tmQuoteConstant:=@InProp.tmQuoteConstant
-(*     ; TMAbs.tmMkDefinition:=@InProp.tmMkDefinition *)
-     ; TMAbs.tmMkInductive:=@InProp.tmMkInductive
-(*
-     ; TMAbs.tmUnquote:=@InProp.tmUnquote
-     ; TMAbs.tmUnquoteTyped:=@InProp.tmUnquoteTyped
-*)
-     ; TMAbs.tmExistingInstance:=@InProp.tmExistingInstance
-(*     ; TMAbs.tmInferInstance:=@InProp.tmInferInstance *)
-    |}.
-
-  Definition TypeInstance@{t u r}: TMAbs.TMInstance@{t u r} :=
-    {| TMAbs.TemplateMonad := InType.TemplateMonad@{t u}
-     ; TMAbs.tmReturn:=@InType.tmReturn
-     ; TMAbs.tmBind:=@InType.tmBind
-     ; TMAbs.tmFail:=@InType.tmFail
-(*     ; TMAbs.tmEval:=@InType.tmEval
-     ; TMAbs.tmDefinitionRed:=@InType.tmDefinitionRed
-     ; TMAbs.tmAxiomRed:=@InType.tmAxiomRed
-     ; TMAbs.tmLemmaRed:=@InType.tmLemmaRed
-*)
-     ; TMAbs.tmFreshName:=@InType.tmFreshName
-     ; TMAbs.tmAbout:=@InType.tmAbout
-     ; TMAbs.tmCurrentModPath:=@InType.tmCurrentModPath
-     ; TMAbs.tmQuoteInductive:=@InType.tmQuoteInductive
-     ; TMAbs.tmQuoteUniverses:=@InType.tmQuoteUniverses
-     ; TMAbs.tmQuoteConstant:=@InType.tmQuoteConstant
-(*     ; TMAbs.tmMkDefinition:=@InType.tmMkDefinition *)
-     ; TMAbs.tmMkInductive:=@InType.tmMkInductive
-(*
-     ; TMAbs.tmUnquote:=@InType.tmUnquote
-     ; TMAbs.tmUnquoteTyped:=@InType.tmUnquoteTyped
-*)
-     ; TMAbs.tmExistingInstance:=@InType.tmExistingInstance
-(*     ; TMAbs.tmInferInstance:=@InType.tmInferInstance *)
-    |}.
-  (* Monadic operations *)
-
-Export InType.
+(* Typeclass registration and querying for an instance *)
+| tmExistingInstance : ident -> TemplateMonad unit
+| tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
+.
 
 Definition print_nf (msg : Ast.term) : TemplateMonad unit
   := tmBind (tmEval all msg) tmPrint.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -23,6 +23,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 
 (* General commands *)
 | tmPrint : forall {A:Type@{t}}, A -> TemplateMonad unit
+| tmMsg   : string -> TemplateMonad unit
 | tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
 | tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 
@@ -56,7 +57,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
 
 (* Typeclass registration and querying for an instance *)
-| tmExistingInstance : ident -> TemplateMonad unit
+| tmExistingInstance : kername -> TemplateMonad unit
 | tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
 .
 

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -27,8 +27,6 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmFail : forall {A:Type@{t}}, string -> TemplateMonad A
 | tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 
-| tmResolve : string -> TemplateMonad Ast.term
-
 (* Return the defined constant *)
 | tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 | tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -15,7 +15,7 @@ Set Printing Universes.
  *)
 
 
-Cumulative Inductive TM@{t u} : Type@{t} -> Type :=
+Cumulative Inductive TM@{t} : Type@{t} -> Type :=
 (* Monadic operations *)
 | tmReturn {A:Type@{t}}
   : A -> TM A
@@ -24,6 +24,7 @@ Cumulative Inductive TM@{t u} : Type@{t} -> Type :=
 
 (* General commands *)
 | tmPrint : Ast.term -> TM unit
+| tmMsg  : string -> TM unit
 | tmFail : forall {A:Type@{t}}, string -> TM A
 | tmEval (red : reductionStrategy) (tm : Ast.term)
   : TM Ast.term
@@ -59,15 +60,14 @@ Cumulative Inductive TM@{t u} : Type@{t} -> Type :=
 | tmMkInductive : mutual_inductive_entry -> TM unit
 
 (* Typeclass registration and querying for an instance *)
-| tmExistingInstance : ident -> TM unit
+| tmExistingInstance : kername -> TM unit
 | tmInferInstance (red : option reductionStrategy)
                   (type : Ast.term)
   : TM (option Ast.term)
 .
 
-
-Definition TypeInstance@{t u r}: Common.TMInstance@{t u r} :=
-  {| Common.TemplateMonad := TM@{t u}
+Definition TypeInstance : Common.TMInstance :=
+  {| Common.TemplateMonad := TM
    ; Common.tmReturn:=@tmReturn
    ; Common.tmBind:=@tmBind
    ; Common.tmFail:=@tmFail

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -1,0 +1,99 @@
+From Coq Require Import Strings.String.
+From Template Require Import
+     Ast AstUtils TemplateMonad.Common.
+
+Set Universe Polymorphism.
+Set Universe Minimization ToSet.
+Set Primitive Projections.
+Set Printing Universes.
+
+(** ** The Extractable Template Monad
+
+  A monad for programming with Template Coq structures. Use [Run
+  TemplateProgram] on a monad action to produce its side-effects.
+
+ *)
+
+
+Cumulative Inductive TM@{t u} : Type@{t} -> Type :=
+(* Monadic operations *)
+| tmReturn {A:Type@{t}}
+  : A -> TM A
+| tmBind {A B : Type@{t}}
+  : TM A -> (A -> TM B) -> TM B
+
+(* General commands *)
+| tmPrint : Ast.term -> TM unit
+| tmFail : forall {A:Type@{t}}, string -> TM A
+| tmEval (red : reductionStrategy) (tm : Ast.term)
+  : TM Ast.term
+
+| tmResolve : string -> TM kername
+
+(* Return the defined constant *)
+| tmDefinitionRed (nm : ident) (red : option reductionStrategy)
+                  (type : option Ast.term) (term : Ast.term)
+  : TM kername
+| tmAxiomRed (nm : ident) (red : option reductionStrategy)
+             (type : Ast.term)
+  : TM kername
+| tmLemmaRed (nm : ident) (red : option reductionStrategy)
+             (type : option Ast.term) (term : Ast.term)
+  : TM kername
+
+(* Guaranteed to not cause "... already declared" error *)
+| tmFreshName : ident -> TM ident
+
+| tmAbout : ident -> TM (option global_reference)
+| tmCurrentModPath : unit -> TM string
+
+(* Quote the body of a definition or inductive. *)
+| tmQuoteInductive (nm : kername)
+  : TM mutual_inductive_body
+| tmQuoteUniverses : TM uGraph.t
+| tmQuoteConstant (nm : kername) (bypass_opacity : bool)
+  : TM constant_entry
+
+(* unquote before making the definition *)
+(* FIXME take an optional universe context as well *)
+| tmMkInductive : mutual_inductive_entry -> TM unit
+
+(* Typeclass registration and querying for an instance *)
+| tmExistingInstance : ident -> TM unit
+| tmInferInstance (red : option reductionStrategy)
+                  (type : Ast.term)
+  : TM (option Ast.term)
+.
+
+
+Definition TypeInstance@{t u r}: Common.TMInstance@{t u r} :=
+  {| Common.TemplateMonad := TM@{t u}
+   ; Common.tmReturn:=@tmReturn
+   ; Common.tmBind:=@tmBind
+   ; Common.tmFail:=@tmFail
+   ; Common.tmFreshName:=@tmFreshName
+   ; Common.tmAbout:=@tmAbout
+   ; Common.tmCurrentModPath:=@tmCurrentModPath
+   ; Common.tmQuoteInductive:=@tmQuoteInductive
+   ; Common.tmQuoteUniverses:=@tmQuoteUniverses
+   ; Common.tmQuoteConstant:=@tmQuoteConstant
+   ; Common.tmMkInductive:=@tmMkInductive
+   ; Common.tmExistingInstance:=@tmExistingInstance
+   |}.
+(* Monadic operations *)
+
+Definition print_nf (msg : Ast.term) : TM unit
+  := tmBind (tmEval all msg) tmPrint.
+
+(*
+Definition fail_nf {A} (msg : string) : TM A
+  := tmBind (tmEval all msg) tmFail.
+*)
+
+Definition tmMkInductive' (mind : mutual_inductive_body) : TM unit
+  := tmMkInductive (mind_body_to_entry mind).
+
+Definition tmLemma (i : ident) := tmLemmaRed i (Some hnf).
+Definition tmAxiom (i : ident) := tmAxiomRed i (Some hnf).
+Definition tmDefinition (i : ident) :=
+  @tmDefinitionRed i (Some hnf).

--- a/test-suite/add_constructor.v
+++ b/test-suite/add_constructor.v
@@ -48,28 +48,27 @@ Polymorphic Definition add_ctor (mind : mutual_inductive_body) (ind0 : inductive
                             ind_projs := ind.(ind_projs) |})
                             mind.(ind_bodies) |}.
 
+
 (* [add_constructor] is a new command (in Template Coq style) *)
 (* which do what we want *)
 
-Polymorphic Definition add_constructor {A} (ind : A) (idc : ident) {B} (ctor : B)
+Polymorphic Definition add_constructor (tm : Ast.term)
+            (idc : ident) (type : Ast.term)
   : TemplateMonad unit
-  := tm <- tmQuote ind ;;
-     match tm with
+  := match tm with
      | tInd ind0 _ =>
        decl <- tmQuoteInductive (inductive_mind ind0) ;;
-       ctor <- tmQuote ctor ;;
-       ind' <- tmEval lazy (add_ctor decl ind0 idc ctor) ;;
+       let ind' := add_ctor decl ind0 idc type in
        tmMkInductive' ind'
-     | _ => tmPrint ind ;; tmFail " is not an inductive"
+     | _ => tmPrint tm ;; tmFail " is not an inductive"
      end.
 
 
 (** * Examples *)
 
 (** Here we add a silly constructor to bool. *)
-Run TemplateProgram (add_constructor bool "foo" (fun bool' => nat -> bool' -> bool -> bool')).
-
-Print bool'.
+Run TemplateProgram (
+    add_constructor <% bool %> "foo" <% (fun x : Type => nat -> x -> bool -> x) %>).
 (* Inductive bool' : Set := *)
 (*     true' : bool' *)
 (*   | false' : bool' *)
@@ -82,7 +81,7 @@ Inductive tm :=
 | lam : tm -> tm
 | app : tm -> tm -> tm.
 
-Run TemplateProgram (add_constructor tm "letin" (fun tm' => tm' -> tm' -> tm')).
+Run TemplateProgram (add_constructor <%tm%> "letin" <% (fun tm' => tm' -> tm' -> tm') %>).
 
 Print tm'.
 (* Inductive tm' : Type := *)
@@ -92,14 +91,14 @@ Print tm'.
 (*   | letin : tm' -> tm' -> tm' *)
 
 
-Run TemplateProgram (add_constructor (@eq) "foo'"
-                    (fun (eq':forall A, A -> A -> Type) => forall A x y, nat -> eq' A x x -> bool -> eq' A x y)).
+Run TemplateProgram (add_constructor <%@eq%> "foo'"
+                    <% (fun (eq':forall A, A -> A -> Type) => forall A x y, nat -> eq' A x x -> bool -> eq' A x y) %>).
 
 Require Import Even.
-Run TemplateProgram (add_constructor (@odd) "foo''"
-                    (fun (even' odd':nat -> Prop) => odd' 0)).
+Run TemplateProgram (add_constructor <%@odd%> "foo''"
+                    <%(fun (even' odd':nat -> Prop) => odd' 0)%>).
 
 Module A.
-Run TemplateProgram (add_constructor even "foo'"
-                    (fun (even' odd':nat -> Prop) => even' 0)).
+Run TemplateProgram (add_constructor <%even%> "foo'"
+                    <%(fun (even' odd':nat -> Prop) => even' 0)%>).
 End A.

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -222,7 +222,6 @@ Qed.
 Run TemplateProgram ((tmQuoteConstant "six" true) >>= tmPrint).
 Run TemplateProgram ((tmQuoteConstant "six" false) >>= tmPrint).
 
-
 Run TemplateProgram (t <- tmLemma "foo4" nat ;;
                      tmDefinition "foo5" (t + t + 2)).
 Next Obligation.

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -155,6 +155,8 @@ Quote Recursively Definition qfoo3 := foo3.
 Compute qfoo3.
 
 Require Import Template.monad_utils. Import MonadNotation.
+Require Import Template.TemplateMonad.Core.
+
 Run TemplateProgram (tmQuoteInductive "foo" >>= tmPrint).
 Run TemplateProgram (tmQuoteInductive "foo2" >>= tmPrint).
 Run TemplateProgram (tmQuoteInductive "foo3" >>= tmPrint).


### PR DESCRIPTION
This PR phase splits the TemplateMonad type (only the `InType` one) so that it can be extracted to Ocaml and run natively.

There are two main changes:
1. I drop `tmQuote` and `tmQuoteRec`.
2. Constructors which previously took Gallina terms now take `Ast.term`s

To construct these `Ast.term`s, we use the quoting notation `<% f x %>` (suggestions for better syntax are welcome). This quotes the term `f x` **at elaboration time**. Some examples,

- `<% 1 + 1 %>` ~ `tApp <% plus %> [<% 1 %> , <% 1 %>]`

To see how this works in practice, see the porting in `add_constructors`.

Free variables in the term (even if they are bound outside the term are quoted as variables. For example,

- `<% f x %>` ~ `tApp (tVar "f") (tVar "x")`

This is unfortunate, but the best we can do with the simple quoting
mechanism that we have. I took a brief look at how to code splicing
but i'm not sure how to implement this.

**problem** This can't be merged yet because it doesn't handle universes on polymorphic terms. Mainly, the actions such as `tmQuoteInductive`, etc, need to take a list of universes.

**problem** It is also essential that quoted terms are completely portable (i.e. fully qualified). If terms resolve symbols then the behavior of tactics could change depending on the context at *run time* rather than *definition time*.

I'm wondering what others think of this. Personally, I think that it is more principled, but is a little bit more verbose. I'm interested in knowing if a few helper notations would ease the burden. The prospect of compiling this to Ocaml is quite intriguing to me (this was brought up by @aa755 and @mattam82 and was the original impetus for #84 ). 