### PR TITLE
Make Coq symbol references lazy (fixes #149; coq-8.8 port of #155)

### DIFF
--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -153,7 +153,7 @@ struct
 
   let quote_context l = l
 
-  let mkAnon = Coq_nAnon
+  let mkAnon () = Coq_nAnon
   let mkName i = Coq_nNamed i
 
   let mkRel n = Coq_tRel n
@@ -219,7 +219,7 @@ struct
 
   let mk_constant_decl kn bdy = ConstantDecl (kn, bdy)
 
-  let empty_global_declartions = []
+  let empty_global_declartions () = []
 
   let add_global_decl a b = a :: b
 

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -34,22 +34,22 @@ struct
     Names.Id.of_string (unquote_string trm)
 
   let unquote_cast_kind trm =
-    if Constr.equal trm kVmCast then
+    if constr_equall trm kVmCast then
       Constr.VMcast
-    else if Constr.equal trm kCast then
+    else if constr_equall trm kCast then
       Constr.DEFAULTcast
-    else if Constr.equal trm kRevertCast then
+    else if constr_equall trm kRevertCast then
       Constr.REVERTcast
-    else if Constr.equal trm kNative then
+    else if constr_equall trm kNative then
       Constr.VMcast
     else
       not_supported_verb trm "unquote_cast_kind"
 
   let unquote_name trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h nAnon then
+    if constr_equall h nAnon then
       Names.Anonymous
-    else if Constr.equal h nNamed then
+    else if constr_equall h nNamed then
       match args with
         n :: [] -> Names.Name (unquote_ident n)
       | _ -> bad_term_verb trm "unquote_name"
@@ -88,20 +88,20 @@ struct
 
   let unquote_level evm trm (* of type level *) : Evd.evar_map * Univ.Level.t =
     let (h,args) = app_full trm [] in
-    if Constr.equal h lProp then
+    if constr_equall h lProp then
       match args with
       | [] -> evm, Univ.Level.prop
       | _ -> bad_term_verb trm "unquote_level"
-    else if Constr.equal h lSet then
+    else if constr_equall h lSet then
       match args with
       | [] -> evm, Univ.Level.set
       | _ -> bad_term_verb trm "unquote_level"
-    else if Constr.equal h tLevel then
+    else if constr_equall h tLevel then
       match args with
       | s :: [] -> debug (fun () -> str "Unquoting level " ++ pr_constr trm);
         get_level evm (unquote_string s)
       | _ -> bad_term_verb trm "unquote_level"
-    else if Constr.equal h tLevelVar then
+    else if constr_equall h tLevelVar then
       match args with
       | l :: [] -> evm, Univ.Level.var (unquote_nat l)
       | _ -> bad_term_verb trm "unquote_level"
@@ -149,7 +149,7 @@ struct
 
   let unquote_inductive trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h tmkInd then
+    if constr_equall h tmkInd then
       match args with
         nm :: num :: _ ->
         let s = unquote_string nm in
@@ -175,55 +175,55 @@ struct
   let inspect_term (t:Constr.t)
   : (Constr.t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
     let (h,args) = app_full t [] in
-    if Constr.equal h tRel then
+    if constr_equall h tRel then
       match args with
         x :: _ -> ACoq_tRel x
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tVar then
+    else if constr_equall h tVar then
       match args with
         x :: _ -> ACoq_tVar x
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tSort then
+    else if constr_equall h tSort then
       match args with
         x :: _ -> ACoq_tSort x
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tCast then
+    else if constr_equall h tCast then
       match args with
         x :: y :: z :: _ -> ACoq_tCast (x, y, z)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tProd then
+    else if constr_equall h tProd then
       match args with
         n :: t :: b :: _ -> ACoq_tProd (n,t,b)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tLambda then
+    else if constr_equall h tLambda then
       match args with
         n  :: t :: b :: _ -> ACoq_tLambda (n,t,b)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tLetIn then
+    else if constr_equall h tLetIn then
       match args with
         n :: e :: t :: b :: _ -> ACoq_tLetIn (n,e,t,b)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tApp then
+    else if constr_equall h tApp then
       match args with
         f::xs::_ -> ACoq_tApp (f, unquote_list xs)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tConst then
+    else if constr_equall h tConst then
       match args with
         s::u::_ -> ACoq_tConst (s, u)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tInd then
+    else if constr_equall h tInd then
       match args with
         i::u::_ -> ACoq_tInd (i,u)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tConstructor then
+    else if constr_equall h tConstructor then
       match args with
         i::idx::u::_ -> ACoq_tConstruct (i,idx,u)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure: constructor case"))
-    else if Constr.equal h tCase then
+    else if constr_equall h tCase then
       match args with
         info::ty::d::brs::_ -> ACoq_tCase (unquote_pair info, ty, d, List.map unquote_pair (unquote_list brs))
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tFix then
+    else if constr_equall h tFix then
       match args with
         bds::i::_ ->
         let unquoteFbd  b  =
@@ -240,7 +240,7 @@ struct
         let lbd = List.map unquoteFbd (unquote_list bds) in
         ACoq_tFix (lbd, i)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tCoFix then
+    else if constr_equall h tCoFix then
       match args with
         bds::i::_ ->
         let unquoteFbd  b  =
@@ -257,7 +257,7 @@ struct
         let lbd = List.map unquoteFbd (unquote_list bds) in
         ACoq_tCoFix (lbd, i)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if Constr.equal h tProj then
+    else if constr_equall h tProj then
       match args with
         proj::t::_ -> ACoq_tProj (proj, t)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))

--- a/template-coq/src/constr_quoted.ml
+++ b/template-coq/src/constr_quoted.ml
@@ -50,11 +50,11 @@ struct
   type quoted_reduction_strategy = Constr.t (* of type Ast.reductionStrategy *)
 *)
 
-  let resolve_symbol (path : string list) (tm : string) : Constr.t =
+  let resolve_symbol (path : string list) (tm : string) : Constr.t Lazy.t =
     gen_constant_in_modules contrib_name [path] tm
 
-  let resolve_symbol_p (path : string list) (tm : string) : Globnames.global_reference =
-    Coqlib.gen_reference_in_modules contrib_name [path] tm
+  let resolve_symbol_p (path : string list) (tm : string) : Globnames.global_reference Lazy.t =
+    lazy (Coqlib.gen_reference_in_modules contrib_name [path] tm)
 
   let pkg_datatypes = ["Coq";"Init";"Datatypes"]
   let pkg_string = ["Coq";"Strings";"String"]
@@ -92,9 +92,13 @@ struct
   let bool_type = resolve_symbol pkg_datatypes "bool"
   let cInl = resolve_symbol pkg_datatypes "inl"
   let cInr = resolve_symbol pkg_datatypes "inr"
-  let prod a b = Constr.mkApp (prod_type, [| a ; b |])
+  let constr_mkApp (h, a) = Constr.mkApp (Lazy.force h, a)
+  let constr_mkAppl (h, a) = Constr.mkApp (Lazy.force h, Array.map Lazy.force a)
+  let prod a b = constr_mkApp (prod_type, [| a ; b |])
+  let prodl a b = prod (Lazy.force a) (Lazy.force b)
   let c_pair = resolve_symbol pkg_datatypes "pair"
-  let pair a b f s = Constr.mkApp (c_pair, [| a ; b ; f ; s |])
+  let pair a b f s = constr_mkApp (c_pair, [| a ; b ; f ; s |])
+  let pairl a b f s = pair (Lazy.force a) (Lazy.force b) f s
 
     (* reify the constructors in Template.Ast.v, which are the building blocks of reified terms *)
   let nAnon = r_base_reify "nAnon"
@@ -140,8 +144,8 @@ struct
   let tUContext = resolve_symbol (ext_pkg_univ "UContext") "t"
   let tUContextmake = resolve_symbol (ext_pkg_univ "UContext") "make"
   (* let tConstraintSetempty = resolve_symbol (ext_pkg_univ "ConstraintSet") "empty" *)
-  let tConstraintSetempty = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "empty")
-  let tConstraintSetadd = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "add")
+  let tConstraintSetempty = lazy (Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "empty"))
+  let tConstraintSetadd = lazy (Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "add"))
   let tmake_univ_constraint = resolve_symbol pkg_univ "make_univ_constraint"
   let tinit_graph = resolve_symbol pkg_ugraph "init_graph"
   let tadd_global_constraints = resolve_symbol pkg_ugraph  "add_global_constraints"
@@ -181,9 +185,11 @@ struct
   let texistT = resolve_symbol pkg_specif "existT"
   let texistT_typed_term = r_template_monad_p "existT_typed_term"
 
+  let constr_equall h t = Constr.equal h (Lazy.force t)
+
   let unquote_sigt trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h texistT then
+    if constr_equall h texistT then
       match args with
         _ :: _ :: x :: y :: [] -> (x, y)
       | _ -> bad_term_verb trm "unquote_sigt"
@@ -192,7 +198,7 @@ struct
 
   let unquote_pair trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h c_pair then
+    if constr_equall h c_pair then
       match args with
         _ :: _ :: x :: y :: [] -> (x, y)
       | _ -> bad_term_verb trm "unquote_pair"
@@ -201,9 +207,9 @@ struct
 
   let rec unquote_list trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h c_nil then
+    if constr_equall h c_nil then
       []
-    else if Constr.equal h c_cons then
+    else if constr_equall h c_cons then
       match args with
         _ :: x :: xs :: [] -> x :: unquote_list xs
       | _ -> bad_term_verb trm "unquote_list"
@@ -213,9 +219,9 @@ struct
   (* Unquote Coq nat to OCaml int *)
   let rec unquote_nat trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h tO then
+    if constr_equall h tO then
       0
-    else if Constr.equal h tS then
+    else if constr_equall h tS then
       match args with
         n :: [] -> 1 + unquote_nat n
       | _ -> bad_term_verb trm "unquote_nat"
@@ -223,15 +229,15 @@ struct
       not_supported_verb trm "unquote_nat"
 
   let unquote_bool trm =
-    if Constr.equal trm ttrue then
+    if constr_equall trm ttrue then
       true
-    else if Constr.equal trm tfalse then
+    else if constr_equall trm tfalse then
       false
     else not_supported_verb trm "from_bool"
 
   let unquote_char trm =
     let (h,args) = app_full trm [] in
-    if Constr.equal h tAscii then
+    if constr_equall h tAscii then
       match args with
         a :: b :: c :: d :: e :: f :: g :: h :: [] ->
         let bits = List.rev [a;b;c;d;e;f;g;h] in
@@ -244,9 +250,9 @@ struct
   let unquote_string trm =
     let rec go n trm =
       let (h,args) = app_full trm [] in
