### PR TITLE
Formalize the invariants on allowed elimination sorts of inductives i…

### DIFF
--- a/checker/Makefile
+++ b/checker/Makefile
@@ -19,7 +19,7 @@ install:
 
 .PHONY: plugin
 
-clean:
+clean: Makefile.coq
 	$(MAKE) -f Makefile.coq clean
 
 mrproper:

--- a/extraction/theories/Extract.v
+++ b/extraction/theories/Extract.v
@@ -12,12 +12,6 @@ Import MonadNotation.
 
 Existing Instance config.default_checker_flags.
 
-Definition is_prop_sort s :=
-  match Universe.level s with
-  | Some l => Level.is_prop l
-  | None => false
-  end.
-
 Section IsType.
   Context {F : Fuel}.
   Variables (Σ : global_context) (Γ : context).
@@ -39,7 +33,7 @@ Section IsType.
      if is_arity F ty then ret true
      else
        s <- type_of_as_sort Σ (type_of Σ) Γ ty ;;
-       ret (is_prop_sort s).
+       ret (Universe.is_prop s).
 End IsType.
 
 Module E := EAst.
@@ -233,7 +227,7 @@ Definition computational_ind Σ ind :=
     match List.nth_error decl.(ind_bodies) n with
     | Some body =>
       match destArity [] body.(ind_type) with
-      | Some arity => negb (is_prop_sort (snd arity))
+      | Some arity => negb (Universe.is_prop (snd arity))
       | None => false
       end
     | None => false

--- a/pcuic/theories/Extraction.v
+++ b/pcuic/theories/Extraction.v
@@ -1,4 +1,4 @@
-(** Extraction setup for the pcuic phase of template-coq.
+(** Extraction setup for the pcuic phase of MetaCoq.
 
     Any extracted code planning to link with the plugin's OCaml reifier
     should use these same directives for consistency.
@@ -38,8 +38,8 @@ From Equations Require Import Equations.
 
 (* Extraction Inline NoConfusionPackage_All_local_env_over. *)
 (* Extraction Inline NoConfusionPackage_context_decl. *)
-
-Extraction Library Classes.
+(* Extraction Library Signature. *)
+(* Extraction Library Classes. *)
 (* Extraction Library CRelationClasses. *)
 
 Extraction Library PCUICAst.

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -279,7 +279,7 @@ Proof.
   - rewrite closedn_subst_instance_constr.
     eapply declared_inductive_inv in X0; eauto.
     apply onArity in X0. repeat red in X0.
-    destruct X0 as [[s Hs] _]. rewrite -> andb_and in Hs.
+    destruct X0 as [Hisa [s Hs] _]. rewrite -> andb_and in Hs.
     intuition eauto using closed_upwards with arith.
 
   - destruct isdecl as [Hidecl Hcdecl].
@@ -310,10 +310,7 @@ Proof.
     simpl. apply closedn_mkApps_inv in H2.
     rewrite forallb_rev H1. apply H2.
     rewrite closedn_subst_instance_constr.
-    destruct isdecl as [isdecl [Hpdecl Hnpar]].
-    eapply declared_inductive_inv in isdecl; eauto.
-    apply onProjections in isdecl.
-    eapply nth_error_alli in isdecl; eauto.
+    eapply declared_projection_inv in isdecl; eauto.
     red in isdecl.
     destruct decompose_prod_assum eqn:Heq.
     destruct isdecl as [[s Hs] Hc]. simpl in *.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -21,9 +21,6 @@ Existing Instance config.default_checker_flags.
 
 Definition subst_decl s k (d : context_decl) := map_decl (subst s k) d.
 
-Definition subst_context n k (Γ : context) : context :=
-  fold_context (fun k' => subst n (k' + k)) Γ.
-
 (** Well-typed substitution into a context with *no* let-ins *)
 
 Inductive subs  Σ (Γ : context) : list term -> context -> Type :=
@@ -361,15 +358,15 @@ Proof.
   eapply subst_closedn; eauto using closed_upwards with arith wf.
 Qed.
 
-Definition subst_mutual_inductive_body n k mind m :=
-  map_mutual_inductive_body mind (fun k' => subst n (k' + k)) m.
+Definition subst_mutual_inductive_body n k m :=
+  map_mutual_inductive_body (fun k' => subst n (k' + k)) m.
 
 From Equations Require Import Equations.
 
 Lemma subst_declared_minductive  Σ cst decl n k :
   wf Σ ->
   declared_minductive (fst Σ) cst decl ->
