### PR TITLE
Progress with dependencies for safe reduction and conversion

### DIFF
--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -213,3 +213,19 @@ Proof.
   constructor. econstructor 3. 2:eauto. apply IHX.
   econstructor 2; eauto. apply IHX.
 Qed.
+
+Lemma conv_alt_red :
+  forall Σ Γ t u,
+    Σ ;;; Γ |- t == u ->
+    ∑ t' u',
+      red Σ Γ t t' ×
+      red Σ Γ u u' ×
+      eq_term (snd Σ) t' u'.
+Proof.
+  intros Σ Γ t u h. induction h.
+  - exists t, u. intuition auto.
+  - destruct IHh as [t' [u' [? [? ?]]]].
+    exists t', u'. intuition auto. now eapply red_step.
+  - destruct IHh as [t' [u' [? [? ?]]]].
+    exists t', u'. intuition auto. now eapply red_step.
+Qed.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -179,7 +179,7 @@ Section Inversion.
   Lemma inversion_Case :
     forall {Γ ind npar p c brs T},
       Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
-      ∑ u npar args mdecl idecl pty indctx pctx ps btys,
+      ∑ u args mdecl idecl pty indctx pctx ps btys,
         declared_inductive Σ mdecl ind idecl ×
         ind_npars mdecl = npar ×
         let pars := firstn npar args in

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -293,6 +293,6 @@ Section Inversion.
       repeat pih.
       repeat outsum. repeat outtimes.
       (* Not very clear how to do *)
-  Abort.
+  Admitted.
 
 End Inversion.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -240,6 +240,15 @@ Section Inversion.
     intros Γ mfix idx T h. invtac h.
   Qed.
 
+  Ltac pih :=
+    lazymatch goal with
+    | ih : forall _ _ _, _ -> _ ;;; _ |- ?u : _ -> _,
+      h1 : _ ;;; _ |- ?u : _,
+      h2 : _ ;;; _ |- ?u : _
+      |- _ =>
+        specialize (ih _ _ _ h1 h2)
+    end.
+
   Lemma principal_typing :
     forall {Γ u A B},
       Σ ;;; Γ |- u : A ->
@@ -250,7 +259,7 @@ Section Inversion.
        (Σ ;;; Γ |- u : C).
   Proof.
     intros Γ u A B hA hB.
-    induction u.
+    induction u in Γ, A, B, hA, hB |- *.
     - apply inversion_Rel in hA as iA.
       destruct iA as [decl [? [e ?]]].
       apply inversion_Rel in hB as iB.
@@ -259,7 +268,24 @@ Section Inversion.
       repeat insum. repeat intimes.
       all: try eassumption.
       constructor ; assumption.
-    -
+    - apply inversion_Var in hA. destruct hA.
+    - apply inversion_Evar in hA. destruct hA.
+    - apply inversion_Sort in hA as iA.
+      apply inversion_Sort in hB as iB.
+      repeat outsum. repeat outtimes. subst.
+      inversion e. subst.
+      repeat insum. repeat intimes.
+      all: try eassumption.
+      constructor ; assumption.
+    - apply inversion_Prod in hA as iA.
+      apply inversion_Prod in hB as iB.
+      repeat outsum. repeat outtimes.
+      repeat pih.
+      repeat outsum. repeat outtimes.
+      (* We would like to know x4 and x3 are sorts... *)
+      (* repeat insum. repeat intimes. *)
+      (* all: try eassumption. *)
+      (* constructor ; assumption. *)
   Abort.
 
 End Inversion.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -286,6 +286,13 @@ Section Inversion.
       (* repeat insum. repeat intimes. *)
       (* all: try eassumption. *)
       (* constructor ; assumption. *)
+      admit.
+    - apply inversion_Lambda in hA as iA.
+      apply inversion_Lambda in hB as iB.
+      repeat outsum. repeat outtimes.
+      repeat pih.
+      repeat outsum. repeat outtimes.
+      (* Not very clear how to do *)
   Abort.
 
 End Inversion.

--- a/pcuic/theories/PCUICSafeConversion.v
+++ b/pcuic/theories/PCUICSafeConversion.v
@@ -1547,7 +1547,7 @@ Section Conversion.
     apply welltyped_zipc_zippx in hh1 ; auto.
     pose proof (decompose_stack_eq _ _ _ e1). subst.
     unfold zippx in hh1. rewrite e1 in hh1.
