### PR TITLE
Fix lambda n : prod n' typing rule

### DIFF
--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -803,8 +803,6 @@ Proof.
     eapply typing_wf_local. eauto. eauto. simpl. exists s; auto. reflexivity. eauto.
     simpl. unfold subst1. rewrite simpl_subst; auto. now rewrite lift0_p.
 
-  - admit. (* FIX Typing  alhpa-equiv *)
-
   - (* The interesting application case *)
     eapply type_mkApps; eauto.
     eapply typing_wf in X; eauto. destruct X.
@@ -938,4 +936,4 @@ Proof.
     apply typing_all_wf_decl in wfΓ; auto. solve_all.
     destruct x as [na [body|] ty']; simpl in *; intuition auto.
     destruct H0. auto.
-Admitted.
+Qed.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -695,10 +695,10 @@ Inductive typing `{checker_flags} (Σ : global_context) (Γ : context) : term ->
     Σ ;;; Γ ,, vass n t |- b : tSort s2 ->
     Σ ;;; Γ |- (tProd n t b) : tSort (Universe.sort_of_product s1 s2)
 
-| type_Lambda n n' t b s1 bty :
+| type_Lambda n t b s1 bty :
     Σ ;;; Γ |- t : tSort s1 ->
     Σ ;;; Γ ,, vass n t |- b : bty ->
-    Σ ;;; Γ |- (tLambda n t b) : tProd n' t bty
+    Σ ;;; Γ |- (tLambda n t b) : tProd n t bty
 
 | type_LetIn n b b_ty b' s1 b'_ty :
     Σ ;;; Γ |- b_ty : tSort s1 ->
@@ -1275,11 +1275,11 @@ Lemma typing_ind_env `{cf : checker_flags} :
         Σ ;;; Γ,, vass n t |- b : tSort s2 ->
         P Σ (Γ,, vass n t) b (tSort s2) -> P Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
 
-    (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) (n n' : name) (t b : term)
+    (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (t b : term)
             (s1 : universe) (bty : term),
         Σ ;;; Γ |- t : tSort s1 ->
         P Σ Γ t (tSort s1) ->
-        Σ ;;; Γ,, vass n t |- b : bty -> P Σ (Γ,, vass n t) b bty -> P Σ Γ (tLambda n t b) (tProd n' t bty)) ->
+        Σ ;;; Γ,, vass n t |- b : bty -> P Σ (Γ,, vass n t) b bty -> P Σ Γ (tLambda n t b) (tProd n t bty)) ->
 
     (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (b b_ty b' : term)
             (s1 : universe) (b'_ty : term),


### PR DESCRIPTION
Useless generality, the alpha-conversion is available through conversion