-  subst_mutual_inductive_body n k cst decl = decl.
+  subst_mutual_inductive_body n k decl = decl.
 Proof.
   unfold declared_minductive.
   intros.
@@ -389,7 +386,7 @@ Proof.
     destruct (decompose_prod_assum [] (subst n k ind_type)) eqn:Heq'.
     destruct X0. simpl in *.
     assert (subst n k ind_type = ind_type).
-    destruct onArity as [Hisa [s Hs] Hpars].
+    destruct onArity as [s Hs].
     eapply typed_subst; eauto. simpl; lia.
     rewrite H in Heq'. rewrite Heq in Heq'. revert Heq'; intros [= <- <-].
     f_equal; auto.
@@ -401,16 +398,16 @@ Proof.
     apply on_projs in onProjections.
     apply (Alli_map_id onProjections).
     intros n1 [x p]. unfold on_projection; simpl.
-    destruct decompose_prod_assum.
-    intros [[s Hty] Hpars].
+    intros [s Hty].
     unfold on_snd; f_equal; f_equal.
-    eapply typed_subst. 3:eapply Hty. eauto. simpl. injection Heq. intros -> ->. lia.
+    eapply typed_subst. 3:eapply Hty. eauto. simpl.
+    rewrite smash_context_length context_assumptions_fold. simpl; lia.
 Qed.
 
 Lemma subst_declared_inductive  Σ ind mdecl idecl n k :
   wf Σ ->
   declared_inductive (fst Σ) mdecl ind idecl ->
-  map_one_inductive_body (inductive_mind ind) (polymorphic_instance (mdecl.(ind_universes)))
+  map_one_inductive_body (context_assumptions mdecl.(ind_params))
                          (length (arities_context mdecl.(ind_bodies)))
                          (fun k' => subst n (k' + k)) (inductive_ind ind) idecl = idecl.
 Proof.
