### PR TITLE
Fix the order of global environments in Quote Recursively

### DIFF
--- a/checker/theories/Checker.v
+++ b/checker/theories/Checker.v
@@ -1146,7 +1146,7 @@ Section Checker.
     end.
 
   Definition typecheck_program (p : program) : EnvCheck term :=
-    let Σ := List.rev (fst p) in
+    let Σ := fst p in
     G <- check_wf_env Σ ;;
     infer_term Σ G (snd p).
 

--- a/erasure/theories/SafeTemplateErasure.v
+++ b/erasure/theories/SafeTemplateErasure.v
@@ -18,7 +18,7 @@ Local Open Scope string_scope.
 
 Program Definition erase_template_program_check (p : Ast.program)
   : EnvCheck (EAst.global_context * EAst.term) :=
-  let Σ := List.rev (trans_global (Ast.empty_ext p.1)).1 in
+  let Σ := (trans_global (Ast.empty_ext p.1)).1 in
   G <- check_wf_env Σ ;;
   Σ' <- wrap_error (empty_ext Σ) "erasure of the global context" (erase_global Σ _) ;;
   t <- wrap_error (empty_ext Σ) ("During erasure of " ++ string_of_term (trans p.2)) (erase (empty_ext Σ) _ nil _ (trans p.2));;
@@ -129,7 +129,7 @@ Program Fixpoint check_wf_env_only_univs (Σ : global_env)
 
 Program Definition erase_template_program (p : Ast.program)
   : EnvCheck (EAst.global_context * EAst.term) :=
-  let Σ := List.rev (trans_global (Ast.empty_ext p.1)).1 in
+  let Σ := (trans_global (Ast.empty_ext p.1)).1 in
   G <- check_wf_env_only_univs Σ ;;
   Σ' <- wrap_error (empty_ext Σ) "erasure of the global context" (SafeErasureFunction.erase_global Σ _) ;;
   t <- wrap_error (empty_ext Σ) ("During erasure of " ++ string_of_term (trans p.2)) (SafeErasureFunction.erase (empty_ext Σ) _ nil (trans p.2) _);;

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1651,8 +1651,8 @@ Section CheckEnv.
 
 
   Program Definition typecheck_program (p : program) φ Hφ
-    : EnvCheck (∑ A, ∥ (List.rev p.1, φ) ;;; [] |- p.2  : A ∥) :=
-    let Σ := List.rev (fst p) in
+    : EnvCheck (∑ A, ∥ (p.1, φ) ;;; [] |- p.2  : A ∥) :=
+    let Σ := fst p in
     G <- check_wf_env Σ ;;
     uctx <- check_udecl "toplevel term" Σ _ G.π1 (proj1 G.π2) φ ;;
     let G' := add_uctx uctx.π1 G.π1 in
@@ -1668,7 +1668,7 @@ Section CheckEnv.
     unfold global_ext_constraints; simpl.
     rewrite gc_of_constraints_union. rewrite Hctrs'.
     red in i. unfold gc_of_uctx in i; simpl in i.
-    case_eq (gc_of_constraints (global_constraints (List.rev p.1)));
+    case_eq (gc_of_constraints (global_constraints p.1));
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
     intros Σctrs HΣctrs; rewrite HΣctrs in *; simpl in *.
     subst G. unfold global_ext_levels; simpl. rewrite no_prop_levels_union.

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -10,16 +10,9 @@ Import MonadNotation.
 
 
 Program Definition infer_template_program {cf : checker_flags} (p : Ast.program) φ Hφ
-  : EnvCheck (∑ A, ∥ (trans_global_decls (List.rev p.1), φ) ;;; [] |- trans p.2 : A ∥) :=
+  : EnvCheck (∑ A, ∥ (trans_global_decls p.1, φ) ;;; [] |- trans p.2 : A ∥) :=
   p <- typecheck_program (cf:=cf) (trans_global_decls p.1, trans p.2) φ Hφ ;;
   ret (p.π1 ; _).
-
-Next Obligation.
-  unfold trans_global.
-  simpl. unfold empty_ext in X.
-  unfold trans_global_decls in X.
-  rewrite <-map_rev in X. eapply X.
-Qed.
 
 Local Open Scope string_scope.
 
@@ -102,7 +95,7 @@ Definition fix_global_env_universes (Σ : Ast.global_env) : Ast.global_env :=
     let dangling := dangling_universes declared declcstrs in
     ((kn, update_universes (LevelSet.union declu dangling, declcstrs) decl), LevelSet.union declared dangling)
   in
-  fst (fold_map_left fix_decl Σ LevelSet.empty).
+  fst (fold_map_right fix_decl Σ LevelSet.empty).
 
 Definition fix_program_universes (p : Ast.program) : Ast.program :=
   let '(Σ, t) := p in

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -441,7 +441,7 @@ struct
       (x,y)
     in
     let (tm, _) = quote_rem () env trm in
-    let decls =  List.fold_right (fun (kn, d) acc -> Q.add_global_decl kn d acc)  !constants Q.empty_global_declartions in
+    let decls =  List.fold_right (fun (kn, d) acc -> Q.add_global_decl kn d acc)  !constants (Q.empty_global_declarations ()) in
     Q.mk_program decls tm
 
   let quote_rel_context env ctx = 

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -441,7 +441,7 @@ struct
       (x,y)
     in
     let (tm, _) = quote_rem () env trm in
