### PR TITLE
Nameless terms and erasure

### DIFF
--- a/pcuic/_CoqProject
+++ b/pcuic/_CoqProject
@@ -8,6 +8,7 @@ theories/PCUICInduction.v
 theories/PCUICLiftSubst.v
 theories/PCUICUnivSubst.v
 theories/PCUICTyping.v
+theories/PCUICNameless.v
 theories/PCUICWeakeningEnv.v
 theories/PCUICClosed.v
 theories/PCUICWeakening.v

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -47,7 +47,7 @@ Proof.
   induction X. apply cumul_refl'.
   econstructor 3; eauto.
 Qed.
-  
+
 
 Lemma eq_universe_refl φ s : eq_universe φ s s.
 Proof.
@@ -75,10 +75,12 @@ Proof.
   induction t using term_forall_list_ind; simpl;
     try constructor; try apply Forall_Forall2, All_Forall; try easy;
       try now apply Forall_All, Forall_True.
-  destruct p. constructor; try assumption.
-  apply Forall_Forall2, All_Forall. assumption.
-  eapply All_impl. eassumption. now intros x [? ?]. 
-  eapply All_impl. eassumption. now intros x [? ?]. 
+  - destruct p. constructor; try assumption.
+    apply Forall_Forall2, All_Forall.
+    eapply All_impl ; try eassumption.
+    intros. split ; auto.
+  - eapply All_impl. eassumption. now intros x [? ?].
+  - eapply All_impl. eassumption. now intros x [? ?].
 Qed.
 
 Lemma eq_term_refl `{checker_flags} φ t : eq_term φ t t.
@@ -117,11 +119,13 @@ Proof.
   now apply eq_universe'_leq_universe'.
   all: try (apply Forall_True, eq_universe'_leq_universe').
   eapply Forall_impl. eapply All_Forall. eassumption.
-  intros x HH y; apply HH.
+  intros x HH y [? ?]. split ; auto. apply HH. assumption.
   eapply Forall_impl. eapply All_Forall. eassumption.
-  cbn. intros x [HH HH'] y [? ?]. split; [now apply HH|now apply HH'].
+  cbn. intros x [HH HH'] y [? [? ?]].
+  repeat split ; [now apply HH|now apply HH' | assumption].
   eapply Forall_impl. eapply All_Forall. eassumption.
-  cbn. intros x [HH HH'] y [? ?]. split; [now apply HH|now apply HH'].
+  cbn. intros x [HH HH'] y [? [? ?]].
+  repeat split; [now apply HH|now apply HH'|assumption].
 Qed.
 
 Lemma eq_term_App `{checker_flags} φ f f' :

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -53,12 +53,113 @@ Fixpoint nl (t : term) : term :=
   | tCoFix mfix idx => tCoFix mfix idx
   end.
 
