### PR TITLE
 Fix the SafeChecker with type_Case_valid_btys

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -208,6 +208,7 @@ Proof.
     destruct x, decl_body; cbn in H0; try now inv H0.
 Qed.
 
+
 Lemma tConstruct_no_Type (Σ : global_env_ext) ind c u x1 : wf Σ ->
   isErasable Σ [] (mkApps (tConstruct ind c u) x1) ->
   Is_proof Σ [] (mkApps (tConstruct ind c u) x1).
@@ -262,7 +263,7 @@ Proof.
     eapply typing_spine_red in t0. 3:auto. 2:{ eapply PCUICCumulativity.All_All2_refl. clear. induction x1; eauto. }
     2: eapply PCUICCumulativity.red_cumul. 2: eassumption. 2:eapply PCUICCumulativity.cumul_refl'.
     clear - wfΣ t0 H c2.
-    2:{ eapply isWfArity_or_Type_cumul. eapply PCUICCumulativity.red_cumul. eassumption. eauto. }
+    2:{ eapply isWfArity_or_Type_red; eassumption. }
 
     (* assert ((Σ;;; [] |- it_mkProd_or_LetIn c (mkApps (tInd i u) l) <= x0) + (Σ;;; [] |- x0 <= it_mkProd_or_LetIn c (mkApps (tInd i u) l))) by eauto. clear c2. *)
     rename c2 into X.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -902,7 +902,7 @@ Proof.
     eexists. split.
     +  eapply cofix_red_body. eassumption.
     + constructor. all: eauto.
-Admitted.
+Qed.
 
 Lemma red1_eq_context_upto_r Σ Re Γ Δ u v :
   Reflexive Re -> Symmetric Re ->

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -90,22 +90,4 @@ Open Scope type_scope.
            now rewrite app_context_assoc in H2.
    Admitted.
 
-   Lemma isWfArity_red1 :
-     forall {Γ A B},
-       red1 (fst Σ) Γ A B ->
-       isWfArity typing Σ Γ A ->
-       isWfArity typing Σ Γ B.
-   Admitted.
-
-   Lemma isWfArity_red :
-     forall {Γ A B},
-       red (fst Σ) Γ A B ->
-       isWfArity typing Σ Γ A ->
-       isWfArity typing Σ Γ B.
-   Proof.
-     induction 1.
-     - easy.
-     - intro. now eapply isWfArity_red1.
-   Qed.
-
  End Normalisation.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -2346,3 +2346,165 @@ Lemma isWfArity_or_Type_cumul {cf:checker_flags} :
     isWfArity_or_Type Σ Γ A.
 Admitted.
 
