### PR TITLE
Add cumulativity for λ-abstractions' bodies

### DIFF
--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -611,6 +611,22 @@ Proof.
     econstructor. assumption.
 Qed.
 
+Lemma cumul_Lambda_r :
+  forall Σ Γ na A b b',
+    Σ ;;; Γ,, vass na A |- b <= b' ->
+    Σ ;;; Γ |- tLambda na A b <= tLambda na A b'.
+Proof.
+  intros Σ Γ na A b b' h.
+  induction h.
+  - eapply cumul_refl. constructor.
+    + eapply eq_term_refl.
+    + assumption.
+  - eapply cumul_red_l ; try eassumption.
+    econstructor. assumption.
+  - eapply cumul_red_r ; try eassumption.
+    econstructor. assumption.
+Qed.
+
 Lemma cumul_it_mkLambda_or_LetIn :
   forall Σ Δ Γ u v,
     Σ ;;; (Δ ,,, Γ) |- u <= v ->
@@ -622,6 +638,5 @@ Proof.
   - simpl. cbn. eapply ih.
     eapply cumul_LetIn_bo. assumption.
   - simpl. cbn. eapply ih.
-    (* Need cumul for Lambda *)
-    admit.
-Admitted.
+    eapply cumul_Lambda_r. assumption.
+Qed.

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -45,7 +45,7 @@ Fixpoint eqb_term_upto_univ (equ lequ : universe -> universe -> bool) (u v : ter
 
   | tLambda na A t, tLambda na' A' t' =>
     eqb_term_upto_univ equ equ A A' &&
-    eqb_term_upto_univ equ equ t t'
+    eqb_term_upto_univ equ lequ t t'
 
   | tProd na A B, tProd na' A' B' =>
     eqb_term_upto_univ equ equ A A' &&

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -958,7 +958,6 @@ Section Lemmata.
       eexists. split.
       + constructor. constructor.
       + eapply eq_term_upto_univ_subst ; eauto.
-        eapply eq_term_upto_univ_leq ; eauto.
     - dependent destruction e.
       eexists. split.
       + constructor. constructor.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -473,19 +473,18 @@ Section Lemmata.
       assumption.
     - unfold zippx. simpl.
       eapply cumul_it_mkLambda_or_LetIn. cbn.
-      eapply conv_cumul. eapply conv_Lambda_r.
-      (* Need cumul for Lambda again *)
-      admit.
+      eapply cumul_Lambda_r.
+      assumption.
     - unfold zippx. simpl.
       eapply cumul_it_mkLambda_or_LetIn.
       assumption.
     - unfold zippx. simpl.
       eapply cumul_it_mkLambda_or_LetIn. cbn.
-      (* cumul lambda *)
-      admit.
+      eapply cumul_Lambda_r.
+      assumption.
     - unfold zippx. simpl.
       eapply cumul_it_mkLambda_or_LetIn. assumption.
-  Admitted.
+  Qed.
 
   Lemma conv_zippx :
     forall Γ u v ρ,

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -474,7 +474,7 @@ Inductive eq_term_upto_univ (Re Rle : universe -> universe -> Prop) : term -> te
 
 | eq_Lambda na na' ty ty' t t' :
     eq_term_upto_univ Re Re ty ty' ->
-    eq_term_upto_univ Re Re t t' ->
+    eq_term_upto_univ Re Rle t t' ->
     eq_term_upto_univ Re Rle (tLambda na ty t) (tLambda na' ty' t')
 
 | eq_Prod na na' a a' b b' :
@@ -987,7 +987,7 @@ Section GlobalMaps.
     match universe_family u with
     | InProp =>
       (** The inductive is declared in the impredicative sort Prop *)
-      let topsort := 
+      let topsort :=
           match onConstructors with
           | Alli_nil => (* Empty inductive proposition: *) InType
           | Alli_cons cstr nil onc Alli_nil =>

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -420,7 +420,7 @@ Inductive eq_term_upto_univ (Re Rle : universe -> universe -> Prop) : term -> te
 
 | eq_Lambda na na' ty ty' t t' :
     eq_term_upto_univ Re Re ty ty' ->
-    eq_term_upto_univ Re Re t t' ->
+    eq_term_upto_univ Re Rle t t' ->
     eq_term_upto_univ Re Rle (tLambda na ty t) (tLambda na' ty' t')
 
 | eq_Prod na na' a a' b b' :


### PR DESCRIPTION
I decided to allow cumulativity in the body of a λ, maybe it doesn't make sense, but I don't see why we should forbid it.
It is also useful for me to have it, so this PR also contains useful "consequences" of this change.