-    let decls =  List.fold_left (fun acc (kn, d) -> Q.add_global_decl kn d acc) (Q.empty_global_declarations ()) !constants in
+    let decls =  List.fold_right (fun (kn, d) acc -> Q.add_global_decl kn d acc)  !constants Q.empty_global_declartions in
     Q.mk_program decls tm
 
   let quote_rel_context env ctx = 

--- a/template-coq/theories/monad_utils.v
+++ b/template-coq/theories/monad_utils.v
@@ -83,7 +83,14 @@ Section MonadOperations.
        | y :: l => x' <- g x y ;;
                    monad_fold_left l x'
        end.
-
+  
+  Fixpoint monad_fold_right (l : list B) (x : A) : T A
+       := match l with
+          | nil => ret x
+          | y :: l => l' <- monad_fold_right l x ;;
+                      g l' y
+          end.
+   
   Context (h : nat -> A -> T B).
   Fixpoint monad_map_i_aux (n0 : nat) (l : list A) : T (list B)
     := match l with

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -42,3 +42,4 @@ TypingTests.v
 unfold.v
 univ.v
 vs.v
+order_rec.v

--- a/test-suite/order_rec.v
+++ b/test-suite/order_rec.v
@@ -1,0 +1,12 @@
+Require Import List Arith String.
+Require Import Template.All.
+Import ListNotations MonadNotation.
+
+Local Open Scope string_scope.
+
+Quote Recursively Definition plus_syntax := plus.
+
+Goal ∑ s1 t1 s2 t2, fst plus_syntax = [ConstantDecl s1 t1; InductiveDecl s2 t2].
+Proof.
+  repeat eexists.
+Qed.

--- a/test-suite/order_rec.v
+++ b/test-suite/order_rec.v
@@ -1,12 +1,12 @@
 Require Import List Arith String.
-Require Import Template.All.
+From MetaCoq Require Import Template.All.
 Import ListNotations MonadNotation.
 
 Local Open Scope string_scope.
 
 Quote Recursively Definition plus_syntax := plus.
 
-Goal ∑ s1 t1 s2 t2, fst plus_syntax = [ConstantDecl s1 t1; InductiveDecl s2 t2].
+Goal ∑ s1 t1 s2 t2, fst plus_syntax = [(s1, ConstantDecl t1); (s2, InductiveDecl t2)].
 Proof.
   repeat eexists.
 Qed.

--- a/translations/param_cheap_packed.v
+++ b/translations/param_cheap_packed.v
@@ -1,8 +1,7 @@
-
-From MetaCoq Require Import Template.All.
+Require Import MetaCoq.Template.All.
 Require Import Arith.Compare_dec.
 From MetaCoq.Translations Require Import translation_utils sigma.
-From MetaCoq.Checker Require Import All.
+Require Import MetaCoq.Checker.All.
 Import String Lists.List.ListNotations MonadNotation.
 Open Scope string_scope.
 Open Scope list_scope.

--- a/translations/sigma.v
+++ b/translations/sigma.v
@@ -1,4 +1,5 @@
-From MetaCoq.Template Require Import Ast Loader.
+From MetaCoq.Template Require Import Ast.
+Require Import MetaCoq.Template.Loader.
 Require Import List String. Import ListNotations.
 
 Set Primitive Projections.
@@ -9,6 +10,8 @@ Record sigma A B :=
 Arguments π1 {A B} _.
 Arguments π2 {A B} _.
 Arguments mk_sig {A B} _ _.
+
+Declare Scope sigma_scope.
 
 Notation "{ x  &&  P }" := (sigma (fun x => P)) : type_scope.
 Notation "{ t : A && P }" := (sigma A (fun t => P)) : type_scope.

--- a/translations/standard_model.v
+++ b/translations/standard_model.v
@@ -1,4 +1,4 @@
-From MetaCoq.Template Require Import All.
+Require Import MetaCoq.Template.All.
 Require Import Arith.Compare_dec.
 From MetaCoq.Translations Require Import translation_utils.
 Import String List Lists.List.ListNotations MonadNotation.

--- a/translations/translation_utils.v
+++ b/translations/translation_utils.v
@@ -1,5 +1,6 @@
-From MetaCoq.Template Require Import All TemplateMonad.Core monad_utils.
-From MetaCoq.Checker Require Import All.
+Require Import MetaCoq.Template.All.
+Require Import MetaCoq.Checker.All.
+From MetaCoq.Template Require Import TemplateMonad.Core monad_utils.
 Require Import List String.
 Import ListNotations MonadNotation.
 Open Scope string_scope.
@@ -326,7 +327,7 @@ Definition tsl_kn (tsl_ident : ident -> ident) (kn : kername) mp
 Definition TranslateRec {tsl : Translation} (ΣE : tsl_context) {A} (t : A) := 
   p <- tmQuoteRec t ;;
   tmPrint "~~~~~~~~~~~~~~~~~~" ;;
-  monad_fold_left (fun ΣE '(kn, decl) =>
+  monad_fold_right (fun ΣE '(kn, decl) =>
     print_nf ("Translating " ++ kn) ;;
     match decl with
     | ConstantDecl decl =>


### PR DESCRIPTION
Things defined last should appear first in the list generated by `Quote Recursively`.

Apparently it used to be like this, but was changed at some point. In case the change was intentional (maybe during the refactoring?) please intervene