+
+Arguments red1_ctx _ _ _ : clear implicits.
+
+Require Import PCUICClosed PCUICPrincipality PCUICSubstitution.
+
+Section SRContext.
+  Context {cf:checker_flags}.
+  (* Context {Σ : global_env_ext} (wfΣ : wf Σ) *)
+
+  Lemma destArity_spec_Some ctx T ctx' s :
+    destArity ctx T = Some (ctx', s)
+    -> it_mkProd_or_LetIn ctx T = it_mkProd_or_LetIn ctx' (tSort s).
+  Proof.
+    pose proof (PCUICClosed.destArity_spec ctx T) as H.
+    intro e; now rewrite e in H.
+  Qed.
+
+  (* todo: rename wf_local_app *)
+  Definition wf_local_app' {Σ Γ1 Γ2} :
+    wf_local Σ Γ1 -> wf_local_rel Σ Γ1 Γ2
+    -> wf_local Σ (Γ1 ,,, Γ2).
+  Proof.
+    intros H1 H2. apply wf_local_local_rel.
+    apply wf_local_rel_local in H1.
+    apply wf_local_rel_app_inv; tas.
+    now rewrite app_context_nil_l.
+  Qed.
+
+  Lemma subject_reduction_ctx :
+    env_prop (fun Σ Γ t A => forall Γ', @red1_ctx Σ Γ Γ' -> Σ ;;; Γ' |- t : A).
+  Proof.
+  Admitted.
+
+  Lemma wf_local_red {Σ Γ Γ'} :
+    red_ctx Σ.1 Γ Γ' -> wf_local Σ Γ -> wf_local Σ Γ'.
+  Proof.
+    (* induction 1; cbn in *. *)
+    (* - intro e. inversion e; subst; cbn in *. *)
+    (*   constructor; tas. destruct X0 as [s Ht]. exists s. *)
+    (*   eapply subject_reduction1; tea. *)
+    (* - intro e. inversion e; subst; cbn in *. *)
+    (*   destruct p as [[? []]|[? []]]; constructor; cbn; tas. *)
+    (*   + eapply subject_reduction1; tea. *)
+    (*   + destruct X0; eexists; eapply subject_reduction1; tea. *)
+    (*   + econstructor; tea. *)
+    (*     right; destruct X0; eexists; eapply subject_reduction1; tea. *)
+    (*     econstructor 2. eassumption. reflexivity. *)
+    (* - intro H; inversion H; subst; constructor; cbn in *; auto. *)
+  Admitted.
+
+
+  Lemma wf_local_subst1 Σ (wfΣ : wf Σ.1) Γ na b t Γ' :
+      wf_local Σ (Γ ,,, [],, vdef na b t ,,, Γ') ->
+      wf_local Σ (Γ ,,, subst_context [b] 0 Γ').
+  Proof.
+    induction Γ' as [|d Γ']; [now inversion 1|].
+    change (d :: Γ') with (Γ' ,, d).
+    destruct d as [na' [bd|] ty]; rewrite !app_context_cons; intro HH.
+    - simpl. rewrite subst_context_snoc0. simpl.
+      inversion HH; subst; cbn in *. destruct X0 as [s X0].
+      change (Γ,, vdef na b t ,,, Γ') with (Γ ,,, [vdef na b t] ,,, Γ') in *.
+      assert (subslet Σ Γ [b] [vdef na b t]). {
+        pose proof (cons_let_def Σ Γ [] [] na b t) as XX.
+        rewrite !subst_empty in XX. apply XX. constructor. 
+        apply wf_local_app in X. inversion X; subst; cbn in *; assumption. }
+      constructor; cbn; auto. exists s.
+      change (tSort s) with (subst [b] #|Γ'| (tSort s)).
+      all: eapply substitution_alt; tea.
+    - simpl. rewrite subst_context_snoc0. simpl.
+      inversion HH; subst; cbn in *. destruct X0 as [s X0].
+      change (Γ,, vdef na b t ,,, Γ') with (Γ ,,, [vdef na b t] ,,, Γ') in *.
+      assert (subslet Σ Γ [b] [vdef na b t]). {
+        pose proof (cons_let_def Σ Γ [] [] na b t) as XX.
+        rewrite !subst_empty in XX. apply XX. constructor. 
+        apply wf_local_app in X. inversion X; subst; cbn in *; assumption. }
+      constructor; cbn; auto. exists s.
+      change (tSort s) with (subst [b] #|Γ'| (tSort s)).
+      all: eapply substitution_alt; tea.
+  Qed.
+
+
+  Lemma red_ctx_app_context_l {Σ Γ Γ' Δ}
+    : red_ctx Σ Γ Γ' -> red_ctx Σ (Γ ,,, Δ) (Γ' ,,, Δ).
+  Proof.
+    induction Δ as [|[na [bd|] ty] Δ]; [trivial| |];
+      intro H; simpl; constructor; cbn; eauto; now apply IHΔ.
+  Qed.
+
+
+   Lemma isWfArity_red1 {Σ Γ A B} :
+     wf Σ.1 -> 
+       red1 (fst Σ) Γ A B ->
+       isWfArity typing Σ Γ A ->
+       isWfArity typing Σ Γ B.
+   Proof.
+     intro wfΣ. induction 1 using red1_ind_all.
+     all: intros [ctx [s [H1 H2]]]; cbn in *; try discriminate.
+     - rewrite destArity_app in H1.
+       case_eq (destArity [] b'); [intros [ctx' s']|]; intro ee;
+         [|rewrite ee in H1; discriminate].
+       pose proof (subst_destArity [] b' [b] 0) as H; cbn in H.
+       rewrite ee in H. eexists _, s'. split. eassumption.
+       rewrite ee in H1. cbn in *. inversion H1; subst.
+       rewrite app_context_assoc in H2.
+       now eapply wf_local_subst1.         
+     - rewrite destArity_tFix in H1; discriminate.
+     - rewrite destArity_app in H1.
+       case_eq (destArity [] b'); [intros [ctx' s']|]; intro ee;
+         rewrite ee in H1; [|discriminate].
+       eexists _, s'; split. cbn. rewrite destArity_app, ee. reflexivity.
+       cbn in H1. inversion H1; subst.
+       eapply wf_local_red; [|exact H2].
+       rewrite !app_context_assoc. apply red_ctx_app_context_l.
+       constructor; cbn. reflexivity. split; auto.
+     - rewrite destArity_app in H1.
+       case_eq (destArity [] b'); [intros [ctx' s']|]; intro ee;
+         rewrite ee in H1; [|discriminate].
+       eexists _, s'; split. cbn. rewrite destArity_app, ee. reflexivity.
+       cbn in H1. inversion H1; subst.
+       eapply wf_local_red; [|exact H2].
+       rewrite !app_context_assoc. apply red_ctx_app_context_l.
+       constructor; cbn. reflexivity. split; auto.
+     - rewrite destArity_app in H1.
+       case_eq (destArity [] b'); [intros [ctx' s']|]; intro ee;
+         rewrite ee in H1; [|discriminate].
+       forward IHX. {
+         eexists _, s'; split; tea. cbn in H1.
+         inversion H1; subst. now rewrite app_context_assoc in H2. }
+       destruct IHX as [ctx'' [s'' [ee' ?]]].
+       eexists _, s''; split. cbn. rewrite destArity_app, ee'. reflexivity.
+       now rewrite app_context_assoc. 
+     - rewrite destArity_app in H1.
+       case_eq (destArity [] M2); [intros [ctx' s']|]; intro ee;
+         rewrite ee in H1; [|discriminate].
+       eexists _, s'; split. cbn. rewrite destArity_app, ee. reflexivity.
+       cbn in H1. inversion H1; subst.
+       eapply wf_local_red; [|exact H2].
+       rewrite !app_context_assoc. apply red_ctx_app_context_l.
+       constructor; cbn. reflexivity. auto.
+     - rewrite destArity_app in H1.
+       case_eq (destArity [] M2); [intros [ctx' s']|]; intro ee;
+         rewrite ee in H1; [|discriminate].
+       forward IHX. {
+         eexists _, s'; split; tea. cbn in H1.
+         inversion H1; subst. now rewrite app_context_assoc in H2. }
+       destruct IHX as [ctx'' [s'' [ee' ?]]].
+       eexists _, s''; split. cbn. rewrite destArity_app, ee'. reflexivity.
+       now rewrite app_context_assoc.
+   Qed.
+
+   Lemma isWfArity_red {Σ Γ A B} :
+     wf Σ.1 -> 
+       red (fst Σ) Γ A B ->
+       isWfArity typing Σ Γ A ->
+       isWfArity typing Σ Γ B.
+   Proof.
+     induction 2.
+     - easy.
+     - intro. now eapply isWfArity_red1.
+   Qed.
+
+End SRContext.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -566,7 +566,7 @@ Definition types_of_case ind mdecl idecl params u p pty :=
 Lemma types_of_case_spec ind mdecl idecl pars u p pty indctx pctx ps btys :
   types_of_case ind mdecl idecl pars u p pty
   = Some (indctx, pctx, ps, btys)
-  <-> exists s', option_map (destArity [])
+  <~> ∑ s', option_map (destArity [])
                      (instantiate_params (subst_instance_context u (ind_params mdecl)) pars (subst_instance_constr u (ind_type idecl)))
           = Some (Some (indctx, s'))
           /\ destArity [] pty = Some (pctx, ps)

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -599,8 +599,22 @@ Section Typecheck.
     unfold gc_of_uctx in XX; simpl in XX.
     destruct (gc_of_constraints Σ); [|discriminate].
     inversion XX; subst. generalize (global_ext_levels Σ); intros lvs; cbn.
-    unfold no_prop_levels.
-  Admitted.
+    clear. intro H. apply LevelSet.mem_spec. apply wGraph.VSet.mem_spec in H.
+    apply LevelSetProp.FM.elements_2.
+    unfold no_prop_levels in H.
+    rewrite LevelSet.fold_spec in H.
+    cut (SetoidList.InA eq (level_of_no_prop l) (LevelSet.elements lvs)
+         \/ wGraph.VSet.In l wGraph.VSet.empty). {
+      intros [|H0]; [trivial|].
+      now apply wGraph.VSet.empty_spec in H0. }
+    revert H. generalize (LevelSet.elements lvs), wGraph.VSet.empty; clear.
+    intros lvs; induction lvs; cbn; [intuition|].
+    intros S H. apply IHlvs in H. destruct H as [H|H].
+    - left. now constructor 2.
+    - destruct a; cbn in *. now right.
+      all: apply wGraph.VSet.add_spec in H; destruct H as [H|H]; [left|now right].
+      all: rewrite H; now constructor.
+  Qed.
 
 
   Program Definition check_consistent_instance uctx u


### PR DESCRIPTION
I can't do a naive checker which recheck that the `btys` have type `ps` because it is not structurally smaller.
So we will have to prove `type_Case_valid_btys`!