### PR TITLE
 Define commands of Template Coq (Test Quote, Make Definition, ...) as TemplateMonad programs

### DIFF
--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -11,6 +11,7 @@ src/denote.ml
 # src/g_template_coq.mli
 src/g_template_coq.ml4
 src/template_coq.mlpack
+src/template_monad.mli
 src/template_monad.ml
 src/run_template_monad.mli
 src/run_template_monad.ml

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -2,9 +2,7 @@
 (*i camlp4use: "pa_extend.cmp" i*)
 
 open Ltac_plugin
-open Entries
 open Names
-
 
 DECLARE PLUGIN "template_coq"
 
@@ -47,6 +45,80 @@ let ltac_apply (f : Value.t) (args: Tacinterp.Value.t list) =
 let to_ltac_val c = Tacinterp.Value.of_constr c
 
 
+let run_template_program env evm pgm =
+  Run_template_monad.run_template_program_rec (fun _ -> ()) env (evm, pgm)
+
+
+(** ********* Commands ********* *)
+
+VERNAC COMMAND EXTEND Make_tests CLASSIFIED AS QUERY
+    | [ "Test" "Quote" constr(def) ] ->
+      [ let (evm,env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmTestQuote in
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr.mkRel 0; EConstr.to_constr evm def|]) in
+        run_template_program env evm pgm ]
+END;;
+
+VERNAC COMMAND EXTEND Make_vernac CLASSIFIED AS SIDEFF
+    | [ "Quote" "Definition" ident(name) ":=" constr(def) ] ->
+      [ let (evm,env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmQuoteDefinition in
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; Constr.mkRel 0; EConstr.to_constr evm def|]) in
+        run_template_program env evm pgm ]
+END;;
+
+VERNAC COMMAND EXTEND Make_vernac_reduce CLASSIFIED AS SIDEFF
+    | [ "Quote" "Definition" ident(name) ":=" "Eval" red_expr(rd) "in" constr(def) ] ->
+      [ let (evm, env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        (* TODO : implem quoting of tactic reductions so that we can use ptmQuoteDefinitionRed *)
+        let (evm, rd) = Tacinterp.interp_redexp env evm rd in
+	let (evm, def) = Quoter.reduce env evm rd (EConstr.to_constr evm def) in
+        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmQuoteDefinition in
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; Constr.mkRel 0; def|]) in
+        run_template_program env evm pgm ]
+END;;
+
+VERNAC COMMAND EXTEND Make_recursive CLASSIFIED AS SIDEFF
+    | [ "Quote" "Recursively" "Definition" ident(name) ":=" constr(def) ] ->
+      [ let (evm,env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmQuoteRecDefinition in
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; Constr.mkRel 0; EConstr.to_constr evm def|]) in
+        run_template_program env evm pgm ]
+END;;
+
+VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
+    | [ "Make" "Definition" ident(name) ":=" constr(def) ] ->
+      [ let (evm, env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmMkDefinition in
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; EConstr.to_constr evm def|]) in
+        run_template_program env evm pgm ]
+END;;
+
+VERNAC COMMAND EXTEND Unquote_inductive CLASSIFIED AS SIDEFF
+    | [ "Make" "Inductive" constr(def) ] ->
+      [ let (evm, env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmMkInductive in
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|EConstr.to_constr evm def|]) in
+        run_template_program env evm pgm ]
+END;;
+
+VERNAC COMMAND EXTEND Run_program CLASSIFIED AS SIDEFF
+    | [ "Run" "TemplateProgram" constr(def) ] ->
+      [ let (evm, env) = Pfedit.get_current_context () in
+        let (evm, def) = Constrintern.interp_open_constr env evm def in
+        let pgm = EConstr.to_constr evm def in
+        run_template_program env evm pgm ]
+END;;
+
+
+(** ********* Tactics ********* *)
+
 TACTIC EXTEND get_goal
     | [ "quote_term" constr(c) tactic(tac) ] ->
       [ (** quote the given term, pass the result to t **)
@@ -68,80 +140,6 @@ TACTIC EXTEND denote_term
       end) ]
 END;;
 
-
-VERNAC COMMAND EXTEND Make_vernac CLASSIFIED AS SIDEFF
-    | [ "Quote" "Definition" ident(name) ":=" constr(def) ] ->
-      [ let (evm,env) = Pfedit.get_current_context () in
-	let def,uctx = Constrintern.interp_constr env evm def in
-	let trm = Constr_quoter.TermReify.quote_term env (EConstr.to_constr evm def) in
-	ignore(Declare.declare_definition
-                 ~kind:Decl_kinds.Definition name
-                 (trm, Monomorphic_const_entry (UState.context_set uctx))) ]
-END;;
-
-VERNAC COMMAND EXTEND Make_vernac_reduce CLASSIFIED AS SIDEFF
-    | [ "Quote" "Definition" ident(name) ":=" "Eval" red_expr(rd) "in" constr(def) ] ->
-      [ let (evm,env) = Pfedit.get_current_context () in
-	let def, uctx = Constrintern.interp_constr env evm def in
-        let evm = Evd.from_ctx uctx in
-        let (evm,rd) = Tacinterp.interp_redexp env evm rd in
-	let (evm,def) = Quoter.reduce env evm rd (EConstr.to_constr evm def) in
-	let trm = Constr_quoter.TermReify.quote_term env def in
-	ignore(Declare.declare_definition
-                 ~kind:Decl_kinds.Definition
-                 name
-                 (trm, Monomorphic_const_entry (Evd.universe_context_set evm))) ]
-END;;
-
-VERNAC COMMAND EXTEND Make_recursive CLASSIFIED AS SIDEFF
-    | [ "Quote" "Recursively" "Definition" ident(name) ":=" constr(def) ] ->
-      [ let (evm,env) = Pfedit.get_current_context () in
-	let def, uctx = Constrintern.interp_constr env evm def in
-	let trm = Constr_quoter.TermReify.quote_term_rec env (EConstr.to_constr evm def) in
-	ignore(Declare.declare_definition
-	  ~kind:Decl_kinds.Definition name
-	  (trm, Monomorphic_const_entry (UState.context_set uctx))) ]
-END;;
-
-VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
-    | [ "Make" "Definition" ident(name) ":=" constr(def) ] ->
-      [ let (evm, env) = Pfedit.get_current_context () in
-	let (trm, uctx) = Constrintern.interp_constr env evm def in
-	let evm, trm = Denote.denote_term evm (EConstr.to_constr evm trm) in
-	let _ = Declare.declare_definition
-                  ~kind:Decl_kinds.Definition
-                  name
-                  (trm, Monomorphic_const_entry (Evd.universe_context_set evm)) in
-        () ]
-END;;
-
-VERNAC COMMAND EXTEND Unquote_vernac_red CLASSIFIED AS SIDEFF
-    | [ "Make" "Definition" ident(name) ":=" "Eval" red_expr(rd) "in" constr(def) ] ->
-      [ let (evm, env) = Pfedit.get_current_context () in
-	let (trm, uctx) = Constrintern.interp_constr env evm def in
-        let evm = Evd.from_ctx uctx in
-        let (evm,rd) = Tacinterp.interp_redexp env evm rd in
-	let (evm,trm) = Quoter.reduce env evm rd (EConstr.to_constr evm trm) in
-        let evm, trm = Denote.denote_term evm trm in
-	let _ = Declare.declare_definition ~kind:Decl_kinds.Definition name
-                  (trm, Monomorphic_const_entry (Evd.universe_context_set evm)) in
-        () ]
-END;;
-
-VERNAC COMMAND EXTEND Unquote_inductive CLASSIFIED AS SIDEFF
-    | [ "Make" "Inductive" constr(def) ] ->
-      [ let (evm,env) = Pfedit.get_current_context () in
-	let (body,uctx) = Constrintern.interp_constr env evm def in
-        Run_template_monad.declare_inductive env evm (EConstr.to_constr evm body) ]
-END;;
-
-VERNAC COMMAND EXTEND Run_program CLASSIFIED AS SIDEFF
-    | [ "Run" "TemplateProgram" constr(def) ] ->
-      [ let (evm, env) = Pfedit.get_current_context () in
-        let (evm, def) = Constrintern.interp_open_constr env evm def in
-        Run_template_monad.run_template_program_rec (fun _ -> ()) env (evm, (EConstr.to_constr evm def)) ]
-END;;
-
 TACTIC EXTEND run_program
     | [ "run_template_program" constr(c) tactic(tac) ] ->
       [ Proofview.Goal.enter (begin fun gl ->
@@ -156,13 +154,4 @@ TACTIC EXTEND run_program
               (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr t]))
          | None -> Proofview.tclUNIT ()
        end) ]
