### PR TITLE
remove redundant make in checker opam file

### DIFF
--- a/coq-metacoq-checker.opam
+++ b/coq-metacoq-checker.opam
@@ -16,7 +16,6 @@ authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
 ]
 license: "MIT"
 build: [
-  [make "-j%{jobs}%" "template-coq"]
   [make "-j%{jobs}%" "checker"]
 ]
 install: [


### PR DESCRIPTION
Template Coq is assumed to already be installed when building the checker, so no point in building it. So currently, this package is doing lots of unnecessary work.