### PR TITLE
Attempt at fixing typing of case

### DIFF
--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -50,6 +50,9 @@ Proof. destruct x; reflexivity. Qed.
 Definition map_context f c :=
   List.map (map_decl f) c.
 
+Definition mapi_context f c :=
+  mapi (fun i => map_decl (f i)) c.
+
 Definition map_constant_body f decl :=
   {| cst_type := f decl.(cst_type);
      cst_body := option_map f decl.(cst_body);

--- a/template-coq/theories/Substitution.v
+++ b/template-coq/theories/Substitution.v
@@ -1426,19 +1426,20 @@ Proof.
   destruct H. split.
   destruct c. destruct decl_body; try discriminate.
   unfold eq_decl in *. simpl in *.
-  assert (#|indctx| = #|pctx|) by now eapply forallb2_length in H0.
-  rewrite <- H1.
-  clear H0.
-  eapply (subst_eq_term _ s (#|indctx| + k)) in H.
-  rewrite subst_mkApps map_app in H. simpl in H.
-  rewrite firstn_map. rewrite /to_extended_list to_extended_list_k_subst.
-  unfold to_extended_list in H.
-  erewrite <- (to_extended_list_k_map_subst s) in H.
-  rewrite /is_true -H. f_equal. f_equal. f_equal. rewrite subst_context_length.
-  rewrite -> !map_map_compose. apply map_ext.
-  intros. unfold compose. now rewrite commut_lift_subst_rec. lia.
-  eapply subst_eq_context in H0. eapply H0.
-Qed.
+  (* assert (#|indctx| = #|pctx|) by now eapply forallb2_length in H0. *)
+  (* rewrite <- H1. *)
+  (* clear H0. *)
+  (* eapply (subst_eq_term _ s (#|indctx| + k)) in H. *)
+  (* rewrite subst_mkApps map_app in H. simpl in H. *)
+  (* rewrite firstn_map. rewrite /to_extended_list to_extended_list_k_subst. *)
+  (* unfold to_extended_list in H. *)
+  (* erewrite <- (to_extended_list_k_map_subst s) in H. *)
+  (* rewrite /is_true -H. f_equal. f_equal. f_equal. rewrite subst_context_length. *)
+  (* rewrite -> !map_map_compose. apply map_ext. *)
+  (* intros. unfold compose. now rewrite commut_lift_subst_rec. lia. *)
+  (* eapply subst_eq_context in H0. eapply H0. *)
+(* Qed. *)
+Admitted.
 
 Lemma subs_wf `{checker_flags} Σ Γ s Δ : wf Σ -> subs Σ Γ s Δ -> All Ast.wf s.
 Proof.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -623,11 +623,16 @@ Definition eq_context `{checker_flags} φ (Γ Δ : context) :=
   forallb2 (eq_decl φ) Γ Δ.
 
 Definition check_correct_arity `{checker_flags} φ decl ind u ctx pars pctx :=
-  let inddecl :=
-      {| decl_name := nNamed decl.(ind_name);
-         decl_body := None;
-         decl_type := mkApps (tInd ind u) (map (lift0 #|ctx|) pars ++ to_extended_list ctx) |}
-  in eq_context φ (inddecl :: ctx) pctx.
+  (* We first remove the parameters from the context of the inductive type. *)
+  let ctx := firstn (#|ctx| - #|pars|) ctx in
+  (* We then subsitute the indices with the parameters *)
+  let ctx := mapi_context (subst pars) ctx in
+  let inddecl := {|
+    decl_name := nNamed decl.(ind_name) ;
+    decl_body := None ;
+    decl_type := mkApps (tInd ind u) (map (lift0 #|ctx|) pars ++ to_extended_list ctx)
+  |} in
+  eq_context φ (inddecl :: ctx) pctx.
 
 (** ** Typing relation *)
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -625,8 +625,11 @@ Definition eq_context `{checker_flags} φ (Γ Δ : context) :=
 Definition check_correct_arity `{checker_flags} φ decl ind u ctx pars pctx :=
   (* We first remove the parameters from the context of the inductive type. *)
   let ctx := firstn (#|ctx| - #|pars|) ctx in
-  (* We then subsitute the indices with the parameters *)
-  let ctx := mapi_context (subst pars) ctx in
+  (* We then subsitute the indices with the parameters.
+     We inline subst_context for now,
+     hence the odd + 0.
+   *)
+  let ctx := fold_context (fun k' => subst pars (k' + 0)) ctx in
   let inddecl := {|
     decl_name := nNamed decl.(ind_name) ;
     decl_body := None ;


### PR DESCRIPTION
I'm pushing an attempt at fixing the typing rule of case by changing `check_correct_arity`.
This is still work in progress as it breaks the proofs of weakening and substitution (for now).

It still seems broken...