-    pose proof (red_welltyped flags _ hΣ hh1 r) as hh.
+    pose proof (red_welltyped _ hΣ hh1 r) as hh.
     apply welltyped_it_mkLambda_or_LetIn in hh.
     assumption.
   Qed.
@@ -1568,11 +1568,11 @@ Section Conversion.
     case_eq (decompose_stack ρ). intros l ξ e.
     rewrite e in d2. cbn in d2. subst.
     apply welltyped_zipx in h1 as hh1.
-    pose proof (red_welltyped flags _ hΣ hh1 r1) as hh.
+    pose proof (red_welltyped _ hΣ hh1 r1) as hh.
     apply red_context in r2.
     pose proof (decompose_stack_eq _ _ _ (eq_sym eq2)). subst.
     rewrite zipc_appstack in hh. cbn in r2.
-    pose proof (red_welltyped flags _ hΣ hh (sq r2)) as hh2.
+    pose proof (red_welltyped _ hΣ hh (sq r2)) as hh2.
     eapply zipx_welltyped ; auto.
     rewrite zipc_stack_cat.
     assumption.
@@ -1661,7 +1661,7 @@ Section Conversion.
     apply welltyped_zipc_zippx in hh2 ; auto.
     pose proof (decompose_stack_eq _ _ _ e2). subst.
     unfold zippx in hh2. rewrite e2 in hh2.
-    pose proof (red_welltyped flags _ hΣ hh2 r) as hh.
+    pose proof (red_welltyped _ hΣ hh2 r) as hh.
     apply welltyped_it_mkLambda_or_LetIn in hh.
     assumption.
   Qed.
@@ -1682,11 +1682,11 @@ Section Conversion.
     case_eq (decompose_stack ρ). intros l ξ e.
     rewrite e in d2. cbn in d2. subst.
     apply welltyped_zipx in h2 as hh2.
-    pose proof (red_welltyped flags _ hΣ hh2 r1) as hh.
+    pose proof (red_welltyped _ hΣ hh2 r1) as hh.
     apply red_context in r2.
     pose proof (decompose_stack_eq _ _ _ (eq_sym eq2)). subst.
     rewrite zipc_appstack in hh. cbn in r2.
-    pose proof (red_welltyped flags _ hΣ hh (sq r2)) as hh'.
+    pose proof (red_welltyped _ hΣ hh (sq r2)) as hh'.
     eapply zipx_welltyped ; auto.
     rewrite zipc_stack_cat.
     assumption.