-END;;
-
-VERNAC COMMAND EXTEND Make_tests CLASSIFIED AS QUERY
-    | [ "Test" "Quote" constr(c) ] ->
-      [ let (evm,env) = Pfedit.get_current_context () in
-	let c = Constrintern.interp_constr env evm c in
-	let result = Constr_quoter.TermReify.quote_term env (EConstr.to_constr evm (fst c)) in
-        Feedback.msg_notice (Quoter.pr_constr result) ;
-	() ]
 END;;

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -228,16 +228,6 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
       let env = Global.env () in
       k (env, evm, Constr.mkConst n)
 
-  | TmMkDefinition (name, body) ->
-    if intactic
-    then not_in_tactic "tmMkDefinition"
-    else
-      let name = unquote_ident (reduce_all env evm name) in
-      let evm, trm = denote_term evm (reduce_all env evm body) in
-      let (evm, _) = Typing.type_of env evm (EConstr.of_constr trm) in
-      let _ = Declare.declare_definition ~kind:Decl_kinds.Definition name (trm, Monomorphic_const_entry (Evd.universe_context_set evm)) in
-      let env = Global.env () in
-      k (env, evm, unit_tt)
   | TmDefinitionTerm (name, typ, body) ->
     if intactic
     then not_in_tactic "tmDefinition"

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -215,19 +215,17 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
     k (env, evm, h)
   | TmBind (a,f) ->
     run_template_program_rec ~intactic:intactic (fun (env, evm, ar) -> run_template_program_rec ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
-  | TmDefinition (name,s,typ,body) ->
+  | TmDefinition (name,typ,body) ->
     if intactic
     then not_in_tactic "tmDefinition"
     else
       let name = unquote_ident (reduce_all env evm name) in
-      let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
       let univs =
         if Flags.is_universe_polymorphism () then Polymorphic_const_entry (Evd.to_universe_context evm)
         else Monomorphic_const_entry (Evd.universe_context_set evm) in
       let n = Declare.declare_definition ~kind:Decl_kinds.Definition name ~types:typ (body, univs) in
       let env = Global.env () in
       k (env, evm, Constr.mkConst n)
-
   | TmDefinitionTerm (name, typ, body) ->
     if intactic
     then not_in_tactic "tmDefinition"
@@ -244,23 +242,12 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
       let poly = Flags.is_universe_polymorphism () in
       PluginCore.run (PluginCore.tmDefinition name ~poly typ body) env evm
         (fun env evm res -> k (env, evm, quote_kn res))
-  | TmLemmaTerm (name, typ) ->
-    let ident = unquote_ident (reduce_all env evm name) in
-    let evm,typ = denote_term evm (reduce_all env evm typ) in
-    let poly = Flags.is_universe_polymorphism () in
-    PluginCore.run (PluginCore.tmLemma ident ~poly typ) env evm
-      (fun env evm kn -> k (env, evm, quote_kn kn))
-  | TmAxiom (name,s,typ) ->
+
+  | TmAxiom (name,typ) ->
     if intactic
     then not_in_tactic "tmAxiom"
     else
       let name = unquote_ident (reduce_all env evm name) in
-      let evm, typ =
-        match denote_option s with
-          Some s ->
-          let red = unquote_reduction_strategy env evm s in
-          reduce env evm red typ
-        | None -> evm, typ in
       let param = Entries.ParameterEntry (None, (typ, Monomorphic_const_entry (Evd.universe_context_set evm)), None) in
       let n = Declare.declare_constant name (param, Decl_kinds.IsDefinition Decl_kinds.Definition) in
       let env = Global.env () in
@@ -274,9 +261,9 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
       let poly = Flags.is_universe_polymorphism () in
       PluginCore.run (PluginCore.tmAxiom name ~poly typ) env evm
         (fun a b c -> k (a,b,quote_kn c))
-  | TmLemma (name,s,typ) ->
+
+  | TmLemma (name,typ) ->
     let name = reduce_all env evm name in
-    let evm, typ = (match denote_option s with Some s -> let red = unquote_reduction_strategy env evm s in reduce env evm red typ | None -> evm, typ) in
     let poly = Flags.is_universe_polymorphism () in
     let kind = (Decl_kinds.Global, poly, Decl_kinds.Definition) in
     let hole = CAst.make (Constrexpr.CHole (None, Misctypes.IntroAnonymous, None)) in
@@ -296,6 +283,13 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
     (* let evm, t = Evd.fresh_global env evm gr in k (env, evm, t) *)
     (* k (env, evm, unit_tt) *)
     (* )); *)
+  | TmLemmaTerm (name, typ) ->
+    let ident = unquote_ident (reduce_all env evm name) in
+    let evm,typ = denote_term evm (reduce_all env evm typ) in
+    let poly = Flags.is_universe_polymorphism () in
+    PluginCore.run (PluginCore.tmLemma ident ~poly typ) env evm
+      (fun env evm kn -> k (env, evm, quote_kn kn))
+
   | TmQuote (false, trm) ->
     (* user should do the reduction (using tmEval) if they want *)
     let qt = TermReify.quote_term env trm

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -6,7 +6,6 @@ open Redops
 open Genredexpr
 open Pp (* this adds the ++ to the current scope *)
 
-open Tm_util
 open Quoter
 open Constr_quoter
 open TemplateCoqQuoter
@@ -209,7 +208,6 @@ let not_in_tactic s =
   CErrors.user_err  (str ("You can not use " ^ s ^ " in a tactic."))
 
 let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_map * Constr.t -> unit) env ((evm, pgm) : Evd.evar_map * Constr.t) : unit =
