### PR TITLE
Check fix

### DIFF
--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -410,32 +410,33 @@ Proof.
     rewrite smash_context_length in i. simpl in i.
     eapply closed_upwards; eauto. lia.
 
-  - clear H0.
-    split. solve_all.
+  - clear H0 H1.
+    split. solve_all. rename_all_hyps.
+    destruct x; simpl in *.
+    unfold test_def. simpl. toProp.
+    split.
+    rewrite -> app_context_length in *. rewrite -> Nat.add_comm in *.
+    eapply closedn_lift_inv in H0; eauto. lia.
+    subst types.
+    now rewrite app_context_length fix_context_length in H.
+    eapply nth_error_all in H; eauto. simpl in H. intuition. toProp.
+    subst types. rewrite app_context_length in H0.
+    rewrite Nat.add_comm in H0.
+    now eapply closedn_lift_inv in H0.
+
+  - split. solve_all. rename_all_hyps.
     destruct x; simpl in *.
     unfold test_def. simpl. toProp.
     split.
     rewrite -> app_context_length in *. rewrite -> Nat.add_comm in *.
     eapply closedn_lift_inv in H1; eauto. lia.
     subst types.
-    now rewrite app_context_length fix_context_length in H0.
-    eapply nth_error_all in H; eauto. simpl in H. intuition. toProp.
-    subst types. rewrite app_context_length in H0.
-    rewrite Nat.add_comm in H0.
-    now eapply closedn_lift_inv in H0.
-
-  - split. solve_all. destruct x; simpl in *.
-    unfold test_def. simpl. toProp.
-    split.
-    rewrite -> app_context_length in *. rewrite -> Nat.add_comm in *.
-    eapply closedn_lift_inv in H2; eauto. lia.
-    subst types.
-    now rewrite -> app_context_length, fix_context_length in H1.
+    now rewrite -> app_context_length, fix_context_length in H.
     eapply (nth_error_all) in H; eauto. simpl in *.
     intuition. toProp.
-    subst types. rewrite app_context_length in H1.
-    rewrite Nat.add_comm in H1.
-    now eapply closedn_lift_inv in H1.
+    subst types. rewrite app_context_length in H2.
+    rewrite Nat.add_comm in H2.
+    now eapply closedn_lift_inv in H2.
 
   - destruct X2; intuition eauto.
     + destruct i as [[u [ctx [Heq Hi]]] Hwfi]. simpl in Hwfi.

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -370,3 +370,18 @@ Defined.
 
 Derive NoConfusion NoConfusionHom for sig.
 Derive NoConfusion NoConfusionHom for prod.
+
+Definition eq_recursivity_kind r r' :=
+  match r, r' with
+  | Finite, Finite => true
+  | CoFinite, CoFinite => true
+  | BiFinite, BiFinite => true
+  | _, _ => false
+  end.
+
+Instance reflect_recursivity_kind : ReflectEq recursivity_kind := {
+  eqb := eq_recursivity_kind
+}.
+Proof.
+  destruct x, y; simpl; constructor; congruence.
+Defined.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -1014,7 +1014,7 @@ Proof.
   - rewrite -> (map_dtype _ (lift #|Γ''| (#|mfix| + #|Γ'|))).
     assert (wf_local Σ (Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ' ,,, lift_context #|Γ''| #|Γ'| (fix_context mfix))).
     subst types.
-    apply All_local_env_app in X as [X Hfixc].
+    apply All_local_env_app in wf as [X Hfixc].
     apply All_local_env_app_inv. intuition.
     revert Hfixc. clear X0 X heq_nth_error.
     induction 1; simpl; auto; try constructor; rewrite -> lift_context_snoc. econstructor; auto.
@@ -1064,7 +1064,7 @@ Proof.
        specialize (IH Γ (Γ' ,,, fix_context mfix) Γ'').
        rewrite -> lift_context_app in IH.
        rewrite -> !app_context_assoc, Nat.add_0_r, !app_context_length, fix_context_length in IH.
-       specialize (IH X1 eq_refl).
+       specialize (IH wf eq_refl).
        rewrite -> permute_lift, lift_context_length, fix_context_length by lia.
        subst types; rewrite -> fix_context_length in IH.
        rewrite (Nat.add_comm #|Γ'|). apply IH.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -39,7 +39,7 @@ Proof.
     now inv H2.
 Qed.
 
-Lemma extends_lookup `{checker_flags} Σ Σ' c decl :
+Lemma extends_lookup `{checker_flags} {Σ Σ' c decl} :
   wf Σ' -> extends Σ Σ' -> lookup_env Σ c = Some decl -> lookup_env Σ' c = Some decl.
 Proof.
   intros wfΣ' [Σ'' ->]. simpl.
@@ -236,17 +236,29 @@ Proof.
     apply weakening_env_global_ext_constraints; tas.
     close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
-    eapply All_local_env_impl. eapply X.
+    eapply All_local_env_impl. eapply all.
     clear -wfΣ' extΣ. simpl; intros.
     unfold lift_typing in *; destruct T; intuition eauto with extends.
     destruct X as [u [tyu Hu]]. exists u. eauto.
     eapply All_impl; eauto; simpl; intuition eauto with extends.
+    move:wffixmfix. rewrite /check_wf_fix //.
+    case: map_option_out => //. case; auto => /= => a l.
+    rewrite /check_recursivity_kind.
+    case e: lookup_env => [decl'|] //.
+    now rewrite (extends_lookup wfΣ' extΣ e).
+    rewrite andb_false_r //.
   - econstructor; eauto with extends. auto.
-    eapply All_local_env_impl. eapply X.
+    eapply All_local_env_impl. eapply all.
     clear -wfΣ' extΣ. simpl; intros.
     unfold lift_typing in *; destruct T; intuition eauto with extends.
     destruct X as [u [tyu Hu]]. exists u. eauto.
     eapply All_impl; eauto; simpl; intuition eauto with extends.
+    move:wfcofixmfix. rewrite /check_wf_cofix //.
+    case: map_option_out => //. case; auto => /= => a l.
+    rewrite /check_recursivity_kind.
+    case e: lookup_env => [decl'|] //.
+    now rewrite (extends_lookup wfΣ' extΣ e).
+    rewrite andb_false_r //.
   - econstructor. eauto.
     destruct X2 as [isB|[u [Hu Ps]]].
     + left; auto. destruct isB. destruct x as [ctx [u [Heq Hu]]].


### PR DESCRIPTION
Working on checking at least the well-formedness of fix/cofix without the guard:
i.e. that fix is recursive on an inductive argument and cofix is producing a coinductive (necessary for one part of subject reduction).