@@ -2026,7 +2026,7 @@ Section Conversion.
       rewrite zipc_appstack in r. cbn in r.
       assert (r' : ∥ red Σ Γ (tCase (ind, par) p c brs) (tCase (ind, par) p (mkApps (tConstruct ind0 n ui) l) brs) ∥).
       { constructor. eapply red_case_c. eassumption. }
-      pose proof (red_welltyped flags _ hΣ h r') as h'.
+      pose proof (red_welltyped _ hΣ h r') as h'.
       eapply Case_Construct_ind_eq in h' ; eauto. subst.
       eapply cored_red_cored.
       + constructor. eapply red_iota.
@@ -2043,7 +2043,7 @@ Section Conversion.
       rewrite zipc_appstack in r. cbn in r.
       assert (r' : ∥ red Σ Γ (tCase (ind, par) p c brs) (tCase (ind, par) p (mkApps (tCoFix mfix idx) l) brs) ∥).
       { constructor. eapply red_case_c. eassumption. }
-      pose proof (red_welltyped flags _ hΣ h r') as h'.
+      pose proof (red_welltyped _ hΣ h r') as h'.
       eapply cored_red_cored.
       + constructor. eapply red_cofix_case. eauto.
       + eapply red_case_c. eassumption.
@@ -2099,7 +2099,7 @@ Section Conversion.
       clear H0. symmetry in e0. apply decompose_stack_eq in e0. subst.
       rewrite zipc_appstack in r. cbn in r.
       pose proof (red_proj_c _ _ (i, n0, n) _ _ r) as r'.
-      pose proof (red_welltyped flags _ hΣ h (sq r')) as h'.
+      pose proof (red_welltyped _ hΣ h (sq r')) as h'.
       apply Proj_Constuct_ind_eq in h' ; auto. subst.
       eapply cored_red_cored.
       + constructor. eapply red_proj. eauto.
@@ -2115,7 +2115,7 @@ Section Conversion.
       clear H0. symmetry in e0. apply decompose_stack_eq in e0. subst.
       rewrite zipc_appstack in r. cbn in r.
       pose proof (red_proj_c _ _ (i, n0, n) _ _ r) as r'.
-      pose proof (red_welltyped flags _ hΣ h (sq r')) as h'.
+      pose proof (red_welltyped _ hΣ h (sq r')) as h'.
       eapply cored_red_cored.
       + constructor. eapply red_cofix_proj. eauto.
       + eapply red_proj_c. eassumption.
@@ -2266,7 +2266,7 @@ Section Conversion.
     apply welltyped_zipc_zippx in hh1 ; auto.
     apply decompose_stack_eq in e1 as ?. subst.
     unfold zippx in hh1. rewrite e1 in hh1.
-    pose proof (red_welltyped flags _ hΣ hh1 r) as hh.
+    pose proof (red_welltyped _ hΣ hh1 r) as hh.
     apply welltyped_it_mkLambda_or_LetIn in hh.
     symmetry in eq2.
     apply decompose_stack_eq in eq2. subst.
@@ -2388,7 +2388,7 @@ Section Conversion.
     apply welltyped_zipc_zippx in hh2 ; auto.
     apply decompose_stack_eq in e2 as ?. subst.
     unfold zippx in hh2. rewrite e2 in hh2.
-    pose proof (red_welltyped flags _ hΣ hh2 r) as hh.
+    pose proof (red_welltyped _ hΣ hh2 r) as hh.
     apply welltyped_it_mkLambda_or_LetIn in hh.
     symmetry in eq2.
     apply decompose_stack_eq in eq2. subst.

--- a/pcuic/theories/PCUICSafeConversion.v
+++ b/pcuic/theories/PCUICSafeConversion.v
@@ -1290,7 +1290,7 @@ Section Conversion.
     destruct h1 as [T h1].
     apply inversion_Case in h1 as hh.
     destruct hh
-      as [uni [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]].
+      as [uni [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
     eexists. eassumption.
   Qed.
   Next Obligation.
@@ -1300,7 +1300,7 @@ Section Conversion.
     destruct h2 as [T h2].
     apply inversion_Case in h2 as hh.
     destruct hh
-      as [uni [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]].
+      as [uni [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
     eexists. eassumption.
   Qed.
   Next Obligation.
@@ -2011,7 +2011,7 @@ Section Conversion.
     cbn. destruct h as [T h].
     apply inversion_Case in h ; auto.
     destruct h as
-        [u [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [? [? ?]]]]]]]]]]]]]]]]]].
+        [u [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [? [? ?]]]]]]]]]]]]]]]]].
     eexists. eassumption.
   Qed.
 

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -574,6 +574,22 @@ Section Lemmata.
       econstructor. assumption.
   Qed.
 
+  Lemma cumul_App_r :
+    forall {Γ f u v},
+      Σ ;;; Γ |- u <= v ->
+      Σ ;;; Γ |- tApp f u <= tApp f v.
+  Proof.
+    intros Γ f u v h.
+    induction h.
+    - eapply cumul_refl. constructor.
+      + apply leq_term_refl.
+      + assumption.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
   Lemma conv_App_r :
     forall {Γ f x y},
       Σ ;;; Γ |- x = y ->
