### PR TITLE
Update README.md for 8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,17 +177,12 @@ Requirements through opam
 The easiest way to get all is through [opam](http://opam.ocaml.org):
 
 You might want to create a "switch" (an environment of `opam` packages) for `Coq` if
-you don't have one yet. If you are using opam2 this works as follows:
+you don't have one yet. You need to use **opam 2** to obtain the right version of `Equations`.
 
     # opam switch create coq.8.8.2 4.04.1 
     # eval $(opam env)
     
-Or if you are still using opam 1:    
-    
-    # opam switch -A 4.04.1 coq.8.8.2
-    # eval `opam config env`
-    
-This creates the `coq.8.8.1` switch which initially contains only the
+This creates the `coq.8.8.2` switch which initially contains only the
 basic `OCaml` `4.04.1` compiler, and puts you in the right environment
 (check with `ocamlc -v`).
 

--- a/README.md
+++ b/README.md
@@ -166,31 +166,38 @@ Requirements
 
 To compile the library, you need:
 
-- `Coq 8.8.1`
+- `Coq 8.8.2` (older versions of `8.8` might also work)
 - `OCaml` (tested with `4.04.1`, beware that `OCaml 4.06.0` can 
-  produce linking errors on some platforms).
+  produce linking errors on some platforms)
+- [`Equations 1.2`](http://mattam82.github.io/Coq-Equations/)
 
 Requirements through opam
 -------------------------
 
-The easiest way to get both is through [opam](http://opam.ocaml.org):
+The easiest way to get all is through [opam](http://opam.ocaml.org):
 
 You might want to create a "switch" (an environment of `opam` packages) for `Coq` if
-you don't have one yet:
+you don't have one yet. If you are using opam2 this works as follows:
+
+    # opam switch create coq.8.8.2 4.04.1 
+    # eval $(opam env)
     
-    # opam switch -A 4.04.1 coq.8.8.1
+Or if you are still using opam 1:    
+    
+    # opam switch -A 4.04.1 coq.8.8.2
     # eval `opam config env`
     
 This creates the `coq.8.8.1` switch which initially contains only the
 basic `OCaml` `4.04.1` compiler, and puts you in the right environment
 (check with `ocamlc -v`).
 
-Once in the right switch, you can install `Coq` using:
+Once in the right switch, you can install `Coq` and the `Equations` package using:
     
-    # opam pin add coq 8.8.1 
+    # opam pin add coq 8.8.2
+    # opam pin add coq-equations 1.2+8.8
     
-Pinning `coq` prevents opam from trying to upgrade it afterwards, in
-this switch. If the command is successful you should have `coq`
+Pinning the packages prevents opam from trying to upgrade it afterwards, in
+this switch. If the commands are successful you should have `coq`
 available (check with `coqc -v`).
 
 Compile


### PR DESCRIPTION
- Added Equations to the requirements, which is needed for the new safe conversion. Only `1.2+8.8` seems to work, noy the betas.
- Also updated instructions to `8.8.2`, which is the newest `8.8` version
- I've added instructions for both opam2 and opam 1. This should be redundant in a while, but for now opam 1 is still in use.

Thanks to @DmxLarchey who went through installing MetaCoq and encountered all this problems.