### PR TITLE
Fix make clean

### DIFF
--- a/pcuic/Makefile
+++ b/pcuic/Makefile
@@ -17,7 +17,7 @@ install: theory plugin
 	$(MAKE) -f Makefile.pcuic install
 	$(MAKE) -f Makefile.plugin install
 
-clean: Makefile.extraction Makefile.plugin
+clean: Makefile.pcuic Makefile.plugin
 	make -f Makefile.pcuic clean
 	make -f Makefile.plugin clean
 


### PR DESCRIPTION
Using `make clean` currently results in 

```
make -C pcuic clean
make[1]: *** No rule to make target 'Makefile.extraction', needed by 'clean'.  Stop.
make: *** [Makefile:21: clean] Error 2
```