-      if Constr.equal h tEmptyString then
+      if constr_equall h tEmptyString then
         Bytes.create n
-      else if Constr.equal h tString then
+      else if constr_equall h tString then
         match args with
           c :: s :: [] ->
           let res = go (n + 1) s in
@@ -261,17 +267,19 @@ struct
 
 
   let to_coq_list typ =
-    let the_nil = Constr.mkApp (c_nil, [| typ |]) in
+    let the_nil = constr_mkApp (c_nil, [| typ |]) in
     let rec to_list (ls : Constr.t list) : Constr.t =
       match ls with
 	[] -> the_nil
       | l :: ls ->
-	Constr.mkApp (c_cons, [| typ ; l ; to_list ls |])
+	constr_mkApp (c_cons, [| typ ; l ; to_list ls |])
     in to_list
+  let to_coq_listl typ = to_coq_list (Lazy.force typ)
 
   let quote_option ty = function
-    | Some tm -> Constr.mkApp (cSome, [|ty; tm|])
-    | None -> Constr.mkApp (cNone, [|ty|])
+    | Some tm -> constr_mkApp (cSome, [|ty; tm|])
+    | None -> constr_mkApp (cNone, [|ty|])
+  let quote_optionl ty = quote_option (Lazy.force ty)
 
   (* Quote OCaml int to Coq nat *)
   let quote_int =
@@ -282,11 +290,11 @@ struct
       with
 	Not_found ->
 	  if i = 0 then
-	    let result = tO in
+	    let result = Lazy.force tO in
 	    let _ = Hashtbl.add cache i result in
 	    result
 	  else
-	    let result = Constr.mkApp (tS, [| recurse (i - 1) |]) in
+	    let result = constr_mkApp (tS, [| recurse (i - 1) |]) in
 	    let _ = Hashtbl.add cache i result in
 	    result
     in
@@ -295,15 +303,15 @@ struct
       CErrors.anomaly Pp.(str "Negative int can't be unquoted to nat.")
 
   let quote_bool b =
-    if b then ttrue else tfalse
+    if b then Lazy.force ttrue else Lazy.force tfalse
 
   let quote_char i =
-    Constr.mkApp (tAscii, Array.of_list (List.map (fun m -> quote_bool ((i land m) = m))
-					 (List.rev [128;64;32;16;8;4;2;1])))
+    constr_mkApp (tAscii, Array.of_list (List.map (fun m -> quote_bool ((i land m) = m))
+					(List.rev [128;64;32;16;8;4;2;1])))
 
-  let chars = Array.init 255 quote_char
+  let chars = lazy (Array.init 255 quote_char)
 
-  let quote_char c = chars.(int_of_char c)
+  let quote_char c = (Lazy.force chars).(int_of_char c)
 
   let string_hash = Hashtbl.create 420
 
@@ -312,10 +320,10 @@ struct
     let rec go from acc =
       if from < 0 then acc
       else
-        let term = Constr.mkApp (tString, [| quote_char (String.get s from) ; acc |]) in
+        let term = constr_mkApp (tString, [| quote_char (String.get s from) ; acc |]) in
         go (from - 1) term
     in
-    go (len - 1) tEmptyString
+    go (len - 1) (Lazy.force tEmptyString)
 
   let quote_string s =
     try Hashtbl.find string_hash s
@@ -329,15 +337,15 @@ struct
 
   let quote_name n =
     match n with
-      Names.Name id -> Constr.mkApp (nNamed, [| quote_ident id |])
-    | Names.Anonymous -> nAnon
+      Names.Name id -> constr_mkApp (nNamed, [| quote_ident id |])
+    | Names.Anonymous -> Lazy.force nAnon
 
   let quote_cast_kind k =
     match k with
-      Constr.VMcast -> kVmCast
-    | Constr.DEFAULTcast -> kCast
-    | Constr.REVERTcast -> kRevertCast
-    | Constr.NATIVEcast -> kNative
+      Constr.VMcast -> Lazy.force kVmCast
+    | Constr.DEFAULTcast -> Lazy.force kCast
+    | Constr.REVERTcast -> Lazy.force kRevertCast
+    | Constr.NATIVEcast -> Lazy.force kNative
 
   let string_of_level s =
     to_string (Univ.Level.to_string s)
@@ -345,59 +353,59 @@ struct
   let quote_level l =
     let open Univ in
     debug (fun () -> str"quote_level " ++ Level.pr l);
-    if Level.is_prop l then lProp
-    else if Level.is_set l then lSet
+    if Level.is_prop l then Lazy.force lProp
+    else if Level.is_set l then  Lazy.force lSet
     else match Level.var_index l with
-         | Some x -> Constr.mkApp (tLevelVar, [| quote_int x |])
-         | None -> Constr.mkApp (tLevel, [| string_of_level l|])
+         | Some x -> constr_mkApp (tLevelVar, [| quote_int x |])
+         | None -> constr_mkApp (tLevel, [| string_of_level l|])
 
   let quote_universe s =
-    let levels = Universe.map (fun (l,i) -> pair tlevel bool_type (quote_level l) (if i > 0 then ttrue else tfalse)) s in
-    to_coq_list (prod tlevel bool_type) levels
+    let levels = Universe.map (fun (l,i) -> pairl tlevel bool_type (quote_level l) (quote_bool (i > 0))) s in
+    to_coq_list (prodl tlevel bool_type) levels
 
   (* todo : can be deduced from quote_level, hence shoud be in the Reify module *)
   let quote_univ_instance u =
     let arr = Univ.Instance.to_array u in
-    to_coq_list tlevel (CArray.map_to_list quote_level arr)
+    to_coq_listl tlevel (CArray.map_to_list quote_level arr)
 
   let quote_constraint_type (c : Univ.constraint_type) =
     match c with
-    | Lt -> tunivLt
-    | Le -> tunivLe
-    | Eq -> tunivEq
+    | Lt -> Lazy.force tunivLt
+    | Le -> Lazy.force tunivLe
+    | Eq -> Lazy.force tunivEq
 
   let quote_univ_constraint ((l1, ct, l2) : Univ.univ_constraint) =
     let l1 = quote_level l1 in
     let l2 = quote_level l2 in
     let ct = quote_constraint_type ct in
-    Constr.mkApp (tmake_univ_constraint, [| l1; ct; l2 |])
+    constr_mkApp (tmake_univ_constraint, [| l1; ct; l2 |])
 
   let quote_univ_constraints const =
     let const = Univ.Constraint.elements const in
     List.fold_left (fun tm c ->
         let c = quote_univ_constraint c in
-        Constr.mkApp (tConstraintSetadd, [| c; tm|])
-      ) tConstraintSetempty const
+        constr_mkApp (tConstraintSetadd, [| c; tm|])
+      ) (Lazy.force tConstraintSetempty) const
 
   let quote_variance v =
     match v with
-    | Univ.Variance.Irrelevant -> cIrrelevant
-    | Univ.Variance.Covariant -> cCovariant
-    | Univ.Variance.Invariant -> cInvariant
+    | Univ.Variance.Irrelevant -> Lazy.force cIrrelevant
+    | Univ.Variance.Covariant -> Lazy.force cCovariant
+    | Univ.Variance.Invariant -> Lazy.force cInvariant
 
   let quote_cuminfo_variance var =
     let var_list = CArray.map_to_list quote_variance var in
-    to_coq_list tVariance var_list
+    to_coq_listl tVariance var_list
 
   let quote_ucontext inst const =
     let inst' = quote_univ_instance inst in
     let const' = quote_univ_constraints const in
-    Constr.mkApp (tUContextmake, [|inst'; const'|])
+    constr_mkApp (tUContextmake, [|inst'; const'|])
 
   let quote_univ_context uctx =
     let inst = Univ.UContext.instance uctx in
     let const = Univ.UContext.constraints uctx in
-    Constr.mkApp (cMonomorphic_ctx, [| quote_ucontext inst const |])
+    constr_mkApp (cMonomorphic_ctx, [| quote_ucontext inst const |])
 
   let quote_cumulative_univ_context cumi =
     let uctx = Univ.CumulativityInfo.univ_context cumi in
@@ -406,14 +414,14 @@ struct
     let var = Univ.CumulativityInfo.variance cumi in
     let uctx' = quote_ucontext inst const in
     let var' = quote_cuminfo_variance var in
