### PR TITLE
Fix treatment of universes in run_template_program_rec

### DIFF
--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -692,7 +692,9 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
   let open TemplateMonad in
   let (kind, universes) = next_action env pgm in
   match kind with
-    TmReturn h -> k (env, evm, h)
+    TmReturn h ->
+     let (evm, _) = Typing.type_of env evm (EConstr.of_constr h) in
+     k (env, evm, h)
   | TmBind (a,f) ->
     run_template_program_rec ~intactic:intactic (fun (env, evm, ar) -> run_template_program_rec ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
   | TmDefinition (name,s,typ,body) ->
@@ -865,9 +867,9 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
          let make_typed_term typ term evm =
            match texistT_typed_term with
            | ConstructRef ctor ->
-             let u = (Univ.Instance.to_array universes).(1) in
-             let term = Constr.mkApp
-               (Constr.mkConstructU (ctor, Univ.Instance.of_array [|u|]), [|typ; t'|]) in
+              let (evm,c) = Evarutil.new_global evm texistT_typed_term in
+              let term = Constr.mkApp
+               (EConstr.to_constr evm c, [|typ; t'|]) in
              let evm, _ = Typing.type_of env evm (EConstr.of_constr term) in
                (env, evm, term)
            | _ -> anomaly (str "texistT_typed_term does not refer to a constructor")

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -150,10 +150,12 @@ TACTIC EXTEND run_program
          let evm = Proofview.Goal.sigma gl in
          let env = Proofview.Goal.env gl in
          let ret = ref None in
-         Denote.run_template_program_rec ~intactic:true (fun (env, evm, t) -> ret := Some t) env (evm, EConstr.to_constr evm c);
+         Denote.run_template_program_rec ~intactic:true (fun x -> ret := Some x) env (evm, EConstr.to_constr evm c);
          match !ret with
-           Some c ->
-           ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c])
+           Some (env, evm, t) ->
+            Proofview.tclTHEN
+              (Proofview.Unsafe.tclEVARS evm) 
+              (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr t]))
          | None -> Proofview.tclUNIT ()
        end) ]
 END;;


### PR DESCRIPTION
This is a re-opened request of @fakusb's #78.

Three problems are fixed:
- `tmReturn` did not update universe constraints
- when returning a typed term, the chose universe might have been incompatible with the universe `existT_typed_term` lived in
- when running in a tactic, the universe constraints generated while running the program where dropped

Maybe a similar propagation of universe constraints has to be done in the handling of `tmBind`, but I'm not too sure.

If we agree this is the right thing to do I can port to `master` and `coq-8.9` as well. Our big development where the issue occurred is on 8.8, so that was most convenient.