@@ -449,9 +446,7 @@ Proof.
   destruct Σ. eapply (subst_declared_inductive _ _ _ _ n k) in Hidecl; eauto.
   unfold type_of_constructor. destruct cdecl as [[id t'] arity].
   destruct idecl; simpl in *.
-  destruct (decompose_prod_assum [] _) eqn:Heq.
-  injection Hidecl.
-  intros.
+  injection Hidecl. intros.
   pose Hcdecl as Hcdecl'.
   rewrite <- H0 in Hcdecl'.
   rewrite nth_error_map in Hcdecl'. rewrite Hcdecl in Hcdecl'.
@@ -469,20 +464,22 @@ Lemma subst_declared_projection  Σ c mdecl idecl pdecl n k :
 Proof.
   intros wfΣ Hd.
   destruct Hd as [[Hmdecl Hidecl] [Hpdecl Hnpar]].
-  eapply declared_decl_closed in Hmdecl.
+  eapply declared_decl_closed in Hmdecl; auto.
   simpl in Hmdecl.
+  pose proof (onNpars _ _ _ _ Hmdecl) as Hnpars.
   apply onInductives in Hmdecl.
   eapply nth_error_alli in Hmdecl; eauto.
   assert (Hp : ind_projs idecl <> []).
-  { apply nth_error_Some_length in Hpdecl.
-    destruct (ind_projs idecl); try congruence. simpl in *; lia. }
-  eapply onProjections, on_projs in Hmdecl; eauto.
-  eapply nth_error_alli in Hmdecl; eauto.
-  red in Hmdecl.
-  destruct decompose_prod_assum eqn:Heq.
-  case: Hmdecl => [/andb_and[Hb Ht] Hpars].
-  intuition auto. destruct pdecl as [id ty]. unfold on_snd; simpl in *.
-  f_equal. eapply subst_closedn; auto. rewrite <- Hpars. eapply closed_upwards; eauto. lia. auto.
+  { now apply nth_error_Some_non_nil in Hpdecl. }
+  pose proof (onProjections Hmdecl Hp) as onp.
+  apply on_projs in onp; eauto.
+  eapply nth_error_alli in onp; eauto.
+  hnf in onp. simpl in onp.
+  rewrite smash_context_length in onp. simpl in onp.
+  rewrite Hnpars in onp.
+  move: onp => /andb_and[Hb Ht].
+  destruct pdecl as [id ty]. unfold on_snd; simpl in *.
+  f_equal. eapply subst_closedn; auto. eapply closed_upwards; eauto. lia.
 Qed.
 
 Lemma subst_fix_context:
@@ -677,7 +674,7 @@ Proof.
   rewrite rev_map_app.
   simpl. apply Alli_app in Ha as [Hl Hx].
   inv Hx. clear X0.
-  apply onArity in X as [_ [s Hs] _].
+  apply onArity in X as [s Hs].
   specialize (IHl Hl).
   econstructor; eauto.
   fold (arities_context l) in *.
@@ -711,20 +708,21 @@ Proof.
 Qed.
 
 Lemma on_projection_closed  {Σ mind mdecl u i idecl pdecl} :
-  wf Σ ->
+  wf Σ -> mdecl.(ind_npars) = context_assumptions mdecl.(ind_params) ->
   on_projection (lift_typing typing) Σ (inductive_mind mind) mdecl (inductive_ind mind) idecl i pdecl ->
   let pty := subst_instance_constr u (snd pdecl) in
   closedn (S (ind_npars mdecl)) pty.
 Proof.
-  intros wfΣ. unfold on_projection.
-  destruct decompose_prod_assum.
-  intros [[s Hs] Hparams].
+  intros wfΣ Hpar.
+  unfold on_projection.
+  intros [s Hs].
   pose proof (typing_wf_local Hs).
   destruct pdecl as [id cty].
   eapply (env_prop_typing _ typecheck_closed) in Hs; eauto.
   rewrite -> andb_and in *. simpl in *.
   destruct Hs as [Hs _].
-  rewrite Hparams in Hs. now rewrite -> closedn_subst_instance_constr.
+  rewrite smash_context_length in Hs. simpl in *.
+  rewrite - Hpar in Hs. now rewrite -> closedn_subst_instance_constr.
 Qed.
 
 Lemma context_subst_length Γ a s : context_subst Γ a s -> #|Γ| = #|s|.
@@ -908,7 +906,7 @@ Proof.
   assert(forall brs,
          map_option_out (build_branches_type ind mdecl idecl args u p) = Some brs ->
          map_option_out (build_branches_type ind mdecl
-         (map_one_inductive_body (inductive_mind ind) (polymorphic_instance (ind_universes mdecl))
+         (map_one_inductive_body (context_assumptions (ind_params mdecl))
             (length (arities_context (ind_bodies mdecl))) (fun k' => subst n (k' + k))
             (inductive_ind ind) idecl) (map (subst n k) args) u (subst n k p)) =
          Some (map (on_snd (subst n k)) brs)).
@@ -1837,7 +1835,7 @@ Proof.
 
   - eapply refine_type. econstructor; eauto.
     eapply on_declared_inductive in isdecl as [on_mind on_ind]; auto.
-    apply onArity, arity_typed in on_ind as [s' Hindty].
+    apply onArity in on_ind as [s' Hindty].
     apply typecheck_closed in Hindty as [_ Hindty]; eauto. symmetry.
     move/andP/proj1: Hindty. rewrite -(closedn_subst_instance_constr _ _ u) => Hty.
     apply: (subst_closedn s #|Δ|); auto with wf.
@@ -1875,7 +1873,9 @@ Proof.
     erewrite distr_subst_rec. simpl.
     rewrite map_rev. subst ty.
     f_equal.
-    apply on_declared_projection in isdecl as [_ isdecl]; auto.
+
+    apply on_declared_projection in isdecl as [[Hmdecl _] isdecl]; auto.
+    eapply onNpars in Hmdecl.
     eapply on_projection_closed in isdecl as clty; auto.
     symmetry. apply subst_closedn; eauto.
     rewrite List.rev_length H. eapply closed_upwards; eauto. lia.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -2309,5 +2309,3 @@ Proof.
   - destruct n. noconf eq. simpl. split; auto.
     apply IHX.
 Defined.
-
-Derive Signature for Alli.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -302,15 +302,17 @@ Proof.
     destruct (decompose_prod_assum [] (lift n k ind_type)) eqn:Heq'.
     destruct X. simpl in *.
     assert (lift n k ind_type = ind_type).
-    destruct onArity as [[s Hs] Hpars].
+    destruct onArity as [Hisa [s Hs] Hpars].
     eapply typed_liftn; eauto. constructor. simpl; lia.
     rewrite H0 in Heq'. rewrite Heq in Heq'. revert Heq'; intros [= <- <-].
     f_equal; auto.
     apply (Alli_map_id onConstructors).
-    intros n1 [[x p] n']. intros [[s Hty] Hpars].
+    intros n1 [[x p] n']. intros [[s Hty] [cs Hargs]].
     unfold on_pi2; f_equal; f_equal.
     simpl in Hty.
     eapply typed_liftn. 4:eapply Hty. eauto. apply typing_wf_local in Hty; eauto. lia.
+    destruct(eq_dec ind_projs []) as [Hp|Hp]. subst; auto. specialize (onProjections Hp).
+    destruct onProjections as [_ _ onProjections].
     apply (Alli_map_id onProjections).
     intros n1 [x p].
     unfold on_projection. simpl. rewrite Heq.
@@ -385,14 +387,16 @@ Proof.
   simpl in Hmdecl.
   apply onInductives in Hmdecl.
   eapply nth_error_alli in Hmdecl; eauto.
-  eapply onProjections in Hmdecl; eauto.
+  eapply onProjections, on_projs in Hmdecl; eauto.
   eapply nth_error_alli in Hmdecl; eauto.
   red in Hmdecl.
   destruct decompose_prod_assum eqn:Heq.
   case: Hmdecl => /= [/andb_and[Hd Hp] Hpars]. simpl in *.
   intuition auto. destruct pdecl as [id ty]. unfold on_snd; simpl in *.
   f_equal. eapply lift_closed. rewrite <- Hpars.
-  eapply closed_upwards; eauto. lia. auto.
+  eapply closed_upwards; eauto. lia.
+  destruct (ind_projs idecl). destruct (snd c); discriminate. congruence.
+  auto.
 Qed.
 
 Lemma lift_fix_context:

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -253,8 +253,8 @@ Proof.
   rewrite ccst. reflexivity. lia. auto. constructor.
 Qed.
 
-Definition lift_mutual_inductive_body n k mind m :=
-  map_mutual_inductive_body mind (fun k' => lift n (k' + k)) m.
+Definition lift_mutual_inductive_body n k m :=
+  map_mutual_inductive_body (fun k' => lift n (k' + k)) m.
 
 Lemma lift_wf_local `{checker_flags} Σ Γ n k : wf Σ -> wf_local Σ Γ -> lift_context n k Γ = Γ.
 Proof.
@@ -283,10 +283,17 @@ Proof.
   rewrite List.rev_length. lia.
 Qed.
 
+Lemma context_assumptions_fold Γ f : context_assumptions (fold_context f Γ) = context_assumptions Γ.
+Proof.
+  rewrite fold_context_alt.
+  unfold mapi. generalize 0 (Nat.pred #|Γ|).
+  induction Γ as [|[na [body|] ty] tl]; cbn; intros; eauto.
+Qed.
+
 Lemma lift_declared_minductive `{checker_flags} Σ cst decl n k :
   wf Σ ->
   declared_minductive (fst Σ) cst decl ->
-  lift_mutual_inductive_body n k cst decl = decl.
+  lift_mutual_inductive_body n k decl = decl.
 Proof.
   intros wfΣ Hdecl. eapply on_declared_minductive in Hdecl; eauto.
   destruct decl. simpl in *. f_equal.
@@ -301,8 +308,8 @@ Proof.
     destruct (decompose_prod_assum [] ind_type) eqn:Heq.
     destruct (decompose_prod_assum [] (lift n k ind_type)) eqn:Heq'.
     destruct X. simpl in *.
-    assert (lift n k ind_type = ind_type).
-    destruct onArity as [Hisa [s Hs] Hpars].
+    assert (lift n k ind_type = ind_type). repeat red in onArity.
+    destruct onArity as [s Hs].
     eapply typed_liftn; eauto. constructor. simpl; lia.
     rewrite H0 in Heq'. rewrite Heq in Heq'. revert Heq'; intros [= <- <-].
     f_equal; auto.
@@ -312,19 +319,21 @@ Proof.
     simpl in Hty.
     eapply typed_liftn. 4:eapply Hty. eauto. apply typing_wf_local in Hty; eauto. lia.
     destruct(eq_dec ind_projs []) as [Hp|Hp]. subst; auto. specialize (onProjections Hp).
-    destruct onProjections as [_ _ onProjections].
+    destruct onProjections as [_ _ _ onProjections].
     apply (Alli_map_id onProjections).
     intros n1 [x p].
-    unfold on_projection. simpl. rewrite Heq.
-    intros [[s Hty] Hpars].
+    unfold on_projection. simpl.
+    intros [s Hty].
     unfold on_snd; f_equal; f_equal.
-    eapply typed_liftn. 4:eapply Hty. all:eauto. eapply typing_wf_local in Hty; eauto. simpl. lia.
+    eapply typed_liftn. 4:eapply Hty. all:eauto. eapply typing_wf_local in Hty; eauto. simpl.
+    rewrite smash_context_length. simpl.
+    rewrite context_assumptions_fold. lia.
 Qed.
 
 Lemma lift_declared_inductive `{checker_flags} Σ ind mdecl idecl n k :
   wf Σ ->
   declared_inductive (fst Σ) mdecl ind idecl ->
-  map_one_inductive_body (inductive_mind ind) (polymorphic_instance (mdecl.(ind_universes)))
+  map_one_inductive_body (context_assumptions mdecl.(ind_params))
                          (length (arities_context mdecl.(ind_bodies))) (fun k' => lift n (k' + k))
                          (inductive_ind ind) idecl = idecl.
 Proof.
@@ -363,7 +372,6 @@ Proof.
   destruct Σ. eapply (lift_declared_inductive _ _ _ _ n k) in Hidecl; eauto.
   unfold type_of_constructor. destruct cdecl as [[id t'] arity].
   destruct idecl; simpl in *.
-  destruct (decompose_prod_assum [] _) eqn:Heq.
   injection Hidecl.
   intros.
   pose Hcdecl as Hcdecl'.
@@ -376,6 +384,11 @@ Proof.
   now rewrite subst0_inds_lift.
 Qed.
 
+Lemma nth_error_Some_non_nil {A} (l : list A) (n : nat) (x : A) : nth_error l n = Some x -> l <> [].
+Proof.
+  destruct l, n; simpl; congruence.
+Qed.
+
 Lemma lift_declared_projection `{checker_flags} Σ c mdecl idecl pdecl n k :
   wf Σ ->
   declared_projection (fst Σ) mdecl idecl c pdecl ->
@@ -383,20 +396,19 @@ Lemma lift_declared_projection `{checker_flags} Σ c mdecl idecl pdecl n k :
 Proof.
   intros.
   destruct H0 as [[Hmdecl Hidecl] [Hpdecl Hnpar]].
-  eapply declared_decl_closed in Hmdecl.
+  eapply declared_decl_closed in Hmdecl; auto.
   simpl in Hmdecl.
+  pose proof (onNpars _ _ _ _ Hmdecl).
   apply onInductives in Hmdecl.
   eapply nth_error_alli in Hmdecl; eauto.
-  eapply onProjections, on_projs in Hmdecl; eauto.
-  eapply nth_error_alli in Hmdecl; eauto.
-  red in Hmdecl.
-  destruct decompose_prod_assum eqn:Heq.
-  case: Hmdecl => /= [/andb_and[Hd Hp] Hpars]. simpl in *.
-  intuition auto. destruct pdecl as [id ty]. unfold on_snd; simpl in *.
-  f_equal. eapply lift_closed. rewrite <- Hpars.
+  pose proof (onProjections Hmdecl) as onp; eauto. forward onp.
+  now eapply nth_error_Some_non_nil in Hpdecl.
+  eapply on_projs, nth_error_alli in onp; eauto.
+  move: onp => /= /andb_and[Hd _]. simpl in Hd.
+  rewrite smash_context_length in Hd. simpl in *. rewrite H0 in Hd.
+  destruct pdecl as [id ty]. unfold on_snd; simpl in *.
+  f_equal. eapply lift_closed.
   eapply closed_upwards; eauto. lia.
-  destruct (ind_projs idecl). destruct (snd c); discriminate. congruence.
-  auto.
 Qed.
 
 Lemma lift_fix_context:
@@ -608,7 +620,7 @@ Lemma lift_types_of_case ind mdecl idecl args u p pty indctx pctx ps btys n k :
   let f_ctx := lift_context n k in
   closed_ctx mdecl.(ind_params) ->
   types_of_case ind mdecl idecl args u p pty = Some (indctx, pctx, ps, btys) ->
-  types_of_case ind mdecl (map_one_inductive_body (inductive_mind ind) (polymorphic_instance mdecl.(ind_universes))
+  types_of_case ind mdecl (map_one_inductive_body (context_assumptions mdecl.(ind_params))
                                                   (length (arities_context mdecl.(ind_bodies)))
                                                   f (inductive_ind ind) idecl)
                 (map (f 0) args) u (f 0 p) (f 0 pty) =
@@ -630,7 +642,7 @@ Proof.
   assert(forall brs,
          build_branches_type ind mdecl idecl args u p = brs ->
          (build_branches_type ind mdecl
-         (map_one_inductive_body (inductive_mind ind) (polymorphic_instance (ind_universes mdecl))
+         (map_one_inductive_body (context_assumptions mdecl.(ind_params))
             (length (arities_context (ind_bodies mdecl))) (fun k' => lift n (k' + k))
             (inductive_ind ind) idecl) (map (lift n k) args) u (lift n k p)) =
          map (option_map (on_snd (lift n k))) brs).
@@ -818,7 +830,6 @@ Proof.
       rewrite !plus_n_Sm. now apply IHm.
 Qed.
 
-
 Lemma lift_eq_term `{checker_flags} ϕ n k T U :
   eq_term ϕ T U -> eq_term ϕ (lift n k T) (lift n k U).
 Proof.
@@ -830,7 +841,6 @@ Lemma lift_leq_term `{checker_flags} ϕ n k T U :
 Proof.
   apply lift_eq_term_upto_univ.
 Qed.
-
 
 Lemma weakening_cumul `{CF:checker_flags} Σ Γ Γ' Γ'' M N :
   wf Σ ->
@@ -986,7 +996,6 @@ Proof.
        erewrite lift_declared_inductive; eauto.
        apply lift_check_correct_arity.
     -- destruct idecl; simpl in *; auto.
-       destruct decompose_prod_assum. auto.
     -- now rewrite -> !lift_mkApps in IHc.
     -- solve_all.
 

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -209,15 +209,29 @@ Proof.
   simpl in *.
   destruct Hdecl as [onI onP onnP]; constructor; eauto.
   - eapply Alli_impl; eauto. intros.
-    destruct X. constructor.
-    unfold on_arity, on_type in *; intuition eauto.
-    unfold on_constructors in *. eapply Alli_impl; eauto.
+    destruct X. unshelve econstructor.
+    unfold on_constructors in *. eapply Alli_impl_trans; eauto.
     intros ik [[id t] ar]. unfold on_constructor, on_type in *; intuition eauto.
-    red in onProjections |- *.
-    eapply Alli_impl; eauto. intros ip [id trm].
-    unfold on_projection, on_type; eauto.
-    destruct decompose_prod_assum. intuition auto.
-    eapply HPΣ; eauto.
+    destruct b. exists x0.
+    -- induction (cshape_args x0); simpl in *; auto.
+       destruct a0 as [na [b|] ty]; simpl in *; intuition eauto.
+    -- destruct onArity; constructor; unfold on_type in *; intuition eauto.
+    -- intros Hprojs; destruct onProjections; try constructor; auto.
+       eapply Alli_impl; eauto. intros ip [id trm].
+       unfold on_projection, on_type; eauto.
+       destruct decompose_prod_assum. intuition auto.
+       eapply HPΣ; eauto.
+    -- unfold Alli_impl_trans. simpl.
+       destruct onkelim as [sf [Hsf Hsfle]].
+       exists sf; intuition eauto. rewrite -{}Hsf.
+       unfold elimination_topsort.
+       destruct destArity as [[ctx s]|]; simpl; auto.
+       destruct universe_family; auto.
+       revert onConstructors. generalize (ind_ctors x).
+       unfold Alli_rect.
+       intros ? onCs. depelim onCs; auto. depelim onCs; simpl; auto.
+       destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
+       destruct o as [? [? ?]]. simpl. reflexivity.
   - red in onP |- *. eapply All_local_env_impl; eauto.
 Qed.
 
@@ -309,8 +323,10 @@ Proof.
   intros.
   destruct H0 as [Hidecl [Hcdecl Hnpar]].
   eapply declared_inductive_inv in Hidecl; eauto.
-  apply onProjections in Hidecl.
+  apply onProjections, on_projs in Hidecl.
   eapply nth_error_alli in Hidecl; eauto.
+  eapply nth_error_Some_length in Hcdecl.
+  destruct (ind_projs idecl); simpl in *. lia. congruence.
 Qed.
 
 Lemma wf_extends `{checker_flags} {Σ Σ'} : wf Σ' -> extends Σ Σ' -> wf Σ.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -6,6 +6,8 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLif
 Require Import ssreflect ssrbool.
 From Equations Require Import Equations.
 
+Derive Signature for Alli.
+
 (** * Weakening lemmas w.r.t. the global environment *)
 
 Set Asymmetric Patterns.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -209,29 +209,31 @@ Proof.
   simpl in *.
   destruct Hdecl as [onI onP onnP]; constructor; eauto.
   - eapply Alli_impl; eauto. intros.
-    destruct X. unshelve econstructor.
+    destruct X. unshelve econstructor; eauto.
     unfold on_constructors in *. eapply Alli_impl_trans; eauto.
     intros ik [[id t] ar]. unfold on_constructor, on_type in *; intuition eauto.
     destruct b. exists x0.
     -- induction (cshape_args x0); simpl in *; auto.
        destruct a0 as [na [b|] ty]; simpl in *; intuition eauto.
-    -- destruct onArity; constructor; unfold on_type in *; intuition eauto.
+    -- unfold on_type in *; intuition eauto.
     -- intros Hprojs; destruct onProjections; try constructor; auto.
        eapply Alli_impl; eauto. intros ip [id trm].
        unfold on_projection, on_type; eauto.
-       destruct decompose_prod_assum. intuition auto.
-       eapply HPΣ; eauto.
     -- unfold Alli_impl_trans. simpl.
-       destruct onkelim as [sf [Hsf Hsfle]].
-       exists sf; intuition eauto. rewrite -{}Hsf.
-       unfold elimination_topsort.
-       destruct destArity as [[ctx s]|]; simpl; auto.
-       destruct universe_family; auto.
-       revert onConstructors. generalize (ind_ctors x).
+       revert onConstructors ind_sorts. generalize (ind_ctors x).
        unfold Alli_rect.
-       intros ? onCs. depelim onCs; auto. depelim onCs; simpl; auto.
-       destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
-       destruct o as [? [? ?]]. simpl. reflexivity.
+       unfold check_ind_sorts. destruct universe_family; auto.
+       --- intros ? onCs. depelim onCs; simpl; auto. depelim onCs; simpl; auto.
+           destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
+           destruct o as [? [? ?]]. simpl. auto.
+       --- intros ? onCs. clear onI. induction onCs; simpl; intuition auto.
+           destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
+           destruct p as [? [? ?]]. simpl in *. auto.
+           destruct Hext; subst; simpl; auto.
+       --- intros ? onCs. clear onI. induction onCs; simpl; intuition auto.
+           destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
+           destruct p as [? [? ?]]. simpl in *. auto.
+           destruct Hext; subst; simpl; auto.
   - red in onP |- *. eapply All_local_env_impl; eauto.
 Qed.
 
@@ -323,8 +325,8 @@ Proof.
   intros.
   destruct H0 as [Hidecl [Hcdecl Hnpar]].
   eapply declared_inductive_inv in Hidecl; eauto.
-  apply onProjections, on_projs in Hidecl.
-  eapply nth_error_alli in Hidecl; eauto.
+  pose proof (onProjections Hidecl). apply on_projs in X2.
+  eapply nth_error_alli in X2; eauto.
   eapply nth_error_Some_length in Hcdecl.
   destruct (ind_projs idecl); simpl in *. lia. congruence.
 Qed.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -363,7 +363,7 @@ Proof.
   rewrite !Template.UnivSubst.subst_instance_constr_it_mkProd_or_LetIn in Hdecomp.
   rewrite !trans_it_mkProd_or_LetIn in Hdecomp.
   assert (#|Template.Ast.ind_params mdecl| =
-    #|PCUICSubstitution.subst_context
+    #|PCUICTyping.subst_context
       (inds (inductive_mind ind) u (map trans_one_ind_body (Template.Ast.ind_bodies mdecl))) 0
       (map trans_decl (Template.UnivSubst.subst_instance_context u (Template.Ast.ind_params mdecl)))|).
   now rewrite PCUICSubstitution.subst_context_length map_length Template.UnivSubst.subst_instance_context_length.

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -199,6 +199,12 @@ Module Universe.
     | _ => false
     end.
 
+  Definition is_prop s :=
+    match Universe.level s with
+    | Some l => Level.is_prop l
+    | None => false
+    end.
+
   Definition type0m : t := make Level.prop.
   Definition type0 : t := make Level.set.
   Definition type1  :t := make' Expr.type1.


### PR DESCRIPTION
…n PCUIC

Actually, I went and did much more, now a well-formed inductive declaration has:
- A well-typed arity as a declared type
- The corresponding sort is compared to the sorts of the arguments of constructors to check which eliminations should be allowed (in case of Prop-squashing), and to ensure that constructor types are smaller than the inductive type (in the predicative case).
- For primitive projections, if there is any then the inductive must have a single constructor and all eliminations allowed.

This should be enough to let @yforster prove the necessary lemmas about extraction.

~~Still missing the universe check that the constructor's arguments types are <= the declared type (for consistency).~~
