### PR TITLE
Extraction extraction

### DIFF
--- a/extraction/theories/EAstUtils.v
+++ b/extraction/theories/EAstUtils.v
@@ -14,3 +14,17 @@ Fixpoint decompose_app_rec t l :=
   end.
 
 Definition decompose_app f := decompose_app_rec f [].
+
+
+Lemma decompose_app_rec_mkApps f l l' :
+  decompose_app_rec (mkApps f l) l' = decompose_app_rec f (l ++ l').
+Proof.
+  induction l in f, l' |- *; simpl; auto; rewrite IHl ?app_nil_r; auto.
+Qed.
+
+Lemma decompose_app_mkApps f l :
+  isApp f = false -> decompose_app (mkApps f l) = (f, l).
+Proof.
+  intros Hf. unfold decompose_app. rewrite decompose_app_rec_mkApps. rewrite app_nil_r.
+  destruct f; simpl in *; (discriminate || reflexivity).
+Qed.

--- a/extraction/theories/EInversion.v
+++ b/extraction/theories/EInversion.v
@@ -48,18 +48,15 @@ Notation type_tFix_inv := PCUICInversion.inversion_Fix.
 
 From MetaCoq.Extraction Require Import EAst ELiftSubst ETyping EWcbvEval Extract Prelim.
 
-Lemma eval_tBox_inv Σ' x2 :
-  eval Σ' E.tBox x2 -> x2 = tBox.
-Proof.
-  intros. dependent induction H.
-  - induction args using rev_ind. inv x. rewrite emkApps_snoc in x. inv x.
-  - induction l using rev_ind. cbn in x. invs H0. cbn. eapply IHeval. eauto.
-    rewrite emkApps_snoc in x. inv x.
-  - reflexivity.
-Qed.
-
+Derive Signature for Forall2.
 Lemma eval_box_apps:
-  forall (Σ' : list E.global_decl) (e : E.term) (x : list E.term), eval Σ' e tBox -> eval Σ' (mkApps e x) tBox.
+  forall (Σ' : list E.global_decl) (e : E.term) (x x' : list E.term),
+    Forall2 (eval Σ') x x' ->
+    eval Σ' e tBox -> eval Σ' (mkApps e x) tBox.
 Proof.
-  intros Σ' e x H2. revert e H2; induction x; cbn; intros; eauto using eval.
+  intros Σ' e x H2. revert e H2; induction x using rev_ind; cbn; intros; eauto using eval.
+  eapply Forall2_app_inv_l in H as [l1' [l2' [H [H' eq]]]]. subst H2.
+  depelim H'.
+  specialize (IHx e _ H H0). simpl.
+  rewrite mkApps_app. simpl. econstructor; eauto.
 Qed.

--- a/extraction/theories/ESubstitution.v
+++ b/extraction/theories/ESubstitution.v
@@ -121,6 +121,15 @@ Proof.
     eapply weakening_typing in t1; eauto.
 Qed.
 
+Require Import MetaCoq.PCUIC.PCUICInversion.
+Derive Signature for erases.
+
+Lemma erases_ctx_ext (Σ : global_env_ext) Γ Γ' t t' :
+  erases Σ Γ t t' -> Γ = Γ' -> erases Σ Γ' t t'.
+Proof.
+  intros. now subst.
+Qed.
+
 Lemma erases_weakening' (Σ : global_env_ext) (Γ Γ' Γ'' : PCUICAst.context) (t T : PCUICAst.term) t' :
     wf Σ ->
     wf_local Σ (Γ ,,, Γ') ->
@@ -176,7 +185,7 @@ Proof.
 
     eapply weakening_typing in HT; eauto.
 
-    Require Import MetaCoq.PCUIC.PCUICInversion. cbn in HT.
+    cbn in HT.
     eapply inversion_Fix in HT as (? & ? & ? & ? & ? & ?) ; auto. clear a0 c.
 
 
@@ -195,11 +204,6 @@ Proof.
     rewrite app_length in *.
     subst types. rewrite fix_context_length in *.
     rewrite (All2_length _ _ H4) in *.
-    Lemma erases_ctx_ext (Σ : global_env_ext) Γ Γ' t t' :
-      erases Σ Γ t t' -> Γ = Γ' -> erases Σ Γ' t t'.
-    Proof.
-      intros. now subst.
-    Qed.
     eapply erases_ctx_ext. eapply e4.
     rewrite lift_context_app. unfold app_context.
     rewrite !app_assoc. repeat f_equal.

--- a/extraction/theories/EWcbvEval.v
+++ b/extraction/theories/EWcbvEval.v
@@ -2,11 +2,13 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils Ast.
-From MetaCoq.Extraction Require Import EAst EInduction ELiftSubst ETyping.
+From MetaCoq.PCUIC Require Import PCUICAstUtils.
+From MetaCoq.Extraction Require Import EAst EAstUtils EInduction ELiftSubst ETyping Prelim.
 From MetaCoq.Template Require AstUtils.
 Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
+Require Import ssreflect ssrbool.
 
 Existing Instance config.default_checker_flags.
 
@@ -29,8 +31,218 @@ Definition atom t :=
   match t with
   | tBox
   | tConstruct _ _
-  | tFix _ _
+  | tCoFix _ _
+  | tLambda _ _
+  | tFix _ _ => true
+  | _ => false
+  end.
+
+Lemma mkApps_app t l l' : mkApps t (l ++ l') = mkApps (mkApps t l) l'.
+Proof.
+  induction l in t, l' |- *; simpl; auto.
+Qed.
+
+Lemma decompose_app_rec_inv {t l' f l} :
+  decompose_app_rec t l' = (f, l) ->
+  mkApps t l' = mkApps f l.
+Proof.
+  induction t in f, l', l |- *; try intros [= <- <-]; try reflexivity.
+  simpl. apply/IHt1.
+Qed.
+
+Lemma decompose_app_inv {t f l} :
+  decompose_app t = (f, l) -> t = mkApps f l.
+Proof. by apply/decompose_app_rec_inv. Qed.
+Lemma atom_decompose_app t l : ~~ isApp t -> decompose_app_rec t l = pair t l.
+Proof. destruct t; simpl; congruence. Qed.
+
+Lemma mkApps_eq_decompose_app_rec {f args t l} :
+  mkApps f args = t ->
+  ~~ isApp f ->
+  match decompose_app_rec t l with
+  | (f', args') => f' = f /\ mkApps t l = mkApps f' args'
+  end.
+Proof.
+  revert f t l.
+  induction args using rev_ind; simpl.
+  - intros * -> **. rewrite atom_decompose_app; auto.
+  - intros. rewrite mkApps_app in H.
+    specialize (IHargs f).
+    destruct (isApp t) eqn:Heq.
+    destruct t; try discriminate.
+    simpl in Heq. inv H. simpl.
+    specialize (IHargs (mkApps f args) (t2 :: l) eq_refl H0).
+    destruct decompose_app_rec. intuition.
+    subst t.
+    simpl in Heq. discriminate.
+Qed.
+
+Lemma decompose_app_eq_right t l l' : decompose_app_rec t l = decompose_app_rec t l' -> l = l'.
+Proof.
+  induction t in l, l' |- *; simpl; intros [=]; auto.
+  specialize (IHt1 _ _ H0). now inv IHt1.
+Qed.
+
+Lemma mkApps_eq_right t l l' : mkApps t l = mkApps t l' -> l = l'.
+Proof.
+  intros. eapply (f_equal decompose_app) in H. unfold decompose_app in H.
+  rewrite !decompose_app_rec_mkApps in H. apply decompose_app_eq_right in H.
+  now rewrite !app_nil_r in H.
+Qed.
+
+Lemma mkApps_eq_decompose' {f args t} :
+  mkApps f args = t ->
+  ~~ isApp f ->
+  match decompose_app t with
+  | (f', args') => f' = f /\ args' = args /\ t = mkApps f' args'
+  end.
+Proof.
+  intros.
+  have H' := (@mkApps_eq_decompose_app_rec f args t [] H H0).
+  rewrite /decompose_app. destruct (decompose_app_rec t []).
+  intuition subst; auto. simpl in H2. now eapply mkApps_eq_right in H2.
+Qed.
+
+
+Lemma decompose_app_rec_notApp :
+  forall t l u l',
+    decompose_app_rec t l = (u, l') ->
+    ~~ isApp u.
+Proof.
+  intros t l u l' e.
+  induction t in l, u, l', e |- *.
+  all: try (cbn in e ; inversion e ; reflexivity).
+  cbn in e. eapply IHt1. eassumption.
+Qed.
+
+Lemma decompose_app_notApp :
+  forall t u l,
+    decompose_app t = (u, l) ->
+    ~~ isApp u.
+Proof.
+  intros t u l e.
+  eapply decompose_app_rec_notApp. eassumption.
+Qed.
+
+Inductive mkApps_spec : term -> list term -> term -> list term -> term -> Type :=
+| mkApps_intro f l n :
+    ~~ isApp f ->
+    mkApps_spec f l (mkApps f (firstn n l)) (skipn n l) (mkApps f l).
+
+Lemma decompose_app_rec_eq f l :
+  ~~ isApp f ->
+  decompose_app_rec f l = (f, l).
+Proof.
+  destruct f; simpl; try discriminate; congruence.
+Qed.
+Close Scope string_scope.
+
+Lemma firstn_add {A} x y (args : list A) : firstn (x + y) args = firstn x args ++ firstn y (skipn x args).
+Proof.
+  induction x in y, args |- *. simpl. reflexivity.
+  simpl. destruct args. simpl.
+  now rewrite skipn_nil firstn_nil.
+  rewrite IHx. now rewrite app_comm_cons.
+Qed.
+
+Lemma decompose_app_rec_inv' f l hd args :
+  decompose_app_rec f l = (hd, args) ->
+  ∑ n, ~~ isApp hd /\ l = skipn n args /\ f = mkApps hd (firstn n args).
+Proof.
+  destruct (isApp f) eqn:Heq.
+  revert l args hd.
+  induction f; try discriminate. intros.
+  simpl in H.
+  destruct (isApp f1) eqn:Hf1.
+  2:{ rewrite decompose_app_rec_eq in H => //. now apply negbT.
+      inv H. exists 1. simpl. intuition auto. now eapply negbT. }
+  destruct (IHf1 eq_refl _ _ _ H).
+  clear IHf1.
+  exists (S x); intuition auto. eapply (f_equal (skipn 1)) in H2.
+  rewrite [l]H2. now rewrite skipn_skipn Nat.add_1_r.
+  rewrite -Nat.add_1_r firstn_add H3 -H2.
+  now rewrite -[tApp _ _](mkApps_app hd _ [f2]).
+  rewrite decompose_app_rec_eq; auto. now apply negbT.
+  move=> [] H ->. subst f. exists 0. intuition auto.
+  now apply negbT.
+Qed.
+
+Lemma mkApps_elim_rec t l l' :
+  let app' := decompose_app_rec (mkApps t l) l' in
+  mkApps_spec app'.1 app'.2 t (l ++ l') (mkApps t (l ++ l')).
+Proof.
+  destruct app' as [hd args] eqn:Heq.
+  subst app'.
+  rewrite decompose_app_rec_mkApps in Heq.
+  have H := decompose_app_rec_inv' _ _ _ _ Heq.
+  destruct H. simpl. destruct a as [isapp [Hl' Hl]].
+  subst t.
+  have H' := mkApps_intro hd args x. rewrite Hl'.
+  rewrite -mkApps_app. now rewrite firstn_skipn.
+Qed.
+
+Lemma mkApps_elim t l  :
+  let app' := decompose_app (mkApps t l) in
+  mkApps_spec app'.1 app'.2 t l (mkApps t l).
+Proof.
+  have H := @mkApps_elim_rec t l [].
+  now rewrite app_nil_r in H.
+Qed.
+
+Lemma mkApps_eq_inj {t t' l l'} :
+  mkApps t l = mkApps t' l' ->
+  ~~ isApp t -> ~~ isApp t' -> t = t' /\ l = l'.
+Proof.
+  intros Happ Ht Ht'. eapply (f_equal decompose_app) in Happ. unfold decompose_app in Happ.
+  rewrite !decompose_app_rec_mkApps in Happ. rewrite !atom_decompose_app in Happ; auto.
+  now rewrite !app_nil_r in Happ.
+Qed.
+
+Ltac solve_discr :=
+  match goal with
+    H : mkApps _ _ = mkApps ?f ?l |- _ =>
+    eapply mkApps_eq_inj in H as [? ?]; [|easy|easy]; subst; try intuition congruence
+  | H : ?t = mkApps ?f ?l |- _ =>
+    change t with (mkApps t []) in H ;
+    eapply mkApps_eq_inj in H as [? ?]; [|easy|easy]; subst; try intuition congruence
+  | H : mkApps ?f ?l = ?t |- _ =>
+    change t with (mkApps t []) in H ;
+    eapply mkApps_eq_inj in H as [? ?]; [|easy|easy]; subst; try intuition congruence
+  end.
+
+Lemma atom_mkApps f l : atom (mkApps f l) -> (l = []) /\ atom f.
+Proof.
+  revert f; induction l using rev_ind. simpl. intuition auto.
+  simpl. intros. now rewrite mkApps_app in H.
+Qed.
+
+Definition isEvar t :=
+  match t with
+  | tEvar _ _ => true
+  | _ => false
+  end.
+
+Definition isFix t :=
+  match t with
+  | tFix _ _ => true
+  | _ => false
+  end.
+
+Definition isCoFix t :=
+  match t with
   | tCoFix _ _ => true
+  | _ => false
+  end.
+
+Definition isConstruct t :=
+  match t with
+  | tConstruct _ _ => true
+  | _ => false
+  end.
+
+Definition isBox t :=
+  match t with
+  | tBox => true
   | _ => false
   end.
 
@@ -40,9 +252,10 @@ Section Wcbv.
 
   Inductive eval : term -> term -> Prop :=
   (** Reductions *)
-  | eval_box a l :
+  | eval_box a t t' :
       eval a tBox ->
-      eval (tApp a l) tBox
+      eval t t' ->
+      eval (tApp a t) tBox
 
   (** Beta *)
   | eval_beta f na b a a' res :
@@ -70,16 +283,15 @@ Section Wcbv.
       eval (mkApps f (repeat tBox n)) res ->
       eval (tCase (ind, pars) discr brs) res
            
-  (** Fix unfolding, with guard *)
-  | eval_fix mfix idx args args' narg fn res :
+  (** Fix unfolding, without guard *)
+  | eval_fix mfix idx arg narg fn res :
       unfold_fix mfix idx = Some (narg, fn) ->
       (* We do not need to check the guard in the extracted language
          as we assume reduction of closed terms, whose canonical
-         form will be a constructor or a box.  *)
-      (* is_constructor_or_box narg args' -> *)
-      Forall2 eval args args' ->
-      eval (mkApps fn args') res ->
-      eval (mkApps (tFix mfix idx) args) res
+         form will be a constructor or a box. A fixpoint must
+         still be applied to at least one argument to unfold. *)
+      eval (tApp fn arg) res ->
+      eval (tApp (tFix mfix idx) arg) res
 
   (** CoFix-case unfolding *)
   | red_cofix_case ip mfix idx args narg fn brs res :
@@ -109,157 +321,319 @@ Section Wcbv.
   | eval_proj_box i pars arg discr :
       eval discr tBox ->
       eval (tProj (i, pars, arg) discr) tBox
-           
-  (** Abstractions are values *)
-  | eval_abs na N : eval (tLambda na N) (tLambda na N)
 
-  (** Constructors applied to values are values *)
-  | eval_constr f i k l l' :
-      eval f (tConstruct i k) ->
-      Forall2 eval l l' ->
-      eval (mkApps f l) (mkApps (tConstruct i k) l')
+  (** Atoms (non redex-producing heads) applied to values are values *)
+  | eval_app_cong f f' a a' :
+      eval f f' ->
+      ~~ (isLambda f' || isFix f' || isBox f') ->
+      eval a a' ->
+      eval (tApp f a) (tApp f' a')
 
-  (** Atoms are values *)
-  | eval_atom t : atom t -> eval t t
+  (** Evars complicate reasoning due to the embedded substitution, we skip
+      them for now *)
+  (* | eval_evar n l l' : *)
+  (*     Forall2 eval l l' -> *)
+  (*     eval (tEvar n l) (tEvar n l') *)
 
-  | eval_evar ev l : eval (tEvar ev l) (tEvar ev l) (* Lets say it is a value for now *).
 
-  (* (** The right induction principle for the nested [Forall] cases: *) *)
+  (** Atoms are values (includes abstractions, cofixpoints and constructors) *)
+  | eval_atom t : atom t -> eval t t.
 
-  Lemma eval_evals_ind :
-    forall P : term -> term -> Prop,
-      (forall a l, eval a tBox ->
-                   P (tApp a l) tBox) ->
-      (forall (f : term) (na : name) (b a a' : term) (res : term),
-          eval f (tLambda na b) ->
-          P f (tLambda na b) ->
-          eval a a' -> P a a' ->
-          eval (b {0 := a'}) res -> P (b {0 := a'}) res -> P (tApp f a) res) ->
+  (** Characterization of values for this reduction relation.
+      Only constructors and cofixpoints can accumulate arguments.
+      All other values are atoms and cannot have arguments:
+      - box
+      - abstractions
+      - constant constructors
+      - unapplied fixpoints and cofixpoints
+   *)
 
-      (forall (na : name) (b0 b0' b1 res : term),
-          eval b0 b0' -> P b0 b0' -> eval (b1 {0 := b0'}) res -> P (b1 {0 := b0'}) res ->
-          P (tLetIn na b0 b1) res) ->
-
-      (forall (ind : inductive) (pars : nat) (discr : term) (c : nat)
-              (args : list term) (brs : list (nat * term)) (res : term),
-          eval discr (mkApps (tConstruct ind c) args) ->
-          P discr (mkApps (tConstruct ind c) args) ->
-          eval (iota_red pars c args brs) res ->
-          P (iota_red pars c args brs) res -> P (tCase (ind, pars) discr brs) res) ->
-
-      (forall (ind : inductive) (pars : nat) (discr : term) (brs : list (nat * term)) (n : nat) (f3 res : term),
-        eval discr tBox ->
-        P discr tBox ->
-        brs = [(n, f3)] ->
-        eval (mkApps f3 (repeat tBox n)) res ->
-        P (mkApps f3 (repeat tBox n)) res -> P (tCase (ind, pars) discr brs) res) ->
-      
-      (forall (mfix : mfixpoint term) (idx : nat) (args args' : list term) (narg : nat) (fn res : term),
-          unfold_fix mfix idx = Some (narg, fn) ->
-          Forall2 eval args args' ->
-          Forall2 P args args' ->
-          (* is_constructor_or_box narg args' = true -> *)
-          eval (mkApps fn args') res -> P (mkApps fn args') res -> P (mkApps (tFix mfix idx) args) res) ->
-
-      (forall (ip : inductive * nat)  (mfix : mfixpoint term) (idx : nat) (args : list term)
-              (narg : nat) (fn : term) (brs : list (nat * term)) (res : term),
-          unfold_cofix mfix idx = Some (narg, fn) ->
-          eval (tCase ip (mkApps fn args) brs) res ->
-          P (tCase ip (mkApps fn args) brs) res -> P (tCase ip (mkApps (tCoFix mfix idx) args) brs) res) ->
-
-      (forall (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn res : term),
-          unfold_cofix mfix idx = Some (narg, fn) ->
-          eval (tProj p (mkApps fn args)) res ->
-          P (tProj p (mkApps fn args)) res -> P (tProj p (mkApps (tCoFix mfix idx) args)) res) ->
-
-      (forall (c : ident) (decl : constant_body) (body : term),
-          declared_constant Σ c decl ->
-          forall (res : term),
-            cst_body decl = Some body ->
-            eval body res -> P body res -> P (tConst c) res) ->
-
-      (forall (i : inductive) (pars arg : nat) (discr : term) (args : list term) (k : nat)
-              (res : term),
-          eval discr (mkApps (tConstruct i k) args) ->
-          P discr (mkApps (tConstruct i k) args) ->
-          eval (nth (pars + arg) args tDummy) res ->
-          P (nth (pars + arg) args tDummy) res -> P (tProj (i, pars, arg) discr) res) ->
-
-      (forall (i : inductive) (pars arg : nat) (discr : term),
-          eval discr tBox ->
-          P discr tBox ->
-          P (tProj (i, pars, arg) discr) tBox) ->
-      
-      (forall (na : name) (M N : term), P (tLambda na N) (tLambda na N)) ->
-
-      (forall (f8 : term) (i : inductive) (k : nat) (l l' : list term),
-          eval f8 (tConstruct i k) ->
-          P f8 (tConstruct i k) -> Forall2 eval l l' -> Forall2 P l l' -> P (mkApps f8 l) (mkApps (tConstruct i k) l')) ->
-      (forall t, atom t -> P t t) ->
-
-      (forall (ev : nat) (l : list term), P (tEvar ev l) (tEvar ev l)) ->
-
-      forall t t0 : term, eval t t0 -> P t t0.
-  Proof.
-    intros P Hbox Hbeta Hlet Hcase Hscase Hfix Hcoficase Hcofixproj
-           Hconst Hproj Hproj2 Hlam Hcstr Hatom Hevar.
-    fix eval_evals_ind 3. destruct 1;
-             try match goal with [ H : _ |- _ ] =>
-                             match type of H with
-                               forall t t0, eval t t0 -> _ => fail 1
-                             | context [ atom _ ] => fail
-                             | _ => try solve [eapply H; eauto]
-                             end end; eauto.
-    eapply Hfix. eauto. eauto.
-    clear H1.
-    revert args args' H0. fix aux 3. destruct 1. constructor; auto.
-    constructor. now apply eval_evals_ind. now apply aux. all:eauto.
-    eapply Hcstr; eauto.
-    revert l l' H0. fix aux 3. destruct 1; constructor.
-    now apply eval_evals_ind. apply aux. auto.
-  Defined.
-
-  (** Characterization of values for this reduction relation: *)
-  (*     Basically atoms (constructors, inductives, products (FIXME sorts missing)) *)
-  (*     and de Bruijn variables and lambda abstractions. Closed values disallow *)
-  (*     de Bruijn variables. *)
+  Definition value_head x :=
+    isConstruct x || isCoFix x.
 
   Inductive value : term -> Prop :=
   | value_atom t : atom t -> value t
-  | value_tEvar ev l : value (tEvar ev l)
-  | value_tLam na b : value (tLambda na b)
-  | value_tConstructApp i k l : Forall value l -> value (mkApps (tConstruct i k) l).
+  (* | value_evar n l l' : Forall value l -> Forall value l' -> value (mkApps (tEvar n l) l') *)
+  | value_app t l : value_head t -> Forall value l -> value (mkApps t l).
 
   Lemma value_values_ind : forall P : term -> Prop,
       (forall t, atom t -> P t) ->
-      (forall (ev : nat) (l : list term), P (tEvar ev l)) ->
-      (forall (na : name) (b : term), P (tLambda na b)) ->
-      (forall (i : inductive) (k : nat) (l : list term),
-          Forall value l -> Forall P l -> P (mkApps (tConstruct i k) l)) ->
+      (* (forall n l l', Forall value l -> Forall P l -> Forall value l' -> Forall P l' -> *)
+      (*                 P (mkApps (tEvar n l) l')) -> *)
+      (forall t l, value_head t -> Forall value l -> Forall P l -> P (mkApps t l)) ->
       forall t : term, value t -> P t.
   Proof.
-    intros P ????.
-    fix value_values_ind 2. destruct 1. 1-3:clear value_values_ind; auto.
-    apply H2; auto.
-    revert l H3. fix aux 2. destruct 1. constructor; auto.
-    constructor. now apply value_values_ind. now apply aux.
+    intros P ??.
+    fix value_values_ind 2. destruct 1. apply H; auto.
+    eapply H0; auto.
+    revert l H2. fix aux 2. destruct 1. constructor; auto.
+    constructor. now eapply value_values_ind. now apply aux.
   Defined.
+
+  Lemma value_head_nApp t : value_head t -> ~~ isApp t.
+  Proof. destruct t; auto. Qed.
+  Hint Resolve value_head_nApp : core.
+
+  Lemma value_mkApps_inv t l :
+    ~~ isApp t ->
+    value (mkApps t l) ->
+    (l = [] /\ atom t) \/ (value_head t /\ Forall value l).
+  Proof.
+    intros H H'. generalize_eqs H'. revert t H. induction H' using value_values_ind.
+    intros.
+    subst.
+    - now eapply atom_mkApps in H.
+    - intros * isapp appeq. solve_discr.
+  Qed.
 
   (** The codomain of evaluation is only values: *)
   (*     It means no redex can remain at the head of an evaluated term. *)
 
-  Lemma eval_to_value e e' : eval e e' -> value e'.
+  Lemma Forall_skipn {A} (P : A -> Prop) n l : Forall P l -> Forall P (skipn n l).
   Proof.
-    induction 1 using eval_evals_ind; simpl; auto using value.
-    eapply (value_tConstructApp i k).
-    apply (Forall2_right _ _ _ H1).
+    intros H. revert n; induction H; intros n. rewrite skipn_nil; auto.
+    destruct n; simpl.
+    - rewrite /skipn. constructor; auto.
+    - now rewrite skipn_S.
   Qed.
 
-  (** Evaluation preserves closedness: *)
-  Lemma eval_closed : forall n t u, closedn n t = true -> eval t u -> closedn n u = true.
+  Lemma Forall_firstn {A} (P : A -> Prop) n l : Forall P l -> Forall P (firstn n l).
   Proof.
-    induction 2 using eval_evals_ind; simpl in *; auto. eapply IHeval3.
-    admit.
-  Admitted. (* closedness of evaluates for Eterms, not needed for verification *)
+    intros H. revert n; induction H; intros n. rewrite firstn_nil; auto.
+    destruct n; simpl.
+    - constructor; auto.
+    - constructor; auto.
+  Qed.
+
+  Lemma value_head_spec t :
+    value_head t = (~~ (isLambda t || isFix t || isBox t)) && atom t.
+  Proof.
+    destruct t; intuition auto.
+  Qed.
+
+  Lemma eval_to_value e e' : eval e e' -> value e'.
+  Proof.
+    induction 1 using eval_ind; simpl; auto using value.
+    (* eapply (value_app (tEvar n l') []). constructor. constructor. *)
+    destruct (mkApps_elim f' []).
+    eapply value_mkApps_inv in IHeval1.
+    destruct IHeval1; intuition subst.
+    rewrite H3.
+    simpl. rewrite H3 in H0. simpl in *.
+    apply (value_app f0 [a']).
+    rewrite value_head_spec. now rewrite H0 H4.
+    constructor; auto.
+    rewrite -[tApp _ _](mkApps_app _ (firstn n l) [a']).
+    constructor 2; auto. eapply app_Forall; auto. auto.
+  Qed.
+
+  Lemma Forall2_app_r {A} (P : A -> A -> Prop) l l' r r' : Forall2 P (l ++ [r]) (l' ++ [r']) ->
+                                                           (Forall2 P l l') * (P r r').
+  Proof.
+    induction l in l', r |- *. simpl. intros. destruct l'. simpl in *.
+    depelim H; intuition auto.
+    depelim H. destruct l'; depelim H0.
+    intros.
+    depelim l'; depelim H. destruct l; depelim H0.
+    specialize (IHl _ _ H0). intuition auto.
+  Qed.
+
+  Lemma value_final e : value e -> eval e e.
+  Proof.
+    induction 1 using value_values_ind; simpl; auto using value.
+    now constructor.
+    assert (Forall2 eval l l).
+    induction H1; constructor; auto. eapply IHForall. now depelim H0.
+    rewrite value_head_spec in H.
+    induction l using rev_ind. simpl.
+    move/andP: H => [H H'].
+    constructor; try easy.
+    rewrite mkApps_app.
+    eapply Forall_app in H0 as [Hl Hx]. depelim Hx.
+    eapply Forall2_app_r in H2 as [Hl' Hx'].
+    eapply eval_app_cong; auto.
+    eapply IHl. auto.
+    now eapply Forall2_Forall. auto.
+    move/andP: H => [Ht Ht'].
+    destruct l using rev_ind; auto. now rewrite mkApps_app; simpl.
+  Qed.
+
+  (* (** Evaluation preserves closedness: *) *)
+  (* Lemma eval_closed : forall n t u, closedn n t = true -> eval t u -> closedn n u = true. *)
+  (* Proof. *)
+  (*   induction 2 using eval_ind; simpl in *; auto. eapply IHeval3. *)
+  (*   admit. *)
+  (* Admitted. (* closedness of evaluates for Eterms, not needed for verification *) *)
+
+  Lemma eval_tApp_tFix_inv mfix idx a v :
+    eval (tApp (tFix mfix idx) a) v ->
+    (exists fn arg,
+        (unfold_fix mfix idx = Some (arg, fn)) /\
+        (eval (tApp fn a) v)).
+  Proof.
+    intros H; depind H; try solve_discr.
+    - depelim H.
+    - depelim H.
+    - eexists _, _; firstorder eauto.
+    - now depelim H.
+    - discriminate.
+  Qed.
+
+  Lemma eval_tBox t : eval tBox t -> t = tBox.
+  Proof.
+    intros H; depind H; try solve_discr. auto.
+  Qed.
+
+  Lemma eval_tRel n t : eval (tRel n) t -> False.
+  Proof.
+    intros H; depind H; try solve_discr; try now easy.
+  Qed.
+
+  Lemma eval_tVar i t : eval (tVar i) t -> False.
+  Proof.
+    intros H; depind H; try solve_discr; try now easy.
+  Qed.
+
+  Lemma eval_tEvar n l t : eval (tEvar n l) t -> False.
+                          (* exists l', Forall2 eval l l' /\ (t = tEvar n l'). *)
+  Proof.
+    intros H; depind H; try solve_discr; try now easy.
+  Qed.
+
+  Lemma eval_atom_inj t t' : atom t -> eval t t' -> t = t'.
+  Proof.
+    intros Ha H; depind H; try solve_discr; try now easy.
+  Qed.
+
+  Lemma eval_LetIn {n b t v} :
+    eval (tLetIn n b t) v ->
+    exists b',
+      eval b b' /\ eval (t {0 := b'}) v.
+  Proof.
+    intros H; depind H; try solve_discr; try now easy.
+  Qed.
+
+  Lemma eval_Const {c v} :
+    eval (tConst c) v ->
+    exists decl body, declared_constant Σ c decl /\
+                      cst_body decl = Some body /\
+                      eval body v.
+  Proof.
+    intros H; depind H; try solve_discr; try now easy.
+    exists decl, body. intuition auto.
+  Qed.
+
+  Lemma eval_mkApps_tCoFix mfix idx l v :
+    eval (mkApps (tCoFix mfix idx) l) v ->
+    (exists l', Forall2 eval l l' /\ (v = mkApps (tCoFix mfix idx) l')).
+  Proof.
+    intros H.
+    depind H; try solve_discr.
+    destruct (mkApps_elim a [t]).
+    rewrite -[tApp _ _](mkApps_app f (firstn n l0) [t]) in x.
+    solve_discr.
+    specialize (IHeval1 _ _ _ eq_refl).
+    firstorder eauto.
+    solve_discr.
+    destruct (mkApps_elim f [a]).
+    rewrite -[tApp _ _](mkApps_app f (firstn n l0) [a]) in x. solve_discr.
+    specialize (IHeval1 _ _ _ eq_refl).
+    firstorder eauto. solve_discr.
+    change (tApp (tFix mfix0 idx0) arg) with (mkApps (tFix mfix0 idx0) [arg]) in x.
+    solve_discr.
+    change (tApp f a) with (mkApps f [a]) in x.
+    assert (l <> []).
+    destruct l; simpl in *; discriminate.
+    rewrite (app_removelast_last a H2) in x |- *.
+    rewrite mkApps_app in x. simpl in x. inv x.
+    specialize (IHeval1 _ _ _ eq_refl).
+    destruct IHeval1 as [l' [evl' eqf']].
+    exists (l' ++ [a']).
+    split. eapply Forall2_app; auto. constructor. now rewrite -!H5. constructor.
+    subst f'.
+    now rewrite mkApps_app.
+    eapply atom_mkApps in H; intuition try easy.
+    subst.
+    exists []. intuition auto.
+  Qed.
+
+  Lemma eval_deterministic {t v v'} : eval t v -> eval t v' -> v = v'.
+  Proof.
+    intros tv. revert v'.
+    revert t v tv.
+    induction 1 using eval_ind; intros v' tv'.
+    - depelim tv'; auto. specialize (IHtv1 _ tv'1); congruence.
+      depelim tv1. specialize (IHtv1 _ tv'1). now subst. easy.
+    - depelim tv'; auto; try specialize (IHtv1 _ tv'1) || solve [depelim tv1]; try congruence.
+      inv IHtv1. specialize (IHtv2 _ tv'2). subst.
+      now specialize (IHtv3 _ tv'3).
+      now subst f'. easy.
+    - eapply eval_LetIn in tv' as [b' [evb evt]].
+      rewrite -(IHtv1 _ evb) in evt.
+      eapply (IHtv2 _ evt).
+    - depelim tv'; try solve_discr.
+      * specialize (IHtv1 _ tv'1).
+        solve_discr. inv H.
+        now specialize (IHtv2 _ tv'2).
+      * specialize (IHtv1 _ tv'1); solve_discr.
+      * eapply eval_mkApps_tCoFix in tv1 as [l' [ev' eq]]. solve_discr.
+      * easy.
+    - subst.
+      depelim tv'.
+      * specialize (IHtv1 _ tv'1).
+        solve_discr.
+      * specialize (IHtv1 _ tv'1).
+        now specialize (IHtv2 _ tv'2).
+      * pose proof tv1. eapply eval_mkApps_tCoFix in H0.
+        destruct H0 as [l' [evargs eq]]. solve_discr.
+      * easy.
+    - depelim tv' => //.
+      * depelim tv'1.
+      * depelim tv'1.
+      * rewrite H in H0. inv H0.
+        now specialize (IHtv _ tv').
+      * now depelim tv'1.
+
+    - depelim tv'; try easy.
+      * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]].
+        solve_discr.
+      * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]].
+        solve_discr.
+      * solve_discr. inv H1. rewrite H in H0. inv H0.
+        now specialize (IHtv _ tv').
+
+    - depelim tv'; try easy.
+      * solve_discr. inv H1. rewrite H in H0. inv H0.
+        now specialize (IHtv _ tv').
+      * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]].
+        solve_discr.
+      * eapply eval_mkApps_tCoFix in tv' as [l' [evargs eq]].
+        solve_discr.
+
+    - eapply eval_Const in tv' as [decl' [body' [? ?]]].
+      intuition eauto. eapply IHtv.
+      red in isdecl, H0. rewrite H0 in isdecl. inv isdecl.
+      now rewrite H in H2; inv H2.
+
+    - depelim tv'.
+      * eapply eval_mkApps_tCoFix in tv1 as [l' [evargs eq]].
+        solve_discr.
+      * specialize (IHtv1 _ tv'1). inv IHtv1.
+        solve_discr. inv H.
+        now specialize (IHtv2 _ tv'2).
+      * specialize (IHtv1 _ tv'). solve_discr.
+      * easy.
+
+    - depelim tv'; try easy.
+      * eapply eval_mkApps_tCoFix in tv as [l' [evargs eq]].
+        solve_discr.
+      * specialize (IHtv _ tv'1). solve_discr.
+
+    - depelim tv'; try specialize (IHtv1 _ tv'1); subst; try easy.
+      depelim tv1. easy.
+      specialize (IHtv2 _ tv'2). congruence.
+
+    - depelim tv'; try easy.
+  Qed.
 
 End Wcbv.

--- a/extraction/theories/EWcbvEval.v
+++ b/extraction/theories/EWcbvEval.v
@@ -73,8 +73,11 @@ Section Wcbv.
   (** Fix unfolding, with guard *)
   | eval_fix mfix idx args args' narg fn res :
       unfold_fix mfix idx = Some (narg, fn) ->
-      Forall2 eval args args' -> (* QUESTION should we reduce the args after the recursive arg here? *)
-      is_constructor_or_box narg args' ->
+      (* We do not need to check the guard in the extracted language
+         as we assume reduction of closed terms, whose canonical
+         form will be a constructor or a box.  *)
+      (* is_constructor_or_box narg args' -> *)
+      Forall2 eval args args' ->
       eval (mkApps fn args') res ->
       eval (mkApps (tFix mfix idx) args) res
 
@@ -155,7 +158,7 @@ Section Wcbv.
           unfold_fix mfix idx = Some (narg, fn) ->
           Forall2 eval args args' ->
           Forall2 P args args' ->
-          is_constructor_or_box narg args' = true ->
+          (* is_constructor_or_box narg args' = true -> *)
           eval (mkApps fn args') res -> P (mkApps fn args') res -> P (mkApps (tFix mfix idx) args) res) ->
 
       (forall (ip : inductive * nat)  (mfix : mfixpoint term) (idx : nat) (args : list term)
@@ -208,7 +211,7 @@ Section Wcbv.
                              | _ => try solve [eapply H; eauto]
                              end end; eauto.
     eapply Hfix. eauto. eauto.
-    clear H1 H2.
+    clear H1.
     revert args args' H0. fix aux 3. destruct 1. constructor; auto.
     constructor. now apply eval_evals_ind. now apply aux. all:eauto.
     eapply Hcstr; eauto.

--- a/extraction/theories/Extract.v
+++ b/extraction/theories/Extract.v
@@ -4,7 +4,7 @@
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICElimination.
-From MetaCoq.Extraction Require EAst ELiftSubst ETyping EWcbvEval.
+From MetaCoq.Extraction Require EAst ELiftSubst ETyping.
 Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.

--- a/extraction/theories/ExtractionCorrectness.v
+++ b/extraction/theories/ExtractionCorrectness.v
@@ -613,42 +613,42 @@ Proof.
               rewrite e0. reflexivity.
               eassumption.
               all:eauto.
-              ** unfold is_constructor in *.
-                 destruct ?; inv H1.
-                 unfold is_constructor_or_box.
-                 eapply Forall2_nth_error_Some in H as (? & ? & ?); eauto.
-                 rewrite H.
+              (* ** unfold is_constructor in *. *)
+              (*    (* destruct ?; inv H1. *) *)
+              (*    (* unfold is_constructor_or_box. *) *)
+              (*    eapply Forall2_nth_error_Some in H as (? & ? & ?); eauto. *)
+              (*    rewrite H. *)
 
-                 unfold isConstruct_app in H8.
-                 destruct (decompose_app t) eqn:EE.
-                 assert (E2 : fst (decompose_app t) = t1) by now rewrite EE.
-                 destruct t1.
-                 all:inv H8.
-                 (* erewrite <- PCUICConfluence.fst_decompose_app_rec in E2. *)
+              (*    unfold isConstruct_app in H8. *)
+              (*    destruct (decompose_app t) eqn:EE. *)
+              (*    assert (E2 : fst (decompose_app t) = t1) by now rewrite EE. *)
+              (*    destruct t1. *)
+              (*    all:inv H8. *)
+              (*    (* erewrite <- PCUICConfluence.fst_decompose_app_rec in E2. *) *)
 
-                 pose proof (decompose_app_rec_inv EE).
-                 cbn in H7. subst.
-                 assert (∑ T, Σ ;;; [] |- mkApps (tConstruct ind n ui) l : T) as [T' HT'].
-                 { eapply typing_spine_eval in t0; eauto.
-                   eapply typing_spine_inv in t0; eauto.
-                   eapply PCUICValidity.validity; eauto.
-                 }
-                 eapply erases_mkApps_inv in H1.
-                 destruct H1 as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-                 --- subst.
-                     eapply nth_error_forall in Hv; eauto.
-                     eapply value_app_inv in Hv. subst. reflexivity.
-                 --- subst. inv H7.
-                     +++ eapply nth_error_forall in Hv; eauto.
-                         destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity.
-                         rewrite emkApps_snoc at 1.
-                         generalize (x6 ++ [x4])%list. clear. intros.
-                         rewrite Prelim.decompose_app_mkApps. reflexivity.
-                         reflexivity.
-                     +++ eapply nth_error_forall in Hv; eauto.
-                         eapply value_app_inv in Hv. subst. eauto.
-                 --- eauto.
-                 --- eauto.
+              (*    pose proof (decompose_app_rec_inv EE). *)
+              (*    cbn in H7. subst. *)
+              (*    assert (∑ T, Σ ;;; [] |- mkApps (tConstruct ind n ui) l : T) as [T' HT']. *)
+              (*    { eapply typing_spine_eval in t0; eauto. *)
+              (*      eapply typing_spine_inv in t0; eauto. *)
+              (*      eapply PCUICValidity.validity; eauto. *)
+              (*    } *)
+              (*    eapply erases_mkApps_inv in H1. *)
+              (*    destruct H1 as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ]. *)
+              (*    --- subst. *)
+              (*        eapply nth_error_forall in Hv; eauto. *)
+              (*        eapply value_app_inv in Hv. subst. reflexivity. *)
+              (*    --- subst. inv H7. *)
+              (*        +++ eapply nth_error_forall in Hv; eauto. *)
+              (*            destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity. *)
+              (*            rewrite emkApps_snoc at 1. *)
+              (*            generalize (x6 ++ [x4])%list. clear. intros. *)
+              (*            rewrite Prelim.decompose_app_mkApps. reflexivity. *)
+              (*            reflexivity. *)
+              (*        +++ eapply nth_error_forall in Hv; eauto. *)
+              (*            eapply value_app_inv in Hv. subst. eauto. *)
+              (*    --- eauto. *)
+              (*    --- eauto. *)
               ** eapply subject_reduction. eauto. exact Hty.
                  etransitivity.
                  eapply PCUICReduction.red_mkApps. econstructor.

--- a/extraction/theories/ExtractionCorrectness.v
+++ b/extraction/theories/ExtractionCorrectness.v
@@ -393,7 +393,7 @@ Proof.
         eapply Is_type_eval.
         eauto. eapply H1. eassumption.
         all: eauto. econstructor. econstructor. rewrite parsubst_empty.
-        eauto. econstructor. eauto.
+        eauto. econstructor. eauto. eauto.
       * auto.
     + exists tBox. split. 2:econstructor; eauto.
       econstructor.
@@ -587,7 +587,7 @@ Proof.
 
     eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
     + subst. assert (X100 := X1). eapply Is_type_app in X100 as[].
-      exists tBox. split. 2:eapply eval_box_apps; econstructor; eauto.
+      exists tBox. split. 2:{ eapply eval_box_apps. admit. econstructor; eauto. }
       econstructor.
       eapply Is_type_eval. eauto. eassumption.
       rewrite <- mkApps_nested.  eassumption. eauto. econstructor.
@@ -609,10 +609,11 @@ Proof.
 
               eapply erases_mkApps in e3; eauto.
               eapply IHeval in e3 as (? & ? & ?); cbn; eauto.
-              exists x1. split. eauto. econstructor. unfold ETyping.unfold_fix.
-              rewrite e0. reflexivity.
-              eassumption.
-              all:eauto.
+              exists x1. split. eauto. admit.
+              (*  econstructor. unfold ETyping.unfold_fix. *)
+              (* rewrite e0. reflexivity. *)
+              (* eassumption. *)
+              (* all:eauto. *)
               (* ** unfold is_constructor in *. *)
               (*    (* destruct ?; inv H1. *) *)
               (*    (* unfold is_constructor_or_box. *) *)
@@ -649,6 +650,7 @@ Proof.
               (*            eapply value_app_inv in Hv. subst. eauto. *)
               (*    --- eauto. *)
               (*    --- eauto. *)
+
               ** eapply subject_reduction. eauto. exact Hty.
                  etransitivity.
                  eapply PCUICReduction.red_mkApps. econstructor.
@@ -677,7 +679,7 @@ Proof.
         econstructor.
         eapply Is_type_eval. eauto. eassumption.
         eauto.
-        eapply eval_box_apps. econstructor. eauto. eauto. econstructor. eauto.
+        eapply eval_box_apps. admit. econstructor. eauto. eauto. econstructor. eauto.
     + auto.
   - destruct Σ as (Σ, univs).
     unfold erases_global in Heg.
@@ -764,7 +766,7 @@ Proof.
       eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
     + auto.
   - inv He.
-    + eexists. split; eauto. econstructor.
+    + eexists. split; eauto. econstructor. constructor.
     + eexists. split; eauto. now econstructor.
   - inv He. eexists. split; eauto. now econstructor.
   - inv He. eexists. split; eauto. now econstructor.
@@ -787,7 +789,7 @@ Proof.
       eapply eval_app_ind. eauto. eauto.
       eauto. destruct H1.
       exists tBox.
-      split. 2:{ eapply eval_box_apps. now econstructor. }
+      split. 2:{ eapply eval_box_apps. admit. now econstructor. }
       econstructor. eauto.
     + subst.
       eapply IHeval in H2 as (? & ? & ?).
@@ -795,7 +797,7 @@ Proof.
       exists tBox.
       split. econstructor.
       eauto.
-      eapply eval_box_apps; eauto. eauto. econstructor. eauto. eauto.
+      eapply eval_box_apps; eauto. eauto. admit. (* econstructor. *) eauto. eauto. eauto. eauto.
     + auto.
   - inv He.
     + eexists. split; eauto. now econstructor.
@@ -822,7 +824,7 @@ Proof.
       eapply All2_impl. exact a. intros.
       eapply wcbeval_red; eauto. eauto. destruct H1.
       exists tBox.
-      split. 2:{ eapply eval_box_apps. now econstructor. }
+      split. 2:{ eapply eval_box_apps. admit. now econstructor. }
       eauto.
     + subst.
       eapply type_mkApps_inv in Hty' as (? & ? & [] & ?); eauto.
@@ -832,14 +834,14 @@ Proof.
         inv H1.
         -- exists (E.mkApps (E.tConstruct i k) l''). split.
            eapply erases_mkApps; eauto.
-           firstorder. econstructor; firstorder.
+           firstorder. eapply Ee.eval_mkApps_cong; eauto. firstorder.
         -- eapply Is_type_app in X0 as []; eauto. exists tBox.
            split.
            econstructor. eauto. eauto.
-           eapply eval_box_apps. eauto.
+           eapply eval_box_apps. intuition eauto. eauto.
       * clear - t0 H0 H3. revert x1 x0 H3 t0. induction H0; intros.
         -- inv H3. eauto.
         -- inv H3. inv t0. eapply IHAll2 in H5 as (? & ? & ?).
            eapply r in H2 as (? & ? & ?); eauto.
            eauto.
-Qed.
+Admitted.

--- a/extraction/theories/Prelim.v
+++ b/extraction/theories/Prelim.v
@@ -155,19 +155,6 @@ Proof.
   revert a; induction n; cbn; firstorder congruence.
 Qed.
 
-Lemma decompose_app_rec_mkApps f l l' : EAstUtils.decompose_app_rec (E.mkApps f l) l' =
-                                    EAstUtils.decompose_app_rec f (l ++ l').
-Proof.
-  induction l in f, l' |- *; simpl; auto; rewrite IHl, ?app_nil_r; auto.
-Qed.
-
-Lemma decompose_app_mkApps f l :
-  E.isApp f = false -> EAstUtils.decompose_app (E.mkApps f l) = (f, l).
-Proof.
-  intros Hf. unfold EAstUtils.decompose_app. rewrite decompose_app_rec_mkApps. rewrite app_nil_r.
-  destruct f; simpl in *; (discriminate || reflexivity).
-Qed.
-
 (** ** Prelim stuff, should move *)
 
 Lemma All2_right_triv {A B} {l : list A} {l' : list B} P :
@@ -264,18 +251,11 @@ Proof.
   - destruct L using rev_ind.
     reflexivity.
     rewrite emkApps_snoc in H. inv H.
-  - induction L using rev_ind.
-    + reflexivity.
-    + rewrite emkApps_snoc in x. inv x.
-  - induction L using rev_ind.
-    + reflexivity.
-    + rewrite emkApps_snoc in x. inv x.
-  - assert (EAst.isApp (EAst.tConstruct i k) = false) by reflexivity.
-    assert (EAst.isApp tBox = false) by reflexivity.
-    eapply decompose_app_mkApps in H0.
-    eapply decompose_app_mkApps in H1.
-    rewrite <- x in H1. rewrite H0 in H1.
-    inv H1.
+  - destruct (Ee.mkApps_elim t l). Ee.solve_discr.
+    rewrite Ee.value_head_spec in H.
+    eapply andP in H. destruct H.
+    eapply Ee.atom_mkApps in H1 as [H1 _].
+    destruct n, L; discriminate.
 Qed.
 
 (** ** Prelim on eliminations  *)

--- a/pcuic/theories/TemplateToPCUIC.v
+++ b/pcuic/theories/TemplateToPCUIC.v
@@ -11,68 +11,66 @@ Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
 
-Module T := Template.Ast.
-
-Fixpoint trans (t : T.term) : term :=
+Fixpoint trans (t : Ast.term) : term :=
   match t with
-  | T.tRel n => tRel n
-  | T.tVar n => tVar n
-  | T.tEvar ev args => tEvar ev (List.map trans args)
-  | T.tSort u => tSort u
-  | T.tConst c u => tConst c u
-  | T.tInd c u => tInd c u
-  | T.tConstruct c k u => tConstruct c k u
-  | T.tLambda na T M => tLambda na (trans T) (trans M)
-  | T.tApp u v => mkApps (trans u) (List.map trans v)
-  | T.tProd na A B => tProd na (trans A) (trans B)
-  | T.tCast c kind t => tApp (tLambda nAnon (trans t) (tRel 0)) (trans c)
-  | T.tLetIn na b t b' => tLetIn na (trans b) (trans t) (trans b')
-  | T.tCase ind p c brs =>
+  | Ast.tRel n => tRel n
+  | Ast.tVar n => tVar n
+  | Ast.tEvar ev args => tEvar ev (List.map trans args)
+  | Ast.tSort u => tSort u
+  | Ast.tConst c u => tConst c u
+  | Ast.tInd c u => tInd c u
+  | Ast.tConstruct c k u => tConstruct c k u
+  | Ast.tLambda na T M => tLambda na (trans T) (trans M)
+  | Ast.tApp u v => mkApps (trans u) (List.map trans v)
+  | Ast.tProd na A B => tProd na (trans A) (trans B)
+  | Ast.tCast c kind t => tApp (tLambda nAnon (trans t) (tRel 0)) (trans c)
+  | Ast.tLetIn na b t b' => tLetIn na (trans b) (trans t) (trans b')
+  | Ast.tCase ind p c brs =>
     let brs' := List.map (on_snd trans) brs in
     tCase ind (trans p) (trans c) brs'
-  | T.tProj p c => tProj p (trans c)
-  | T.tFix mfix idx =>
+  | Ast.tProj p c => tProj p (trans c)
+  | Ast.tFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tFix mfix' idx
-  | T.tCoFix mfix idx =>
+  | Ast.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
   end.
 
-Definition trans_decl (d : T.context_decl) :=
-  let 'T.mkdecl na b t := d in
+Definition trans_decl (d : Ast.context_decl) :=
+  let 'Ast.mkdecl na b t := d in
   {| decl_name := na;
      decl_body := option_map trans b;
      decl_type := trans t |}.
 
 Definition trans_local Γ := List.map trans_decl Γ.
 
-Definition trans_one_ind_body (d : T.one_inductive_body) :=
-  {| ind_name := d.(T.ind_name);
-     ind_type := trans d.(T.ind_type);
-     ind_kelim := d.(T.ind_kelim);
-     ind_ctors := List.map (fun '(x, y, z) => (x, trans y, z)) d.(T.ind_ctors);
-     ind_projs := List.map (fun '(x, y) => (x, trans y)) d.(T.ind_projs) |}.
+Definition trans_one_ind_body (d : Ast.one_inductive_body) :=
+  {| ind_name := d.(Ast.ind_name);
+     ind_type := trans d.(Ast.ind_type);
+     ind_kelim := d.(Ast.ind_kelim);
+     ind_ctors := List.map (fun '(x, y, z) => (x, trans y, z)) d.(Ast.ind_ctors);
+     ind_projs := List.map (fun '(x, y) => (x, trans y)) d.(Ast.ind_projs) |}.
 
 Definition trans_constant_body bd :=
-  {| cst_type := trans bd.(T.cst_type); cst_body := option_map trans bd.(T.cst_body);
-     cst_universes := bd.(T.cst_universes) |}.
+  {| cst_type := trans bd.(Ast.cst_type); cst_body := option_map trans bd.(Ast.cst_body);
+     cst_universes := bd.(Ast.cst_universes) |}.
 
 Definition trans_minductive_body md :=
-  {| ind_finite := md.(T.ind_finite);
-     ind_npars := md.(T.ind_npars);
-     ind_params := trans_local md.(T.ind_params);
-     ind_bodies := map trans_one_ind_body md.(T.ind_bodies);
-     ind_universes := md.(T.ind_universes) |}.
+  {| ind_finite := md.(Ast.ind_finite);
+     ind_npars := md.(Ast.ind_npars);
+     ind_params := trans_local md.(Ast.ind_params);
+     ind_bodies := map trans_one_ind_body md.(Ast.ind_bodies);
+     ind_universes := md.(Ast.ind_universes) |}.
 
-Definition trans_global_decl (d : T.global_decl) :=
+Definition trans_global_decl (d : Ast.global_decl) :=
   match d with
-  | T.ConstantDecl kn bd => ConstantDecl kn (trans_constant_body bd)
-  | T.InductiveDecl kn bd => InductiveDecl kn (trans_minductive_body bd)
+  | Ast.ConstantDecl kn bd => ConstantDecl kn (trans_constant_body bd)
+  | Ast.InductiveDecl kn bd => InductiveDecl kn (trans_minductive_body bd)
   end.
 
 Definition trans_global_decls d :=
   List.map trans_global_decl d.
 
-Definition trans_global (Σ : T.global_env_ext) :=
+Definition trans_global (Σ : Ast.global_env_ext) :=
   (trans_global_decls (fst Σ), snd Σ).

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1384,8 +1384,8 @@ Section CheckEnv.
 
   Program Definition check_udecl id (Σ : global_env) (HΣ : ∥ wf Σ ∥) G
           (HG : is_graph_of_uctx G (global_uctx Σ)) (udecl : universes_decl)
-    : EnvCheck (∑ uctx', gc_of_uctx (uctx_of_udecl udecl) = Some uctx'
-                         × ∥ on_udecl Σ udecl ∥) :=
+    : EnvCheck (∑ uctx', gc_of_uctx (uctx_of_udecl udecl) = Some uctx' /\
+                         ∥ on_udecl Σ udecl ∥) :=
     let levels := levels_of_udecl udecl in
     let global_levels := global_levels Σ in
     let all_levels := LevelSet.union levels global_levels in
@@ -1405,7 +1405,7 @@ Section CheckEnv.
     | Some uctx' => fun Huctx =>
       check_eq_true (wGraph.is_acyclic (add_uctx uctx' G))
                     (IllFormedDecl id (Msg "constraints not satisfiable"));;
-                                 ret (uctx'; (_, _))
+                                 ret (uctx'; (conj _ _))
     end eq_refl.
   Next Obligation.
     assert (HH: ConstraintSet.For_all
@@ -1465,17 +1465,15 @@ Section CheckEnv.
         rewrite no_prop_levels_union. reflexivity.
   Defined.
 
-
-
   Program Fixpoint check_wf_env (Σ : global_env)
-    : EnvCheck (∑ G, (is_graph_of_uctx G (global_uctx Σ) * ∥ wf Σ ∥)) :=
+    : EnvCheck (∑ G, (is_graph_of_uctx G (global_uctx Σ)) /\ ∥ wf Σ ∥) :=
     match Σ with
     | [] => ret (init_graph; _)
     | d :: Σ =>
         G <- check_wf_env Σ ;;
         check_fresh (global_decl_ident d) Σ ;;
         let udecl := universes_decl_of_decl d in
-        uctx <- check_udecl (global_decl_ident d) Σ _ G.π1 G.π2.1 udecl ;;
+        uctx <- check_udecl (global_decl_ident d) Σ _ G.π1 (proj1 G.π2) udecl ;;
         let G' := add_uctx uctx.π1 G.π1 in
         check_wf_decl (Σ, udecl) _ _ G' _ d ;;
         match udecl with
@@ -1581,7 +1579,7 @@ Section CheckEnv.
     : EnvCheck (∑ A, ∥ empty_ext (List.rev p.1) ;;; [] |- p.2  : A ∥) :=
     let Σ := List.rev (fst p) in
     G <- check_wf_env Σ ;;
-    @infer_term (empty_ext Σ) G.π2.2 _ G.π1 _ (snd p).
+    @infer_term (empty_ext Σ) (proj2 G.π2) _ G.π1 _ (snd p).
   Next Obligation.
     sq. repeat split.
     - intros l Hl; now apply LevelSetFact.empty_iff in Hl.
@@ -1591,7 +1589,7 @@ Section CheckEnv.
       apply wf_consistent in X. destruct X as [v Hv].
       exists v. intros c Hc.
       apply ConstraintSet.union_spec in Hc. destruct Hc.
-      apply ConstraintSetFact.empty_iff in H; contradiction.
+      apply ConstraintSetFact.empty_iff in H0; contradiction.
       now apply Hv.
   Defined.
 

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -2,6 +2,9 @@
 -I ../checker/src
 -Q ../template-coq/theories MetaCoq.Template
 -Q ../checker/theories MetaCoq.Checker
+-Q ../pcuic/theories MetaCoq.PCUIC
+-Q ../safechecker/theories MetaCoq.SafeChecker
+-Q ../extraction/theories MetaCoq.Extraction
 -R . MetaCoq.TestSuite
 
 demo.v

--- a/test-suite/main.scm
+++ b/test-suite/main.scm
@@ -1,0 +1,7 @@
+(module foo
+ (main main)
+ (import (erase "erase.scm")))
+
+(define (main argv)
+  (print "argv: " argv)
+  (print (erase_prog)))

--- a/test-suite/test_extraction.v
+++ b/test-suite/test_extraction.v
@@ -1,0 +1,147 @@
+(** Extraction setup for the safechecker phase of MetaCoq.
+
+    Any extracted code planning to link with the plugin's OCaml reifier
+    should use these same directives for consistency.
+*)
+
+Require Import FSets.
+(* Require Import ExtrOcamlString ExtrOcamlZInt. *)
+From MetaCoq.Template Require Import All.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils TemplateToPCUIC.
+From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion.
+From MetaCoq.Extraction Require Import ErasureFunction.
+
+
+(* Ignore [Decimal.int] before the extraction issue is solved:
+   https://github.com/coq/coq/issues/7017. *)
+(* Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)". *)
+
+(* Extract Constant utils.ascii_compare => *)
+(*  "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt". *)
+
+Extraction Blacklist config uGraph universes Ast String List Nat Int
+           UnivSubst Typing Checker Retyping OrderedType Classes.
+Set Warnings "-extraction-opaque-accessed".
+
+Extraction Inline PCUICSafeConversion.Ret.
+
+Quote Recursively Definition foo := (2 + 3)%nat.
+Require Import Strings.String.
+Definition string_of_env_error e : string :=
+  match e with
+  | IllFormedDecl e t =>
+    "Ill-formed declaration of \'" ++ e ++ "\':" ++ string_of_type_error t
+  | AlreadyDeclared id =>
+    "Ill-formed environment: \'" ++ id ++ "\' is already declared"
+  end.
+
+Program
+Definition erase_program (p : Ast.program) : String.string :=
+  let Σ' := trans_global_decls p.1 in
+  match check_wf_env (List.rev Σ') with
+  | CorrectDecl (existT graph H) =>
+    let p' := trans p.2 in
+    match erase (empty_ext (List.rev Σ')) _ nil _ p' with
+    | Checked eterm => "erasure succeeded"
+    | TypeError e => string_of_type_error e
+    end
+  | EnvError e => string_of_env_error e
+  end.
+
+Next Obligation.
+  destruct s. constructor.
+  split. simpl. apply w.
+  simpl. red. simpl.
+  split. todo "constraints proof".
+  todo "constraints proof".
+Defined.
+Next Obligation.
+  destruct s. constructor. constructor.
+Defined.
+
+Definition erase_prog := erase_program foo.
+
+(* Cd "src". *)
+
+Extraction Language Scheme.
+Extract Inductive Equations.Init.sigma => "(,)" ["(,)"].
+Extract Constant PCUICTyping.fix_guard => "(lambda (x) `True)".
+Extract Constant PCUICTyping.ind_guard => "(lambda (x) `True)".
+
+Extract Constant check_one_ind_body => "(lambdas (_ _ _ _ _ _ _) `(@ret env_monad __))".
+Extract Constant erase_mfix_obligation_1 => "(lambdas (_ _ _ _) (@ret typing_monad __))".
+(*
+import qualified Data.Bits
+import qualified Data.Char
+*)
+Extraction "erase.scm" erase_prog.
+
+(* Require Import ExtrHaskellBasic ExtrHaskellString. *)
+(* Extraction Language Haskell. *)
+(* Extract Inductive Equations.Init.sigma => "(,)" ["(,)"]. *)
+(* Extract Constant PCUICTyping.fix_guard => "\ _ -> Prelude.True". *)
+(* Extract Constant PCUICTyping.ind_guard => "\ _ -> Prelude.True". *)
+
+(*
+
+
+;; Because of fixed arity, we always use unary lambda
+;; (lambdas (a b) c) ==> (lambda (a) (lambda (b) c))
+
+(define-syntax lambdas
+  (syntax-rules ()
+    ((lambdas () c) c)
+    ((lambdas (a b ...) c) (lambda (a) (lambdas (b ...) c)))))
+
+;; Hence all applications should be unary: ((f x) y)
+;; to remove some parenthesis, we introduce a macro: (@ f x y) = ((f x) y)
+
+(define-syntax @
+  (syntax-rules  ()
+    ((@ f) (f))
+    ((@ f x) (f x))
+    ((@ f x . l) (@ (f x) . l))))
+
+;; Bigloo provides a native pattern matching construct named
+;; match-case. But its patterns use some ? that cannot easily
+;; be emulated in other (r5rs) scheme implementations.
+;; Hence we extract to a simplier syntax without ? and then
+;; adapt it here to the bigloo style, using a lisp-like macro.
+;; Example: predecessor should be written
+;;    (define (pred n)
+;;       (match n
+;;          ((O) '(O))
+;;          ((S n) n)))
+
+(define-macro (match e . br)
+  (let*
+      ((add-?
+        (lambda (id) (string->symbol (string-append "?" (symbol->string id)))))
+       (fixbr (lambda (l) `((,(caar l) ,@(map add-? (cdar l))) ,@(cdr l)))))
+    `(match-case ,e ,@(map fixbr br))))
+
+;; The extracted code uses a unary error function
+
+(define !error error)
+(define (error m) (!error "" "" m))
+
+;;;;;;;;; end of macros;;;;;;;
+
+
+
+(define andb (lambda (x y) (match x
+                                  ((`True) y)
+                                  ((`False) `(False)))))
+(define orb (lambda (x y) (match x
+                                 ((`True) (`True))
+                                 ((`False) y))))
+*)
+(* Extract Constant check_one_ind_body => "\_ _ _ _ _ _ _ -> CorrectDecl ()". *)
+(* Extract Constant erase_mfix_obligation_1 => "\_ _ _ _ -> Checked ()". *)
+(* (* *)
+(* import qualified Data.Bits *)
+(* import qualified Data.Char *)
+(* *) *)
+(* Extraction "erase.hs" erase_prog. *)
+
+Cd "..".


### PR DESCRIPTION
This is a try at extracting the verified checker and erasure, using Haskell or Scheme. Haskell has the same type error problem as OCaml, even with -fdefer-type-errors. Scheme seems to work though! But I don't know how to program a printer for the extracted Ascii representation in Scheme yet.