-  let open TemplateMonad in
   let (kind, universes) = next_action env evm pgm in
   match kind with
     TmReturn h ->

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -26,9 +26,9 @@ let (ptmReturn,
 
      ptmEval,
 
-     ptmDefinitionRed,
-     ptmLemmaRed,
-     ptmAxiomRed,
+     ptmDefinition,
+     ptmLemma,
+     ptmAxiom,
      ptmMkDefinition,
      ptmMkInductive,
 
@@ -62,9 +62,9 @@ let (ptmReturn,
 
    r_template_monad_prop_p "tmEval",
 
-   r_template_monad_prop_p "tmDefinitionRed",
-   r_template_monad_prop_p "tmLemmaRed",
-   r_template_monad_prop_p "tmAxiomRed",
+   r_template_monad_prop_p "tmDefinition",
+   r_template_monad_prop_p "tmLemma",
+   r_template_monad_prop_p "tmAxiom",
    r_template_monad_prop_p "tmMkDefinition",
    r_template_monad_prop_p "tmMkInductive",
 
@@ -153,11 +153,11 @@ type template_monad =
   | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
 
     (* creating definitions *)
-  | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
+  | TmDefinition of Constr.t * Constr.t * Constr.t
   | TmDefinitionTerm of Constr.t * Constr.t * Constr.t
-  | TmLemma of Constr.t * Constr.t * Constr.t
+  | TmLemma of Constr.t * Constr.t
   | TmLemmaTerm of Constr.t * Constr.t
-  | TmAxiom of Constr.t * Constr.t * Constr.t
+  | TmAxiom of Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
   | TmMkInductive of Constr.t
 
@@ -245,33 +245,33 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     | strat::trm::[] -> (TmEvalTerm (strat, trm), universes)
     | _ -> monad_failure "tmEval" 2
 
-  else if Globnames.eq_gr glob_ref ptmDefinitionRed then
+  else if Globnames.eq_gr glob_ref ptmDefinition then
     match args with
-    | name::s::typ::body::[] ->
-      (TmDefinition (name, s, typ, body), universes)
-    | _ -> monad_failure "tmDefinitionRed" 4
+    | name::typ::body::[] ->
+      (TmDefinition (name, typ, body), universes)
+    | _ -> monad_failure "tmDefinitionRed" 3
   else if Globnames.eq_gr glob_ref ttmDefinition then
     match args with
     | name::typ::body::[] ->
       (TmDefinitionTerm (name, typ, body), universes)
     | _ -> monad_failure "tmDefinition" 3
 
-  else if Globnames.eq_gr glob_ref ptmLemmaRed then
+  else if Globnames.eq_gr glob_ref ptmLemma then
     match args with
-    | name::s::typ::[] ->
-      (TmLemma (name,s,typ), universes)
-    | _ -> monad_failure "tmLemmaRed" 3
+    | name::typ::[] ->
+      (TmLemma (name,typ), universes)
+    | _ -> monad_failure "tmLemma" 2
   else if Globnames.eq_gr glob_ref ttmLemma then
     match args with
     | name::typ::[] ->
       (TmLemmaTerm (name, typ), universes)
     | _ -> monad_failure "tmLemma" 2
 
-  else if Globnames.eq_gr glob_ref ptmAxiomRed then
+  else if Globnames.eq_gr glob_ref ptmAxiom then
     match args with
-    | name::s::typ::[] ->
-      (TmAxiom (name,s,typ), universes)
-    | _ -> monad_failure "tmAxiomRed" 3
+    | name::typ::[] ->
+      (TmAxiom (name,typ), universes)
+    | _ -> monad_failure "tmAxiom" 2
   else if Globnames.eq_gr glob_ref ttmAxiom then
     match args with
     | name::typ::[] ->

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -159,7 +159,6 @@ type template_monad =
   | TmLemmaTerm of Constr.t * Constr.t
   | TmAxiom of Constr.t * Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
-  | TmMkDefinition of Constr.t * Constr.t
   | TmMkInductive of Constr.t
 
   | TmFreshName of Constr.t
@@ -298,12 +297,6 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     match args with
     | [] -> (TmCurrentModPath, universes)
     | _ -> monad_failure "tmCurrentModPath" 1
-
-  else if Globnames.eq_gr glob_ref ptmMkDefinition then
-    match args with
-    | name::body::[] ->
-      (TmMkDefinition (name, body), universes)
-    | _ -> monad_failure "tmMkDefinition" 2
 
   else if Globnames.eq_gr glob_ref ptmQuote then
     match args with

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -5,408 +5,366 @@ open Pp
 
 open Quoter
 
-module TemplateMonad :
-sig
-  type template_monad =
-      TmReturn of Constr.t
-    | TmBind  of Constr.t * Constr.t
-
-      (* printing *)
-    | TmPrint of Constr.t      (* only Prop *)
-    | TmPrintTerm of Constr.t  (* only Extractable *)
-    | TmMsg of Constr.t
-    | TmFail of Constr.t
 
-      (* evaluation *)
-    | TmEval of Constr.t * Constr.t      (* only Prop *)
-    | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
+let resolve_symbol_p (path : string list) (tm : string) : global_reference =
+  Coqlib.gen_reference_in_modules contrib_name [path] tm
+
+let pkg_template_monad_prop = ["Template";"TemplateMonad";"Core"]
+let pkg_template_monad_type = ["Template";"TemplateMonad";"Extractable"]
+
+let r_template_monad_prop_p = resolve_symbol_p pkg_template_monad_prop
+let r_template_monad_type_p = resolve_symbol_p pkg_template_monad_type
+
+
+(* for "Core" *)
+let (ptmReturn,
+     ptmBind,
+
+     ptmPrint,
+     ptmMsg,
+     ptmFail,
+
+     ptmEval,
+
+     ptmDefinitionRed,
+     ptmLemmaRed,
+     ptmAxiomRed,
+     ptmMkDefinition,
+     ptmMkInductive,
+
+     ptmFreshName,
 
-      (* creating definitions *)
-    | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
-    | TmDefinitionTerm of Constr.t * Constr.t * Constr.t
-    | TmLemma of Constr.t * Constr.t * Constr.t
-    | TmLemmaTerm of Constr.t * Constr.t
-    | TmAxiom of Constr.t * Constr.t * Constr.t
-    | TmAxiomTerm of Constr.t * Constr.t
-    | TmMkDefinition of Constr.t * Constr.t
-    | TmMkInductive of Constr.t
+     ptmAbout,
+     ptmCurrentModPath,
 
-    | TmFreshName of Constr.t
+     ptmQuote,
+     ptmQuoteRec,
+     ptmQuoteInductive,
+     ptmQuoteConstant,
+     ptmQuoteUniverses,
 
-    | TmAbout of Constr.t
-    | TmCurrentModPath
-
-      (* quoting *)
-    | TmQuote of bool * Constr.t  (* only Prop *)
-    | TmQuoteInd of Constr.t
-    | TmQuoteConst of Constr.t * Constr.t
-    | TmQuoteUnivs
-
-    | TmUnquote of Constr.t                 (* only Prop *)
-    | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
-
-      (* typeclass resolution *)
-    | TmExistingInstance of Constr.t
-    | TmInferInstance of Constr.t * Constr.t (* only Prop *)
-    | TmInferInstanceTerm of Constr.t        (* only Extractable *)
-
-  val next_action
-    : Environ.env -> Evd.evar_map -> Constr.t -> (template_monad * Univ.Instance.t)
-
-end =
-struct
-
-  let resolve_symbol_p (path : string list) (tm : string) : global_reference =
-    Coqlib.gen_reference_in_modules contrib_name [path] tm
-
-  let pkg_template_monad_prop = ["Template";"TemplateMonad";"Core"]
-  let pkg_template_monad_type = ["Template";"TemplateMonad";"Extractable"]
-
-  let r_template_monad_prop_p = resolve_symbol_p pkg_template_monad_prop
-  let r_template_monad_type_p = resolve_symbol_p pkg_template_monad_type
-
-
-  (* for "Core" *)
-  let (ptmReturn,
-       ptmBind,
-
-       ptmPrint,
-       ptmMsg,
-       ptmFail,
-
-       ptmEval,
-
-       ptmDefinitionRed,
-       ptmLemmaRed,
-       ptmAxiomRed,
-       ptmMkDefinition,
-       ptmMkInductive,
-
-       ptmFreshName,
-
-       ptmAbout,
-       ptmCurrentModPath,
-
-       ptmQuote,
-       ptmQuoteRec,
-       ptmQuoteInductive,
-       ptmQuoteConstant,
-       ptmQuoteUniverses,
-
-       ptmUnquote,
-       ptmUnquoteTyped,
-
-       ptmInferInstance,
-       ptmExistingInstance) =
-    (r_template_monad_prop_p "tmReturn",
-     r_template_monad_prop_p "tmBind",
-
-     r_template_monad_prop_p "tmPrint",
-     r_template_monad_prop_p "tmMsg",
-     r_template_monad_prop_p "tmFail",
-
-     r_template_monad_prop_p "tmEval",
-
-     r_template_monad_prop_p "tmDefinitionRed",
-     r_template_monad_prop_p "tmLemmaRed",
-     r_template_monad_prop_p "tmAxiomRed",
-     r_template_monad_prop_p "tmMkDefinition",
-     r_template_monad_prop_p "tmMkInductive",
-
-     r_template_monad_prop_p "tmFreshName",
-
-     r_template_monad_prop_p "tmAbout",
-     r_template_monad_prop_p "tmCurrentModPath",
-
-     r_template_monad_prop_p "tmQuote",
-     r_template_monad_prop_p "tmQuoteRec",
-     r_template_monad_prop_p "tmQuoteInductive",
-     r_template_monad_prop_p "tmQuoteConstant",
-     r_template_monad_prop_p "tmQuoteUniverses",
-
-     r_template_monad_prop_p "tmUnquote",
-     r_template_monad_prop_p "tmUnquoteTyped",
-
-     r_template_monad_prop_p "tmInferInstance",
-     r_template_monad_prop_p "tmExistingInstance")
-
-  (* for "Extractable" *)
-  let (ttmReturn,
-       ttmBind,
-       ttmPrintTerm,
-       ttmMsg,
-       ttmFail,
-       ttmEval,
-
-       ttmDefinition,
-       ttmAxiom,
-       ttmLemma,
-       ttmFreshName,
-       ttmAbout,
-       ttmCurrentModPath,
-       ttmQuoteInductive,
-       ttmQuoteConstant,
-       ttmQuoteUniverses,
-       ttmInductive,
-       ttmInferInstance,
-       ttmExistingInstance) =
-    (r_template_monad_type_p "tmReturn",
-     r_template_monad_type_p "tmBind",
-
-     r_template_monad_type_p "tmPrint",
-     r_template_monad_type_p "tmMsg",
-     r_template_monad_type_p "tmFail",
-     r_template_monad_type_p "tmEval",
-
-     r_template_monad_type_p "tmDefinition",
-     r_template_monad_type_p "tmAxiom",
-     r_template_monad_type_p "tmLemma",
-
-     r_template_monad_type_p "tmFreshName",
-
-     r_template_monad_type_p "tmAbout",
-     r_template_monad_type_p "tmCurrentModPath",
-
-     r_template_monad_type_p "tmQuoteInductive",
-     r_template_monad_type_p "tmQuoteUniverses",
-     r_template_monad_type_p "tmQuoteConstant",
-
-     r_template_monad_type_p "tmInductive",
-
-     r_template_monad_type_p "tmInferInstance",
-     r_template_monad_type_p "tmExistingInstance")
-
-  type constr = Constr.t
-
-  type template_monad =
-      TmReturn of Constr.t
-    | TmBind  of Constr.t * Constr.t
-
-      (* printing *)
-    | TmPrint of Constr.t      (* only Prop *)
-    | TmPrintTerm of Constr.t  (* only Extractable *)
-    | TmMsg of Constr.t
-    | TmFail of Constr.t
-
-      (* evaluation *)
-    | TmEval of Constr.t * Constr.t      (* only Prop *)
-    | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
-
-      (* creating definitions *)
-    | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
-    | TmDefinitionTerm of Constr.t * Constr.t * Constr.t
-    | TmLemma of Constr.t * Constr.t * Constr.t
-    | TmLemmaTerm of Constr.t * Constr.t
-    | TmAxiom of Constr.t * Constr.t * Constr.t
-    | TmAxiomTerm of Constr.t * Constr.t
-    | TmMkDefinition of Constr.t * Constr.t
-    | TmMkInductive of Constr.t
-
-    | TmFreshName of Constr.t
-
-    | TmAbout of Constr.t
-    | TmCurrentModPath
-
-      (* quoting *)
-    | TmQuote of bool * Constr.t  (* only Prop *)
-    | TmQuoteInd of Constr.t
-    | TmQuoteConst of Constr.t * Constr.t
-    | TmQuoteUnivs
-
-    | TmUnquote of Constr.t                   (* only Prop *)
-    | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
-
-      (* typeclass resolution *)
-    | TmExistingInstance of Constr.t
-    | TmInferInstance of Constr.t * Constr.t (* only Prop *)
-    | TmInferInstanceTerm of Constr.t        (* only Extractable *)
-
-  (* todo: the recursive call is uneeded provided we call it on well formed terms *)
-  let rec app_full trm acc =
-    match Constr.kind trm with
-      Constr.App (f, xs) -> app_full f (Array.to_list xs @ acc)
-    | _ -> (trm, acc)
-
-  let monad_failure s k =
-    CErrors.user_err  Pp.(str s ++ str " must take " ++ int k ++
-                          str " argument" ++ str (if k > 0 then "s" else "") ++ str "." ++ fnl () ++
-                          str "Please file a bug with MetaCoq.")
-
-  let next_action env evd (pgm : constr) : template_monad * _ =
-    let pgm = Reduction.whd_all env pgm in
-    let (coConstr, args) = app_full pgm [] in
-    let (glob_ref, universes) =
-      try
-        let open Constr in
-        match kind coConstr with
-        | Const (c, u) -> ConstRef c, u
-        | Ind (i, u) -> IndRef i, u
-        | Construct (c, u) -> ConstructRef c, u
-        | Var id -> VarRef id, Instance.empty
-        | _ -> raise Not_found
-      with _ ->
-        CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ Printer.pr_constr_env env evd coConstr)
-    in
-    if Globnames.eq_gr glob_ref ptmReturn || Globnames.eq_gr glob_ref ttmReturn then
-      match args with
-      | _::h::[] ->
-        (TmReturn h, universes)
-      | _ -> monad_failure "tmReturn" 2
-    else if Globnames.eq_gr glob_ref ptmBind || Globnames.eq_gr glob_ref ttmBind then
-      match args with
-      | _::_::a::f::[] ->
-        (TmBind (a, f), universes)
-      | _ -> monad_failure "tmBind" 4
-    else if Globnames.eq_gr glob_ref ptmPrint then
-      match args with
-      | _::trm::[] ->
-        (TmPrint trm, universes)
-      | _ -> monad_failure "tmPrint" 2
-    else if Globnames.eq_gr glob_ref ttmPrintTerm then
-      match args with
-      | trm::[] ->
-        (TmPrintTerm trm, universes)
-      | _ -> monad_failure "tmPrint" 1
-    else if Globnames.eq_gr glob_ref ptmMsg || Globnames.eq_gr glob_ref ttmMsg then
-      match args with
-      | trm::[] ->
-        (TmMsg trm, universes)
-      | _ -> monad_failure "tmMsg" 2
-    else if Globnames.eq_gr glob_ref ptmFail || Globnames.eq_gr glob_ref ttmFail then
-      match args with
-      | _::trm::[] ->
-        (TmFail trm, universes)
-      | _ -> monad_failure "tmFail" 2
-    else if Globnames.eq_gr glob_ref ptmEval then
-      match args with
-      | strat::_::trm::[] -> (TmEval (strat, trm), universes)
-      | _ -> monad_failure "tmEval" 3
-    else if Globnames.eq_gr glob_ref ttmEval then
-      match args with
-      | strat::trm::[] -> (TmEvalTerm (strat, trm), universes)
-      | _ -> monad_failure "tmEval" 2
-
-    else if Globnames.eq_gr glob_ref ptmDefinitionRed then
-      match args with
-      | name::s::typ::body::[] ->
-        (TmDefinition (name, s, typ, body), universes)
-      | _ -> monad_failure "tmDefinitionRed" 4
-    else if Globnames.eq_gr glob_ref ttmDefinition then
-      match args with
-      | name::typ::body::[] ->
-        (TmDefinitionTerm (name, typ, body), universes)
-      | _ -> monad_failure "tmDefinition" 3
-
-    else if Globnames.eq_gr glob_ref ptmLemmaRed then
-      match args with
-      | name::s::typ::[] ->
-        (TmLemma (name,s,typ), universes)
-      | _ -> monad_failure "tmLemmaRed" 3
-    else if Globnames.eq_gr glob_ref ttmLemma then
-      match args with
-      | name::typ::[] ->
-        (TmLemmaTerm (name, typ), universes)
-      | _ -> monad_failure "tmLemma" 2
-
-    else if Globnames.eq_gr glob_ref ptmAxiomRed then
-      match args with
-      | name::s::typ::[] ->
-        (TmAxiom (name,s,typ), universes)
-      | _ -> monad_failure "tmAxiomRed" 3
-    else if Globnames.eq_gr glob_ref ttmAxiom then
-      match args with
-      | name::typ::[] ->
-        (TmAxiomTerm (name, typ), universes)
-      | _ -> monad_failure "tmAxiom" 2
-
-    else if Globnames.eq_gr glob_ref ptmFreshName || Globnames.eq_gr glob_ref ttmFreshName then
-      match args with
-      | name::[] ->
-        (TmFreshName name, universes)
-      | _ -> monad_failure "tmFreshName" 1
-
-    else if Globnames.eq_gr glob_ref ptmAbout || Globnames.eq_gr glob_ref ttmAbout then
-      match args with
-      | id::[] ->
-        (TmAbout id, universes)
-      | _ -> monad_failure "tmAbout" 1
-    else if Globnames.eq_gr glob_ref ptmCurrentModPath then
-      match args with
-      | _::[] -> (TmCurrentModPath, universes)
-      | _ -> monad_failure "tmCurrentModPath" 1
-    else if Globnames.eq_gr glob_ref ttmCurrentModPath then
-      match args with
-      | [] -> (TmCurrentModPath, universes)
-      | _ -> monad_failure "tmCurrentModPath" 1
-
-    else if Globnames.eq_gr glob_ref ptmMkDefinition then
-      match args with
-      | name::body::[] ->
-        (TmMkDefinition (name, body), universes)
-      | _ -> monad_failure "tmMkDefinition" 2
-
-    else if Globnames.eq_gr glob_ref ptmQuote then
-      match args with
-      | _::trm::[] ->
-        (TmQuote (false,trm), universes)
-      | _ -> monad_failure "tmQuote" 2
-    else if Globnames.eq_gr glob_ref ptmQuoteRec then
-      match args with
-      | _::trm::[] ->
-        (TmQuote (true,trm), universes)
-      | _ -> monad_failure "tmQuoteRec" 2
-
-    else if Globnames.eq_gr glob_ref ptmQuoteInductive || Globnames.eq_gr glob_ref ttmQuoteInductive then
-      match args with
-      | name::[] ->
-        (TmQuoteInd name, universes)
-      | _ -> monad_failure "tmQuoteInductive" 1
-    else if Globnames.eq_gr glob_ref ptmQuoteUniverses || Globnames.eq_gr glob_ref ttmQuoteUniverses then
-      match args with
-      | [] ->
-        (TmQuoteUnivs, universes)
-      | _ -> monad_failure "tmQuoteUniverses" 0
-    else if Globnames.eq_gr glob_ref ptmQuoteConstant || Globnames.eq_gr glob_ref ttmQuoteConstant then
-      match args with
-      | name::bypass::[] ->
-        (TmQuoteConst (name, bypass), universes)
-      | _ -> monad_failure "tmQuoteConstant" 2
-
-    else if Globnames.eq_gr glob_ref ptmMkInductive then
-      match args with
-      | mind::[] -> (TmMkInductive mind, universes)
-      | _ -> monad_failure "tmMkInductive" 1
-    else if Globnames.eq_gr glob_ref ttmInductive then
-      match args with
-      | mind::[] -> (TmMkInductive mind, universes)
-      | _ -> monad_failure "tmInductive" 1
-    else if Globnames.eq_gr glob_ref ptmUnquote then
-      match args with
-      | t::[] ->
-        (TmUnquote t, universes)
-      | _ -> monad_failure "tmUnquote" 1
-    else if Globnames.eq_gr glob_ref ptmUnquoteTyped then
-      match args with
-      | typ::t::[] ->
-        (TmUnquoteTyped (typ, t), universes)
-      | _ -> monad_failure "tmUnquoteTyped" 2
-
-    else if Globnames.eq_gr glob_ref ptmExistingInstance || Globnames.eq_gr glob_ref ttmExistingInstance then
-      match args with
-      | name :: [] ->
-        (TmExistingInstance name, universes)
-      | _ -> monad_failure "tmExistingInstance" 1
-    else if Globnames.eq_gr glob_ref ptmInferInstance then
-      match args with
-      | s :: typ :: [] ->
-        (TmInferInstance (s, typ), universes)
-      | _ -> monad_failure "tmInferInstance" 2
-    else if Globnames.eq_gr glob_ref ttmInferInstance then
-      match args with
-      | typ :: [] ->
-        (TmInferInstanceTerm typ, universes)
-      | _ -> monad_failure "tmInferInstance" 2
-
-    else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)
-
-end
+     ptmUnquote,
+     ptmUnquoteTyped,
+
+     ptmInferInstance,
+     ptmExistingInstance,
+
+     ptmTestQuote,
+     ptmQuoteDefinition,
+     ptmQuoteDefinitionRed,
+     ptmQuoteRecDefinition) =
+  (r_template_monad_prop_p "tmReturn",
+   r_template_monad_prop_p "tmBind",
+
+   r_template_monad_prop_p "tmPrint",
+   r_template_monad_prop_p "tmMsg",
+   r_template_monad_prop_p "tmFail",
+
+   r_template_monad_prop_p "tmEval",
+
+   r_template_monad_prop_p "tmDefinitionRed",
+   r_template_monad_prop_p "tmLemmaRed",
+   r_template_monad_prop_p "tmAxiomRed",
+   r_template_monad_prop_p "tmMkDefinition",
+   r_template_monad_prop_p "tmMkInductive",
+
+   r_template_monad_prop_p "tmFreshName",
+
+   r_template_monad_prop_p "tmAbout",
+   r_template_monad_prop_p "tmCurrentModPath",
+
+   r_template_monad_prop_p "tmQuote",
+   r_template_monad_prop_p "tmQuoteRec",
+   r_template_monad_prop_p "tmQuoteInductive",
+   r_template_monad_prop_p "tmQuoteConstant",
+   r_template_monad_prop_p "tmQuoteUniverses",
+
+   r_template_monad_prop_p "tmUnquote",
+   r_template_monad_prop_p "tmUnquoteTyped",
+
+   r_template_monad_prop_p "tmInferInstance",
+   r_template_monad_prop_p "tmExistingInstance",
+
+   r_template_monad_prop_p "tmTestQuote",
+   r_template_monad_prop_p "tmQuoteDefinition",
+   r_template_monad_prop_p "tmQuoteDefinitionRed",
+   r_template_monad_prop_p "tmQuoteRecDefinition")
+
+(* for "Extractable" *)
+let (ttmReturn,
+     ttmBind,
+     ttmPrintTerm,
+     ttmMsg,
+     ttmFail,
+     ttmEval,
+
+     ttmDefinition,
+     ttmAxiom,
+     ttmLemma,
+     ttmFreshName,
+     ttmAbout,
+     ttmCurrentModPath,
+     ttmQuoteInductive,
+     ttmQuoteConstant,
+     ttmQuoteUniverses,
+     ttmInductive,
+     ttmInferInstance,
+     ttmExistingInstance) =
+  (r_template_monad_type_p "tmReturn",
+   r_template_monad_type_p "tmBind",
+
+   r_template_monad_type_p "tmPrint",
+   r_template_monad_type_p "tmMsg",
+   r_template_monad_type_p "tmFail",
+   r_template_monad_type_p "tmEval",
+
+   r_template_monad_type_p "tmDefinition",
+   r_template_monad_type_p "tmAxiom",
+   r_template_monad_type_p "tmLemma",
+
+   r_template_monad_type_p "tmFreshName",
+
+   r_template_monad_type_p "tmAbout",
+   r_template_monad_type_p "tmCurrentModPath",
+
+   r_template_monad_type_p "tmQuoteInductive",
+   r_template_monad_type_p "tmQuoteUniverses",
+   r_template_monad_type_p "tmQuoteConstant",
+
+   r_template_monad_type_p "tmInductive",
+
+   r_template_monad_type_p "tmInferInstance",
+   r_template_monad_type_p "tmExistingInstance")
+
+type constr = Constr.t
+
+type template_monad =
+    TmReturn of Constr.t
+  | TmBind  of Constr.t * Constr.t
+
+    (* printing *)
+  | TmPrint of Constr.t      (* only Prop *)
+  | TmPrintTerm of Constr.t  (* only Extractable *)
+  | TmMsg of Constr.t
+  | TmFail of Constr.t
+
+    (* evaluation *)
+  | TmEval of Constr.t * Constr.t      (* only Prop *)
+  | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
+
+    (* creating definitions *)
+  | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
+  | TmDefinitionTerm of Constr.t * Constr.t * Constr.t
+  | TmLemma of Constr.t * Constr.t * Constr.t
+  | TmLemmaTerm of Constr.t * Constr.t
+  | TmAxiom of Constr.t * Constr.t * Constr.t
+  | TmAxiomTerm of Constr.t * Constr.t
+  | TmMkDefinition of Constr.t * Constr.t
+  | TmMkInductive of Constr.t
+
+  | TmFreshName of Constr.t
+
+  | TmAbout of Constr.t
+  | TmCurrentModPath
+
+    (* quoting *)
+  | TmQuote of bool * Constr.t  (* only Prop *)
+  | TmQuoteInd of Constr.t
+  | TmQuoteConst of Constr.t * Constr.t
+  | TmQuoteUnivs
+
+  | TmUnquote of Constr.t                   (* only Prop *)
+  | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
+
+    (* typeclass resolution *)
+  | TmExistingInstance of Constr.t
+  | TmInferInstance of Constr.t * Constr.t (* only Prop *)
+  | TmInferInstanceTerm of Constr.t        (* only Extractable *)
+
+(* todo: the recursive call is uneeded provided we call it on well formed terms *)
+let rec app_full trm acc =
+  match Constr.kind trm with
+    Constr.App (f, xs) -> app_full f (Array.to_list xs @ acc)
+  | _ -> (trm, acc)
+
+let monad_failure s k =
+  CErrors.user_err  Pp.(str s ++ str " must take " ++ int k ++
+                        str " argument" ++ str (if k > 0 then "s" else "") ++ str "." ++ fnl () ++
+                        str "Please file a bug with MetaCoq.")
+
+let next_action env evd (pgm : constr) : template_monad * _ =
+  let pgm = Reduction.whd_all env pgm in
+  let (coConstr, args) = app_full pgm [] in
+  let (glob_ref, universes) =
+    try
+      let open Constr in
+      match kind coConstr with
+      | Const (c, u) -> ConstRef c, u
+      | Ind (i, u) -> IndRef i, u
+      | Construct (c, u) -> ConstructRef c, u
+      | Var id -> VarRef id, Instance.empty
+      | _ -> raise Not_found
+    with _ ->
+      CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ Printer.pr_constr_env env evd coConstr)
+  in
+  if Globnames.eq_gr glob_ref ptmReturn || Globnames.eq_gr glob_ref ttmReturn then
+    match args with
+    | _::h::[] ->
+      (TmReturn h, universes)
+    | _ -> monad_failure "tmReturn" 2
+  else if Globnames.eq_gr glob_ref ptmBind || Globnames.eq_gr glob_ref ttmBind then
+    match args with
+    | _::_::a::f::[] ->
+      (TmBind (a, f), universes)
+    | _ -> monad_failure "tmBind" 4
+  else if Globnames.eq_gr glob_ref ptmPrint then
+    match args with
+    | _::trm::[] ->
+      (TmPrint trm, universes)
+    | _ -> monad_failure "tmPrint" 2
+  else if Globnames.eq_gr glob_ref ttmPrintTerm then
+    match args with
+    | trm::[] ->
+      (TmPrintTerm trm, universes)
+    | _ -> monad_failure "tmPrint" 1
+  else if Globnames.eq_gr glob_ref ptmMsg || Globnames.eq_gr glob_ref ttmMsg then
+    match args with
+    | trm::[] ->
+      (TmMsg trm, universes)
+    | _ -> monad_failure "tmMsg" 2
+  else if Globnames.eq_gr glob_ref ptmFail || Globnames.eq_gr glob_ref ttmFail then
+    match args with
+    | _::trm::[] ->
+      (TmFail trm, universes)
+    | _ -> monad_failure "tmFail" 2
+  else if Globnames.eq_gr glob_ref ptmEval then
+    match args with
+    | strat::_::trm::[] -> (TmEval (strat, trm), universes)
+    | _ -> monad_failure "tmEval" 3
+  else if Globnames.eq_gr glob_ref ttmEval then
+    match args with
+    | strat::trm::[] -> (TmEvalTerm (strat, trm), universes)
+    | _ -> monad_failure "tmEval" 2
+
+  else if Globnames.eq_gr glob_ref ptmDefinitionRed then
+    match args with
+    | name::s::typ::body::[] ->
+      (TmDefinition (name, s, typ, body), universes)
+    | _ -> monad_failure "tmDefinitionRed" 4
+  else if Globnames.eq_gr glob_ref ttmDefinition then
+    match args with
+    | name::typ::body::[] ->
+      (TmDefinitionTerm (name, typ, body), universes)
+    | _ -> monad_failure "tmDefinition" 3
+
+  else if Globnames.eq_gr glob_ref ptmLemmaRed then
+    match args with
+    | name::s::typ::[] ->
+      (TmLemma (name,s,typ), universes)
+    | _ -> monad_failure "tmLemmaRed" 3
+  else if Globnames.eq_gr glob_ref ttmLemma then
+    match args with
+    | name::typ::[] ->
+      (TmLemmaTerm (name, typ), universes)
+    | _ -> monad_failure "tmLemma" 2
+
+  else if Globnames.eq_gr glob_ref ptmAxiomRed then
+    match args with
+    | name::s::typ::[] ->
+      (TmAxiom (name,s,typ), universes)
+    | _ -> monad_failure "tmAxiomRed" 3
+  else if Globnames.eq_gr glob_ref ttmAxiom then
+    match args with
+    | name::typ::[] ->
+      (TmAxiomTerm (name, typ), universes)
+    | _ -> monad_failure "tmAxiom" 2
+
+  else if Globnames.eq_gr glob_ref ptmFreshName || Globnames.eq_gr glob_ref ttmFreshName then
+    match args with
+    | name::[] ->
+      (TmFreshName name, universes)
+    | _ -> monad_failure "tmFreshName" 1
+
+  else if Globnames.eq_gr glob_ref ptmAbout || Globnames.eq_gr glob_ref ttmAbout then
+    match args with
+    | id::[] ->
+      (TmAbout id, universes)
+    | _ -> monad_failure "tmAbout" 1
+  else if Globnames.eq_gr glob_ref ptmCurrentModPath then
+    match args with
+    | _::[] -> (TmCurrentModPath, universes)
+    | _ -> monad_failure "tmCurrentModPath" 1
+  else if Globnames.eq_gr glob_ref ttmCurrentModPath then
+    match args with
+    | [] -> (TmCurrentModPath, universes)
+    | _ -> monad_failure "tmCurrentModPath" 1
+
+  else if Globnames.eq_gr glob_ref ptmMkDefinition then
+    match args with
+    | name::body::[] ->
+      (TmMkDefinition (name, body), universes)
+    | _ -> monad_failure "tmMkDefinition" 2
+
+  else if Globnames.eq_gr glob_ref ptmQuote then
+    match args with
+    | _::trm::[] ->
+      (TmQuote (false,trm), universes)
+    | _ -> monad_failure "tmQuote" 2
+  else if Globnames.eq_gr glob_ref ptmQuoteRec then
+    match args with
+    | _::trm::[] ->
+      (TmQuote (true,trm), universes)
+    | _ -> monad_failure "tmQuoteRec" 2
+
+  else if Globnames.eq_gr glob_ref ptmQuoteInductive || Globnames.eq_gr glob_ref ttmQuoteInductive then
+    match args with
+    | name::[] ->
+      (TmQuoteInd name, universes)
+    | _ -> monad_failure "tmQuoteInductive" 1
+  else if Globnames.eq_gr glob_ref ptmQuoteUniverses || Globnames.eq_gr glob_ref ttmQuoteUniverses then
+    match args with
+    | [] ->
+      (TmQuoteUnivs, universes)
+    | _ -> monad_failure "tmQuoteUniverses" 0
+  else if Globnames.eq_gr glob_ref ptmQuoteConstant || Globnames.eq_gr glob_ref ttmQuoteConstant then
+    match args with
+    | name::bypass::[] ->
+      (TmQuoteConst (name, bypass), universes)
+    | _ -> monad_failure "tmQuoteConstant" 2
+
+  else if Globnames.eq_gr glob_ref ptmMkInductive then
+    match args with
+    | mind::[] -> (TmMkInductive mind, universes)
+    | _ -> monad_failure "tmMkInductive" 1
+  else if Globnames.eq_gr glob_ref ttmInductive then
+    match args with
+    | mind::[] -> (TmMkInductive mind, universes)
+    | _ -> monad_failure "tmInductive" 1
+  else if Globnames.eq_gr glob_ref ptmUnquote then
+    match args with
+    | t::[] ->
+      (TmUnquote t, universes)
+    | _ -> monad_failure "tmUnquote" 1
+  else if Globnames.eq_gr glob_ref ptmUnquoteTyped then
+    match args with
+    | typ::t::[] ->
+      (TmUnquoteTyped (typ, t), universes)
+    | _ -> monad_failure "tmUnquoteTyped" 2
+
+  else if Globnames.eq_gr glob_ref ptmExistingInstance || Globnames.eq_gr glob_ref ttmExistingInstance then
+    match args with
+    | name :: [] ->
+      (TmExistingInstance name, universes)
+    | _ -> monad_failure "tmExistingInstance" 1
+  else if Globnames.eq_gr glob_ref ptmInferInstance then
+    match args with
+    | s :: typ :: [] ->
+      (TmInferInstance (s, typ), universes)
+    | _ -> monad_failure "tmInferInstance" 2
+  else if Globnames.eq_gr glob_ref ttmInferInstance then
+    match args with
+    | typ :: [] ->
+      (TmInferInstanceTerm typ, universes)
+    | _ -> monad_failure "tmInferInstance" 2
+
+  else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -22,11 +22,11 @@ type template_monad =
   | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
 
     (* creating definitions *)
