### PR TITLE
Fix cofix unfolding which was swapping return branch and scrutinee

### DIFF
--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -1177,16 +1177,34 @@ Section ParallelReduction.
   Lemma red1_pred1 Γ : forall M N, red1 Σ Γ M N -> pred1 Γ Γ M N.
   Proof with eauto with pcuic.
     induction 1 using red1_ind_all; intros; eauto with pcuic;
-      try constructor; intuition auto with pcuic.
-    (* FIXNE cofix rule in red1 *) admit.
-    admit.
-
-    (* FIXME red1 allows conversion with differently annotated branches *)
-    admit.
-  (*   (* TODO update red1 to keep extra info equalities (on_Trel_eq) *) *)
-    eapply OnOne2_All2...
-    (* FIXME red1 converts in the wrong contexts, fixpoints and cofixpoints *)
-    all:admit.
+      try solve [ constructor ; intuition auto with pcuic ].
+    - eapply pred_cofix_case ; intuition auto with pcuic ...
+      + admit.
+      + admit.
+    - eapply pred_cofix_proj ; intuition auto with pcuic ...
+      + admit.
+      + admit.
+    - constructor ; intuition auto with pcuic ...
+      (* eapply OnOne2_All2 ... intros x y X0. *)
+      admit.
+    - constructor ; intuition auto with pcuic ...
+      eapply OnOne2_All2 ...
+    - constructor ; intuition auto with pcuic ...
+      + admit.
+      + (* eapply OnOne2_All2 ... *)
+        admit.
+    - constructor ; intuition auto with pcuic ...
+      + admit.
+      + (* eapply OnOne2_All2 ... *)
+        admit.
+    - constructor ; intuition auto with pcuic ...
+      + admit.
+      + (* eapply OnOne2_All2 ... *)
+        admit.
+    - constructor ; intuition auto with pcuic ...
+      + admit.
+      + (* eapply OnOne2_All2 ... *)
+        admit.
   Admitted.
 
 End ParallelReduction.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -198,7 +198,7 @@ Inductive red1 (Σ : global_declarations) (Γ : context) : term -> term -> Type 
 | red_cofix_case ip p mfix idx args narg fn brs :
     unfold_cofix mfix idx = Some (narg, fn) ->
     red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
-         (tCase ip (mkApps fn args) p brs)
+         (tCase ip p (mkApps fn args) brs)
 
 (** CoFix-proj unfolding *)
 | red_cofix_proj p mfix idx args narg fn :

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -288,7 +288,7 @@ Lemma red1_ind_all :
        (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
           (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
         unfold_cofix mfix idx = Some (narg, fn) ->
-        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip (mkApps fn args) p brs)) ->
+        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
 
        (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
           (narg : nat) (fn : term),

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -252,7 +252,7 @@ Lemma red1_ind_all :
        (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
           (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
         unfold_cofix mfix idx = Some (narg, fn) ->
-        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip (mkApps fn args) p brs)) ->
+        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
        (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
           (narg : nat) (fn : term),
         unfold_cofix mfix idx = Some (narg, fn) -> P Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -175,7 +175,7 @@ Inductive red1 (Σ : global_declarations) (Γ : context) : term -> term -> Type 
 | red_cofix_case ip p mfix idx args narg fn brs :
     unfold_cofix mfix idx = Some (narg, fn) ->
     red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
-         (tCase ip (mkApps fn args) p brs)
+         (tCase ip p (mkApps fn args) brs)
 
 (** CoFix-proj unfolding *)
 | red_cofix_proj p mfix idx args narg fn :


### PR DESCRIPTION
I made the change in both TemplateCoq and PCUIC.
I don't if it had been caught before already.