### PR TITLE
Add allow_cofix and prop_sub_type flags

### DIFF
--- a/checker/src/g_metacoq_checker.ml4
+++ b/checker/src/g_metacoq_checker.ml4
@@ -15,7 +15,7 @@ let check env evm c =
   let term = Ast_quoter.quote_term_rec env (EConstr.to_constr evm c) in
   (* Feedback.msg_debug (str"Finished quoting.. checking."); *)
   let fuel = pow two (pow two (pow two two)) in
-  let checker_flags = true in
+  let checker_flags = Config0.default_checker_flags in
   match Checker0.typecheck_program checker_flags fuel term with
   | CorrectDecl t ->
      Feedback.msg_info (str "Successfully checked of type: " ++ pr_char_list (Checker0.string_of_term t))

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -355,14 +355,13 @@ Proof.
     unfold test_def. simpl. toProp.
     split.
     rewrite -> app_context_length in *. rewrite -> Nat.add_comm in *.
-    eapply closedn_lift_inv in H1; eauto. lia.
-    subst types.
-    now rewrite -> app_context_length, fix_context_length in H0.
-    eapply (nth_error_all) in H; eauto. simpl in *.
+    eapply closedn_lift_inv in H2; eauto. lia.
+    now rewrite -> app_context_length, fix_context_length in H1.
+    eapply (nth_error_all) in H0; eauto. simpl in *.
     intuition. toProp.
-    subst types. rewrite app_context_length in H0.
-    rewrite Nat.add_comm in H0.
-    now eapply closedn_lift_inv in H0.
+    rewrite app_context_length in H1.
+    rewrite Nat.add_comm in H1.
+    now eapply closedn_lift_inv in H1.
 
   - destruct X2; intuition eauto.
     + destruct i as [[u [ctx [Heq Hi]]] Hwfi]. simpl in Hwfi.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -229,6 +229,7 @@ Section Inversion.
     forall {Γ mfix idx T},
       Σ ;;; Γ |- tCoFix mfix idx : T ->
       ∑ decl,
+        allow_cofix ×
         let types := fix_context mfix in
         nth_error mfix idx = Some decl ×
         wf_local Σ (Γ ,,, types) ×

--- a/pcuic/theories/PCUICSafeReduce.v
+++ b/pcuic/theories/PCUICSafeReduce.v
@@ -705,7 +705,7 @@ Section Reduce.
     - apply welltyped_context in h'. simpl in h'.
       destruct h' as [T h'].
       apply inversion_CoFix in h'.
-      destruct h' as [decl [e [? [? ?]]]].
+      destruct h' as [decl [? [e [? [? ?]]]]].
       unfold unfold_cofix in bot.
       rewrite e in bot. discriminate.
     - cbn. rewrite zipc_appstack. reflexivity.
@@ -824,7 +824,7 @@ Section Reduce.
     - apply welltyped_context in h'. simpl in h'.
       destruct h' as [T h'].
       apply inversion_CoFix in h'.
-      destruct h' as [decl [e [? [? ?]]]].
+      destruct h' as [decl [? [e [? [? ?]]]]].
       unfold unfold_cofix in bot.
       rewrite e in bot. discriminate.
     - cbn. rewrite zipc_appstack. reflexivity.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1957,7 +1957,8 @@ Proof.
       * simpl. eexists. apply IHt; apply All_local_env_app_inv; intuition.
       * apply IHt'; apply All_local_env_app_inv; intuition.
     + erewrite map_dtype. eapply type_CoFix.
-      * rewrite nth_error_map H. reflexivity.
+      * assumption.
+      * rewrite nth_error_map H0. reflexivity.
       * now rewrite subst_fix_context.
       * rewrite subst_fix_context.
         apply All_map.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -832,6 +832,7 @@ Inductive typing `{checker_flags} (Σ : global_context) (Γ : context) : term ->
     Σ ;;; Γ |- tFix mfix n : decl.(dtype)
 
 | type_CoFix mfix n decl :
+    allow_cofix ->
     let types := fix_context mfix in
     nth_error mfix n = Some decl ->
     All_local_env (lift_typing typing Σ) (Γ ,,, types) ->

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -603,7 +603,8 @@ Definition types_of_case ind mdecl idecl params u p pty :=
 
 (** Check that [uctx] instantiated at [u] is consistent with the current universe graph. *)
 
-Definition consistent_universe_context_instance (φ : constraints) uctx u :=
+Definition consistent_universe_context_instance `{checker_flags}
+           (φ : constraints) uctx u :=
   match uctx with
   | Monomorphic_ctx c => True
   | Polymorphic_ctx c