-Conjecture nameless_eq_term_spec :
+Derive Signature for eq_term_upto_univ.
+Derive NoConfusion NoConfusionHom for term.
+
+Ltac destruct_one_andb :=
+  lazymatch goal with
+  | h : is_true (_ && _) |- _ =>
+    apply andP in h ; destruct h as [? ?]
+  end.
+
+Ltac destruct_andb :=
+  repeat destruct_one_andb.
+
+Local Ltac anonify :=
+  repeat lazymatch goal with
+  | h : is_true (anon ?na) |- _ =>
+    destruct na ; [clear h | discriminate h]
+  end.
+
+Local Ltac ih :=
+  lazymatch goal with
+  | ih : forall v : term, _ -> _ -> eq_term _ _ _ -> ?u = _
+    |- ?u = ?v =>
+    eapply ih ; assumption
+  end.
+
+Lemma nameless_eq_term_spec :
   forall `{checker_flags} φ u v,
     nameless u ->
     nameless v ->
     eq_term φ u v ->
     u = v.
+Proof.
+  intros flags φ u v hu hv eq.
+  revert v hu hv eq.
+  induction u using term_forall_list_ind ; intros v hu hv eq.
+  all: dependent destruction eq.
+  all: try reflexivity.
+  all: try solve [ cbn in hu, hv ; destruct_andb ; anonify ; f_equal ; ih ].
+  - f_equal. cbn in hu, hv.
+    revert args' hu hv H0. induction l ; intros args' hu hv h.
+    + destruct args' ; try solve [ inversion h ].
+      reflexivity.
+    + destruct args' ; try solve [ inversion h ].
+      inversion h. subst.
+      inversion H. subst.
+      cbn in hu, hv. destruct_andb.
+      f_equal.
+      * eapply H2 ; assumption.
+      * eapply IHl ; assumption.
+  - (* Problem indeed, must not be general on checker_flags
+       IDEA: Erase universes depending on the flag??
+     *)
+    give_up.
+  - cbn in hu, hv. destruct_andb.
+    anonify.
+    f_equal ; try solve [ ih ].
+    (* Universe problem again... *)
+    give_up.
+  - cbn in hu, hv. destruct_andb.
+    anonify.
+    f_equal ; try solve [ ih ].
+    (* Universe problem again... *)
+    give_up.
+  - cbn in hu, hv. destruct_andb.
+    anonify.
+    f_equal ; try solve [ ih ].
+    (* Universe problem again... *)
+    give_up.
+  - cbn in hu, hv. destruct_andb.
+    anonify.
+    f_equal ; try solve [ ih ].
+    revert brs' H4 H1 H.
+    induction l ; intros brs' h1 h2 h.
+    + destruct brs' ; try solve [ inversion h ]. reflexivity.
+    + destruct brs' ; try solve [ inversion h ].
+      inversion h. subst.
+      cbn in h1, h2. destruct_andb.
+      f_equal.
+      * destruct a, p. cbn in *.
+        (* Problem: the natural numbers aren't checked *)
+        admit.
+      * inversion X. subst.
+        eapply IHl ; assumption.
+  - cbn in hu, hv. destruct_andb.
+    anonify.
+    f_equal ; try solve [ ih ].
+    revert mfix' H.
+    induction m ; intros m' h.
+    + destruct m' ; inversion h. reflexivity.
+    + destruct m' ; inversion h. subst.
+      inversion X. subst.
+      f_equal.
+      * destruct a, d. cbn in *. destruct H2.
+        f_equal.
+        -- (* maybe should be erased *) give_up.
+        -- eapply H1 ; try assumption.
+           (* NEED Strengthen nameless to check inside mfixpoints *)
+           all: give_up.
+        -- eapply H1 ; try assumption.
+           (* NEED Strengthen nameless to check inside mfixpoints *)
+           all: give_up.
+        -- (* PROBLEM here as well *)
+           give_up.
+      * eapply IHm ; assumption.
+  - (* SAME *)
+    admit.
+Abort.
 
 Conjecture nl_spec :
   forall u, nameless (nl u).

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -140,12 +140,11 @@ Proof.
     + destruct brs' ; inversion h. reflexivity.
     + destruct brs' ; inversion h. subst.
       cbn in h1, h2. destruct_andb.
+      inversion X. subst.
       f_equal.
-      * destruct a, p. cbn in *.
-        (* Problem: the natural numbers aren't checked *)
-        admit.
-      * inversion X. subst.
-        eapply IHl ; assumption.
+      * destruct a, p. cbn in *. destruct H6. subst.
+        f_equal. eapply H11 ; assumption.
+      * eapply IHl ; assumption.
   - f_equal ; try solve [ ih ].
     revert mfix' H2 H3 H0 H1 H.
     induction m ; intros m' h1 h2 h3 h4 h.
@@ -178,7 +177,7 @@ Proof.
         -- eapply H1 ; assumption.
         -- assumption.
       * eapply IHm ; assumption.
-Abort.
+Qed.
 
 Lemma nl_spec :
   forall u, nameless (nl u).

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -213,3 +213,15 @@ Proof.
         all: try assumption.
         eapply IHm. assumption.
 Qed.
+
+Corollary eq_term_nl_eq :
+  forall `{checker_flags} u v,
+    eq_term_upto_univ eq u v ->
+    nl u = nl v.
+Proof.
+  intros flags u v h.
+  eapply nameless_eq_term_spec.
+  - eapply nl_spec.
+  - eapply nl_spec.
+  - admit.
+Admitted.

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -214,6 +214,13 @@ Proof.
         eapply IHm. assumption.
 Qed.
 
