### PR TITLE
State of erasure: Move meta-theory stuff to pcuic

### DIFF
--- a/extraction/theories/EArities.v
+++ b/extraction/theories/EArities.v
@@ -9,14 +9,13 @@ Local Open Scope string_scope.
 Set Asymmetric Patterns.
 Import MonadNotation.
 
-
-Definition is_prop_sort s :=
-  match Universe.level s with
-  | Some l => Level.is_prop l
-  | None => false
-  end.
-
 Require Import Extract.
+
+Lemma isErasable_Proof Σ Γ t :
+  Is_proof Σ Γ t -> isErasable Σ Γ t.
+Proof.
+  intros. destruct X as (? & ? & ? & ? & ?). exists x. split. eauto. right. eauto.
+Qed.
 
 Lemma it_mkProd_isArity:
   forall (l : list context_decl) A,

--- a/extraction/theories/EArities.v
+++ b/extraction/theories/EArities.v
@@ -18,37 +18,6 @@ Definition is_prop_sort s :=
 
 Require Import Extract.
 
-Lemma cumul_prop1 (Σ : global_env_ext) Γ A B u :
-  wf Σ -> 
-  is_prop_sort u -> Σ ;;; Γ |- B : tSort u ->
-                                 Σ ;;; Γ |- A <= B -> Σ ;;; Γ |- A : tSort u.
-Proof.
-  intros. induction X1.
-  - admit.
-  - eapply IHX1 in X0. admit.
-  - eapply IHX1. eapply subject_reduction. eauto. eassumption. eauto.
-Admitted.                       (* cumul_prop1 *)
-
-Lemma cumul_prop2 (Σ : global_env_ext) Γ A B u :
-  wf Σ ->
-  is_prop_sort u -> Σ ;;; Γ |- A <= B ->
-                             Σ ;;; Γ |- A : tSort u -> Σ ;;; Γ |- B : tSort u.
-Proof.
-Admitted.                       (* cumul_prop2 *)
-
-Lemma leq_universe_prop cf (Σ : global_env_ext) u1 u2 :
-  (* @check_univs cf = true -> *)
-  (* @prop_sub_type cf = false -> *)
-  wf Σ ->
-  @leq_universe cf (global_ext_constraints Σ) u1 u2 ->
-  (is_prop_sort u1 \/ is_prop_sort u2) ->
-  (is_prop_sort u1 /\ is_prop_sort u2).
-Proof.
-  intros. unfold leq_universe in *. (* rewrite H in H1. *)
-  (* unfold leq_universe0 in H1. *)
-  (* unfold leq_universe_n in H1. *)
-Admitted.                       (* leq_universe_prop *)
-
 Lemma it_mkProd_isArity:
   forall (l : list context_decl) A,
     isArity A ->
@@ -463,7 +432,7 @@ Proof.
   revert u H c0.
   depind t1; intros.
   - eapply cumul_prop2 in c0; eauto.
-  - eapply cumul_prop2 in c0. 2:eauto. 2:eauto. 2:eauto.
+  - eapply cumul_prop2 in c0. 2:eauto. 2:eauto. 2:eauto. 2:eauto.
     eapply invert_cumul_prod_r in c as (? & ? & ? & [] & ?); eauto.
     eapply subject_reduction in c0. 3:eauto. 2:eauto.
     eapply inversion_Prod in c0 as (? & ? & ? & ? & ?).

--- a/extraction/theories/EArities.v
+++ b/extraction/theories/EArities.v
@@ -1,7 +1,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR PCUICNormal PCUICSafeReduce PCUICSafeLemmata PCUICSafeChecker PCUICPrincipality PCUICGeneration PCUICSubstitution.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR PCUICNormal PCUICSafeReduce PCUICSafeLemmata PCUICSafeChecker PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination.
 From MetaCoq.Extraction Require EAst ELiftSubst ETyping EWcbvEval Extract.
 From Equations Require Import Equations.
 Require Import String.