@@ -612,6 +628,42 @@ Section Lemmata.
       conv leq Σ Γ (tProd na A1 B1) (tProd na' A2 B2).
   Admitted.
 
+  Lemma cumul_Case_c :
+    forall Γ indn p brs u v,
+      Σ ;;; Γ |- u <= v ->
+      Σ ;;; Γ |- tCase indn p u brs <= tCase indn p v brs.
+  Proof.
+    intros Γ indn p brs u v h.
+    induction h.
+    - eapply cumul_refl. destruct indn. constructor.
+      + eapply leq_term_refl.
+      + assumption.
+      + eapply Forall_Forall2. eapply Forall_True.
+        intros x. split ; auto.
+        eapply leq_term_refl.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma cumul_Proj_c :
+    forall Γ p u v,
+      Σ ;;; Γ |- u <= v ->
+      Σ ;;; Γ |- tProj p u <= tProj p v.
+  Proof.
+    intros Γ p u v h.
+    induction h.
+    - eapply cumul_refl. constructor. assumption.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  (* TODO We only use this to prove conv_context, the latter seems to be true,
+     but not this one. FIXME.
+   *)
   Lemma cumul_context :
     forall Γ u v ρ,
       Σ ;;; Γ |- u <= v ->
@@ -623,12 +675,16 @@ Section Lemmata.
     - cbn. apply IHρ.
       eapply cumul_App_l. assumption.
     - cbn. eapply IHρ.
-      (* eapply conv_App_r. *)
-      (* Congruence for application on the right *)
-      admit.
-    - cbn.
-      (* Congruence for case *)
-      admit.
+      eapply cumul_App_r. assumption.
+    - cbn. eapply IHρ.
+      eapply cumul_App_r. assumption.
+    - cbn. eapply IHρ.
+      eapply cumul_Case_c. assumption.
+    - cbn. eapply IHρ.
+      eapply cumul_Proj_c. assumption.
+    - cbn. eapply IHρ.
+      (* eapply cumul_Prod_l. assumption. *)
+      (* This is WRONG isn't it?? *)
   Admitted.
 
   Lemma conv_context :

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1757,13 +1757,6 @@ Section Lemmata.
       Σ ;;; Γ' |- u = v.
   Admitted.
 
-  (* Lemma principle_typing : *)
-  (*   forall {Γ u A B}, *)
-  (*     Σ ;;; Γ |- u : A -> *)
-  (*     Σ ;;; Γ |- u : B -> *)
-  (*     { C & (Σ ;;; Γ |- C <= A) * (Σ ;;; Γ |- C <= B) * (Σ ;;; Γ |- u : C) }%type. *)
-  (* Admitted. *)
-
   (* Lemma subj_cumul : *)
   (*   forall {Γ u v A B}, *)
   (*     Σ ;;; Γ |- u <= v -> *)

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -334,7 +334,7 @@ Section Lemmata.
       destruct indn.
       apply inversion_Case in h as hh.
       destruct hh
-        as [uni [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]].
+        as [uni [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
       eexists. eassumption.
     - cbn. cbn in h. cbn in IHπ. apply IHπ in h.
       destruct h as [T' h].

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -109,13 +109,6 @@ Section Lemmata.
   Context (Σ : global_context).
   Context (hΣ : wf Σ).
 
-  Lemma subject_reduction :
-    forall {Σ Γ u v A},
-      Σ ;;; Γ |- u : A ->
-      red1 (fst Σ) Γ u v ->
-      Σ ;;; Γ |- v : A.
-  Admitted.
-
   (* red is the reflexive transitive closure of one-step reduction and thus
      can't be used as well order. We thus define the transitive closure,
      but we take the symmetric version.
@@ -209,10 +202,10 @@ Section Lemmata.
     intros Γ u v h r.
     revert h. induction r ; intros h.
     - destruct h as [A h]. exists A.
-      eapply subject_reduction ; eassumption.
+      eapply sr_red1 ; eauto with wf.
     - specialize IHr with (1 := ltac:(eassumption)).
       destruct IHr as [A ?]. exists A.
-      eapply subject_reduction ; eassumption.
+      eapply sr_red1 ; eauto with wf.
   Qed.
 
   Lemma cored_trans' :
@@ -1630,7 +1623,7 @@ Section Lemmata.
     - assumption.
     - specialize IHr with (1 := ltac:(eassumption)).
       destruct IHr as [A ?]. exists A.
-      eapply subject_reduction ; eassumption.
+      eapply sr_red1 ; eauto with wf.
   Qed.
 
   Lemma red_cored_cored :

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -135,8 +135,38 @@ Section Lemmata.
       + apply IHΣ' in h. assumption.
   Qed.
 
+  Lemma fresh_global_nl :
+    forall Σ' k,
+      fresh_global k Σ' ->
+      fresh_global k (map nl_global_decl Σ').
+  Proof.
+    intros Σ' k h. eapply Forall_map.
+    eapply Forall_impl ; try eassumption.
+    intros x hh. cbn in hh.
+    destruct x ; assumption.
+  Qed.
+
   Lemma wf_nlg :
     wf (nlg Σ).
+  Proof.
+    destruct Σ as [Σ' φ].
+    unfold nlg. unfold wf in *. unfold on_global_env in *. simpl in *.
+    induction Σ'.
+    - assumption.
+    - simpl. inversion hΣ. subst.
+      constructor.
+      + eapply IHΣ'. assumption.
+      + destruct a.
+        * simpl in *. eapply fresh_global_nl. assumption.
+        * simpl in *. eapply fresh_global_nl. assumption.
+      + destruct a.
+        * simpl in *. destruct c as [ty [bo |] uni].
+          -- cbn in *.
+             (* Need type_nl or something *)
+             admit.
+          -- cbn in *. (* same *)
+             admit.
+        * simpl in *. destruct m. admit.
   Admitted.
 
   Lemma welltyped_nlg :

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1726,6 +1726,37 @@ Section Lemmata.
       + assumption.
   Qed.
 
+  Lemma welltyped_zipc_replace :
+    forall Γ u v π,
+      welltyped Σ Γ (zipc v π) ->
+      welltyped Σ (Γ ,,, stack_context π) u ->
+      Σ ;;; Γ ,,, stack_context π |- u = v ->
+      welltyped Σ Γ (zipc u π).
+  Proof.
+    intros Γ u v π hv hu heq.
+    induction π in u, v, hu, hv, heq |- *.
+    - simpl in *. assumption.
+    - simpl in *. eapply IHπ.
+      + eassumption.
+      + zip fold in hv. apply welltyped_context in hv.
+        simpl in hv.
+        destruct hv as [Tv hv].
+        destruct hu as [Tu hu].
+        apply inversion_App in hv as ihv.
+        destruct ihv as [na [A' [B' [hv' [ht ?]]]]].
+        (* Seems to be derivable (tediously) from some principle type lemma. *)
+        admit.
+      + (* Congruence *)
+        admit.
+  Admitted.
+
+  Lemma conv_context_conversion :
+    forall {Γ u v Γ'},
+      Σ ;;; Γ |- u = v ->
+      PCUICSR.conv_context Σ Γ Γ' ->
+      Σ ;;; Γ' |- u = v.
+  Admitted.
+
   (* Lemma principle_typing : *)
   (*   forall {Γ u A B}, *)
   (*     Σ ;;; Γ |- u : A -> *)

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1726,6 +1726,39 @@ Section Lemmata.
       + assumption.
   Qed.
 
+  Lemma conversion_reduction :
+    forall Γ u v,
+      Σ ;;; Γ |- u = v ->
+      ∑ u' v',
+        red Σ Γ u u' ×
+        red Σ Γ v v' ×
+        eq_term (snd Σ) u' v'.
+  (* Proof. *)
+  (*   intros Γ u v [h1 h2]. *)
+  (*   induction h1 ; dependent induction h2. *)
+  (*   - exists u, t. repeat split. *)
+  (*     + constructor. *)
+  (*     + constructor. *)
+  (*     + eapply leq_term_antisym ; eassumption. *)
+  (*   -  *)
+  Admitted.
+
+  Lemma subject_conversion :
+    forall Γ u v A B,
+      Σ ;;; Γ |- u : A ->
+      Σ ;;; Γ |- v : B ->
+      Σ ;;; Γ |- u = v ->
+      ∑ C,
+        Σ ;;; Γ |- u : C ×
+        Σ ;;; Γ |- v : C.
+  Proof.
+    intros Γ u v A B hu hv h.
+    apply conversion_reduction in h as [u' [v' [? [? ?]]]].
+    pose proof (subject_reduction _ Γ _ _ _ hΣ hu r) as hu'.
+    pose proof (subject_reduction _ Γ _ _ _ hΣ hv r0) as hv'.
+    (* Not clear.*)
+  Abort.
+
   Lemma welltyped_zipc_replace :
     forall Γ u v π,
       welltyped Σ Γ (zipc v π) ->

--- a/pcuic/theories/PCUICSafeReduce.v
+++ b/pcuic/theories/PCUICSafeReduce.v
@@ -771,7 +771,7 @@ Section Reduce.
   Next Obligation.
     left.
     apply Req_red in r as hr.
-    pose proof (red_welltyped flags _ hΣ h hr) as hh.
+    pose proof (red_welltyped _ hΣ h hr) as hh.
     destruct hr as [hr].
     eapply cored_red_cored ; try eassumption.
     unfold Pr in p. simpl in p. pose proof p as p'.
@@ -792,7 +792,7 @@ Section Reduce.
     symmetry in prf'. apply decompose_stack_eq in prf' as ?.
     subst.
     apply Req_red in r as hr.
-    pose proof (red_welltyped flags _ hΣ h hr) as hh.
+    pose proof (red_welltyped _ hΣ h hr) as hh.
     cbn in hh. rewrite zipc_appstack in hh. cbn in hh.
     zip fold in hh.
     apply welltyped_context in hh. simpl in hh.
@@ -1335,7 +1335,7 @@ Section Reduce.
       subst.
       rewrite stack_context_appstack in haux'. simpl in haux'.
       apply Req_red in r as hr.
-      pose proof (red_welltyped flags _ hΣ h hr) as hh.
+      pose proof (red_welltyped _ hΣ h hr) as hh.
       cbn in hh. rewrite zipc_appstack in hh. cbn in hh.
       zip fold in hh.
       apply welltyped_context in hh. simpl in hh.

--- a/pcuic/theories/PCUICSafeReduce.v
+++ b/pcuic/theories/PCUICSafeReduce.v
@@ -205,6 +205,11 @@ Section Reduce.
     forall Γ i pars narg i' c u l,
       welltyped Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i' c u) l)) ->
       nth_error l (pars + narg) <> None.
+  Proof.
+    intros Γ i pars narg i' c u l [T h].
+    apply inversion_Proj in h.
+    destruct h as [uni [mdecl [idecl [pdecl [args' [d [hc [? ?]]]]]]]].
+    destruct d as [di [? ?]]. simpl in *. subst.
   Admitted.
 
   Definition inspect {A} (x : A) : { y : A | y = x } := exist x eq_refl.

--- a/pcuic/theories/PCUICSafeReduce.v
+++ b/pcuic/theories/PCUICSafeReduce.v
@@ -155,11 +155,15 @@ Section Reduce.
   Derive Signature for typing.
 
   Lemma Case_Construct_ind_eq :
-    forall {Σ Γ ind ind' npar pred i u brs args},
+    forall {Γ ind ind' npar pred i u brs args},
       welltyped Σ Γ (tCase (ind, npar) pred (mkApps (tConstruct ind' i u) args) brs) ->
       ind = ind'.
   (* Proof. *)
-  (*   intros Σ' Γ ind ind' npar pred i u brs args [A h]. *)
+  (*   intros Γ ind ind' npar pred i u brs args [A h]. *)
+  (*   apply inversion_Case in h as ih. *)
+  (*   destruct ih *)
+  (*     as [uni [npar' [args' [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]]. *)
+
   (*   destruct (inversion_Case h) as [args' [ui [hh]]]. *)
   (*   clear - hh. induction args. *)
   (*   - cbn in hh. dependent induction hh. *)
@@ -1262,7 +1266,7 @@ Section Reduce.
       apply welltyped_context in hh. simpl in hh.
       destruct hh as [T hh].
       apply inversion_Case in hh
-        as [u [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]].
+        as [u [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
       constructor. eapply whne_mkApps. constructor.
       eapply whne_mkApps.
       (* Need storng inversion lemma *)
@@ -1410,7 +1414,7 @@ Section Reduce.
       apply welltyped_context in hh. simpl in hh.
       destruct hh as [T hh].
       apply inversion_Case in hh
-        as [u [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]].
+        as [u [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
       (* apply Ind_canonicity in ht0 ; auto. *)
       (* + rewrite decompose_app_mkApps in ht0 ; auto. *)
       (*   destruct p0 as [? ?]. assumption. *)

--- a/pcuic/theories/PCUICSafeReduce.v
+++ b/pcuic/theories/PCUICSafeReduce.v
@@ -1103,8 +1103,10 @@ Section Reduce.
           destruct hh as [na [A [B [hs [? ?]]]]].
           (* We need proper inversion here *)
           admit.
-      + (* Is this one ok? *)
-        give_up.
+      + (* Here, we need to show some isred property stating that under iota,
+           not CoFix can be returned against Case/Proj.
+         *)
+        admit.
     - unfold zipp. case_eq (decompose_stack π0). intros l ρ e.
       constructor. eapply whne_mkApps.
       eapply whne_rel_nozeta. assumption.
@@ -1203,23 +1205,40 @@ Section Reduce.
       pose proof (eq_sym e0) as e1. apply decompose_stack_eq in e1.
       subst.
       rewrite stack_context_appstack in haux'. simpl in haux'.
-      (* apply Req_red in r as hr. *)
-      (* pose proof (red_welltyped h hr) as hh. *)
-      (* cbn in hh. rewrite zipc_appstack in hh. cbn in hh. *)
-      (* zip fold in hh. *)
-      (* apply welltyped_context in hh. simpl in hh. *)
-      (* destruct hh as [T hh]. *)
-      (* apply inversion_Case in hh *)
-      (*   as [u [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]]. *)
-      (* constructor. eapply whne_mkApps. constructor. *)
-      (* eapply whne_mkApps. *)
+      apply Req_red in r as hr.
+      pose proof (red_welltyped _ hΣ h hr) as hh.
+      cbn in hh. rewrite zipc_appstack in hh. cbn in hh.
+      zip fold in hh.
+      apply welltyped_context in hh. simpl in hh.
+      destruct hh as [T hh].
+      apply inversion_Case in hh
+        as [u [npar [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]]].
+      constructor. eapply whne_mkApps. constructor.
+      eapply whne_mkApps.
+      (* Need storng inversion lemma *)
       admit.
-    - admit.
+    - match goal with
+      | |- context [ reduce ?x ?y ?z ] =>
+        case_eq (reduce x y z) ;
+        specialize (haux x y z)
+      end.
+      intros [t' π'] [? [? [? ?]]] eq. cbn.
+      rewrite eq in haux. cbn in haux.
+      assumption.
     - bang.
     - unfold zipp. case_eq (decompose_stack π6). intros.
       constructor. eapply whne_mkApps. eapply whne_proj_noiota. assumption.
     - (* Like case *)
       admit.
+    - match goal with
+      | |- context [ reduce ?x ?y ?z ] =>
+        case_eq (reduce x y z) ;
+        specialize (haux x y z)
+      end.
+      intros [t' π'] [? [? [? ?]]] eq. cbn.
+      rewrite eq in haux. cbn in haux.
+      assumption.
+    - bang.
     - match goal with
       | |- context [ reduce ?x ?y ?z ] =>
         case_eq (reduce x y z) ;
@@ -1355,11 +1374,27 @@ Section Reduce.
   (*        we want to conclude it is necessarily neutral *)
   (*      *)
       admit.
-    - admit.
+    - match goal with
+      | |- context [ reduce ?x ?y ?z ] =>
+        case_eq (reduce x y z) ;
+        specialize (haux x y z)
+      end.
+      intros [t' π'] [? [? [? ?]]] eq. cbn.
+      rewrite eq in haux. cbn in haux.
+      assumption.
     - bang.
     - constructor. eapply whne_proj_noiota. assumption.
     - (* Like case *)
       admit.
+    - match goal with
+      | |- context [ reduce ?x ?y ?z ] =>
+        case_eq (reduce x y z) ;
+        specialize (haux x y z)
+      end.
+      intros [t' π'] [? [? [? ?]]] eq. cbn.
+      rewrite eq in haux. cbn in haux.
+      assumption.
+    - bang.
     - match goal with
       | |- context [ reduce ?x ?y ?z ] =>
         case_eq (reduce x y z) ;


### PR DESCRIPTION
Now that—I think—the definition of both safe reduction and conversion is complete, it *only* remains to prove the lemmata on which they depend.
A lot the remaining lemmata are about cumulativity and conversion, so there is a lot of potential redundancy (maybe some of them are already proven). In any case, they should thus be placed in the right module(s).