+Local Ltac ih2 :=
+  lazymatch goal with
+  | ih : forall v : term, eq_term_upto_univ _ ?u _ -> _
+    |- eq_term_upto_univ _ (nl ?u) _ =>
+    eapply ih ; assumption
+  end.
+
 Corollary eq_term_nl_eq :
   forall `{checker_flags} u v,
     eq_term_upto_univ eq u v ->
@@ -223,5 +230,41 @@ Proof.
   eapply nameless_eq_term_spec.
   - eapply nl_spec.
   - eapply nl_spec.
-  - admit.
-Admitted.
+  - revert v h.
+    induction u using term_forall_list_ind ; intros v h.
+    all: dependent destruction h.
+    all: try (simpl ; constructor ; try ih2 ; assumption).
+    + cbn. constructor.
+      eapply Forall2_map.
+      eapply Forall2_impl' ; try eassumption.
+      eapply All_Forall. assumption.
+    + cbn. constructor ; try ih2.
+      eapply Forall2_map.
+      eapply Forall2_impl' ; try eassumption.
+      clear - X. induction X.
+      * constructor.
+      * constructor ; try assumption.
+        intros [n t] [hn ht].
+        split ; try assumption.
+        eapply p. assumption.
+    + cbn. constructor ; try ih2.
+      eapply Forall2_map.
+      eapply Forall2_impl' ; try eassumption.
+      clear - X. induction X.
+      * constructor.
+      * constructor ; try assumption.
+        intros y [? [? ?]]. repeat split.
+        -- eapply p. assumption.
+        -- eapply p. assumption.
+        -- assumption.
+    + cbn. constructor ; try ih2.
+      eapply Forall2_map.
+      eapply Forall2_impl' ; try eassumption.
+      clear - X. induction X.
+      * constructor.
+      * constructor ; try assumption.
+        intros y [? [? ?]]. repeat split.
+        -- eapply p. assumption.
+        -- eapply p. assumption.
+        -- assumption.
+Qed.

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -154,14 +154,13 @@ Proof.
       inversion X. subst.
       cbn in h1, h2, h3, h4. destruct_andb.
       f_equal.
-      * destruct a, d. cbn in *. destruct H2.
+      * destruct a, d. cbn in *. destruct H2 as [? [? ?]].
         unfold test_def in H7, H. cbn in H7, H.
         destruct_andb. anonify.
         f_equal.
         -- eapply H1 ; assumption.
         -- eapply H1 ; assumption.
-        -- (* PROBLEM not checked! *)
-           give_up.
+        -- assumption.
       * eapply IHm ; assumption.
   - f_equal ; try solve [ ih ].
     revert mfix' H2 H3 H0 H1 H.
@@ -171,14 +170,13 @@ Proof.
       inversion X. subst.
       cbn in h1, h2, h3, h4. destruct_andb.
       f_equal.
-      * destruct a, d. cbn in *. destruct H2.
+      * destruct a, d. cbn in *. destruct H2 as [? [? ?]].
         unfold test_def in H7, H. cbn in H7, H.
         destruct_andb. anonify.
         f_equal.
         -- eapply H1 ; assumption.
         -- eapply H1 ; assumption.
-        -- (* PROBLEM not checked! *)
-           give_up.
+        -- assumption.
       * eapply IHm ; assumption.
 Abort.
 

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -1,0 +1,64 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
+     Classes.RelationClasses.
+From Template
+Require Import config monad_utils utils AstUtils UnivSubst.
+From PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping.
+From Equations Require Import Equations.
+Require Import Equations.Prop.DepElim.
+
+Definition anon (na : name) : bool :=
+  match na with
+  | nAnon => true
+  | nNamed s => false
+  end.
+
+Fixpoint nameless (t : term) : bool :=
+  match t with
+  | tRel n => true
+  | tVar n => true
+  | tEvar n l => forallb nameless l
+  | tSort s => true
+  | tProd na A B => anon na && nameless A && nameless B
+  | tLambda na A b => anon na && nameless A && nameless b
+  | tLetIn na b B t => anon na && nameless b && nameless B && nameless t
+  | tApp u v => nameless u && nameless v
+  | tConst c u => true
+  | tInd i u => true
+  | tConstruct i n u => true
+  | tCase indn p c brs =>
+    nameless p && nameless c && forallb (test_snd nameless) brs
+  | tProj p c => nameless c
+  | tFix mfix idx => true
+  | tCoFix mfix idx => true
+  end.
+
+Fixpoint nl (t : term) : term :=
+  match t with
+  | tRel n => tRel n
+  | tVar n => tVar n
+  | tEvar n l => tEvar n (map nl l)
+  | tSort s => tSort s
+  | tProd na A B => tProd nAnon (nl A) (nl B)
+  | tLambda na A b => tLambda nAnon (nl A) (nl b)
+  | tLetIn na b B t => tLetIn nAnon (nl b) (nl B) (nl t)
+  | tApp u v => tApp (nl u) (nl v)
+  | tConst c u => tConst c u
+  | tInd i u => tInd i u
+  | tConstruct i n u => tConstruct i n u
+  | tCase indn p c brs => tCase indn (nl p) (nl c) (map (on_snd nl )brs)
+  | tProj p c => tProj p (nl c)
+  | tFix mfix idx => tFix mfix idx
+  | tCoFix mfix idx => tCoFix mfix idx
+  end.
+
+Conjecture nameless_eq_term_spec :
+  forall `{checker_flags} φ u v,
+    nameless u ->
+    nameless v ->
+    eq_term φ u v ->
+    u = v.
+
+Conjecture nl_spec :
+  forall u, nameless (nl u).

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -186,5 +186,37 @@ Proof.
       * eapply IHm ; assumption.
 Abort.
 
-Conjecture nl_spec :
+Lemma nl_spec :
   forall u, nameless (nl u).