-    let listvar = Constr.mkApp (tlist, [| tVariance |]) in
-    let cumi' = pair tUContext listvar uctx' var' in
-    Constr.mkApp (cCumulative_ctx, [| cumi' |])
+    let listvar = constr_mkAppl (tlist, [| tVariance |]) in
+    let cumi' = pair (Lazy.force tUContext) listvar uctx' var' in
+    constr_mkApp (cCumulative_ctx, [| cumi' |])
 
   let quote_abstract_univ_context_aux uctx =
     let inst = Univ.UContext.instance uctx in
     let const = Univ.UContext.constraints uctx in
-    Constr.mkApp (cPolymorphic_ctx, [| quote_ucontext inst const |])
+    constr_mkApp (cPolymorphic_ctx, [| quote_ucontext inst const |])
 
   let quote_abstract_univ_context uctx =
     let uctx = Univ.AUContext.repr uctx in
@@ -429,126 +437,126 @@ struct
   let quote_ugraph (g : UGraph.t) =
     let inst' = quote_univ_instance Univ.Instance.empty in
     let const' = quote_univ_constraints (UGraph.constraints_of_universes g) in
-    let uctx = Constr.mkApp (tUContextmake, [|inst' ; const'|]) in
-    Constr.mkApp (tadd_global_constraints, [|Constr.mkApp (cMonomorphic_ctx, [| uctx |]); tinit_graph|])
+    let uctx = constr_mkApp (tUContextmake, [|inst' ; const'|]) in
+    constr_mkApp (tadd_global_constraints, [|constr_mkApp (cMonomorphic_ctx, [| uctx |]); Lazy.force tinit_graph|])
 
   let quote_sort s =
     quote_universe (Sorts.univ_of_sort s)
 
   let quote_sort_family = function
-    | Sorts.InProp -> sfProp
-    | Sorts.InSet -> sfSet
-    | Sorts.InType -> sfType
+    | Sorts.InProp -> Lazy.force sfProp
+    | Sorts.InSet -> Lazy.force sfSet
+    | Sorts.InType -> Lazy.force sfType
 
   let quote_context_decl na b t =
-    Constr.mkApp (tmkdecl, [| na; quote_option tTerm b; t |])
+    constr_mkApp (tmkdecl, [| na; quote_optionl tTerm b; t |])
 
   let quote_context ctx =
-    to_coq_list tcontext_decl ctx
+    to_coq_listl tcontext_decl ctx
 
   let mk_ctor_list =
     let ctor_list =
-      let ctor_info_typ = prod (prod tident tTerm) tnat in
-      to_coq_list ctor_info_typ
+      lazy (let ctor_info_typ = prod (prodl tident tTerm) (Lazy.force tnat) in
+      to_coq_list ctor_info_typ)
     in
     fun ls ->
-    let ctors = List.map (fun (a,b,c) -> pair (prod tident tTerm) tnat
-				              (pair tident tTerm a b) c) ls in
-    ctor_list ctors
+    let ctors = List.map (fun (a,b,c) -> pair (prodl tident tTerm) (Lazy.force tnat)
+				              (pairl tident tTerm a b) c) ls in
+    (Lazy.force ctor_list) ctors
 
   let mk_proj_list d =
-    to_coq_list (prod tident tTerm)
-                (List.map (fun (a, b) -> pair tident tTerm a b) d)
+    to_coq_list (prodl tident tTerm)
+                (List.map (fun (a, b) -> pairl tident tTerm a b) d)
 
   let quote_inductive (kn, i) =
-    Constr.mkApp (tmkInd, [| kn; i |])
+    constr_mkApp (tmkInd, [| kn; i |])
 
   let rec seq f t =
     if f < t then f :: seq (f + 1) t
     else []
 
   let quote_proj ind pars args =
-    pair (prod tIndTy tnat) tnat (pair tIndTy tnat ind pars) args
+    pair (prodl tIndTy tnat) (Lazy.force tnat) (pairl tIndTy tnat ind pars) args
 
-  let mkAnon = nAnon
-  let mkName id = Constr.mkApp (nNamed, [| id |])
+  let mkAnon () = Lazy.force nAnon
+  let mkName id = constr_mkApp (nNamed, [| id |])
   let quote_kn kn = quote_string (KerName.to_string kn)
 
-  let mkRel i = Constr.mkApp (tRel, [| i |])
-  let mkVar id = Constr.mkApp (tVar, [| id |])
-  let mkEvar n args = Constr.mkApp (tEvar, [| n; to_coq_list tTerm (Array.to_list args) |])
-  let mkSort s = Constr.mkApp (tSort, [| s |])
-  let mkCast c k t = Constr.mkApp (tCast, [| c ; k ; t |])
-  let mkConst kn u = Constr.mkApp (tConst, [| kn ; u |])
+  let mkRel i = constr_mkApp (tRel, [| i |])
+  let mkVar id = constr_mkApp (tVar, [| id |])
+  let mkEvar n args = constr_mkApp (tEvar, [| n; to_coq_listl tTerm (Array.to_list args) |])
+  let mkSort s = constr_mkApp (tSort, [| s |])
+  let mkCast c k t = constr_mkApp (tCast, [| c ; k ; t |])
+  let mkConst kn u = constr_mkApp (tConst, [| kn ; u |])
   let mkProd na t b =
-    Constr.mkApp (tProd, [| na ; t ; b |])
+    constr_mkApp (tProd, [| na ; t ; b |])
   let mkLambda na t b =
-    Constr.mkApp (tLambda, [| na ; t ; b |])
+    constr_mkApp (tLambda, [| na ; t ; b |])
   let mkApp f xs =
-    Constr.mkApp (tApp, [| f ; to_coq_list tTerm (Array.to_list xs) |])
+    constr_mkApp (tApp, [| f ; to_coq_listl tTerm (Array.to_list xs) |])
 
   let mkLetIn na t t' b =
-    Constr.mkApp (tLetIn, [| na ; t ; t' ; b |])
+    constr_mkApp (tLetIn, [| na ; t ; t' ; b |])
 
   let mkFix ((a,b),(ns,ts,ds)) =
     let mk_fun xs i =
-      Constr.mkApp (tmkdef, [| tTerm ; Array.get ns i ;
+      constr_mkApp (tmkdef, [| Lazy.force tTerm ; Array.get ns i ;
                              Array.get ts i ; Array.get ds i ; Array.get a i |]) :: xs
     in
     let defs = List.fold_left mk_fun [] (seq 0 (Array.length a)) in
-    let block = to_coq_list (Constr.mkApp (tdef, [| tTerm |])) (List.rev defs) in
-    Constr.mkApp (tFix, [| block ; b |])
+    let block = to_coq_list (constr_mkAppl (tdef, [| tTerm |])) (List.rev defs) in
+    constr_mkApp (tFix, [| block ; b |])
 
   let mkConstruct (ind, i) u =
-    Constr.mkApp (tConstructor, [| ind ; i ; u |])
+    constr_mkApp (tConstructor, [| ind ; i ; u |])
 
   let mkCoFix (a,(ns,ts,ds)) =
     let mk_fun xs i =
-      Constr.mkApp (tmkdef, [| tTerm ; Array.get ns i ;
-                             Array.get ts i ; Array.get ds i ; tO |]) :: xs
+      constr_mkApp (tmkdef, [| Lazy.force tTerm ; Array.get ns i ;
+                             Array.get ts i ; Array.get ds i ; Lazy.force tO |]) :: xs
     in
     let defs = List.fold_left mk_fun [] (seq 0 (Array.length ns)) in
-    let block = to_coq_list (Constr.mkApp (tdef, [| tTerm |])) (List.rev defs) in
-    Constr.mkApp (tCoFix, [| block ; a |])
+    let block = to_coq_list (constr_mkAppl (tdef, [| tTerm |])) (List.rev defs) in
+    constr_mkApp (tCoFix, [| block ; a |])
 
-  let mkInd i u = Constr.mkApp (tInd, [| i ; u |])
+  let mkInd i u = constr_mkApp (tInd, [| i ; u |])
 
   let mkCase (ind, npar) nargs p c brs =
-    let info = pair tIndTy tnat ind npar in
-    let branches = List.map2 (fun br nargs ->  pair tnat tTerm nargs br) brs nargs in
-    let tl = prod tnat tTerm in
-    Constr.mkApp (tCase, [| info ; p ; c ; to_coq_list tl branches |])
+    let info = pairl tIndTy tnat ind npar in
+    let branches = List.map2 (fun br nargs ->  pairl tnat tTerm nargs br) brs nargs in
+    let tl = prodl tnat tTerm in
+    constr_mkApp (tCase, [| info ; p ; c ; to_coq_list tl branches |])
 
   let mkProj kn t =
-    Constr.mkApp (tProj, [| kn; t |])
+    constr_mkApp (tProj, [| kn; t |])
 
   let mk_one_inductive_body (a, b, c, d, e) =
-    let c = to_coq_list tsort_family c in
+    let c = to_coq_listl tsort_family c in
     let d = mk_ctor_list d in
     let e = mk_proj_list e in
-    Constr.mkApp (tBuild_one_inductive_body, [| a; b; c; d; e |])
+    constr_mkApp (tBuild_one_inductive_body, [| a; b; c; d; e |])
 
   let mk_mutual_inductive_body finite npars params inds uctx =
-    let inds = to_coq_list tone_inductive_body inds in
-    Constr.mkApp (tBuild_mutual_inductive_body, [|finite; npars; params; inds; uctx|])
+    let inds = to_coq_listl tone_inductive_body inds in
+    constr_mkApp (tBuild_mutual_inductive_body, [|finite; npars; params; inds; uctx|])
 
   let mk_constant_body ty tm uctx =
-    let tm = quote_option tTerm tm in
-    Constr.mkApp (tBuild_constant_body, [|ty; tm; uctx|])
+    let tm = quote_optionl tTerm tm in
+    constr_mkApp (tBuild_constant_body, [|ty; tm; uctx|])
 
   let mk_inductive_decl kn mind =
-    Constr.mkApp (tInductiveDecl, [|kn; mind|])
+    constr_mkApp (tInductiveDecl, [|kn; mind|])
 
   let mk_constant_decl kn bdy =
-    Constr.mkApp (tConstantDecl, [|kn; bdy|])
+    constr_mkApp (tConstantDecl, [|kn; bdy|])
 
-  let empty_global_declartions =
-    Constr.mkApp (c_nil, [| tglobal_decl |])
+  let empty_global_declartions () =
+    constr_mkAppl (c_nil, [| tglobal_decl |])
 
   let add_global_decl d l =
-    Constr.mkApp (c_cons, [|tglobal_decl; d; l|])
+    constr_mkApp (c_cons, [| Lazy.force tglobal_decl; d; l|])
 
-  let mk_program = pair tglobal_declarations tTerm
+  let mk_program () = pairl tglobal_declarations tTerm
 
   let quote_mind_finiteness (f: Declarations.recursivity_kind) =
     match f with
@@ -557,59 +565,59 @@ struct
     | Declarations.BiFinite -> cBiFinite
 
   let make_one_inductive_entry (iname, arity, templatePoly, consnames, constypes) =
-    let consnames = to_coq_list tident consnames in
-    let constypes = to_coq_list tTerm constypes in
-    Constr.mkApp (tBuild_one_inductive_entry, [| iname; arity; templatePoly; consnames; constypes |])
+    let consnames = to_coq_listl tident consnames in
+    let constypes = to_coq_listl tTerm constypes in
+    constr_mkApp (tBuild_one_inductive_entry, [| iname; arity; templatePoly; consnames; constypes |])
 
   let quote_mind_params l =
-    let pair i l = pair tident tlocal_entry i l in
+    let pair i l = pairl tident tlocal_entry i l in
     let map (id, ob) =
       match ob with
-      | Left b -> pair id (Constr.mkApp (tLocalDef,[|b|]))
-      | Right t -> pair id (Constr.mkApp (tLocalAssum,[|t|]))
+      | Left b -> pair id (constr_mkApp (tLocalDef,[|b|]))
+      | Right t -> pair id (constr_mkApp (tLocalAssum,[|t|]))
     in
-    let the_prod = Constr.mkApp (prod_type,[|tident; tlocal_entry|]) in
+    let the_prod = constr_mkAppl (prod_type,[|tident; tlocal_entry|]) in
     to_coq_list the_prod (List.map map l)
 
   let quote_mutual_inductive_entry (mf, mp, is, mpol) =
-    let is = to_coq_list tOne_inductive_entry (List.map make_one_inductive_entry is) in
-    let mpr = Constr.mkApp (cNone, [|bool_type|]) in
-    let mr = Constr.mkApp (cNone, [|Constr.mkApp (option_type, [|tident|])|])  in
-    Constr.mkApp (tBuild_mutual_inductive_entry, [| mr; mf; mp; is; mpol; mpr |])
+    let is = to_coq_listl tOne_inductive_entry (List.map make_one_inductive_entry is) in
+    let mpr = constr_mkAppl (cNone, [|bool_type|]) in
+    let mr = constr_mkApp (cNone, [|constr_mkAppl (option_type, [|tident|])|])  in
+    constr_mkApp (tBuild_mutual_inductive_entry, [| mr; mf; mp; is; mpol; mpr |])
 
 
   let quote_constant_entry (ty, body, ctx) =
     match body with
     | None ->
-      Constr.mkApp (cParameterEntry, [| Constr.mkApp (cParameter_entry, [|ty; ctx|]) |])
+      constr_mkApp (cParameterEntry, [| constr_mkApp (cParameter_entry, [|ty; ctx|]) |])
     | Some body ->
-      Constr.mkApp (cDefinitionEntry,
-                  [| Constr.mkApp (cDefinition_entry, [|ty;body;ctx;tfalse (*FIXME*)|]) |])
+      constr_mkApp (cDefinitionEntry,
+                  [| constr_mkApp (cDefinition_entry, [|ty;body;ctx;Lazy.force tfalse (*FIXME*)|]) |])
 
   let quote_entry decl =
-    let opType = Constr.mkApp(sum_type, [|tConstant_entry;tMutual_inductive_entry|]) in
-    let mkSome c t = Constr.mkApp (cSome, [|opType; Constr.mkApp (c, [|tConstant_entry;tMutual_inductive_entry; t|] )|]) in
+    let opType = constr_mkAppl(sum_type, [|tConstant_entry;tMutual_inductive_entry|]) in
+    let mkSome c t = constr_mkApp (cSome, [|opType; constr_mkAppl (c, [|tConstant_entry;tMutual_inductive_entry; lazy t|] )|]) in
     let mkSomeDef = mkSome cInl in
     let mkSomeInd  = mkSome cInr in
     match decl with
     | Some (Left centry) -> mkSomeDef (quote_constant_entry centry)
     | Some (Right mind) -> mkSomeInd mind
-    | None -> Constr.mkApp (cNone, [| opType |])
+    | None -> constr_mkApp (cNone, [| opType |])
 
 
   let quote_global_reference : Globnames.global_reference -> quoted_global_reference = function
     | Globnames.VarRef _ -> CErrors.user_err (str "VarRef unsupported")
     | Globnames.ConstRef c ->
        let kn = quote_kn (Names.Constant.canonical c) in
-       Constr.mkApp (tConstRef, [|kn|])
+       constr_mkApp (tConstRef, [|kn|])
     | Globnames.IndRef (i, n) ->
        let kn = quote_kn (Names.MutInd.canonical i) in
        let n = quote_int n in
-       Constr.mkApp (tIndRef, [|quote_inductive (kn ,n)|])
+       constr_mkApp (tIndRef, [|quote_inductive (kn ,n)|])
     | Globnames.ConstructRef ((i, n), k) ->
        let kn = quote_kn (Names.MutInd.canonical i) in
        let n = quote_int n in
        let k = (quote_int (k - 1)) in
-       Constr.mkApp (tConstructRef, [|quote_inductive (kn ,n); k|])
+       constr_mkApp (tConstructRef, [|quote_inductive (kn ,n); k|])
 
 end

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -14,17 +14,17 @@ struct
 
 
   let to_coq_list typ =
-    let the_nil = Constr.mkApp (c_nil, [| typ |]) in
+    let the_nil = constr_mkApp (c_nil, [| typ |]) in
     let rec to_list (ls : Constr.t list) : Constr.t =
       match ls with
 	[] -> the_nil
       | l :: ls ->
-	Constr.mkApp (c_cons, [| typ ; l ; to_list ls |])
+	constr_mkApp (c_cons, [| typ ; l ; to_list ls |])
     in to_list
 
   let quote_option ty = function
-    | Some tm -> Constr.mkApp (cSome, [|ty; tm|])
-    | None -> Constr.mkApp (cNone, [|ty|])
+    | Some tm -> constr_mkApp (cSome, [|ty; tm|])
+    | None -> constr_mkApp (cNone, [|ty|])
 
   (* Quote OCaml int to Coq nat *)
   let quote_int =
@@ -35,11 +35,11 @@ struct
       with
 	Not_found ->
 	  if i = 0 then
-	    let result = tO in
+	    let result = Lazy.force tO in
 	    let _ = Hashtbl.add cache i result in
 	    result
 	  else
-	    let result = Constr.mkApp (tS, [| recurse (i - 1) |]) in
+	    let result = constr_mkApp (tS, [| recurse (i - 1) |]) in
 	    let _ = Hashtbl.add cache i result in
 	    result
     in
@@ -48,15 +48,15 @@ struct
       CErrors.anomaly (str "Negative int can't be unquoted to nat.")
 
   let quote_bool b =
-    if b then ttrue else tfalse
+    if b then Lazy.force ttrue else Lazy.force tfalse
 
   let quote_char i =
-    Constr.mkApp (tAscii, Array.of_list (List.map (fun m -> quote_bool ((i land m) = m))
+    constr_mkApp (tAscii, Array.of_list (List.map (fun m -> quote_bool ((i land m) = m))
 					 (List.rev [128;64;32;16;8;4;2;1])))
 
-  let chars = Array.init 255 quote_char
+  let chars = lazy (Array.init 255 quote_char)
 
-  let quote_char c = chars.(int_of_char c)
+  let quote_char c = (Lazy.force chars).(int_of_char c)
 
   let string_hash = Hashtbl.create 420
 
@@ -65,10 +65,10 @@ struct
     let rec go from acc =
       if from < 0 then acc
       else
-        let term = Constr.mkApp (tString, [| quote_char (String.get s from) ; acc |]) in
+        let term = constr_mkApp (tString, [| quote_char (String.get s from) ; acc |]) in
         go (from - 1) term
     in
-    go (len - 1) tEmptyString
+    go (len - 1) (Lazy.force tEmptyString)
 
   let quote_string s =
     try Hashtbl.find string_hash s
@@ -82,76 +82,76 @@ struct
 
   let quote_name n =
     match n with
-      Names.Name id -> Constr.mkApp (nNamed, [| quote_ident id |])
-    | Names.Anonymous -> nAnon
+      Names.Name id -> constr_mkApp (nNamed, [| quote_ident id |])
+    | Names.Anonymous -> Lazy.force nAnon
 
   let quote_cast_kind k =
     match k with
-      Constr.VMcast -> kVmCast
-    | Constr.DEFAULTcast -> kCast
-    | Constr.REVERTcast -> kRevertCast
-    | Constr.NATIVEcast -> kNative
+      Constr.VMcast -> Lazy.force kVmCast
+    | Constr.DEFAULTcast -> Lazy.force kCast
+    | Constr.REVERTcast -> Lazy.force kRevertCast
+    | Constr.NATIVEcast -> Lazy.force kNative
 
   let string_of_level s =
     to_string (Univ.Level.to_string s)
 
   let quote_level l =
     debug (fun () -> str"quote_level " ++ Level.pr l);
-    if Level.is_prop l then lProp
-    else if Level.is_set l then lSet
+    if Level.is_prop l then Lazy.force lProp
+    else if Level.is_set l then Lazy.force lSet
     else match Level.var_index l with
-         | Some x -> Constr.mkApp (tLevelVar, [| quote_int x |])
-         | None -> Constr.mkApp (tLevel, [| string_of_level l|])
+         | Some x -> constr_mkApp (tLevelVar, [| quote_int x |])
+         | None -> constr_mkApp (tLevel, [| string_of_level l|])
 
   let quote_universe s =
-    let levels = Universe.map (fun (l,i) -> pair tlevel bool_type (quote_level l) (if i > 0 then ttrue else tfalse)) s in
+    let levels = Universe.map (fun (l,i) -> pairl tlevel bool_type (quote_level l) (quote_bool (i > 0))) s in
     let hd = List.hd levels in
-    let tl = to_coq_list (prod tlevel bool_type) (List.tl levels) in
-    Constr.mkApp (tmake_universe, [| hd ; tl |])
+    let tl = to_coq_list (prodl tlevel bool_type) (List.tl levels) in
+    constr_mkApp (tmake_universe, [| hd ; tl |])
 
   (* todo : can be deduced from quote_level, hence shoud be in the Reify module *)
   let quote_univ_instance u =
     let arr = Univ.Instance.to_array u in
-    to_coq_list tlevel (CArray.map_to_list quote_level arr)
+    to_coq_listl tlevel (CArray.map_to_list quote_level arr)
 
   let quote_constraint_type (c : Univ.constraint_type) =
     match c with
-    | Lt -> tunivLt
-    | Le -> tunivLe
-    | Eq -> tunivEq
+    | Lt -> Lazy.force tunivLt
+    | Le -> Lazy.force tunivLe
+    | Eq -> Lazy.force tunivEq
 
   let quote_univ_constraint ((l1, ct, l2) : Univ.univ_constraint) =
     let l1 = quote_level l1 in
     let l2 = quote_level l2 in
     let ct = quote_constraint_type ct in
-    Constr.mkApp (tmake_univ_constraint, [| l1; ct; l2 |])
+    constr_mkApp (tmake_univ_constraint, [| l1; ct; l2 |])
 
   let quote_univ_constraints const =
     let const = Univ.Constraint.elements const in
     List.fold_left (fun tm c ->
         let c = quote_univ_constraint c in
-        Constr.mkApp (tConstraintSetadd, [| c; tm|])
-      ) tConstraintSetempty const
+        constr_mkApp (tConstraintSetadd, [| c; tm|])
+      ) (Lazy.force tConstraintSetempty) const
 
   let quote_variance v =
     match v with
-    | Univ.Variance.Irrelevant -> cIrrelevant
-    | Univ.Variance.Covariant -> cCovariant
-    | Univ.Variance.Invariant -> cInvariant
+    | Univ.Variance.Irrelevant -> Lazy.force cIrrelevant
+    | Univ.Variance.Covariant -> Lazy.force cCovariant
+    | Univ.Variance.Invariant -> Lazy.force cInvariant
 
   let quote_cuminfo_variance var =
     let var_list = CArray.map_to_list quote_variance var in
-    to_coq_list tVariance var_list
+    to_coq_listl tVariance var_list
 
   let quote_ucontext inst const =
     let inst' = quote_univ_instance inst in
     let const' = quote_univ_constraints const in
-    Constr.mkApp (tUContextmake, [|inst'; const'|])
+    constr_mkApp (tUContextmake, [|inst'; const'|])
 
   let quote_univ_context uctx =
     let inst = Univ.UContext.instance uctx in
     let const = Univ.UContext.constraints uctx in
-    Constr.mkApp (cMonomorphic_ctx, [| quote_ucontext inst const |])
+    constr_mkApp (cMonomorphic_ctx, [| quote_ucontext inst const |])
 
   let quote_cumulative_univ_context cumi =
     let uctx = Univ.CumulativityInfo.univ_context cumi in
@@ -160,14 +160,14 @@ struct
     let var = Univ.CumulativityInfo.variance cumi in
     let uctx' = quote_ucontext inst const in
     let var' = quote_cuminfo_variance var in
-    let listvar = Constr.mkApp (tlist, [| tVariance |]) in
-    let cumi' = pair tUContext listvar uctx' var' in
-    Constr.mkApp (cCumulative_ctx, [| cumi' |])
+    let listvar = constr_mkAppl (tlist, [| tVariance |]) in
+    let cumi' = pair (Lazy.force tUContext) listvar uctx' var' in
+    constr_mkApp (cCumulative_ctx, [| cumi' |])
 
   let quote_abstract_univ_context_aux uctx =
     let inst = Univ.UContext.instance uctx in
     let const = Univ.UContext.constraints uctx in
-    Constr.mkApp (cPolymorphic_ctx, [| quote_ucontext inst const |])
+    constr_mkApp (cPolymorphic_ctx, [| quote_ucontext inst const |])
 
   let quote_abstract_univ_context uctx =
     let uctx = Univ.AUContext.repr uctx in
@@ -183,58 +183,58 @@ struct
   let quote_ugraph (g : UGraph.t) =
     let inst' = quote_univ_instance Univ.Instance.empty in
     let const' = quote_univ_constraints (UGraph.constraints_of_universes g) in
-    let uctx = Constr.mkApp (tUContextmake, [|inst' ; const'|]) in
-    Constr.mkApp (tadd_global_constraints, [|Constr.mkApp (cMonomorphic_ctx, [| uctx |]); tinit_graph|])
+    let uctx = constr_mkApp (tUContextmake, [|inst' ; const'|]) in
+    constr_mkApp (tadd_global_constraints, [|constr_mkApp (cMonomorphic_ctx, [| uctx |]); Lazy.force tinit_graph|])
 
   let quote_sort s =
     quote_universe (Sorts.univ_of_sort s)
 
   let quote_sort_family = function
-    | Sorts.InProp -> sfProp
-    | Sorts.InSet -> sfSet
-    | Sorts.InType -> sfType
+    | Sorts.InProp -> Lazy.force sfProp
+    | Sorts.InSet -> Lazy.force sfSet
+    | Sorts.InType -> Lazy.force sfType
 
   let quote_context_decl na b t =
-    Constr.mkApp (tmkdecl, [| na; quote_option tTerm b; t |])
+    constr_mkApp (tmkdecl, [| na; quote_optionl tTerm b; t |])
 
   let quote_context ctx =
-    to_coq_list tcontext_decl ctx
+    to_coq_listl tcontext_decl ctx
 
   let mk_ctor_list =
     let ctor_list =
-      let ctor_info_typ = prod (prod tident tTerm) tnat in
-      to_coq_list ctor_info_typ
+      lazy (let ctor_info_typ = prod (prodl tident tTerm) (Lazy.force tnat) in
+      to_coq_list ctor_info_typ)
     in
     fun ls ->
-    let ctors = List.map (fun (a,b,c) -> pair (prod tident tTerm) tnat
-				              (pair tident tTerm a b) c) ls in
-    ctor_list ctors
+    let ctors = List.map (fun (a,b,c) -> pair (prodl tident tTerm) (Lazy.force tnat)
+				              (pairl tident tTerm a b) c) ls in
+    (Lazy.force ctor_list) ctors
 
   let mk_proj_list d =
-    to_coq_list (prod tident tTerm)
-                (List.map (fun (a, b) -> pair tident tTerm a b) d)
+    to_coq_list (prodl tident tTerm)
+                (List.map (fun (a, b) -> pairl tident tTerm a b) d)
 
   let quote_inductive (kn, i) =
-    Constr.mkApp (tmkInd, [| kn; i |])
+    constr_mkApp (tmkInd, [| kn; i |])
 
-  let mkAnon = nAnon
-  let mkName id = Constr.mkApp (nNamed, [| id |])
+  let mkAnon () = Lazy.force nAnon
+  let mkName id = constr_mkApp (nNamed, [| id |])
   let quote_kn kn = quote_string (KerName.to_string kn)
-  let mkRel i = Constr.mkApp (tRel, [| i |])
-  let mkVar id = Constr.mkApp (tVar, [| id |])
-  let mkEvar n args = Constr.mkApp (tEvar, [| n; to_coq_list tTerm (Array.to_list args) |])
-  let mkSort s = Constr.mkApp (tSort, [| s |])
-  let mkCast c k t = Constr.mkApp (tCast, [| c ; k ; t |])
-  let mkConst kn u = Constr.mkApp (tConst, [| kn ; u |])
+  let mkRel i = constr_mkApp (tRel, [| i |])
+  let mkVar id = constr_mkApp (tVar, [| id |])
+  let mkEvar n args = constr_mkApp (tEvar, [| n; to_coq_listl tTerm (Array.to_list args) |])
+  let mkSort s = constr_mkApp (tSort, [| s |])
+  let mkCast c k t = constr_mkApp (tCast, [| c ; k ; t |])
+  let mkConst kn u = constr_mkApp (tConst, [| kn ; u |])
   let mkProd na t b =
-    Constr.mkApp (tProd, [| na ; t ; b |])
+    constr_mkApp (tProd, [| na ; t ; b |])
   let mkLambda na t b =
-    Constr.mkApp (tLambda, [| na ; t ; b |])
+    constr_mkApp (tLambda, [| na ; t ; b |])
   let mkApp f xs =
-    Constr.mkApp (tApp, [| f ; to_coq_list tTerm (Array.to_list xs) |])
+    constr_mkApp (tApp, [| f ; to_coq_listl tTerm (Array.to_list xs) |])
 
   let mkLetIn na t t' b =
-    Constr.mkApp (tLetIn, [| na ; t ; t' ; b |])
+    constr_mkApp (tLetIn, [| na ; t ; t' ; b |])
 
   let rec seq f t =
     if f < t then f :: seq (f + 1) t
@@ -242,128 +242,128 @@ struct
 
   let mkFix ((a,b),(ns,ts,ds)) =
     let mk_fun xs i =
-      Constr.mkApp (tmkdef, [| tTerm ; Array.get ns i ;
+      constr_mkApp (tmkdef, [| Lazy.force tTerm ; Array.get ns i ;
                              Array.get ts i ; Array.get ds i ; Array.get a i |]) :: xs
     in
     let defs = List.fold_left mk_fun [] (seq 0 (Array.length a)) in
-    let block = to_coq_list (Constr.mkApp (tdef, [| tTerm |])) (List.rev defs) in
-    Constr.mkApp (tFix, [| block ; b |])
+    let block = to_coq_list (constr_mkAppl (tdef, [| tTerm |])) (List.rev defs) in
+    constr_mkApp (tFix, [| block ; b |])
 
   let mkConstruct (ind, i) u =
-    Constr.mkApp (tConstructor, [| ind ; i ; u |])
+    constr_mkApp (tConstructor, [| ind ; i ; u |])
 
   let mkCoFix (a,(ns,ts,ds)) =
     let mk_fun xs i =
-      Constr.mkApp (tmkdef, [| tTerm ; Array.get ns i ;
-                             Array.get ts i ; Array.get ds i ; tO |]) :: xs
+      constr_mkApp (tmkdef, [| Lazy.force tTerm ; Array.get ns i ;
+                             Array.get ts i ; Array.get ds i ; Lazy.force tO |]) :: xs
     in
     let defs = List.fold_left mk_fun [] (seq 0 (Array.length ns)) in
-    let block = to_coq_list (Constr.mkApp (tdef, [| tTerm |])) (List.rev defs) in
-    Constr.mkApp (tCoFix, [| block ; a |])
+    let block = to_coq_list (constr_mkAppl (tdef, [| tTerm |])) (List.rev defs) in
+    constr_mkApp (tCoFix, [| block ; a |])
 
-  let mkInd i u = Constr.mkApp (tInd, [| i ; u |])
+  let mkInd i u = constr_mkApp (tInd, [| i ; u |])
 
   let mkCase (ind, npar) nargs p c brs =
-    let info = pair tIndTy tnat ind npar in
-    let branches = List.map2 (fun br nargs ->  pair tnat tTerm nargs br) brs nargs in
-    let tl = prod tnat tTerm in
-    Constr.mkApp (tCase, [| info ; p ; c ; to_coq_list tl branches |])
+    let info = pairl tIndTy tnat ind npar in
+    let branches = List.map2 (fun br nargs ->  pairl tnat tTerm nargs br) brs nargs in
+    let tl = prodl tnat tTerm in
+    constr_mkApp (tCase, [| info ; p ; c ; to_coq_list tl branches |])
 
   let quote_proj ind pars args =
-    pair (prod tIndTy tnat) tnat (pair tIndTy tnat ind pars) args
+    pair (prodl tIndTy tnat) (Lazy.force tnat) (pairl tIndTy tnat ind pars) args
 
   let mkProj kn t =
-    Constr.mkApp (tProj, [| kn; t |])
+    constr_mkApp (tProj, [| kn; t |])
 
   let mk_one_inductive_body (a, b, c, d, e) =
-    let c = to_coq_list tsort_family c in
+    let c = to_coq_listl tsort_family c in
     let d = mk_ctor_list d in
     let e = mk_proj_list e in
-    Constr.mkApp (tBuild_one_inductive_body, [| a; b; c; d; e |])
+    constr_mkApp (tBuild_one_inductive_body, [| a; b; c; d; e |])
 
   let mk_mutual_inductive_body finite npars params inds uctx =
-    let inds = to_coq_list tone_inductive_body inds in
-    Constr.mkApp (tBuild_mutual_inductive_body, [|finite; npars; params; inds; uctx|])
+    let inds = to_coq_listl tone_inductive_body inds in
+    constr_mkApp (tBuild_mutual_inductive_body, [|finite; npars; params; inds; uctx|])
 
   let mk_constant_body ty tm uctx =
-    let tm = quote_option tTerm tm in
-    Constr.mkApp (tBuild_constant_body, [|ty; tm; uctx|])
+    let tm = quote_optionl tTerm tm in
+    constr_mkApp (tBuild_constant_body, [|ty; tm; uctx|])
 
   let mk_inductive_decl kn mind =
-    Constr.mkApp (tInductiveDecl, [|kn; mind|])
+    constr_mkApp (tInductiveDecl, [|kn; mind|])
 
   let mk_constant_decl kn bdy =
-    Constr.mkApp (tConstantDecl, [|kn; bdy|])
+    constr_mkApp (tConstantDecl, [|kn; bdy|])
 
-  let empty_global_declartions =
-    Constr.mkApp (c_nil, [| tglobal_decl |])
+  let empty_global_declartions () =
+    constr_mkAppl (c_nil, [| tglobal_decl |])
 
   let add_global_decl d l =
-    Constr.mkApp (c_cons, [|tglobal_decl; d; l|])
+    constr_mkApp (c_cons, [|Lazy.force tglobal_decl; d; l|])
 
-  let mk_program = pair tglobal_declarations tTerm
+  let mk_program f s = pairl tglobal_declarations tTerm f s
 
   let quote_mind_finiteness (f: Declarations.recursivity_kind) =
     match f with
-    | Declarations.Finite -> cFinite
-    | Declarations.CoFinite -> cCoFinite
-    | Declarations.BiFinite -> cBiFinite
+    | Declarations.Finite -> Lazy.force cFinite
+    | Declarations.CoFinite -> Lazy.force cCoFinite
+    | Declarations.BiFinite -> Lazy.force cBiFinite
 
   let make_one_inductive_entry (iname, arity, templatePoly, consnames, constypes) =
-    let consnames = to_coq_list tident consnames in
-    let constypes = to_coq_list tTerm constypes in
-    Constr.mkApp (tBuild_one_inductive_entry, [| iname; arity; templatePoly; consnames; constypes |])
+    let consnames = to_coq_listl tident consnames in
+    let constypes = to_coq_listl tTerm constypes in
+    constr_mkApp (tBuild_one_inductive_entry, [| iname; arity; templatePoly; consnames; constypes |])
 
   let quote_mind_params l =
-    let pair i l = pair tident tlocal_entry i l in
+    let pair i l = pairl tident tlocal_entry i l in
     let map (id, ob) =
       match ob with
-      | Left b -> pair id (Constr.mkApp (tLocalDef,[|b|]))
-      | Right t -> pair id (Constr.mkApp (tLocalAssum,[|t|]))
+      | Left b -> pair id (constr_mkApp (tLocalDef,[|b|]))
+      | Right t -> pair id (constr_mkApp (tLocalAssum,[|t|]))
     in
-    let the_prod = Constr.mkApp (prod_type,[|tident; tlocal_entry|]) in
+    let the_prod = constr_mkAppl (prod_type,[|tident; tlocal_entry|]) in
     to_coq_list the_prod (List.map map l)
 
   let quote_mutual_inductive_entry (mf, mp, is, mpol) =
-    let is = to_coq_list tOne_inductive_entry (List.map make_one_inductive_entry is) in
-    let mpr = Constr.mkApp (cNone, [|bool_type|]) in
-    let mr = Constr.mkApp (cNone, [|Constr.mkApp (option_type, [|tident|])|])  in
-    Constr.mkApp (tBuild_mutual_inductive_entry, [| mr; mf; mp; is; mpol; mpr |])
+    let is = to_coq_listl tOne_inductive_entry (List.map make_one_inductive_entry is) in
+    let mpr = constr_mkAppl (cNone, [|bool_type|]) in
+    let mr = constr_mkApp (cNone, [|constr_mkAppl (option_type, [|tident|])|])  in
+    constr_mkApp (tBuild_mutual_inductive_entry, [| mr; mf; mp; is; mpol; mpr |])
 
 
   let quote_constant_entry (ty, body, ctx) =
     match body with
     | None ->
-      Constr.mkApp (cParameterEntry, [| Constr.mkApp (cParameter_entry, [|ty; ctx|]) |])
+      constr_mkApp (cParameterEntry, [| constr_mkApp (cParameter_entry, [|ty; ctx|]) |])
     | Some body ->
-      Constr.mkApp (cDefinitionEntry,
-                  [| Constr.mkApp (cDefinition_entry, [|ty;body;ctx;tfalse (*FIXME*)|]) |])
+      constr_mkApp (cDefinitionEntry,
+                  [| constr_mkApp (cDefinition_entry, [|ty;body;ctx;Lazy.force tfalse (*FIXME*)|]) |])
 
   let quote_entry decl =
-    let opType = Constr.mkApp(sum_type, [|tConstant_entry;tMutual_inductive_entry|]) in
-    let mkSome c t = Constr.mkApp (cSome, [|opType; Constr.mkApp (c, [|tConstant_entry;tMutual_inductive_entry; t|] )|]) in
+    let opType = constr_mkAppl(sum_type, [|tConstant_entry;tMutual_inductive_entry|]) in
+    let mkSome c t = constr_mkApp (cSome, [|opType; constr_mkAppl (c, [|tConstant_entry;tMutual_inductive_entry; lazy t|] )|]) in
     let mkSomeDef = mkSome cInl in
     let mkSomeInd  = mkSome cInr in
     match decl with
     | Some (Left centry) -> mkSomeDef (quote_constant_entry centry)
     | Some (Right mind) -> mkSomeInd mind
-    | None -> Constr.mkApp (cNone, [| opType |])
+    | None -> constr_mkApp (cNone, [| opType |])
 
 
   let quote_global_reference : Globnames.global_reference -> quoted_global_reference = function
     | Globnames.VarRef _ -> CErrors.user_err (str "VarRef unsupported")
     | Globnames.ConstRef c ->
        let kn = quote_kn (Names.Constant.canonical c) in
-       Constr.mkApp (tConstRef, [|kn|])
+       constr_mkApp (tConstRef, [|kn|])
     | Globnames.IndRef (i, n) ->
        let kn = quote_kn (Names.MutInd.canonical i) in
        let n = quote_int n in
-       Constr.mkApp (tIndRef, [|quote_inductive (kn ,n)|])
+       constr_mkApp (tIndRef, [|quote_inductive (kn ,n)|])
     | Globnames.ConstructRef ((i, n), k) ->
        let kn = quote_kn (Names.MutInd.canonical i) in
        let n = quote_int n in
        let k = (quote_int (k - 1)) in
-       Constr.mkApp (tConstructRef, [|quote_inductive (kn ,n); k|])
+       constr_mkApp (tConstructRef, [|quote_inductive (kn ,n); k|])
 end
 
 

--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -54,7 +54,7 @@ VERNAC COMMAND EXTEND Make_tests CLASSIFIED AS QUERY
     | [ "Test" "Quote" constr(def) ] ->
       [ let (evm,env) = Pfedit.get_current_context () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
-        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmTestQuote in
+        let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmTestQuote) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr.mkRel 0; EConstr.to_constr evm def|]) in
         run_template_program env evm pgm ]
 END;;
@@ -63,7 +63,7 @@ VERNAC COMMAND EXTEND Make_vernac CLASSIFIED AS SIDEFF
     | [ "Quote" "Definition" ident(name) ":=" constr(def) ] ->
       [ let (evm,env) = Pfedit.get_current_context () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
-        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmQuoteDefinition in
+        let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmQuoteDefinition) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; Constr.mkRel 0; EConstr.to_constr evm def|]) in
         run_template_program env evm pgm ]
 END;;
@@ -75,7 +75,7 @@ VERNAC COMMAND EXTEND Make_vernac_reduce CLASSIFIED AS SIDEFF
         (* TODO : implem quoting of tactic reductions so that we can use ptmQuoteDefinitionRed *)
         let (evm, rd) = Tacinterp.interp_redexp env evm rd in
 	let (evm, def) = Quoter.reduce env evm rd (EConstr.to_constr evm def) in
-        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmQuoteDefinition in
+        let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmQuoteDefinition) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; Constr.mkRel 0; def|]) in
         run_template_program env evm pgm ]
 END;;
@@ -84,7 +84,7 @@ VERNAC COMMAND EXTEND Make_recursive CLASSIFIED AS SIDEFF
     | [ "Quote" "Recursively" "Definition" ident(name) ":=" constr(def) ] ->
       [ let (evm,env) = Pfedit.get_current_context () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
-        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmQuoteRecDefinition in
+        let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmQuoteRecDefinition) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; Constr.mkRel 0; EConstr.to_constr evm def|]) in
         run_template_program env evm pgm ]
 END;;
@@ -93,7 +93,7 @@ VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
     | [ "Make" "Definition" ident(name) ":=" constr(def) ] ->
       [ let (evm, env) = Pfedit.get_current_context () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
-        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmMkDefinition in
+        let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmMkDefinition) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|Constr_quoter.TemplateCoqQuoter.quote_ident name; EConstr.to_constr evm def|]) in
         run_template_program env evm pgm ]
 END;;
@@ -102,7 +102,7 @@ VERNAC COMMAND EXTEND Unquote_inductive CLASSIFIED AS SIDEFF
     | [ "Make" "Inductive" constr(def) ] ->
       [ let (evm, env) = Pfedit.get_current_context () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
-        let (evm, pgm) = EConstr.fresh_global env evm Template_monad.ptmMkInductive in
+        let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmMkInductive) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, [|EConstr.to_constr evm def|]) in
         run_template_program env evm pgm ]
 END;;

--- a/template-coq/src/quoted.ml
+++ b/template-coq/src/quoted.ml
@@ -117,6 +117,6 @@ sig
   val mkCoFix : quoted_int * (quoted_name array * t array * t array) -> t
 
   val mkName : quoted_ident -> quoted_name
-  val mkAnon : quoted_name
+  val mkAnon : unit -> quoted_name
 
 end

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -91,7 +91,7 @@ sig
 
   val mk_constant_decl : quoted_kernel_name -> quoted_constant_body -> quoted_global_decl
 
-  val empty_global_declartions : quoted_global_declarations
+  val empty_global_declartions : unit -> quoted_global_declarations
   val add_global_decl : quoted_global_decl -> quoted_global_declarations -> quoted_global_declarations
 
   val mk_program : quoted_global_declarations -> t -> quoted_program
@@ -435,7 +435,7 @@ struct
       (x,y)
     in
     let (tm, _) = quote_rem () env trm in
-    let decls =  List.fold_left (fun acc d -> Q.add_global_decl d acc) Q.empty_global_declartions !constants in
+    let decls =  List.fold_left (fun acc d -> Q.add_global_decl d acc) (Q.empty_global_declartions ()) !constants in
     Q.mk_program decls tm
 
   let quote_one_ind envA envC (mi:Entries.one_inductive_entry) =

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -19,12 +19,12 @@ let unquote_reduction_strategy env evm trm (* of type reductionStrategy *) : Red
   let (trm, args) = app_full trm [] in
   (* from g_tactic.ml4 *)
   let default_flags = Redops.make_red_flag [FBeta;FMatch;FFix;FCofix;FZeta;FDeltaBut []] in
-  if Constr.equal trm tcbv then Cbv default_flags
-  else if Constr.equal trm tcbn then Cbn default_flags
-  else if Constr.equal trm thnf then Hnf
-  else if Constr.equal trm tall then Cbv all_flags
-  else if Constr.equal trm tlazy then Lazy all_flags
-  else if Constr.equal trm tunfold then
+  if constr_equall trm tcbv then Cbv default_flags
+  else if constr_equall trm tcbn then Cbn default_flags
+  else if constr_equall trm thnf then Hnf
+  else if constr_equall trm tall then Cbv all_flags
+  else if constr_equall trm tlazy then Lazy all_flags
+  else if constr_equall trm tunfold then
     match args with
     | name (* to unfold *) :: _ ->
        let name = reduce_all env evm name in
@@ -39,10 +39,10 @@ let denote_local_entry evm trm =
   let (h,args) = app_full trm [] in
   match args with
     x :: [] ->
-    if Constr.equal h tLocalDef then
+    if constr_equall h tLocalDef then
       let evm, x = denote_term evm x in
       evm, Entries.LocalDefEntry x
-    else if  Constr.equal h tLocalAssum then
+    else if  constr_equall h tLocalAssum then
       let evm, x = denote_term evm x in
       evm, Entries.LocalAssumEntry x
     else
@@ -53,9 +53,9 @@ let denote_mind_entry_finite trm =
   let (h,args) = app_full trm [] in
   match args with
     [] ->
-    if Constr.equal h cFinite then Declarations.Finite
-    else if  Constr.equal h cCoFinite then Declarations.CoFinite
-    else if  Constr.equal h cBiFinite then Declarations.BiFinite
+    if constr_equall h cFinite then Declarations.Finite
+    else if  constr_equall h cCoFinite then Declarations.CoFinite
+    else if  constr_equall h cBiFinite then Declarations.BiFinite
     else not_supported_verb trm "denote_mind_entry_finite"
   | _ -> bad_term_verb trm "denote_mind_entry_finite"
 
@@ -63,11 +63,11 @@ let denote_mind_entry_finite trm =
 
 let unquote_map_option f trm =
   let (h,args) = app_full trm [] in
-  if Constr.equal h cSome then
+  if constr_equall h cSome then
     match args with
       _ :: x :: [] -> Some (f x)
     | _ -> bad_term trm
-  else if Constr.equal h cNone then
+  else if constr_equall h cNone then
     match args with
       _ :: [] -> None
     | _ -> bad_term trm
@@ -82,9 +82,9 @@ let unquote_constraint_type trm (* of type constraint_type *) : constraint_type 
   let (h,args) = app_full trm [] in
   match args with
     [] ->
-    if Constr.equal h tunivLt then Univ.Lt
-    else if Constr.equal h tunivLe then Univ.Le
-    else if Constr.equal h tunivEq then Univ.Eq
+    if constr_equall h tunivLt then Univ.Lt
+    else if constr_equall h tunivLe then Univ.Le
+    else if constr_equall h tunivEq then Univ.Eq
     else not_supported_verb trm "unquote_constraint_type"
   | _ -> bad_term_verb trm "unquote_constraint_type"
 
@@ -111,9 +111,9 @@ let unquote_constraints evm c (* of type constraints *) : _ * Constraint.t =
 
 
 let denote_variance trm (* of type Variance *) : Variance.t =
-  if Constr.equal trm cIrrelevant then Variance.Irrelevant
-  else if Constr.equal trm cCovariant then Variance.Covariant
-  else if Constr.equal trm cInvariant then Variance.Invariant
+  if constr_equall trm cIrrelevant then Variance.Irrelevant
+  else if constr_equall trm cCovariant then Variance.Covariant
+  else if constr_equall trm cInvariant then Variance.Invariant
   else not_supported_verb trm "denote_variance"
 
 let denote_ucontext evm trm (* of type UContext.t *) : _ * UContext.t =
@@ -143,13 +143,13 @@ let to_entry_inductive_universes = function
 let denote_universe_context evm trm (* of type universe_context *) : _ * universe_context_type =
   let (h, args) = app_full trm [] in
   match args with
-  | ctx :: [] -> if Constr.equal h cMonomorphic_ctx then
+  | ctx :: [] -> if constr_equall h cMonomorphic_ctx then
                    let evm, ctx = denote_ucontext evm ctx in
                    evm, Monomorphic_uctx ctx
-                 else if Constr.equal h cPolymorphic_ctx then
+                 else if constr_equall h cPolymorphic_ctx then
                    let evm, ctx = denote_ucontext evm ctx in
                    evm, Polymorphic_uctx ctx
-                 else if Constr.equal h cCumulative_ctx then
+                 else if constr_equall h cCumulative_ctx then
                    let evm, ctx = denote_cumulativity_info evm ctx in
                    evm, Cumulative_uctx ctx
                  else
@@ -160,7 +160,7 @@ let denote_universe_context evm trm (* of type universe_context *) : _ * univers
 
 let unquote_one_inductive_entry evm trm (* of type one_inductive_entry *) : _ * Entries.one_inductive_entry =
   let (h,args) = app_full trm [] in
-  if Constr.equal h tBuild_one_inductive_entry then
+  if constr_equall h tBuild_one_inductive_entry then
     match args with
     | id::ar::template::cnames::ctms::[] ->
        let id = unquote_ident id in
@@ -179,7 +179,7 @@ let unquote_one_inductive_entry evm trm (* of type one_inductive_entry *) : _ * 
 
 let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) : _ * Entries.mutual_inductive_entry =
   let (h,args) = app_full trm [] in
-  if Constr.equal h tBuild_mutual_inductive_entry then
+  if constr_equall h tBuild_mutual_inductive_entry then
     match args with
     | record::finite::params::inds::univs::priv::[] ->
        let record = unquote_map_option (unquote_map_option unquote_ident) record in
@@ -350,11 +350,11 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
     k (env, evm, quote_ugraph univs)
   | TmPrint trm ->
     Feedback.msg_info (Printer.pr_constr_env env evm trm);
-    k (env, evm, unit_tt)
+    k (env, evm, Lazy.force unit_tt)
   | TmMsg msg ->
      let msg = unquote_string (reduce_all env evm msg) in
      Plugin_core.run (Plugin_core.tmMsg msg) env evm
-      (fun env evm _ -> k (env, evm, unit_tt))
+      (fun env evm _ -> k (env, evm, Lazy.force unit_tt))
   | TmFail trm ->
     let err = unquote_string (reduce_all env evm trm) in
     CErrors.user_err (str err)
@@ -362,10 +362,10 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
     let id = Libnames.qualid_of_string (unquote_string id) in
     Plugin_core.run (Plugin_core.tmAbout id) env evm
       (fun env evm -> function
-           None -> k (env, evm, Constr.mkApp (cNone, [|tglobal_reference|]))
+           None -> k (env, evm, constr_mkAppl (cNone, [|tglobal_reference|]))
          | Some gr ->
            let qgr = quote_global_reference gr in
-           let opt = Constr.mkApp (cSome , [|tglobal_reference ; qgr|]) in
+           let opt = constr_mkApp (cSome , [|Lazy.force tglobal_reference ; qgr|]) in
            k (env, evm, opt))
   | TmCurrentModPath ->
     let mp = Lib.current_mp () in
@@ -384,7 +384,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
   | TmMkInductive mind ->
     declare_inductive env evm mind;
     let env = Global.env () in
-    k (env, evm, unit_tt)
+    k (env, evm, Lazy.force unit_tt)
   | TmUnquote t ->
     begin
        try
@@ -393,9 +393,9 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
          let typ = Retyping.get_type_of env evm (EConstr.of_constr t') in
          let evm, typ = Evarsolve.refresh_universes (Some false) env evm typ in
          let make_typed_term typ term evm =
-           match texistT_typed_term with
+           match Lazy.force texistT_typed_term with
            | ConstructRef ctor ->
-              let (evm,c) = Evarutil.new_global evm texistT_typed_term in
+              let (evm,c) = Evarutil.new_global evm (Lazy.force texistT_typed_term) in
               let term = Constr.mkApp
                (EConstr.to_constr evm c, [|typ; t'|]) in
              let evm, _ = Typing.type_of env evm (EConstr.of_constr term) in
@@ -417,7 +417,7 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
     k (env, evm, quote_ident name')
   | TmExistingInstance name ->
      Classes.existing_instance true (CAst.make (Libnames.Qualid (Libnames.qualid_of_ident (unquote_ident name)))) None;
-     k (env, evm, unit_tt)
+     k (env, evm, Lazy.force unit_tt)
   | TmInferInstance (s, typ) ->
     begin
       let evm, typ =
@@ -428,19 +428,19 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
         | None -> evm, typ in
       try
         let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
-        k (env, evm, Constr.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
+        k (env, evm, constr_mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
       with
-        Not_found -> k (env, evm, Constr.mkApp (cNone, [|typ|]))
+        Not_found -> k (env, evm, constr_mkApp (cNone, [|typ|]))
     end
   | TmInferInstanceTerm typ ->
     let evm,typ = denote_term evm (reduce_all env evm typ) in
     Plugin_core.run (Plugin_core.tmInferInstance typ) env evm
       (fun env evm -> function
-           None -> k (env, evm, Constr.mkApp (cNone, [| tTerm|]))
+           None -> k (env, evm, constr_mkAppl (cNone, [| tTerm|]))
          | Some trm ->
            let qtrm = TermReify.quote_term env trm in
-           k (env, evm, Constr.mkApp (cSome, [| tTerm; qtrm |])))
+           k (env, evm, constr_mkApp (cSome, [| Lazy.force tTerm; qtrm |])))
   | TmPrintTerm trm ->
     let evm,trm = denote_term evm (reduce_all env evm trm) in
     Plugin_core.run (Plugin_core.tmPrint trm) env evm
-      (fun env evm _ -> k (env, evm, unit_tt))
+      (fun env evm _ -> k (env, evm, Lazy.force unit_tt))

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -5,8 +5,8 @@ open Pp
 open Tm_util
 
 
-let resolve_symbol_p (path : string list) (tm : string) : global_reference =
-  Coqlib.gen_reference_in_modules contrib_name [path] tm
+let resolve_symbol_p (path : string list) (tm : string) : global_reference Lazy.t =
+  lazy (Coqlib.gen_reference_in_modules contrib_name [path] tm)
 
 let pkg_template_monad_prop = ["MetaCoq";"Template";"TemplateMonad";"Core"]
 let pkg_template_monad_type = ["MetaCoq";"Template";"TemplateMonad";"Extractable"]
@@ -205,166 +205,167 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     with _ ->
       CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ Printer.pr_constr_env env evd coConstr)
   in
-  if Globnames.eq_gr glob_ref ptmReturn || Globnames.eq_gr glob_ref ttmReturn then
+  let eq_gr t = Globnames.eq_gr glob_ref (Lazy.force t) in
+  if eq_gr ptmReturn || eq_gr ttmReturn then
     match args with
     | _::h::[] ->
        (TmReturn h, universes)
     | _ -> monad_failure "tmReturn" 2
-  else if Globnames.eq_gr glob_ref ptmBind || Globnames.eq_gr glob_ref ttmBind then
+  else if eq_gr ptmBind || eq_gr ttmBind then
     match args with
     | _::_::a::f::[] ->
        (TmBind (a, f), universes)
     | _ -> monad_failure "tmBind" 4
-  else if Globnames.eq_gr glob_ref ptmPrint then
+  else if eq_gr ptmPrint then
     match args with
     | _::trm::[] ->
        (TmPrint trm, universes)
     | _ -> monad_failure "tmPrint" 2
-  else if Globnames.eq_gr glob_ref ttmPrintTerm then
+  else if eq_gr ttmPrintTerm then
     match args with
     | trm::[] ->
        (TmPrintTerm trm, universes)
     | _ -> monad_failure "tmPrint" 1
-  else if Globnames.eq_gr glob_ref ptmMsg || Globnames.eq_gr glob_ref ttmMsg then
+  else if eq_gr ptmMsg || eq_gr ttmMsg then
     match args with
     | trm::[] ->
        (TmMsg trm, universes)
     | _ -> monad_failure "tmMsg" 2
-  else if Globnames.eq_gr glob_ref ptmFail || Globnames.eq_gr glob_ref ttmFail then
+  else if eq_gr ptmFail || eq_gr ttmFail then
     match args with
     | _::trm::[] ->
        (TmFail trm, universes)
     | _ -> monad_failure "tmFail" 2
-  else if Globnames.eq_gr glob_ref ptmEval then
+  else if eq_gr ptmEval then
     match args with
     | strat::_::trm::[] -> (TmEval (strat, trm), universes)
     | _ -> monad_failure "tmEval" 3
-  else if Globnames.eq_gr glob_ref ttmEval then
+  else if eq_gr ttmEval then
     match args with
     | strat::trm::[] -> (TmEvalTerm (strat, trm), universes)
     | _ -> monad_failure "tmEval" 2
 
-  else if Globnames.eq_gr glob_ref ptmDefinitionRed then
+  else if eq_gr ptmDefinitionRed then
     match args with
     | name::s::typ::body::[] ->
       (TmDefinition (name, s, typ, body), universes)
     | _ -> monad_failure "tmDefinitionRed" 4
-  else if Globnames.eq_gr glob_ref ttmDefinition then
+  else if eq_gr ttmDefinition then
     match args with
     | name::typ::body::[] ->
        (TmDefinitionTerm (name, typ, body), universes)
     | _ -> monad_failure "tmDefinition" 3
 
-  else if Globnames.eq_gr glob_ref ptmLemma then
+  else if eq_gr ptmLemma then
     match args with
     | name::typ::[] ->
        (TmLemma (name,typ), universes)
     | _ -> monad_failure "tmLemma" 2
-  else if Globnames.eq_gr glob_ref ttmLemma then
+  else if eq_gr ttmLemma then
     match args with
     | name::typ::[] ->
        (TmLemmaTerm (name, typ), universes)
     | _ -> monad_failure "tmLemma" 2
 
-  else if Globnames.eq_gr glob_ref ptmAxiomRed then
+  else if eq_gr ptmAxiomRed then
     match args with
     | name::s::typ::[] ->
       (TmAxiom (name,s,typ), universes)
     | _ -> monad_failure "tmAxiomRed" 3
-  else if Globnames.eq_gr glob_ref ttmAxiom then
+  else if eq_gr ttmAxiom then
     match args with
     | name::typ::[] ->
        (TmAxiomTerm (name, typ), universes)
     | _ -> monad_failure "tmAxiom" 2
 
-  else if Globnames.eq_gr glob_ref ptmFreshName || Globnames.eq_gr glob_ref ttmFreshName then
+  else if eq_gr ptmFreshName || eq_gr ttmFreshName then
     match args with
     | name::[] ->
        (TmFreshName name, universes)
     | _ -> monad_failure "tmFreshName" 1
 
-  else if Globnames.eq_gr glob_ref ptmAbout || Globnames.eq_gr glob_ref ttmAbout then
+  else if eq_gr ptmAbout || eq_gr ttmAbout then
     match args with
     | id::[] ->
        (TmAbout id, universes)
     | _ -> monad_failure "tmAbout" 1
-  else if Globnames.eq_gr glob_ref ptmCurrentModPath then
+  else if eq_gr ptmCurrentModPath then
     match args with
     | _::[] -> (TmCurrentModPath, universes)
     | _ -> monad_failure "tmCurrentModPath" 1
-  else if Globnames.eq_gr glob_ref ttmCurrentModPath then
+  else if eq_gr ttmCurrentModPath then
     match args with
     | [] -> (TmCurrentModPath, universes)
     | _ -> monad_failure "tmCurrentModPath" 1
 
-  else if Globnames.eq_gr glob_ref ptmQuote then
+  else if eq_gr ptmQuote then
     match args with
     | _::trm::[] ->
        (TmQuote (false,trm), universes)
     | _ -> monad_failure "tmQuote" 2
-  else if Globnames.eq_gr glob_ref ptmQuoteRec then
+  else if eq_gr ptmQuoteRec then
     match args with
     | _::trm::[] ->
        (TmQuote (true,trm), universes)
     | _ -> monad_failure "tmQuoteRec" 2
 
-  else if Globnames.eq_gr glob_ref ptmQuoteInductive then
+  else if eq_gr ptmQuoteInductive then
     match args with
     | name::[] ->
        (TmQuoteInd (name, false), universes)
     | _ -> monad_failure "tmQuoteInductive" 1
-  else if Globnames.eq_gr glob_ref ttmQuoteInductive then
+  else if eq_gr ttmQuoteInductive then
     match args with
     | name::[] ->
        (TmQuoteInd (name, true), universes)
     | _ -> monad_failure "tmQuoteInductive" 1
 
-  else if Globnames.eq_gr glob_ref ptmQuoteUniverses || Globnames.eq_gr glob_ref ttmQuoteUniverses then
+  else if eq_gr ptmQuoteUniverses || eq_gr ttmQuoteUniverses then
     match args with
     | [] ->
        (TmQuoteUnivs, universes)
     | _ -> monad_failure "tmQuoteUniverses" 0
-  else if Globnames.eq_gr glob_ref ptmQuoteConstant then
+  else if eq_gr ptmQuoteConstant then
     match args with
     | name::bypass::[] ->
        (TmQuoteConst (name, bypass, false), universes)
     | _ -> monad_failure "tmQuoteConstant" 2
-  else if Globnames.eq_gr glob_ref ttmQuoteConstant then
+  else if eq_gr ttmQuoteConstant then
     match args with
     | name::bypass::[] ->
        (TmQuoteConst (name, bypass, true), universes)
     | _ -> monad_failure "tmQuoteConstant" 2
 
-  else if Globnames.eq_gr glob_ref ptmMkInductive then
+  else if eq_gr ptmMkInductive then
     match args with
     | mind::[] -> (TmMkInductive mind, universes)
     | _ -> monad_failure "tmMkInductive" 1
-  else if Globnames.eq_gr glob_ref ttmInductive then
+  else if eq_gr ttmInductive then
     match args with
     | mind::[] -> (TmMkInductive mind, universes)
     | _ -> monad_failure "tmInductive" 1
-  else if Globnames.eq_gr glob_ref ptmUnquote then
+  else if eq_gr ptmUnquote then
     match args with
     | t::[] ->
        (TmUnquote t, universes)
     | _ -> monad_failure "tmUnquote" 1
-  else if Globnames.eq_gr glob_ref ptmUnquoteTyped then
+  else if eq_gr ptmUnquoteTyped then
     match args with
     | typ::t::[] ->
        (TmUnquoteTyped (typ, t), universes)
     | _ -> monad_failure "tmUnquoteTyped" 2
 
-  else if Globnames.eq_gr glob_ref ptmExistingInstance || Globnames.eq_gr glob_ref ttmExistingInstance then
+  else if eq_gr ptmExistingInstance || eq_gr ttmExistingInstance then
     match args with
     | name :: [] ->
        (TmExistingInstance name, universes)
     | _ -> monad_failure "tmExistingInstance" 1
-  else if Globnames.eq_gr glob_ref ptmInferInstance then
+  else if eq_gr ptmInferInstance then
     match args with
     | s :: typ :: [] ->
        (TmInferInstance (s, typ), universes)
     | _ -> monad_failure "tmInferInstance" 2
-  else if Globnames.eq_gr glob_ref ttmInferInstance then
+  else if eq_gr ttmInferInstance then
     match args with
     | typ :: [] ->
        (TmInferInstanceTerm typ, universes)

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -1,10 +1,10 @@
 
-val ptmTestQuote : Names.global_reference
-val ptmQuoteDefinition : Names.global_reference
-val ptmQuoteDefinitionRed : Names.global_reference
-val ptmQuoteRecDefinition : Names.global_reference
-val ptmMkDefinition : Names.global_reference
-val ptmMkInductive : Names.global_reference
+val ptmTestQuote : Names.global_reference Lazy.t
+val ptmQuoteDefinition : Names.global_reference Lazy.t
+val ptmQuoteDefinitionRed : Names.global_reference Lazy.t
+val ptmQuoteRecDefinition : Names.global_reference Lazy.t
+val ptmMkDefinition : Names.global_reference Lazy.t
+val ptmMkInductive : Names.global_reference Lazy.t
 
 
 type template_monad =

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -3,7 +3,7 @@ open Pp
 let contrib_name = "template-coq"
 
 let gen_constant_in_modules locstr dirs s =
-  Universes.constr_of_global (Coqlib.gen_reference_in_modules locstr dirs s)
+  lazy (Universes.constr_of_global (Coqlib.gen_reference_in_modules locstr dirs s))
 
 
 let opt_debug = ref false


### PR DESCRIPTION
This PR makes Coq symbol references lazy, fixing the anomalies in asynchronous proof mode described in #149. It is a port of #155 to the coq-8.8 branch.

In contrast to the previous PR, I introduced helper functions that eliminate some explicit Lazy.force expressions (for instance, the `pair` function now has a `pairl` counterpart that takes lazy version of the first two arguments).