-  | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
+  | TmDefinition of Constr.t * Constr.t * Constr.t
   | TmDefinitionTerm of Constr.t * Constr.t * Constr.t
-  | TmLemma of Constr.t * Constr.t * Constr.t
+  | TmLemma of Constr.t * Constr.t
   | TmLemmaTerm of Constr.t * Constr.t
-  | TmAxiom of Constr.t * Constr.t * Constr.t
+  | TmAxiom of Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
   | TmMkInductive of Constr.t
 

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -1,0 +1,58 @@
+
+val ptmTestQuote : Names.global_reference
+val ptmQuoteDefinition : Names.global_reference
+val ptmQuoteDefinitionRed : Names.global_reference
+val ptmQuoteRecDefinition : Names.global_reference
+val ptmMkDefinition : Names.global_reference
+val ptmMkInductive : Names.global_reference
+
+
+type template_monad =
+    TmReturn of Constr.t
+  | TmBind  of Constr.t * Constr.t
+
+    (* printing *)
+  | TmPrint of Constr.t      (* only Prop *)
+  | TmPrintTerm of Constr.t  (* only Extractable *)
+  | TmMsg of Constr.t
+  | TmFail of Constr.t
+
+    (* evaluation *)
+  | TmEval of Constr.t * Constr.t      (* only Prop *)
+  | TmEvalTerm of Constr.t * Constr.t  (* only Extractable *)
+
+    (* creating definitions *)
+  | TmDefinition of Constr.t * Constr.t * Constr.t * Constr.t
+  | TmDefinitionTerm of Constr.t * Constr.t * Constr.t
+  | TmLemma of Constr.t * Constr.t * Constr.t
+  | TmLemmaTerm of Constr.t * Constr.t
+  | TmAxiom of Constr.t * Constr.t * Constr.t
+  | TmAxiomTerm of Constr.t * Constr.t
+  | TmMkInductive of Constr.t
+
+  | TmFreshName of Constr.t
+
+  | TmAbout of Constr.t
+  | TmCurrentModPath
+
+    (* quoting *)
+  | TmQuote of bool * Constr.t  (* only Prop *)
+  | TmQuoteInd of Constr.t
+  | TmQuoteConst of Constr.t * Constr.t
+  | TmQuoteUnivs
+
+  | TmUnquote of Constr.t                   (* only Prop *)
+  | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
+
+    (* typeclass resolution *)
+  | TmExistingInstance of Constr.t
+  | TmInferInstance of Constr.t * Constr.t (* only Prop *)
+  | TmInferInstanceTerm of Constr.t        (* only Extractable *)
+
+
+val app_full
+  : Constr.constr -> Constr.constr list -> Constr.constr * Constr.constr list
+
+
+val next_action
+  : Environ.env -> Evd.evar_map -> Constr.t -> (template_monad * Univ.Instance.t)

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -47,7 +47,6 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmQuoteInductive : qualid -> TemplateMonad mutual_inductive_body
 | tmQuoteUniverses : TemplateMonad uGraph.t
 | tmQuoteConstant : qualid -> bool (* bypass opacity? *) -> TemplateMonad constant_entry