+Proof.
+  intros u. induction u using term_forall_list_ind.
+  all: try reflexivity.
+  all: try (simpl ; repeat (eapply andb_true_intro ; split) ; assumption).
+  - cbn. eapply All_forallb. eapply All_map. assumption.
+  - simpl ; repeat (eapply andb_true_intro ; split) ; try assumption.
+    induction l.
+    + reflexivity.
+    + cbn. inversion X. subst.
+      repeat (eapply andb_true_intro ; split) ; try assumption.
+      eapply IHl. assumption.
+  - simpl ; repeat (eapply andb_true_intro ; split) ; try assumption.
+    + induction m.
+      * reflexivity.
+      * cbn. eapply IHm. inversion X. subst. assumption.
+    + induction m.
+      * reflexivity.
+      * cbn. inversion X. subst. destruct H1.
+        repeat (eapply andb_true_intro ; split).
+        all: try assumption.
+        eapply IHm. assumption.
+  - simpl ; repeat (eapply andb_true_intro ; split) ; try assumption.
+    + induction m.
+      * reflexivity.
+      * cbn. eapply IHm. inversion X. subst. assumption.
+    + induction m.
+      * reflexivity.
+      * cbn. inversion X. subst. destruct H1.
+        repeat (eapply andb_true_intro ; split).
+        all: try assumption.
+        eapply IHm. assumption.
+Qed.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1328,7 +1328,7 @@ Proof.
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eapply All_Forall. eassumption.
-    cbn. intros x HH y HH'; now apply HH.
+    cbn. intros x HH y [? HH']. split ; [assumption | now apply HH].
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eapply All_Forall. eassumption.
@@ -1357,7 +1357,7 @@ Proof.
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eapply All_Forall. eassumption.
-    cbn. intros x HH y HH'; now apply HH.
+    cbn. intros x HH y [? HH']. split ; [assumption | now apply HH].
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eapply All_Forall. eassumption.
@@ -1407,10 +1407,10 @@ Proof.
     assert (XX : subst s (#|indctx| + k) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|subst_context s k indctx|) (firstn npar (map (subst s k) args)) ++ to_extended_list (subst_context s k indctx)) );
       [|now rewrite XX in H0].
     clear H0.
-    rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app. 
+    rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app.
     rewrite -> firstn_map.
     rewrite !map_map_compose. cbn. f_equal.
-    + eapply map_ext. 
+    + eapply map_ext.
       intros. unfold compose. rewrite commut_lift_subst_rec. lia.
       rewrite subst_context_length. f_equal. lia.
     + rewrite /to_extended_list to_extended_list_k_subst.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -429,21 +429,78 @@ Fixpoint subst_app (t : term) (us : list term) : term :=
   We shouldn't look at printing annotations *)
 
 Inductive eq_term_upto_univ (R : universe -> universe -> Prop) : term -> term -> Prop :=
-| eq_Rel n  : eq_term_upto_univ R (tRel n) (tRel n)
-| eq_Evar e args args' : Forall2 (eq_term_upto_univ R) args args' -> eq_term_upto_univ R (tEvar e args) (tEvar e args')
-| eq_Var id : eq_term_upto_univ R (tVar id) (tVar id)
-| eq_Sort s s' : R s s' -> eq_term_upto_univ R (tSort s) (tSort s')
-| eq_App t t' u u' : eq_term_upto_univ R t t' -> eq_term_upto_univ R u u' -> eq_term_upto_univ R (tApp t u) (tApp t' u')
-| eq_Const c u u' : Forall2 R (List.map Universe.make u) (List.map Universe.make u') -> eq_term_upto_univ R (tConst c u) (tConst c u')
-| eq_Ind i u u' : Forall2 R (List.map Universe.make u) (List.map Universe.make u') -> eq_term_upto_univ R (tInd i u) (tInd i u')
-| eq_Construct i k u u' : Forall2 R (List.map Universe.make u) (List.map Universe.make u') -> eq_term_upto_univ R (tConstruct i k u) (tConstruct i k u')
-| eq_Lambda na na' ty ty' t t' : eq_term_upto_univ R ty ty' -> eq_term_upto_univ R t t' -> eq_term_upto_univ R (tLambda na ty t) (tLambda na' ty' t')
-| eq_Prod na na' a a' b b' : eq_term_upto_univ R a a' -> eq_term_upto_univ R b b' -> eq_term_upto_univ R (tProd na a b) (tProd na' a' b')
-| eq_LetIn na na' ty ty' t t' u u' : eq_term_upto_univ R ty ty' -> eq_term_upto_univ R t t' -> eq_term_upto_univ R u u' -> eq_term_upto_univ R (tLetIn na ty t u) (tLetIn na' ty' t' u')
-| eq_Case ind par p p' c c' brs brs' : eq_term_upto_univ R p p' -> eq_term_upto_univ R c c' -> Forall2 (fun x y => eq_term_upto_univ R (snd x) (snd y)) brs brs' -> eq_term_upto_univ R (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
-| eq_Proj p c c' : eq_term_upto_univ R c c' -> eq_term_upto_univ R (tProj p c) (tProj p c')
-| eq_Fix mfix mfix' idx : Forall2 (fun x y => eq_term_upto_univ R x.(dtype) y.(dtype) /\ eq_term_upto_univ R x.(dbody) y.(dbody)) mfix mfix' -> eq_term_upto_univ R (tFix mfix idx) (tFix mfix' idx)
-| eq_CoFix mfix mfix' idx : Forall2 (fun x y => eq_term_upto_univ R x.(dtype) y.(dtype) /\ eq_term_upto_univ R x.(dbody) y.(dbody)) mfix mfix' -> eq_term_upto_univ R (tCoFix mfix idx) (tCoFix mfix' idx).
+| eq_Rel n  :
+    eq_term_upto_univ R (tRel n) (tRel n)
+
+| eq_Evar e args args' :
+    Forall2 (eq_term_upto_univ R) args args' ->
+    eq_term_upto_univ R (tEvar e args) (tEvar e args')
+
+| eq_Var id :
+    eq_term_upto_univ R (tVar id) (tVar id)
+
+| eq_Sort s s' :
+    R s s' ->
+    eq_term_upto_univ R (tSort s) (tSort s')
+
+| eq_App t t' u u' :
+    eq_term_upto_univ R t t' ->
+    eq_term_upto_univ R u u' ->
+    eq_term_upto_univ R (tApp t u) (tApp t' u')
+
+| eq_Const c u u' :
+    Forall2 R (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ R (tConst c u) (tConst c u')
+
+| eq_Ind i u u' :
+    Forall2 R (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ R (tInd i u) (tInd i u')
+
+| eq_Construct i k u u' :
+    Forall2 R (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ R (tConstruct i k u) (tConstruct i k u')
+
+| eq_Lambda na na' ty ty' t t' :
+    eq_term_upto_univ R ty ty' ->
+    eq_term_upto_univ R t t' ->
+    eq_term_upto_univ R (tLambda na ty t) (tLambda na' ty' t')
+
+| eq_Prod na na' a a' b b' :
+    eq_term_upto_univ R a a' ->
+    eq_term_upto_univ R b b' ->
+    eq_term_upto_univ R (tProd na a b) (tProd na' a' b')
+
+| eq_LetIn na na' ty ty' t t' u u' :
+    eq_term_upto_univ R ty ty' ->
+    eq_term_upto_univ R t t' ->
+    eq_term_upto_univ R u u' ->
+    eq_term_upto_univ R (tLetIn na ty t u) (tLetIn na' ty' t' u')
+
+| eq_Case ind par p p' c c' brs brs' :
+    eq_term_upto_univ R p p' ->
+    eq_term_upto_univ R c c' ->
+    Forall2 (fun x y => eq_term_upto_univ R (snd x) (snd y)) brs brs' ->
+    eq_term_upto_univ R (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
+
+| eq_Proj p c c' :
+    eq_term_upto_univ R c c' ->
+    eq_term_upto_univ R (tProj p c) (tProj p c')
+
+| eq_Fix mfix mfix' idx :
+    Forall2 (fun x y =>
+      eq_term_upto_univ R x.(dtype) y.(dtype)
+      /\ eq_term_upto_univ R x.(dbody) y.(dbody)
+      /\ x.(rarg) = y.(rarg)
+    ) mfix mfix' ->
+    eq_term_upto_univ R (tFix mfix idx) (tFix mfix' idx)
+
+| eq_CoFix mfix mfix' idx :
+    Forall2 (fun x y =>
+      eq_term_upto_univ R x.(dtype) y.(dtype)
+      /\ eq_term_upto_univ R x.(dbody) y.(dbody)
+      /\ x.(rarg) = y.(rarg)
+    ) mfix mfix' ->
+    eq_term_upto_univ R (tCoFix mfix idx) (tCoFix mfix' idx).
 
 Definition eq_term `{checker_flags} φ := eq_term_upto_univ (eq_universe' φ).
 

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -479,7 +479,10 @@ Inductive eq_term_upto_univ (R : universe -> universe -> Prop) : term -> term ->
 | eq_Case ind par p p' c c' brs brs' :
     eq_term_upto_univ R p p' ->
     eq_term_upto_univ R c c' ->
-    Forall2 (fun x y => eq_term_upto_univ R (snd x) (snd y)) brs brs' ->
+    Forall2 (fun x y =>
+      fst x = fst y /\
+      eq_term_upto_univ R (snd x) (snd y)
+    ) brs brs' ->
     eq_term_upto_univ R (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
 
 | eq_Proj p c c' :
@@ -488,17 +491,17 @@ Inductive eq_term_upto_univ (R : universe -> universe -> Prop) : term -> term ->
 
 | eq_Fix mfix mfix' idx :
     Forall2 (fun x y =>
-      eq_term_upto_univ R x.(dtype) y.(dtype)
-      /\ eq_term_upto_univ R x.(dbody) y.(dbody)
-      /\ x.(rarg) = y.(rarg)
+      eq_term_upto_univ R x.(dtype) y.(dtype) /\
+      eq_term_upto_univ R x.(dbody) y.(dbody) /\
+      x.(rarg) = y.(rarg)
     ) mfix mfix' ->
     eq_term_upto_univ R (tFix mfix idx) (tFix mfix' idx)
 
 | eq_CoFix mfix mfix' idx :
     Forall2 (fun x y =>
-      eq_term_upto_univ R x.(dtype) y.(dtype)
-      /\ eq_term_upto_univ R x.(dbody) y.(dbody)
-      /\ x.(rarg) = y.(rarg)
+      eq_term_upto_univ R x.(dtype) y.(dtype) /\
+      eq_term_upto_univ R x.(dbody) y.(dbody) /\
+      x.(rarg) = y.(rarg)
     ) mfix mfix' ->
     eq_term_upto_univ R (tCoFix mfix idx) (tCoFix mfix' idx).
 

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -771,7 +771,8 @@ Proof.
   - constructor; try easy. clear -X H3.
     assert (XX:forall k k', Forall2
                          (fun x y  => eq_term_upto_univ R (dtype x) (dtype y) /\
-                                   eq_term_upto_univ R (dbody x) (dbody y))
+                                   eq_term_upto_univ R (dbody x) (dbody y) /\
+                                   rarg x = rarg y)
                          (map (map_def (lift n k) (lift n (#|m| + k'))) m)
                          (map (map_def (lift n k) (lift n (#|mfix'| + k'))) mfix'));
       [|now apply XX]. clear k.
@@ -786,7 +787,8 @@ Proof.
   - constructor; try easy. clear -X H3.
     assert (XX:forall k k', Forall2
                          (fun x y  => eq_term_upto_univ R (dtype x) (dtype y) /\
-                                   eq_term_upto_univ R (dbody x) (dbody y))
+                                   eq_term_upto_univ R (dbody x) (dbody y) /\
+                                   rarg x = rarg y)
                          (map (map_def (lift n k) (lift n (#|m| + k'))) m)
                          (map (map_def (lift n k) (lift n (#|mfix'| + k'))) mfix'));
       [|now apply XX]. clear k.
@@ -799,7 +801,7 @@ Proof.
       unfold tFixProp in IHm. cbn.
       rewrite !plus_n_Sm. now apply IHm.
 Qed.
-      
+
 
 Lemma lift_eq_term `{checker_flags} ϕ n k T U :
   eq_term ϕ T U -> eq_term ϕ (lift n k T) (lift n k U).
@@ -843,9 +845,9 @@ Proof.
   - constructor.
   - inversion H0.
   - inversion H0.
-  - inversion H0; subst. constructor. 
+  - inversion H0; subst. constructor.
     + apply Forall2_length in H6. rewrite H6.
-      now apply lift_eq_decl. 
+      now apply lift_eq_decl.
     + now apply IHl.
 Qed.
 
@@ -868,7 +870,7 @@ Proof.
     assert (XX : lift #|Γ''| (#|indctx| + #|Γ'|) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|lift_context #|Γ''| #|Γ'| indctx|) (firstn npar (map (lift #|Γ''| #|Γ'|) args)) ++ to_extended_list (lift_context #|Γ''| #|Γ'| indctx)));
       [|now rewrite XX in H2].
 
-    rewrite -> lift_mkApps, map_app. 
+    rewrite -> lift_mkApps, map_app.
     rewrite -> firstn_map. rewrite -> to_extended_list_lift.
     erewrite <- (to_extended_list_map_lift #|Γ''|).
     rewrite -> lift_context_length.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -355,7 +355,7 @@ Lemma trans_eq_term ϕ T U :
   T.wf T -> T.wf U -> TTy.eq_term ϕ T U ->
   eq_term ϕ (trans T) (trans U).
 Proof.
-  intros HT HU H. 
+  intros HT HU H.
   revert U HU H; induction HT using Template.Induction.term_wf_forall_list_ind; intros U HU HH; inversion HH; subst; simpl; repeat constructor; unfold eq_term in *;
     inversion_clear HU; try easy.
   - eapply Forall2_map. eapply Forall2_impl.
@@ -370,7 +370,7 @@ Proof.
   - eapply Forall2_map. eapply Forall2_impl.
     eapply Forall_Forall2_and. 2: eassumption.
     eapply Forall_Forall2_and'; eassumption.
-    cbn. now intros x y [? [? ?]].
+    cbn. intros x y [? [? ?]]. split ; easy.
   - eapply Forall2_map. eapply Forall2_impl.
     eapply Forall_Forall2_and. 2: exact H.
     eapply Forall_Forall2_and. 2: exact H0.
@@ -412,7 +412,7 @@ Lemma trans_leq_term ϕ T U :
   T.wf T -> T.wf U -> TTy.leq_term ϕ T U ->
   leq_term ϕ (trans T) (trans U).
 Proof.
-  intros HT HU H. 
+  intros HT HU H.
   revert U HU H; induction HT using Template.Induction.term_wf_forall_list_ind; intros U HU HH; inversion HH; subst; simpl; repeat constructor; unfold leq_term in *;
     inversion_clear HU; try easy.
   - eapply Forall2_map. eapply Forall2_impl.

--- a/template-coq/theories/Substitution.v
+++ b/template-coq/theories/Substitution.v
@@ -1233,7 +1233,7 @@ Proof.
     rewrite -> app_context_assoc, Nat.add_0_r in *.
     auto.
 Qed.
-  
+
 
 Lemma eq_universe_refl φ s : eq_universe φ s s.
 Proof.
@@ -1261,8 +1261,13 @@ Proof.
   induction t using term_forall_list_ind; simpl;
     try constructor; try apply Forall_Forall2; try easy;
       try now apply Forall_True.
-  destruct p. constructor; try assumption.
-  apply Forall_Forall2. assumption.
+  - destruct p. constructor; try assumption.
+    apply Forall_Forall2. eapply Forall_impl ; try eassumption.
+    intros. split ; auto.
+  - eapply Forall_impl ; try eassumption.
+    intros x [? ?]. repeat split ; auto.
+  - eapply Forall_impl ; try eassumption.
+    intros x [? ?]. repeat split ; auto.
 Qed.
 
 Lemma eq_term_refl `{checker_flags} φ t : eq_term φ t t.
@@ -1294,16 +1299,18 @@ Qed.
 Lemma eq_term_leq_term `{checker_flags} φ t u : eq_term φ t u -> leq_term φ t u.
 Proof.
   induction t in u |- * using term_forall_list_ind; simpl; inversion 1;
-    subst; constructor; try (now unfold eq_term, leq_term in * ); 
+    subst; constructor; try (now unfold eq_term, leq_term in * );
   try eapply Forall2_impl'; try easy.
   now apply eq_universe'_leq_universe'.
   all: try (apply Forall_True, eq_universe'_leq_universe').
-  eapply Forall_impl. exact H0. 
-  intros x HH y; apply HH.
-  eapply Forall_impl. exact H0. 
-  cbn. intros x [HH HH'] y [? ?]. split; [now apply HH|now apply HH'].
-  eapply Forall_impl. exact H0. 
-  cbn. intros x [HH HH'] y [? ?]. split; [now apply HH|now apply HH'].
+  eapply Forall_impl. exact H0.
+  intros x HH y [? ?]. split ; auto. apply HH. assumption.
+  eapply Forall_impl. exact H0.
+  cbn. intros x [HH HH'] y [? [? ?]].
+  repeat split; [now apply HH|now apply HH'|assumption].
+  eapply Forall_impl. exact H0.
+  cbn. intros x [HH HH'] y [? [? ?]].
+  repeat split; [now apply HH|now apply HH'|assumption].
 Qed.
 
 
@@ -1389,7 +1396,7 @@ Proof.
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eassumption.
-    cbn. intros x HH y HH'; now apply HH.
+    cbn. intros x HH y [? HH']. split ; auto.
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eassumption.
@@ -1423,7 +1430,7 @@ Proof.
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eassumption.
-    cbn. intros x HH y HH'; now apply HH.
+    cbn. intros x HH y [? HH']. split ; auto.
   + eapply Forall2_map.
     eapply Forall2_impl'. eassumption.
     eapply Forall_impl. eassumption.
@@ -1474,10 +1481,10 @@ Proof.
     assert (XX : subst s (#|indctx| + k) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|subst_context s k indctx|) (firstn npar (map (subst s k) args)) ++ to_extended_list (subst_context s k indctx)) );
       [|now rewrite XX in H0].
     clear H0.
-    rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app. 
+    rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app.
     rewrite -> firstn_map.
     rewrite !map_map_compose. cbn. f_equal.
-    + eapply map_ext. 
+    + eapply map_ext.
       intros. unfold compose. rewrite commut_lift_subst_rec. lia.
       rewrite subst_context_length. f_equal. lia.
     + rewrite /to_extended_list to_extended_list_k_subst.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -380,22 +380,86 @@ Inductive red Σ Γ M : term -> Type :=
 
 
 Inductive eq_term_upto_univ (R : universe -> universe -> Prop) : term -> term -> Prop :=
-| eq_Rel n  : eq_term_upto_univ R (tRel n) (tRel n)
-| eq_Evar e args args' : Forall2 (eq_term_upto_univ R) args args' -> eq_term_upto_univ R (tEvar e args) (tEvar e args')
-| eq_Var id : eq_term_upto_univ R (tVar id) (tVar id)
-| eq_Sort s s' : R s s' -> eq_term_upto_univ R (tSort s) (tSort s')
-| eq_Cast f f' k T T' : eq_term_upto_univ R f f' -> eq_term_upto_univ R T T' -> eq_term_upto_univ R (tCast f k T) (tCast f' k T')
-| eq_App t t' args args' : eq_term_upto_univ R t t' -> Forall2 (eq_term_upto_univ R) args args' -> eq_term_upto_univ R (tApp t args) (tApp t' args')
-| eq_Const c u u' : Forall2 R (List.map Universe.make u) (List.map Universe.make u') -> eq_term_upto_univ R (tConst c u) (tConst c u')
-| eq_Ind i u u' : Forall2 R (List.map Universe.make u) (List.map Universe.make u') -> eq_term_upto_univ R (tInd i u) (tInd i u')
-| eq_Construct i k u u' : Forall2 R (List.map Universe.make u) (List.map Universe.make u') -> eq_term_upto_univ R (tConstruct i k u) (tConstruct i k u')
-| eq_Lambda na na' ty ty' t t' : eq_term_upto_univ R ty ty' -> eq_term_upto_univ R t t' -> eq_term_upto_univ R (tLambda na ty t) (tLambda na' ty' t')
-| eq_Prod na na' a a' b b' : eq_term_upto_univ R a a' -> eq_term_upto_univ R b b' -> eq_term_upto_univ R (tProd na a b) (tProd na' a' b')
-| eq_LetIn na na' ty ty' t t' u u' : eq_term_upto_univ R ty ty' -> eq_term_upto_univ R t t' -> eq_term_upto_univ R u u' -> eq_term_upto_univ R (tLetIn na ty t u) (tLetIn na' ty' t' u')
-| eq_Case ind par p p' c c' brs brs' : eq_term_upto_univ R p p' -> eq_term_upto_univ R c c' -> Forall2 (fun x y => eq_term_upto_univ R (snd x) (snd y)) brs brs' -> eq_term_upto_univ R (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
-| eq_Proj p c c' : eq_term_upto_univ R c c' -> eq_term_upto_univ R (tProj p c) (tProj p c')
-| eq_Fix mfix mfix' idx : Forall2 (fun x y => eq_term_upto_univ R x.(dtype) y.(dtype) /\ eq_term_upto_univ R x.(dbody) y.(dbody)) mfix mfix' -> eq_term_upto_univ R (tFix mfix idx) (tFix mfix' idx)
-| eq_CoFix mfix mfix' idx : Forall2 (fun x y => eq_term_upto_univ R x.(dtype) y.(dtype) /\ eq_term_upto_univ R x.(dbody) y.(dbody)) mfix mfix' -> eq_term_upto_univ R (tCoFix mfix idx) (tCoFix mfix' idx).
+| eq_Rel n  :
+    eq_term_upto_univ R (tRel n) (tRel n)
+
+| eq_Evar e args args' :
+    Forall2 (eq_term_upto_univ R) args args' ->
+    eq_term_upto_univ R (tEvar e args) (tEvar e args')
+
+| eq_Var id :
+    eq_term_upto_univ R (tVar id) (tVar id)
+
+| eq_Sort s s' :
+    R s s' ->
+    eq_term_upto_univ R (tSort s) (tSort s')
+
+| eq_Cast f f' k T T' :
+    eq_term_upto_univ R f f' ->
+    eq_term_upto_univ R T T' ->
+    eq_term_upto_univ R (tCast f k T) (tCast f' k T')
+
+| eq_App t t' args args' :
+    eq_term_upto_univ R t t' ->
+    Forall2 (eq_term_upto_univ R) args args' ->
+    eq_term_upto_univ R (tApp t args) (tApp t' args')
+
+| eq_Const c u u' :
+    Forall2 R (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ R (tConst c u) (tConst c u')
+
+| eq_Ind i u u' :
+    Forall2 R (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ R (tInd i u) (tInd i u')
+
+| eq_Construct i k u u' :
+    Forall2 R (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ R (tConstruct i k u) (tConstruct i k u')
+
+| eq_Lambda na na' ty ty' t t' :
+    eq_term_upto_univ R ty ty' ->
+    eq_term_upto_univ R t t' ->
+    eq_term_upto_univ R (tLambda na ty t) (tLambda na' ty' t')
+
+| eq_Prod na na' a a' b b' :
+    eq_term_upto_univ R a a' ->
+    eq_term_upto_univ R b b' ->
+    eq_term_upto_univ R (tProd na a b) (tProd na' a' b')
+
+| eq_LetIn na na' ty ty' t t' u u' :
+    eq_term_upto_univ R ty ty' ->
+    eq_term_upto_univ R t t' ->
+    eq_term_upto_univ R u u' ->
+    eq_term_upto_univ R (tLetIn na ty t u) (tLetIn na' ty' t' u')
+
+| eq_Case ind par p p' c c' brs brs' :
+    eq_term_upto_univ R p p' ->
+    eq_term_upto_univ R c c' ->
+    Forall2 (fun x y =>
+      fst x = fst y /\
+      eq_term_upto_univ R (snd x) (snd y)
+    ) brs brs' ->
+    eq_term_upto_univ R (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
+
+| eq_Proj p c c' :
+    eq_term_upto_univ R c c' ->
+    eq_term_upto_univ R (tProj p c) (tProj p c')
+
+| eq_Fix mfix mfix' idx :
+    Forall2 (fun x y =>
+      eq_term_upto_univ R x.(dtype) y.(dtype) /\
+      eq_term_upto_univ R x.(dbody) y.(dbody) /\
+      x.(rarg) = y.(rarg)
+    ) mfix mfix' ->
+    eq_term_upto_univ R (tFix mfix idx) (tFix mfix' idx)
+
+| eq_CoFix mfix mfix' idx :
+    Forall2 (fun x y =>
+      eq_term_upto_univ R x.(dtype) y.(dtype) /\
+      eq_term_upto_univ R x.(dbody) y.(dbody) /\
+      x.(rarg) = y.(rarg)
+    ) mfix mfix' ->
+    eq_term_upto_univ R (tCoFix mfix idx) (tCoFix mfix' idx).
 
 Definition eq_term `{checker_flags} φ := eq_term_upto_univ (eq_universe' φ).
 

--- a/template-coq/theories/Weakening.v
+++ b/template-coq/theories/Weakening.v
@@ -746,7 +746,8 @@ Proof.
   - constructor; try easy. clear -H H4.
     assert (XX:forall k k', Forall2
                          (fun x y  => eq_term_upto_univ R (dtype x) (dtype y) /\
-                                   eq_term_upto_univ R (dbody x) (dbody y))
+                                   eq_term_upto_univ R (dbody x) (dbody y) /\
+                                   rarg x = rarg y)
                          (map (map_def (lift n k) (lift n (#|m| + k'))) m)
                          (map (map_def (lift n k) (lift n (#|mfix'| + k'))) mfix'));
       [|now apply XX]. clear k.
@@ -761,7 +762,8 @@ Proof.
   - constructor; try easy. clear -H H4.
     assert (XX:forall k k', Forall2
                          (fun x y  => eq_term_upto_univ R (dtype x) (dtype y) /\
-                                   eq_term_upto_univ R (dbody x) (dbody y))
+                                   eq_term_upto_univ R (dbody x) (dbody y) /\
+                                   rarg x = rarg y)
                          (map (map_def (lift n k) (lift n (#|m| + k'))) m)
                          (map (map_def (lift n k) (lift n (#|mfix'| + k'))) mfix'));
       [|now apply XX]. clear k.
@@ -774,7 +776,7 @@ Proof.
       unfold tFixProp in IHm. cbn.
       rewrite !plus_n_Sm. now apply IHm.
 Qed.
-      
+
 
 Lemma lift_eq_term `{checker_flags} ϕ n k T U :
   eq_term ϕ T U -> eq_term ϕ (lift n k T) (lift n k U).
@@ -817,9 +819,9 @@ Proof.
   - constructor.
   - inversion H0.
   - inversion H0.
-  - inversion H0; subst. constructor. 
+  - inversion H0; subst. constructor.
     + apply Forall2_length in H6. rewrite H6.
-      now apply lift_eq_decl. 
+      now apply lift_eq_decl.
     + now apply IHl.
 Qed.
 
@@ -843,7 +845,7 @@ Proof.
     assert (XX : lift #|Γ''| (#|indctx| + #|Γ'|) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|lift_context #|Γ''| #|Γ'| indctx|) (firstn npar (map (lift #|Γ''| #|Γ'|) args)) ++ to_extended_list (lift_context #|Γ''| #|Γ'| indctx)));
       [|now rewrite XX in H2].
 
-    rewrite -> lift_mkApps, map_app. 
+    rewrite -> lift_mkApps, map_app.
     rewrite -> firstn_map. rewrite -> to_extended_list_lift.
     erewrite <- (to_extended_list_map_lift #|Γ''|).
     rewrite -> lift_context_length.


### PR DESCRIPTION
This is an alternative to #136, in a much less invasive manner.
It provides a function to replace all `nNamed` with `nAnon` in terms as well as interesting properties such as the fact that being `eq_term` is the same as being equal for them.