### PR TITLE
Fix conversion by changing its spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ pcuic/src/pCUICReflect.mli
 /erasure/src/safeTemplateChecker.mli
 /erasure/src/typing0.ml
 /erasure/src/typing0.mli
+/pcuic/Makefile.plugin-e

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -858,6 +858,30 @@ Section Stacks.
     all: try (cbn ; rewrite ?IHρ ; reflexivity).
   Qed.
 
+  Lemma red1_zipp :
+    forall Γ t u π,
+      red1 Σ Γ t u ->
+      red1 Σ Γ (zipp t π) (zipp u π).
+  Proof.
+    intros Γ t u π h.
+    unfold zipp.
+    case_eq (decompose_stack π). intros l ρ e.
+    eapply red1_mkApps_f.
+    assumption.
+  Qed.
+
+  Lemma red_zipp :
+    forall Γ t u π,
+      red Σ Γ t u ->
+      red Σ Γ (zipp t π) (zipp u π).
+  Proof.
+    intros Γ t u π h. induction h.
+    - constructor.
+    - econstructor.
+      + eapply IHh.
+      + eapply red1_zipp. assumption.
+  Qed.
+
   Definition zippx t π :=
     let '(args, ρ) := decompose_stack π in
     it_mkLambda_or_LetIn (stack_context ρ) (mkApps t args).

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1475,6 +1475,19 @@ Section Lemmata.
       eapply conv_Prod_r. assumption.
   Qed.
 
+  Lemma conv_zipp :
+    forall Γ u v ρ,
+      Σ ;;; Γ |- u == v ->
+      Σ ;;; Γ |- zipp u ρ == zipp v ρ.
+  Proof.
+    intros Γ u v ρ h.
+    unfold zipp.
+    destruct decompose_stack.
+    induction l in u, v, h |- *.
+    - assumption.
+    - simpl.  eapply IHl. eapply conv_App_l. assumption.
+  Qed.
+
   Lemma conv_alt_zippx :
     forall Γ u v ρ,
       Σ ;;; (Γ ,,, stack_context ρ) |- u == v ->
@@ -1671,7 +1684,7 @@ Section Lemmata.
         rewrite destArity_tApp in h1. discriminate.
   Qed.
 
-
+  (* WRONG *)
   Lemma it_mkLambda_or_LetIn_wellformed :
     forall Γ Δ t,
       wellformed Σ (Γ ,,, Δ) t ->
@@ -1726,11 +1739,11 @@ Section Lemmata.
     case_eq (decompose_stack π). intros l ρ e.
     pose proof (decompose_stack_eq _ _ _ e). subst. clear e.
     rewrite zipc_appstack in h.
-    (* revert h. generalize (mkApps t l); clear t l. *)
     zip fold in h.
     apply wellformed_context in h ; simpl in h.
-  (* Qed. *)
-  Admitted.
+    eapply it_mkLambda_or_LetIn_wellformed.
+    assumption.
+  Qed.
 
   Lemma lookup_env_const_name :
     forall {c c' d},
@@ -2045,6 +2058,13 @@ Section Lemmata.
     admit. (* Similar *)
   Admitted.
 
+  Lemma conv_Lambda :
+    forall leq Γ na1 na2 A1 A2 b1 b2,
+      ∥ Σ ;;; Γ |- A1 == A2 ∥ ->
+      conv leq Σ (Γ ,, vass na1 A1) b1 b2 ->
+      conv leq Σ Γ (tLambda na1 A1 b1) (tLambda na2 A2 b2).
+  Admitted.
+
   (* Let bindings are not injective, so it_mkLambda_or_LetIn is not either.
      However, when they are all lambdas they become injective for conversion.
      stack_contexts only produce lambdas so we can use this property on them.
@@ -2079,7 +2099,7 @@ Section Lemmata.
   Lemma it_mkLambda_or_LetIn_stack_context_conv_inv :
     forall Γ π1 π2 t1 t2,
       Σ ;;; Γ |- it_mkLambda_or_LetIn (stack_context π1) t1
-                 == it_mkLambda_or_LetIn (stack_context π2) t2 ->
+             == it_mkLambda_or_LetIn (stack_context π2) t2 ->
       conv_ctx Σ (Γ ,,, stack_context π1) (Γ ,,, stack_context π2) ×
       Σ ;;; Γ ,,, stack_context π1 |- t1 == t2.
   Proof.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -2056,7 +2056,7 @@ Section Lemmata.
     forall Γ π1 π2 t1 t2,
       Σ ;;; Γ |- it_mkLambda_or_LetIn (stack_context π1) t1
              == it_mkLambda_or_LetIn (stack_context π2) t2 ->
-      conv_ctx Σ (Γ ,,, stack_context π1) (Γ ,,, stack_context π2) ×
+      conv_context Σ (Γ ,,, stack_context π1) (Γ ,,, stack_context π2) ×
       Σ ;;; Γ ,,, stack_context π1 |- t1 == t2.
   Proof.
     intros Γ π1 π2 t1 t2 h.
@@ -2365,4 +2365,3 @@ Lemma isWfArity_or_Type_cumul {cf:checker_flags} :
     isWfArity_or_Type Σ Γ A' ->
     isWfArity_or_Type Σ Γ A.
 Admitted.
-

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1429,6 +1429,7 @@ Section Conversion.
       simpl. rewrite <- app_nil_r. eapply positionR_poscat. constructor.
   Qed.
   Next Obligation.
+    destruct hΣ as [wΣ].
     destruct b ; auto.
     split. 1: assumption.
     destruct H0 as [h0].
@@ -1459,7 +1460,7 @@ Section Conversion.
     apply mkApps_Prod_nil' in h2 ; auto. subst.
 
     simpl.
-    eapply Prod_conv. all: auto.
+    eapply conv_Prod. all: auto.
   Qed.
 
   (* tCase *)


### PR DESCRIPTION
Implements the change I mentioned to remove false axioms for the proof of conversion.
It does not impact any other module.

One thing to note is that I add a new axiom of context conversion for reduction, but this is something we can believe in more easily.