--- a/extraction/theories/ESubstitution.v
+++ b/extraction/theories/ESubstitution.v
@@ -2,7 +2,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICWeakening PCUICSubstitution PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR PCUICValidity PCUICWeakeningEnv.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICWeakening PCUICSubstitution PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR PCUICValidity PCUICWeakeningEnv PCUICElimination.
 From MetaCoq.Extraction Require Import EAst ELiftSubst ETyping EWcbvEval Extract Prelim.
 From Equations Require Import Equations.
 Require Import String.

--- a/extraction/theories/ErasureFunction.v
+++ b/extraction/theories/ErasureFunction.v
@@ -1,7 +1,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICConfluence PCUICCumulativity PCUICSR PCUICNormal PCUICSafeReduce PCUICSafeLemmata PCUICSafeChecker PCUICValidity PCUICPrincipality.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICConfluence PCUICCumulativity PCUICSR PCUICNormal PCUICSafeReduce PCUICSafeLemmata PCUICSafeChecker PCUICValidity PCUICPrincipality PCUICElimination.
 From MetaCoq.Extraction Require EAst ELiftSubst ETyping EWcbvEval Extract ExtractionCorrectness.
 From Equations Require Import Equations.
 Require Import String.

--- a/extraction/theories/Extract.v
+++ b/extraction/theories/Extract.v
@@ -3,7 +3,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICElimination.
 From MetaCoq.Extraction Require EAst ELiftSubst ETyping EWcbvEval.
 Require Import String.
 Local Open Scope string_scope.

--- a/extraction/theories/Extract.v
+++ b/extraction/theories/Extract.v
@@ -3,7 +3,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICElimination.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval.
 From MetaCoq.Extraction Require EAst ELiftSubst ETyping EWcbvEval.
 Require Import String.
 Local Open Scope string_scope.
@@ -13,12 +13,6 @@ Import MonadNotation.
 Existing Instance extraction_checker_flags.
 
 Definition isErasable Σ Γ t := ∑ T, Σ ;;; Γ |- t : T × (isArity T + (∑ u, (Σ ;;; Γ |- T : tSort u) * is_prop_sort u))%type.
-
-Lemma isErasable_Proof Σ Γ t :
-  Is_proof Σ Γ t -> isErasable Σ Γ t.
-Proof.
-  intros. destruct X as (? & ? & ? & ? & ?). exists x. split. eauto. right. eauto.
-Qed.
 
 Module E := EAst.
 Local Notation Ret t := t.

--- a/extraction/theories/ExtractionCorrectness.v
+++ b/extraction/theories/ExtractionCorrectness.v
@@ -3,7 +3,7 @@
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.Extraction Require Import EAst ELiftSubst ETyping EWcbvEval Extract Prelim ESubstitution EInversion EArities.
-From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction  PCUICWeakening PCUICSubstitution PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR  PCUICClosed PCUICInversion PCUICUnivSubstitution.
+From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction  PCUICWeakening PCUICSubstitution PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR  PCUICClosed PCUICInversion PCUICUnivSubstitution PCUICElimination.
 
 Require Import String.
 Local Open Scope string_scope.
@@ -413,7 +413,7 @@ Proof.
         eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
         econstructor. econstructor. econstructor.
 
-        unfold iota_red. cbn.
+        all:unfold iota_red in *. all:cbn in *.
         eapply erases_mkApps. eauto.
         instantiate (1 := repeat tBox _).
         eapply All2_Forall2.

--- a/extraction/theories/Prelim.v
+++ b/extraction/theories/Prelim.v
@@ -3,7 +3,7 @@
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.Extraction Require Import EAst ELiftSubst Extract EArities.
-From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction  PCUICWeakening PCUICSubstitution PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR  PCUICClosed PCUICInversion PCUICGeneration PCUICSafeChecker.
+From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction  PCUICWeakening PCUICSubstitution PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR  PCUICClosed PCUICInversion PCUICGeneration PCUICSafeChecker PCUICElimination.
 
 Require Import String.
 Local Open Scope string_scope.
