### PR TITLE
Remove red_context_conversion (false) axiom

### DIFF
--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -817,9 +817,3 @@ Proof.
   intros h. eapply eq_context_upto_conv_context; tea.
   reflexivity.
 Qed.
-
-Axiom red_context_conversion :
-  forall {cf : checker_flags} (Σ : global_env_ext) Γ u v Γ',
-    red Σ Γ' u v ->
-    conv_context Σ Γ Γ' ->
-    red Σ Γ u v.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1417,6 +1417,21 @@ Section Lemmata.
     assumption.
   Qed.
 
+  Lemma conv_context_convp :
+    forall Γ Γ' leq u v,
+      conv leq Σ Γ u v ->
+      conv_context Σ Γ Γ' ->
+      conv leq Σ Γ' u v.
+  Proof.
+    intros Γ Γ' leq u v h hx.
+    destruct hΣ.
+    destruct leq.
+    - simpl. destruct h. constructor.
+      eapply conv_alt_conv_ctx. all: eauto.
+    - simpl in *. destruct h. constructor.
+      eapply cumul_conv_ctx. all: eauto.
+  Qed.
+
 End Lemmata.
 
 

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -20,6 +20,22 @@ Import MonadNotation.
 
 Module PSR := PCUICSafeReduce.
 
+(* TODO MOVE *)
+Lemma conv_context_convp :
+  forall {cf : checker_flags} (Σ : global_env_ext) Γ Γ' leq u v,
+    wf Σ ->
+    conv leq Σ Γ u v ->
+    conv_context Σ Γ Γ' ->
+    conv leq Σ Γ' u v.
+Proof.
+  intros cf Σ Γ Γ' leq u v hΣ h hx.
+  destruct leq.
+  - simpl. destruct h. constructor.
+    eapply conv_alt_conv_ctx. all: eauto.
+  - simpl in *. destruct h. constructor.
+    eapply cumul_conv_ctx. all: eauto.
+Qed.
+
 (** * Conversion for PCUIC without fuel
 
   Following PCUICSafereduce, we derive a fuel-free implementation of
@@ -791,10 +807,10 @@ Section Conversion.
     - eapply conv_trans'.
       + assumption.
       + eassumption.
-      + eapply red_conv_r ; auto.
-        eapply red_context_conversion.
-        * eassumption.
+      + eapply conv_context_convp.
         * assumption.
+        * eapply red_conv_r. all: eauto.
+        * eapply conv_context_sym. all: auto.
   Qed.
 
   Equations unfold_one_fix (Γ : context) (mfix : mfixpoint term)
@@ -1639,15 +1655,15 @@ Section Conversion.
         clear.
         induction brs ; eauto.
     - eapply conv_trans' ; try eassumption.
-      eapply red_conv_r ; try assumption.
-      eapply red_zipp.
-      eapply reds_case.
-      + constructor.
-      + eapply red_context_conversion.
-        * eassumption.
-        * assumption.
-      + clear.
-        induction brs' ; eauto.
+      eapply conv_context_convp.
+      + assumption.
+      + eapply red_conv_r. 1: assumption.
+        eapply red_zipp.
+        eapply reds_case. 2: eassumption.
+        * constructor.
+        * clear.
+          induction brs' ; eauto.
+      + eapply conv_context_sym. all: auto.
   Qed.
 
   (* tProj *)
@@ -1978,10 +1994,12 @@ Section Conversion.
       destruct hx as [hx].
       pose proof (red_trans _ _ _ _ _ r1 r2') as r.
       eapply conv_trans' ; revgoals.
-      + eapply red_conv_r. 1: assumption.
-        * eapply red_context_conversion.
-          -- eassumption.
-          -- rewrite e. assumption.
+      + eapply conv_context_convp.
+        * assumption.
+        * eapply red_conv_r. 1: assumption.
+          eassumption.
+        * eapply conv_context_sym. 1: auto.
+          rewrite e. assumption.
       + assumption.
       + assumption.
   Qed.
@@ -2883,14 +2901,16 @@ Section Conversion.
     rewrite decompose_stack_appstack.
     erewrite decompose_stack_twice ; eauto. simpl.
     rewrite app_nil_r.
-    eapply red_conv_r ; try assumption.
-    rewrite stack_context_appstack in r1.
-    eapply red_context_conversion. 2: eassumption.
-    eapply red_trans ; try eassumption.
-    clear eq3. symmetry in eq2. apply decompose_stack_eq in eq2. subst.
-    rewrite stack_context_appstack in r2.
-    rewrite zipc_appstack in r2. cbn in r2.
-    assumption.
+    eapply conv_context_convp.
+    - assumption.
+    - eapply red_conv_r. 1: assumption.
+      rewrite stack_context_appstack in r1.
+      eapply red_trans ; try eassumption.
+      clear eq3. symmetry in eq2. apply decompose_stack_eq in eq2. subst.
+      rewrite stack_context_appstack in r2.
+      rewrite zipc_appstack in r2. cbn in r2.
+      assumption.
+    - eapply conv_context_sym. all: auto.
   Qed.
   Next Obligation.
     destruct eqb_term_stack eqn:e. 2: auto.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -20,22 +20,6 @@ Import MonadNotation.
 
 Module PSR := PCUICSafeReduce.
 
-(* TODO MOVE *)
-Lemma conv_context_convp :
-  forall {cf : checker_flags} (Σ : global_env_ext) Γ Γ' leq u v,
-    wf Σ ->
-    conv leq Σ Γ u v ->
-    conv_context Σ Γ Γ' ->
-    conv leq Σ Γ' u v.
-Proof.
-  intros cf Σ Γ Γ' leq u v hΣ h hx.
-  destruct leq.
-  - simpl. destruct h. constructor.
-    eapply conv_alt_conv_ctx. all: eauto.
-  - simpl in *. destruct h. constructor.
-    eapply cumul_conv_ctx. all: eauto.
-Qed.
-
 (** * Conversion for PCUIC without fuel
 
   Following PCUICSafereduce, we derive a fuel-free implementation of


### PR DESCRIPTION
It turns out the axiom was slightly incorrect (it was only true up to conversion of the reduct because of let-bindings). The silver lining is that it was not needed at all.