-| tmMkDefinition : ident -> Ast.term -> TemplateMonad unit
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)
 | tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
@@ -68,7 +67,19 @@ Definition fail_nf {A} (msg : string) : TemplateMonad A
 Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
   := tmMkInductive (mind_body_to_entry mind).
 
-Definition tmLemma (i : ident) := tmLemmaRed i (Some hnf).
-Definition tmAxiom (i : ident) := tmAxiomRed i (Some hnf).
-Definition tmDefinition (i : ident) {T} (t : T) :=
-  @tmDefinitionRed i (Some hnf) T t.
+Definition tmLemma id := tmLemmaRed id None.
+Definition tmAxiom id := tmAxiomRed id None.
+Definition tmDefinition id {A} t := @tmDefinitionRed id None A t.
+
+(* Don't remove. Constants used in the implem of the plugin *)
+Definition tmTestQuote {A} (t : A) := tmBind (tmQuote t) tmPrint.
+Definition tmQuoteDefinition id {A} (t : A) := tmBind (tmQuote t) (tmDefinition id).
+Definition tmQuoteDefinitionRed id rd {A} (t : A)
+  := tmBind (tmQuote t) (tmDefinitionRed id (Some rd)).
+Definition tmQuoteRecDefinition id {A} (t : A)
+  := tmBind (tmQuoteRec t) (tmDefinition id).
+Definition tmMkDefinition id (tm : term) : TemplateMonad unit
+  := tmBind (tmUnquote tm)
+            (fun t' => tmBind (tmEval all (my_projT2 t'))
+            (fun t'' => tmBind (tmDefinition id t'')
+            (fun _ => tmReturn tt))).

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -28,9 +28,9 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmEval : reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 
 (* Return the defined constant *)
-| tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
-| tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
-| tmLemmaRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
+| tmDefinition : ident -> forall {A:Type@{t}}, A -> TemplateMonad A
+| tmAxiom : ident -> forall A : Type@{t}, TemplateMonad A
+| tmLemma : ident -> forall A : Type@{t}, TemplateMonad A
 
 (* Guaranteed to not cause "... already declared" error *)
 | tmFreshName : ident -> TemplateMonad ident
@@ -67,15 +67,11 @@ Definition fail_nf {A} (msg : string) : TemplateMonad A
 Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
   := tmMkInductive (mind_body_to_entry mind).
 
-Definition tmLemma id := tmLemmaRed id None.
-Definition tmAxiom id := tmAxiomRed id None.
-Definition tmDefinition id {A} t := @tmDefinitionRed id None A t.
-
 (* Don't remove. Constants used in the implem of the plugin *)
 Definition tmTestQuote {A} (t : A) := tmBind (tmQuote t) tmPrint.
 Definition tmQuoteDefinition id {A} (t : A) := tmBind (tmQuote t) (tmDefinition id).
 Definition tmQuoteDefinitionRed id rd {A} (t : A)
-  := tmBind (tmQuote t) (tmDefinitionRed id (Some rd)).
+  := tmBind (tmEval rd t) (tmQuoteDefinition id).
 Definition tmQuoteRecDefinition id {A} (t : A)
   := tmBind (tmQuoteRec t) (tmDefinition id).
 Definition tmMkDefinition id (tm : term) : TemplateMonad unit

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -31,6 +31,8 @@ Quote Definition d' := (fun x : nat => x).
 Definition id_nat : nat -> nat := fun x => x.
 
 Quote Definition d'' := Eval compute in id_nat.
+Quote Definition d3 := Eval cbn in id_nat.
+Quote Definition d4 := Eval unfold id_nat in id_nat.
 
 
 (** Fixpoints **)
@@ -77,7 +79,7 @@ Make Definition two_from_syntax := (Ast.tApp (Ast.tConstruct (BasicAst.mkInd "Co
    (Ast.tApp (Ast.tConstruct (BasicAst.mkInd "Coq.Init.Datatypes.nat" 0) 1 nil)
       (Ast.tConstruct (BasicAst.mkInd "Coq.Init.Datatypes.nat" 0) 0 nil :: nil) :: nil)).
 
-Quote Recursively Definition plus_synax := plus.
+Quote Recursively Definition plus_syntax := plus.
 
 Quote Recursively Definition mult_syntax := mult.
 
@@ -197,7 +199,8 @@ Inductive demoList (A : Set) : Set :=
 
 
 (** Putting the above commands in monadic program *)
-
+Notation inat :=
+  {| inductive_mind := "Coq.Init.Datatypes.nat"; inductive_ind := 0 |}.
 Run TemplateProgram (tmBind (tmQuote (3 + 3)) tmPrint).
 
 Run TemplateProgram (tmBind (tmQuoteRec add) tmPrint).
@@ -349,10 +352,9 @@ Quote Recursively Definition TT := T.
 
 Unset Strict Unquote Universe Mode.
 Make Definition t := (tSort ([(Level.Level "Top.20000", false)])).
-Make Definition t' := (tSort ([(Level.Level "Top.20000", false); (Level.Level "Top.20001", true)])).
+Make Definition t' := (tSort ([])).
 Make Definition myProp := (tSort [(Level.lProp, false)]).
 Make Definition myProp' := (tSort Universe.type0m).
-Make Definition mySucProp := (tSort [(Level.lProp, true)]).
 Make Definition mySet := (tSort [(Level.lSet, false)]).
 
 (** Cofixpoints *)

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -68,10 +68,9 @@ Quote Definition add'_syntax := Eval compute in add'.
 Make Definition zero_from_syntax := (Ast.tConstruct (mkInd "Coq.Init.Datatypes.nat" 0) 0 []).
 
 (* the function unquote_kn in reify.ml4 is not yet implemented *)
-Make Definition add_from_syntax := ltac:(let t:= eval compute in add_syntax in exact t).
+Make Definition add_from_syntax := add_syntax.
 
-Make Definition eo_from_syntax :=
-ltac:(let t:= eval compute in eo_syntax in exact t).
+Make Definition eo_from_syntax := eo_syntax.
 Print eo_from_syntax.
 
 Make Definition two_from_syntax := (Ast.tApp (Ast.tConstruct (BasicAst.mkInd "Coq.Init.Datatypes.nat" 0) 1 nil)
@@ -82,7 +81,7 @@ Quote Recursively Definition plus_synax := plus.
 
 Quote Recursively Definition mult_syntax := mult.
 
-Make Definition d''_from_syntax := ltac:(let t:= eval compute in d'' in exact t).
+Make Definition d''_from_syntax := d''.
 
 
 (** Primitive Projections. *)
@@ -227,7 +226,6 @@ Next Obligation.
   exact 3.
 Defined.
 Print foo5.
-Fail Definition tttt : _ := _.
 
 
 Run TemplateProgram (t <- tmLemma "foo44" nat ;;
@@ -302,23 +300,12 @@ Polymorphic Definition Funtp2@{i j}
    (A: Type@{i}) (B: Type@{j}) := A->B.
 (* Run TemplateProgram (printConstant "Top.demo.Funtp2"). *) (* TODOO *)
 
-
-Definition tmDefinition' : ident -> forall {A}, A -> TemplateMonad unit
-  := fun id A t => tmDefinition id t ;; tmReturn tt.
-
-(** A bit less efficient, but does the same job as tmMkDefinition *)
-Definition tmMkDefinition' : ident -> term -> TemplateMonad unit
-  := fun id t => x <- tmUnquote t ;;
-              x' <- tmEval all (my_projT2 x) ;;
-              tmDefinition' id x'.
-
-Run TemplateProgram (tmMkDefinition' "foo" add_syntax).
-Run TemplateProgram (tmEval all add_syntax >>= tmMkDefinition "foo1").
+Run TemplateProgram (tmEval cbn add_syntax >>= tmMkDefinition "foo1").
 
 Run TemplateProgram ((tmFreshName "foo") >>= tmPrint).
 Run TemplateProgram (tmAxiom "foo0" (nat -> nat) >>= tmPrint).
 Run TemplateProgram (tmAxiom "foo0'" (nat -> nat) >>=
-                     fun t => tmDefinition' "foo0''" t).
+                     fun t => tmDefinition "foo0''" t).
 Run TemplateProgram (tmFreshName "foo" >>= tmPrint).
 
 Run TemplateProgram (tmBind (tmAbout "foo") tmPrint).
@@ -364,7 +351,7 @@ Unset Strict Unquote Universe Mode.
 Make Definition t := (tSort ([(Level.Level "Top.20000", false)])).
 Make Definition t' := (tSort ([(Level.Level "Top.20000", false); (Level.Level "Top.20001", true)])).
 Make Definition myProp := (tSort [(Level.lProp, false)]).
-Make Definition myProp' := Eval compute in (tSort Universe.type0m).
+Make Definition myProp' := (tSort Universe.type0m).
 Make Definition mySucProp := (tSort [(Level.lProp, true)]).
 Make Definition mySet := (tSort [(Level.lSet, false)]).
 
@@ -376,7 +363,7 @@ CoFixpoint ones : streamn := scons 1 ones.
 
 Quote Definition ones_syntax := Eval compute in ones.
 
-Make Definition ones' := Eval compute in ones_syntax.
+Make Definition ones' := ones_syntax.
 
 Check eq_refl : ones = ones'.
 

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -16,7 +16,6 @@ Monomorphic Definition T := Type.
 Unset Strict Unquote Universe Mode.
 Make Definition t2 := (tSort []).
 Make Definition t3 := (tSort [(Level.Level "Top.400", false)]).
-Make Definition t4 := (tSort [(Level.Level "Top.2", false); (Level.Level "Top.2", true); (Level.Level "Top.200", false)]).
 
 
 Monomorphic Universe i j.
@@ -120,7 +119,7 @@ Fail Make Inductive {|
 
 Definition f@{i j k} := fun (E:Type@{i}) => Type@{max(i,j)}.
 Quote Definition qf := Eval cbv in f.
-Make Definition uqf := Eval cbv in qf.
+Make Definition uqf := qf.
 
 
 Inductive foo (A : Type) : Type :=
@@ -200,7 +199,7 @@ Unset Printing Universes.
 Quote Definition qtest := Eval compute in (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
 Print qtest.
 
-Make Definition bla := Eval compute in qtest.
+Make Definition bla := qtest.
 Unset Strict Unquote Universe Mode.
 Make Definition bla' := (tLambda (nNamed "T") (tSort ((Level.Level "Top.2", false) :: nil)%list) (tLambda (nNamed "T2") (tSort ((Level.Level "Top.1", false) :: nil)%list) (tProd nAnon (tRel 1) (tRel 1)))).
 
@@ -229,7 +228,7 @@ Compute (@t Type@{i} Type@{j}).
 Quote Definition qt := Eval compute in t.
 Print qt.
 
-Make Definition t' := Eval compute in qt.
+Make Definition t' := qt.
 
 Polymorphic Definition Funtp@{i} (A B: Type@{i}) := A->B.
 
@@ -237,7 +236,6 @@ Polymorphic Definition F@{i} := Type@{i}.
 
 Quote Definition qT := Eval compute in F.
 Require Import List. Import ListNotations.
-Make Definition T'2 := (tSort [(Level.Var 1, false)]).
 
 Quote Recursively Definition qT' := F.
 


### PR DESCRIPTION
This is less efficient but remove a bit of code duplication and we understand better the behavior of commands.

For instance `Make Definition` is now defined as a call to:
```
Definition tmMkDefinition id (tm : term) : TemplateMonad unit
  := tmBind (tmUnquote tm)
            (fun t' => tmBind (tmEval all (my_projT2 t'))
            (fun t'' => tmBind (tmDefinition id t'')
            (fun _ => tmReturn tt))).
```
(As a nice consequence on this particular command, we don't need anyome to do the `Eval compute in` before.)

Two questions:

1. To do this I broke the abstraction in `template_monad.ml`. @gmalecha Are you ok with that?

2. `tmLemma` was defined as `tmLemmaRed (Some hnf)`. It seems more natural to me to define it as `tmLemmaRed None`. Are you ok with this change?

Any review welcome.