@@ -223,15 +223,6 @@ Proof.
     + eapply IHm.
 Qed.
 
-Lemma declared_inductive_inj {Σ mdecl mdecl' ind idecl idecl'} :
-  declared_inductive Σ mdecl' ind idecl' ->
-  declared_inductive Σ mdecl ind idecl ->
-  mdecl = mdecl' /\ idecl = idecl'.
-Proof.
-  intros [] []. unfold declared_minductive in *.
-  rewrite H in H1. inv H1. rewrite H2 in H0. inv H0. eauto.
-Qed.
-
 Lemma decompose_app_rec_inv2 {t l' f l} :
   decompose_app_rec t l' = (f, l) ->
   isApp f = false.
@@ -271,152 +262,6 @@ Qed.
 (*   intros x6 Eu. *)
 (* Admitted. *)
 
-Existing Instance extraction_checker_flags.
-
-Lemma elim_restriction_works_kelim1 (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
-  declared_inductive (fst Σ) mind ind idecl ->
-  Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
-  (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> In InType (ind_kelim idecl).
-Proof.
-  intros wfΣ. intros.
-  assert (HT := X).
-  eapply inversion_Case in X as (? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ?). 
-  unfold types_of_case in e0.
-  repeat destruct ?; try congruence. subst. inv e0. 
-  eapply declared_inductive_inj in d as []. 2:exact H. subst.
-  enough (universe_family x6 = InType). rewrite H1 in e1.
-  eapply Exists_exists in e1 as (? & ? & ?). subst. eauto.
-  
-  destruct (universe_family x6) eqn:Eu.
-  - exfalso. eapply H0. exists T. exists x6. split. admit.
-    split. (* 2:{ eapply universe_family_is_prop_sort; eauto. } *)
-    admit. admit.
-  - admit. (* no idea what to do for Set *)
-  - reflexivity.  
-Admitted.                       (* elim_restriction_works *)
-
-
-Lemma elim_restriction_works_kelim2 (Σ : global_env_ext) ind mind idecl : wf Σ ->
-  declared_inductive (fst Σ) mind ind idecl ->
-  In InType (ind_kelim idecl) -> Informative Σ ind.
-Proof.
-  intros.
-  destruct (PCUICWeakeningEnv.on_declared_inductive X H) as [[]]; eauto.
-  intros ?. intros. inversion o.
-  eapply declared_inductive_inj in H as []; eauto; subst.
-  clear - onConstructors ind_sorts. try dependent induction onConstructors.
-  (* - cbn. split. omega. econstructor. admit. *)
-  (* -  *)
-Admitted.                       (* elim_restriction_works *)
-
-Lemma elim_restriction_works (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
-  declared_inductive (fst Σ) mind ind idecl ->
-  Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
-  (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> Informative Σ ind.
-Proof.
-  intros. eapply elim_restriction_works_kelim2; eauto.
-  eapply elim_restriction_works_kelim1; eauto.
-Qed.
-
-Lemma declared_projection_projs_nonempty {Σ : global_env_ext} { mind ind p a} :
-  wf Σ ->
-  declared_projection Σ mind ind p a ->
-  ind_projs ind <> [].
-Proof.
-  intros. destruct H. destruct H0.
-  destruct (ind_projs ind); try congruence. destruct p.
-  cbn in *. destruct n; inv H0.
-Qed.
-
-Lemma elim_restriction_works_proj_kelim1 (Σ : global_env_ext) Γ T p c mind idecl :
-  wf Σ ->
-  declared_inductive (fst Σ) mind (fst (fst p)) idecl ->
-  Σ ;;; Γ |- tProj p c : T ->
-  (Is_proof Σ Γ (tProj p c) -> False) -> In InType (ind_kelim idecl).
-Proof.
-  intros. destruct p. destruct p. cbn in *.
-  eapply inversion_Proj in X0 as (? & ? & ? & ? & ? & ? & ? & ? & ?).
-  destruct x2. cbn in *.
-  pose (d' := d). destruct d' as [? _].
-  eapply declared_inductive_inj in H as []; eauto. subst.
-  pose proof (declared_projection_projs_nonempty X d).
-  eapply PCUICWeakeningEnv.on_declared_projection in d; eauto.
-  destruct d as (? & ? & ?). destruct p.
-  inv o. inv o0.
-  forward onProjections. eauto.
-  inversion onProjections.
-  clear - on_projs_elim. revert on_projs_elim. generalize (ind_kelim x1).
-  intros. induction on_projs_elim; subst.
-  - cbn. eauto.
-  - cbn. right. eauto.  
-Qed. (* elim_restriction_works_proj *)
-
-Lemma elim_restriction_works_proj (Σ : global_env_ext) Γ  p c mind idecl T :
-  wf Σ ->
-  declared_inductive (fst Σ) mind (fst (fst p)) idecl ->
-  Σ ;;; Γ |- tProj p c : T ->
-  (Is_proof Σ Γ (tProj p c) -> False) -> Informative Σ (fst (fst p)).
-Proof.
-  intros. eapply elim_restriction_works_kelim2; eauto.
-  eapply elim_restriction_works_proj_kelim1; eauto.
-Qed.                       
-
-Lemma length_of_btys {ind mdecl' idecl' args' u' p pty indctx pctx ps btys} :
-  types_of_case ind mdecl' idecl' (firstn (ind_npars mdecl') args') u' p pty = Some (indctx, pctx, ps, btys) ->
-  #|btys| = #|ind_ctors idecl'|.
-Proof.
-  intros. unfold types_of_case in *.
-  destruct ?; try congruence.
-  destruct ?; try congruence.
-  destruct ?; try congruence.
-  destruct ?; try congruence.
-  destruct ?; try congruence.
-  destruct ?; try congruence. inv H.  unfold build_branches_type in *.
-  unfold mapi in *.
-  clear - E4. revert btys E4. generalize 0 at 3. induction ((ind_ctors idecl')); cbn; intros.
-  - cbn in E4. inv E4. reflexivity.
-  - cbn in E4.
-    destruct ?; try congruence.
-    destruct ?; try congruence.
-    destruct ?; try congruence.
-    destruct ?; try congruence.
-    destruct ?; try congruence.
-    destruct ?; try congruence.
-    destruct ?; try congruence.
-    subst. inv E4. cbn. f_equal.
-    eapply IHl.  eauto.
-Qed.
-
-
-Existing Instance extraction_checker_flags.
-
-Lemma tCase_length_branch_inv (Σ : global_env_ext) Γ ind npar p n u args brs T m t :
-  wf Σ ->
-  Σ ;;; Γ |- tCase (ind, npar) p (mkApps (tConstruct ind n u) args) brs : T ->
-  nth_error brs n = Some (m, t) ->
-  (#|args| = npar + m)%nat.
-Proof.
-  intros. 
-  eapply inversion_Case in X0 as (? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ?). 
-  unfold types_of_case in e0.
-  repeat destruct ?; try congruence. destruct p0, p1; subst. inv E3. inv E1. inv e0.
-  unfold build_branches_type in *.
-  assert (exists t', nth_error x7 n = Some (m, t')).
-  eapply All2_nth_error_Some in H as (? & ?). 2:eassumption. destruct p0.
-  rewrite e. destruct p0. destruct x8. cbn in *. subst. eauto.
-  destruct H0. (* clear - H0 E4. unfold mapi in *. *)
-  (* revert n x7 H0 E4. generalize 0 at 3. induction (ind_ctors x2); intros. *)
-  (* - cbn in E4. inv E4. destruct n0; inv H0. *)
-  (* - cbn in E4. destruct a. destruct ?; try congruence. *)
-  (*   destruct p0. *)
-  (*   destruct ?; try congruence. *)
-  (*   inv E4. destruct ?; try congruence. *)
-  (*   destruct ?; try congruence. *)
-  (*   destruct ?; try congruence. *)
-  (*   inv E. destruct n0; cbn in H0. *)
-  (*   + inversion H0. subst. destruct l. cbn in E0. inv E0. cbn in *. inv H0. *)
-  (*   + eapply IHl in E0. eauto.  *)
-Admitted.                       (* tCase_length_branch_inv *)
 
 (** ** Prelim on fixpoints *)
 
@@ -444,7 +289,7 @@ Proof.
     + cbn. rewrite IHm. reflexivity. omega.
 Qed.
 
-Lemma subslet_fix_subst Σ mfix1 T n :
+Lemma subslet_fix_subst `{cf : checker_flags} Σ mfix1 T n :
   Σ ;;; [] |- tFix mfix1 n : T ->
   (* wf_local Σ (PCUICLiftSubst.fix_context mfix1) -> *)
   subslet Σ [] (PCUICTyping.fix_subst mfix1) (PCUICLiftSubst.fix_context mfix1).

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -30,6 +30,7 @@ theories/PCUICWcbvEval.v
 theories/PCUICChecker.v
 theories/PCUICCheckerCompleteness.v
 theories/PCUICRetyping.v
+theories/PCUICElimination.v
 
 theories/PCUICPosition.v
 theories/PCUICSafeLemmata.v

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -1,0 +1,202 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
+From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction  PCUICWeakening PCUICSubstitution PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR  PCUICClosed PCUICInversion PCUICGeneration PCUICSafeChecker.
+
+Definition is_prop_sort s :=
+  match Universe.level s with
+  | Some l => Level.is_prop l
+  | None => false
+  end.
+
+Definition Is_proof `{cf : checker_flags} Σ Γ t := ∑ T u, Σ ;;; Γ |- t : T × Σ ;;; Γ |- T : tSort u × is_prop_sort u.
+
+Lemma declared_inductive_inj `{cf : checker_flags} {Σ mdecl mdecl' ind idecl idecl'} :
+  declared_inductive Σ mdecl' ind idecl' ->
+  declared_inductive Σ mdecl ind idecl ->
+  mdecl = mdecl' /\ idecl = idecl'.
+Proof.
+  intros [] []. unfold declared_minductive in *.
+  rewrite H in H1. inversion H1. subst. rewrite H2 in H0. inversion H0. eauto.
+Qed.
+
+Definition Informative`{cf : checker_flags} (Σ : global_env_ext) (ind : inductive) :=
+  forall mdecl idecl,
+    declared_inductive (fst Σ) mdecl ind idecl ->
+    forall Γ args u n (Σ' : global_env_ext),
+      wf Σ' ->
+      PCUICWeakeningEnv.extends Σ Σ' ->
+      Is_proof Σ' Γ (mkApps (tConstruct ind n u) args) ->  
+       #|ind_ctors idecl| <= 1 /\
+       squash (All (Is_proof Σ' Γ) (skipn (ind_npars mdecl) args)).
+
+Lemma elim_restriction_works_kelim1 `{cf : checker_flags} (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
+  declared_inductive (fst Σ) mind ind idecl ->
+  Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
+  (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> In InType (ind_kelim idecl).
+Proof.
+  intros wfΣ. intros.
+  assert (HT := X).
+  eapply inversion_Case in X as (? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ?). 
+  unfold types_of_case in e0.
+  repeat destruct ?; try congruence. subst. inv e0. 
+  eapply declared_inductive_inj in d as []. 2:exact H. subst.
+  enough (universe_family x6 = InType). rewrite H1 in e1.
+  eapply Exists_exists in e1 as (? & ? & ?). subst. eauto.
+  
+  destruct (universe_family x6) eqn:Eu.
+  - exfalso. eapply H0. exists T. exists x6. split. admit.
+    split. (* 2:{ eapply universe_family_is_prop_sort; eauto. } *)
+    admit. admit.
+  - admit. (* no idea what to do for Set *)
+  - reflexivity.  
+Admitted.                       (* elim_restriction_works *)
+
+
+Lemma elim_restriction_works_kelim2 `{cf : checker_flags} (Σ : global_env_ext) ind mind idecl : wf Σ ->
+  declared_inductive (fst Σ) mind ind idecl ->
+  In InType (ind_kelim idecl) -> Informative Σ ind.
+Proof.
+  intros.
+  destruct (PCUICWeakeningEnv.on_declared_inductive X H) as [[]]; eauto.
+  intros ?. intros. inversion o.
+  eapply declared_inductive_inj in H as []; eauto; subst.
+  clear - onConstructors ind_sorts. try dependent induction onConstructors.
+  (* - cbn. split. omega. econstructor. admit. *)
+  (* -  *)
+Admitted.                       (* elim_restriction_works *)
+
+Lemma elim_restriction_works `{cf : checker_flags} (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
+  declared_inductive (fst Σ) mind ind idecl ->
+  Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
+  (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> Informative Σ ind.
+Proof.
+  intros. eapply elim_restriction_works_kelim2; eauto.
+  eapply elim_restriction_works_kelim1; eauto.
+Qed.
+
+Lemma declared_projection_projs_nonempty `{cf : checker_flags} {Σ : global_env_ext} { mind ind p a} :
+  wf Σ ->
+  declared_projection Σ mind ind p a ->
+  ind_projs ind <> [].
+Proof.
+  intros. destruct H. destruct H0.
+  destruct (ind_projs ind); try congruence. destruct p.
+  cbn in *. destruct n; inv H0.
+Qed.
+
+Lemma elim_restriction_works_proj_kelim1 `{cf : checker_flags} (Σ : global_env_ext) Γ T p c mind idecl :
+  wf Σ ->
+  declared_inductive (fst Σ) mind (fst (fst p)) idecl ->
+  Σ ;;; Γ |- tProj p c : T ->
+  (Is_proof Σ Γ (tProj p c) -> False) -> In InType (ind_kelim idecl).
+Proof.
+  intros. destruct p. destruct p. cbn in *.
+  eapply inversion_Proj in X0 as (? & ? & ? & ? & ? & ? & ? & ? & ?).
+  destruct x2. cbn in *.
+  pose (d' := d). destruct d' as [? _].
+  eapply declared_inductive_inj in H as []; eauto. subst.
+  pose proof (declared_projection_projs_nonempty X d).
+  eapply PCUICWeakeningEnv.on_declared_projection in d; eauto.
+  destruct d as (? & ? & ?). destruct p.
+  inv o. inv o0.
+  forward onProjections. eauto.
+  inversion onProjections.
+  clear - on_projs_elim. revert on_projs_elim. generalize (ind_kelim x1).
+  intros. induction on_projs_elim; subst.
+  - cbn. eauto.
+  - cbn. right. eauto.  
+Qed. (* elim_restriction_works_proj *)
+
+Lemma elim_restriction_works_proj `{cf : checker_flags} (Σ : global_env_ext) Γ  p c mind idecl T :
+  wf Σ ->
+  declared_inductive (fst Σ) mind (fst (fst p)) idecl ->
+  Σ ;;; Γ |- tProj p c : T ->
+  (Is_proof Σ Γ (tProj p c) -> False) -> Informative Σ (fst (fst p)).
+Proof.
+  intros. eapply elim_restriction_works_kelim2; eauto.
+  eapply elim_restriction_works_proj_kelim1; eauto.
+Qed.                       
+
+Lemma length_of_btys {ind mdecl' idecl' args' u' p pty indctx pctx ps btys} :
+  types_of_case ind mdecl' idecl' (firstn (ind_npars mdecl') args') u' p pty = Some (indctx, pctx, ps, btys) ->
+  #|btys| = #|ind_ctors idecl'|.
+Proof.
+  intros. unfold types_of_case in *.
+  destruct ?; try congruence.
+  destruct ?; try congruence.
+  destruct ?; try congruence.
+  destruct ?; try congruence.
+  destruct ?; try congruence.
+  destruct ?; try congruence. inversion H; subst.  unfold build_branches_type in *.
+  unfold mapi in *.
+  clear - E4. revert btys E4. generalize 0 at 3. induction ((ind_ctors idecl')); cbn; intros.
+  - cbn in E4. inversion E4. subst. reflexivity.
+  - cbn in E4.
+    destruct ?; try congruence.
+    destruct ?; try congruence.
+    destruct ?; try congruence.
+    destruct ?; try congruence.
+    destruct ?; try congruence.
+    destruct ?; try congruence.
+    destruct ?; try congruence.
+    subst. inversion E4. subst. cbn. f_equal.
+    eapply IHl.  eauto.
+Qed.
+
+Lemma tCase_length_branch_inv `{cf : checker_flags} (Σ : global_env_ext) Γ ind npar p n u args brs T m t :
+  wf Σ ->
+  Σ ;;; Γ |- tCase (ind, npar) p (mkApps (tConstruct ind n u) args) brs : T ->
+  nth_error brs n = Some (m, t) ->
+  (#|args| = npar + m)%nat.
+Proof.
+  intros. 
+  eapply inversion_Case in X0 as (? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ?). subst.
+  pose proof (length_of_btys e0).
+  eapply type_mkApps_inv in t1 as (? & ? & [] & ?); eauto.
+  eapply inversion_Construct in t1 as (? & ? & ? & ? & ? & ? & ?); eauto.
+  destruct d0. cbn in *.
+  eapply declared_inductive_inj in d as []; eauto. subst.
+  
+  unfold types_of_case in e0.
+  repeat destruct ?; try congruence. destruct p0, p1; subst. inv E3. inv E1. inv e0.
+  unfold build_branches_type in *.
+  assert (exists t', nth_error x7 n = Some (m, t')).
+  eapply All2_nth_error_Some in H as (? & ?). 2:eassumption. destruct p0.
+  rewrite e. destruct p0. cbn in *. subst. destruct x1. cbn. eauto.
+  destruct H3.
+
+  Lemma map_option_Some X (L : list (option X)) t : map_option_out L = Some t -> All2 (fun x y => x = Some y) L t.
+  Proof.
+    intros. induction L in t, H |- *; cbn in *.
+    - inv H. econstructor.
+    - destruct a. destruct ?. all:inv H. eauto.
+  Qed.
+
+  eapply map_option_Some in E4. 
+  eapply All2_nth_error_Some_r in E4 as (? & ? & ?); eauto. 
+  subst.
+  rewrite nth_error_mapi in e. destruct (nth_error (ind_ctors x11) n) eqn:E7; try now inv e.
+  cbn in e. inv e. destruct p0. destruct p0.
+  cbn in H3.
+  eapply PCUICWeakeningEnv.on_declared_inductive in H1; eauto. destruct H1.
+  depelim o0. cbn in *. unfold on_constructors in *.
+  eapply nth_error_alli in E7; eauto. cbn in E7.
+  depelim E7. cbn in *. destruct s.
+  depelim x2. cbn in *.
+  subst. admit. admit.
+  
+  (* clear - H0 E4. unfold mapi in *. *)
+  (* revert n x7 H0 E4. generalize 0 at 3. induction (ind_ctors x2); intros. *)
+  (* - cbn in E4. inv E4. destruct n0; inv H0. *)
+  (* - cbn in E4. destruct a. destruct ?; try congruence. *)
+  (*   destruct p0. *)
+  (*   destruct ?; try congruence. *)
+  (*   inv E4. destruct ?; try congruence. *)
+  (*   destruct ?; try congruence. *)
+  (*   destruct ?; try congruence. *)
+  (*   inv E. destruct n0; cbn in H0. *)
+  (*   + inversion H0. subst. destruct l. cbn in E0. inv E0. cbn in *. inv H0. *)
+  (*   + eapply IHl in E0. eauto.  *)
+Admitted.                       (* tCase_length_branch_inv *)

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -4,12 +4,6 @@ From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction  PCUICWeakening PCUICSubstitution PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR  PCUICClosed PCUICInversion PCUICGeneration PCUICSafeChecker.
 
-Definition is_prop_sort s :=
-  match Universe.level s with
-  | Some l => Level.is_prop l
-  | None => false
-  end.
-
 Definition Is_proof `{cf : checker_flags} Σ Γ t := ∑ T u, Σ ;;; Γ |- t : T × Σ ;;; Γ |- T : tSort u × is_prop_sort u.
 
 Lemma declared_inductive_inj `{cf : checker_flags} {Σ mdecl mdecl' ind idecl idecl'} :

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -200,3 +200,41 @@ Proof.
   (*   + inversion H0. subst. destruct l. cbn in E0. inv E0. cbn in *. inv H0. *)
   (*   + eapply IHl in E0. eauto.  *)
 Admitted.                       (* tCase_length_branch_inv *)
+
+Section no_prop_leq_type.
+
+Context `{cf : checker_flags}.
+Variable Hcf : prop_sub_type = false.
+  
+Lemma cumul_prop1 (Σ : global_env_ext) Γ A B u :
+  wf Σ -> 
+  is_prop_sort u -> Σ ;;; Γ |- B : tSort u ->
+                                 Σ ;;; Γ |- A <= B -> Σ ;;; Γ |- A : tSort u.
+Proof.
+  intros. induction X1.
+  - admit.
+  - eapply IHX1 in X0. admit.
+  - eapply IHX1. eapply subject_reduction. eauto. eassumption. eauto.
+Admitted.                       (* cumul_prop1 *)
+
+Lemma cumul_prop2 (Σ : global_env_ext) Γ A B u :
+  wf Σ ->
+  is_prop_sort u -> Σ ;;; Γ |- A <= B ->
+                             Σ ;;; Γ |- A : tSort u -> Σ ;;; Γ |- B : tSort u.
+Proof.
+Admitted.                       (* cumul_prop2 *)
+
+Lemma leq_universe_prop (Σ : global_env_ext) u1 u2 :
+  (* @check_univs cf = true -> *)
+  (* @prop_sub_type cf = false -> *)
+  wf Σ ->
+  @leq_universe cf (global_ext_constraints Σ) u1 u2 ->
+  (is_prop_sort u1 \/ is_prop_sort u2) ->
+  (is_prop_sort u1 /\ is_prop_sort u2).
+Proof.
+  intros. unfold leq_universe in *. (* rewrite H in H1. *)
+  (* unfold leq_universe0 in H1. *)
+  (* unfold leq_universe_n in H1. *)
+Admitted.                       (* leq_universe_prop *)
+
+End no_prop_leq_type.

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -562,3 +562,10 @@ Qed.
 Definition fresh_universe : universe. exact Universe.type0. Qed.
 
 End Univ.
+
+
+Definition is_prop_sort s :=
+  match Universe.level s with
+  | Some l => Level.is_prop l
+  | None => false
+  end.


### PR DESCRIPTION
That's my current WIP branch. The `extraction` directory is admit-free (by means of moving the admits to `pcuic`). That at least means that none of the admits is concerned with actual properties of erasure though, so erasure is largely finished I'd say.