@@ -1918,6 +1919,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
         P Σ Γ (tFix mfix n) decl.(dtype)) ->
 
     (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : list (def term)) (n : nat) decl,
+        allow_cofix ->
         let types := fix_context mfix in
         nth_error mfix n = Some decl ->
         All_local_env (lift_typing (fun Σ Γ b ty => (typing Σ Γ b ty * P Σ Γ b ty)%type) Σ) (Γ ,,, types) ->

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -1139,6 +1139,7 @@ Proof.
     }
     rewrite -> (map_dtype _ (lift #|Γ''| (#|mfix| + #|Γ'|))).
     eapply type_CoFix.
+    assumption.
     now rewrite -> nth_error_map, heq_nth_error.
     now rewrite -> lift_fix_context.
     rewrite -> lift_fix_context.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -92,7 +92,7 @@ Proof.
   econstructor 3; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
 Qed.
 
-Lemma weakening_env_consistent_universe_context_instance:
+Lemma weakening_env_consistent_universe_context_instance `{checker_flags} :
   forall (Σ : global_context) (u : list Level.t) univs,
     consistent_universe_context_instance (snd Σ) univs u ->
     forall Σ' : global_context,

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -981,15 +981,15 @@ Proof.
       f_equal. f_equal. extensionality i; extensionality x.
       simpl. rewrite trans_lift. reflexivity. }
     econstructor; eauto.
-    now rewrite nth_error_map H.
+    now rewrite nth_error_map H0.
     -- unfold app_context, trans_local.
-       rewrite H0. unfold trans_local.
+       rewrite H1. unfold trans_local.
        rewrite <- map_app.
        eapply trans_wf_local.
        eapply TTy.All_local_env_impl. eauto. simpl; intuition eauto with wf.
     -- apply All_map. eapply All_impl; eauto.
        unfold compose. simpl. intuition eauto 3 with wf.
-       rewrite H0. rewrite /trans_local map_length.
+       rewrite H1. rewrite /trans_local map_length.
        unfold Template.AstUtils.app_context in b.
        rewrite /trans_local map_app in b.
        rewrite <- trans_lift. apply b.

--- a/template-coq/theories/Closed.v
+++ b/template-coq/theories/Closed.v
@@ -261,14 +261,14 @@ Proof.
     unfold test_def. simpl. toProp.
     split.
     rewrite -> app_context_length in *. rewrite -> Nat.add_comm in *.
-    eapply closedn_lift_inv in H1; eauto. lia.
+    eapply closedn_lift_inv in H2; eauto. lia.
     subst types.
-    now rewrite -> app_context_length, fix_context_length in H0.
-    eapply (nth_error_all) in H; eauto. simpl in *.
+    now rewrite -> app_context_length, fix_context_length in H1.
+    eapply (nth_error_all) in H0; eauto. simpl in *.
     intuition. toProp.
-    subst types. rewrite app_context_length in H0.
-    rewrite Nat.add_comm in H0.
-    now eapply closedn_lift_inv in H0.
+    subst types. rewrite app_context_length in H1.
+    rewrite Nat.add_comm in H1.
+    now eapply closedn_lift_inv in H1.
 Qed.
 
 Lemma declared_decl_closed `{checker_flags} Σ cst decl :

--- a/template-coq/theories/Substitution.v
+++ b/template-coq/theories/Substitution.v
@@ -1719,7 +1719,8 @@ Proof.
       * apply IHt; apply All_local_env_app_inv; intuition.
       * apply IHt'; apply All_local_env_app_inv; intuition.
     + erewrite map_dtype. eapply type_CoFix.
-      * rewrite nth_error_map H0. reflexivity.
+      * assumption.
+      * rewrite nth_error_map H1. reflexivity.
       * now rewrite subst_fix_context.
       * rewrite subst_fix_context.
         apply All_map.

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -366,11 +366,11 @@ Proof.
     clear Hmfix.
     split.
     + revert X0. generalize (fix_context mfix). intros.
-      clear decl H0. constructor. induction mfix. constructor. constructor.
+      clear decl H0 H1. constructor. induction mfix. constructor. constructor.
       2:{ apply IHmfix. inv X0. auto. }
       inv X0. intuition. now apply wf_lift_wf in H1.
     + eapply nth_error_all in X0; eauto. simpl in X0; intuition eauto.
-      now apply wf_lift_wf in H2.
+      now apply wf_lift_wf in H3.
 Qed.
 
 Lemma typing_all_wf_decl `{checker_flags} Σ (wfΣ : wf Σ) Γ (wfΓ : wf_local Σ Γ) :

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -359,9 +359,27 @@ Definition val (v : valuation) (u : universe) : Z :=
   | NEL.cons e u => NEL.fold_left (fun n e => Z.max (val1 v e) n) u (val1 v e)
   end.
 
+Definition llt `{checker_flags} (x y : Z) : Prop :=
+  if prop_sub_type
+  then (x < y)%Z
+  else (0 <= x /\ x < y)%Z.
+
+Notation "x < y" := (llt x y) : univ_scope.
+
+Delimit Scope univ_scope with u.
+
+Definition lle `{checker_flags} (x y : Z) : Prop :=
+  (x < y)%u \/ x = y.
+
+Notation "x <= y" := (lle x y) : univ_scope.
+
+Section Univ.
+
+Context `{cf : checker_flags}.
+
 Inductive satisfies0 (v : valuation) : univ_constraint -> Prop :=
-| satisfies0_Lt l l' : (val0 v l < val0 v l')%Z -> satisfies0 v (l, Lt, l')
-| satisfies0_Le l l' : (val0 v l <= val0 v l')%Z -> satisfies0 v (l, Le, l')
+| satisfies0_Lt l l' : (val0 v l < val0 v l')%u -> satisfies0 v (l, Lt, l')
+| satisfies0_Le l l' : (val0 v l <= val0 v l')%u -> satisfies0 v (l, Le, l')
 | satisfies0_Eq l l' : val0 v l = val0 v l' -> satisfies0 v (l, Eq, l').
 
 Definition satisfies v : constraints -> Prop :=
@@ -378,10 +396,10 @@ Definition leq_universe_n n (φ : constraints) u u' :=
 Definition leq_universe0 := leq_universe_n 0.
 Definition lt_universe := leq_universe_n 1.
 
-Definition eq_universe `{checker_flags} φ u u'
+Definition eq_universe φ u u'
   := if check_univs then eq_universe0 φ u u' else True.
 
-Definition leq_universe `{checker_flags} φ u u'
+Definition leq_universe φ u u'
   := if check_univs then leq_universe0 φ u u' else True.
 
 
@@ -392,7 +410,7 @@ Proof.
   intros vH; reflexivity.
 Qed.
 
-Lemma eq_universe_refl `{checker_flags} φ s : eq_universe φ s s.
+Lemma eq_universe_refl φ s : eq_universe φ s s.
 Proof.
   unfold eq_universe; destruct check_univs;
     [apply eq_universe0_refl|constructor].
@@ -403,7 +421,7 @@ Proof.
   intros vH; reflexivity.
 Qed.
 
-Lemma leq_universe_refl `{checker_flags} φ s : leq_universe φ s s.
+Lemma leq_universe_refl φ s : leq_universe φ s s.
 Proof.
   unfold leq_universe; destruct check_univs;
     [apply leq_universe0_refl|constructor].
@@ -418,7 +436,7 @@ Proof.
   intros v h. etransitivity ; try eapply h1 ; eauto.
 Qed.
 
-Lemma eq_universe_trans `{checker_flags} φ :
+Lemma eq_universe_trans φ :
   forall s1 s2 s3,
     eq_universe φ s1 s2 ->
     eq_universe φ s2 s3 ->
@@ -441,7 +459,7 @@ Proof.
   - eapply h2. assumption.
 Qed.
 
-Lemma leq_universe_trans `{checker_flags} φ :
+Lemma leq_universe_trans φ :
   forall s1 s2 s3,
     leq_universe φ s1 s2 ->
     leq_universe φ s2 s3 ->
@@ -482,7 +500,7 @@ Proof.
   intros v H. rewrite val_sup. Lia.lia.
 Qed.
 
-Lemma leq_universe_product `{checker_flags} φ s1 s2
+Lemma leq_universe_product φ s1 s2
   : leq_universe φ s2 (Universe.sort_of_product s1 s2).
 Proof.
   unfold leq_universe; destruct check_univs; [cbn|constructor].
@@ -491,7 +509,7 @@ Proof.
   apply leq_universe0_sup_r.
 Qed.
 
-Lemma eq_universe_leq_universe `{checker_flags} φ t u
+Lemma eq_universe_leq_universe φ t u
   : eq_universe φ t u -> leq_universe φ t u.
 Proof.
   unfold eq_universe, leq_universe; destruct check_univs.
@@ -504,3 +522,5 @@ Qed.
 
 (* This universe is a hack used in plugings to generate fresh universes *)
 Definition fresh_universe : universe. exact Universe.type0. Qed.
+
+End Univ.

--- a/template-coq/theories/Weakening.v
+++ b/template-coq/theories/Weakening.v
@@ -1185,7 +1185,8 @@ Proof.
           specialize (IHt' eq_refl). simpl. apply IHt'.
     -- rewrite -> (map_dtype _ (lift #|Γ''| (#|mfix| + #|Γ'|))).
        eapply type_CoFix.
-       now rewrite -> nth_error_map, H.
+       assumption.
+       now rewrite -> nth_error_map, H0.
        now rewrite -> lift_fix_context.
        rewrite -> lift_fix_context.
        apply All_map.

--- a/template-coq/theories/WeakeningEnv.v
+++ b/template-coq/theories/WeakeningEnv.v
@@ -82,7 +82,7 @@ Proof.
   econstructor 3; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
 Qed.
 
-Lemma weakening_env_consistent_universe_context_instance:
+Lemma weakening_env_consistent_universe_context_instance `{checker_flags} :
   forall (Σ : global_context) (u : list Level.t) univs,
     consistent_universe_context_instance (snd Σ) univs u ->
     forall Σ' : global_context,

--- a/template-coq/theories/config.v
+++ b/template-coq/theories/config.v
@@ -1,13 +1,25 @@
 Class checker_flags := {
   (* check_guard : bool ; *)
+
   (* Checking universe constraints iff [true] *)
-  check_univs : bool
+  check_univs : bool ;
+
+  (* Allow use of cofix iff [true] *)
+  allow_cofix : bool ;
+
+  (* Prop <= Type iff [true] *)
+  prop_sub_type : bool
 }.
 
+(* Should correspond to Coq *)
 Local Instance default_checker_flags : checker_flags := {|
-  check_univs := true
+  check_univs := true ;
+  allow_cofix := true ;
+  prop_sub_type := true
 |}.
 
 Local Instance type_in_type : checker_flags := {|
-  check_univs := false
+  check_univs := false ;
+  allow_cofix := true ;
+  prop_sub_type := true
 |}.

--- a/template-coq/theories/kernel/Checker.v
+++ b/template-coq/theories/kernel/Checker.v
@@ -576,7 +576,7 @@ Definition check_conv_leq `{checker_flags} {F:Fuel} := check_conv_gen Cumul.
 Definition check_conv `{checker_flags} {F:Fuel} := check_conv_gen Conv.
 
 
-Definition is_graph_of_contraints ctrs G :=
+Definition is_graph_of_contraints `{checker_flags} ctrs G :=
   match gc_of_constraints ctrs with
   | Some ctrs => G = make_graph ctrs
   | None => False
@@ -864,28 +864,28 @@ Lemma cumul_convert_leq : forall `{checker_flags} {F:Fuel} Σ G Γ t t',
   is_graph_of_contraints (snd Σ) G ->
   Σ ;;; Γ |- t <= t' <~> convert_leq (fst Σ) G Γ t t' = Checked ().
 Proof. intros. todo "Checker.cumul_convert_leq". Defined.
- 
+
 Lemma cumul_reduce_to_sort : forall `{checker_flags} {F:Fuel} Σ G Γ t s',
   is_graph_of_contraints (snd Σ) G ->
     Σ ;;; Γ |- t <= tSort s' <~>
     { s'' & reduce_to_sort (fst Σ) Γ t = Checked s''
             /\ try_is_leq_universe G s'' s' = true }.
 Proof. intros. todo "Checker.cumul_reduce_to_sort". Defined.
- 
+
 Lemma cumul_reduce_to_product : forall `{checker_flags} {F:Fuel} Σ Γ t na a b,
     Σ ;;; Γ |- t <= tProd na a b ->
                { a' & { b' &
                         ((reduce_to_prod (fst Σ) Γ t = Checked (a', b')) *
                          cumul Σ Γ (tProd na a' b') (tProd na a b))%type } }.
 Proof. intros. todo "Checker.cumul_reduce_to_product". Defined.
- 
+
 Lemma cumul_reduce_to_ind : forall `{checker_flags} {F:Fuel} Σ Γ t i u args,
     Σ ;;; Γ |- t <= mkApps (tInd i u) args <~>
     { args' &
       ((reduce_to_ind (fst Σ) Γ t = Checked (i, u, args')) *
        cumul Σ Γ (mkApps (tInd i u) args') (mkApps (tInd i u) args))%type }.
 Proof. intros. todo "Checker.cumul_reduce_to_ind". Defined.
- 
+
 Lemma lookup_env_id {Σ id decl} : lookup_env Σ id = Some decl -> id = global_decl_ident decl.
 Proof.
   unfold lookup_env.
@@ -893,7 +893,7 @@ Proof.
   revert H. destruct (ident_eq_spec id (global_decl_ident a)). now intros [= ->].
   apply IHΣ.
 Qed.
- 
+
 Lemma lookup_constant_type_declared Σ cst u decl (isdecl : declared_constant Σ cst decl) :
   lookup_constant_type_cstrs Σ cst u =
   Checked (subst_instance_constr u decl.(cst_type),
@@ -902,7 +902,7 @@ Proof.
   unfold lookup_constant_type_cstrs, lookup_env.
   red in isdecl. rewrite isdecl. destruct decl. reflexivity.
 Qed.
- 
+
 Lemma lookup_constant_type_is_declared Σ cst u T :
   lookup_constant_type_cstrs Σ cst u = Checked T ->
   { decl | declared_constant Σ cst decl /\
@@ -914,11 +914,11 @@ Proof.
   injection H as eq. subst T. rewrite (lookup_env_id Hlook). simpl.
   eexists. split; eauto.
 Qed.
- 
+
 Lemma eq_ind_refl i i' : eq_ind i i' = true <-> i = i'.
 Proof. intros. todo "Checker.eq_ind_refl". Defined.
- 
- 
+
+
 Arguments bind _ _ _ _ ! _.
 Open Scope monad.
 
@@ -929,7 +929,7 @@ Section InferOk.
           (HG : is_graph_of_contraints (snd Σ) G).
 
   Ltac tc := eauto with typecheck.
- 
+
 (*
   Lemma infer_complete Γ t T :
     Σ ;;; Γ |- t : T -> { T' & ((infer Γ t = Checked T') /\ squash (cumul Σ Γ T' T)) }.
@@ -1215,7 +1215,7 @@ Section Checker.
       | None =>
         EnvError (IllFormedDecl (global_decl_ident g)
                              (UnsatisfiableConstraints (global_decl_univs g)))
-      | Some ctrs => 
+      | Some ctrs =>
         wrap_error "" (check_consistent_constraints G (global_decl_univs g)) ;;
         let G' := add_gc_constraints ctrs G in
         check_wf_decl env G' g ;;


### PR DESCRIPTION
I added the two new flags as discussed.
However, I have a problem that I don't understand once `template-coq` is built:
```
File "src/g_metacoq_checker.ml4", line 19, characters 35-48:
Error: This expression has type bool but an expression was expected of type
         Config0.checker_flags
```