### PR TITLE
Cleaning in the typing of inductive declarations

### DIFF
--- a/checker/theories/uGraph.v
+++ b/checker/theories/uGraph.v
@@ -1498,6 +1498,20 @@ Section CheckLeq2.
       destruct a as [[] []]; cbn; lia.
   Qed.
 
+  Lemma val_is_prop' u v :
+    (val v u = -1)%Z -> Universe.is_prop u.
+  Proof.
+    clear.
+    induction u.
+    - destruct a as [[] []]; cbnr; lia.
+    - intro H. cbn. rewrite val_cons in H.
+      apply andb_true_iff. split.
+      destruct a as [[] []]; cbn in *; try reflexivity; try lia.
+      apply IHu.
+      pose proof (val_minus_one u v).
+      lia.
+  Qed.
+
   Lemma val0_equal l1 l2 v :
     Level.equal l1 l2 -> val0 v l1 = val0 v l2.
   Proof.

--- a/checker/theories/uGraph.v
+++ b/checker/theories/uGraph.v
@@ -751,7 +751,7 @@ Proof.
 Qed.
 
 
-Lemma make_graph_invariants uctx (Hi : global_gc_uctx_invariants uctx)
+Global Instance make_graph_invariants uctx (Hi : global_gc_uctx_invariants uctx)
   : invariants (make_graph uctx).
 Proof.
   split; [|split].
@@ -909,20 +909,16 @@ Section MakeGraph.
       apply make_graph_spec'. assumption.
   Defined.
 
-  Corollary consistent_no_loop : gc_consistent ctrs -> acyclic_no_loop G.
+  Global Instance consistent_no_loop : gc_consistent ctrs -> acyclic_no_loop G.
   Proof.
     intro. apply acyclic_caract1, make_graph_spec2.
     now apply make_graph_invariants. assumption.
   Defined.
 End MakeGraph.
 
-Existing Class invariants.
-Existing Instance make_graph_invariants.
-Existing Class acyclic_no_loop.
 Existing Class gc_consistent.
 Existing Class global_gc_uctx_invariants.
 Existing Class global_uctx_invariants.
-Existing Instance consistent_no_loop.
 Existing Instance gc_of_uctx_invariants.
 
 (** ** Check of consistency ** *)

--- a/checker/theories/wGraph.v
+++ b/checker/theories/wGraph.v
@@ -392,7 +392,8 @@ Module WeightedGraph (V : UsualOrderedType).
 
     Definition PosPaths x y := exists p : Paths x y, weight p > 0.
 
-    Definition acyclic_no_loop := forall x (p : Paths x x), weight p = 0.
+    Class acyclic_no_loop
+      := Build_acyclic_no_loop : forall x (p : Paths x x), weight p = 0.
 
     Definition acyclic_no_loop' := forall x, ~ (PosPaths x x).
 
@@ -1160,7 +1161,7 @@ Module WeightedGraph (V : UsualOrderedType).
       - intros [[x n] y] He; cbn. unfold lsp.
         simple refine (let H := lsp0_triangle_inequality
                                   (V G) (s G) x y n He _
-                       in _); [assumption| |clearbody H].
+                       in _); [|clearbody H].
         apply proj1 in HI. specialize (HI _ He); cbn in HI; intuition.
         destruct (lsp_s x) as [m Hm].
         + apply proj1 in HI. apply (HI _ He).
@@ -1282,8 +1283,6 @@ Module WeightedGraph (V : UsualOrderedType).
   End graph.
 
   Section graph2.
-    Existing Class invariants.
-    Existing Class acyclic_no_loop.
     Context (G : t) {HI : invariants G} {HG : acyclic_no_loop G}.
 
     Section subgraph.

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -223,14 +223,9 @@ Proof.
     (* eapply isArity_typing_spine_inv in t0; eauto. *)
     (* destruct t0 as (? & [] & ?). *)
     (* eapply PCUICCumulativity.red_cumul in X. *)
-    eapply PCUICWeakeningEnv.declared_constructor_inv in d.
-    2: eapply PCUICWeakeningEnv.weaken_env_prop_typing. 2:eauto. 2:eauto.
-    cbn in d.
-    (* eapply cumul_trans in X. 2:exact c2. *)
-    (* eapply invert_cumul_arity_r in X; eauto. *)
-    inv d. cbn in X0. destruct x5. destruct p. cbn in *.
-    destruct X0. destruct x5. cbn in *. subst.
-    unfold cshape_concl_head in *.
+    destruct (PCUICWeakeningEnv.on_declared_constructor _ d) as [XX [s [XX1 [Ht [cs XX2]]]]].
+    destruct cs; cbn in *.
+    destruct x5 as [[? ?] ?]; cbn in *; subst.
 
     rewrite <- it_mkProd_or_LetIn_app in c2.
     rewrite PCUICUnivSubst.subst_instance_constr_it_mkProd_or_LetIn in c2.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -198,10 +198,9 @@ Proof.
   cbn in H3.
   eapply PCUICWeakeningEnv.on_declared_inductive in H1; eauto. destruct H1.
   depelim o0. cbn in *. unfold on_constructors in *.
-  eapply nth_error_alli in E7; eauto. cbn in E7.
-  depelim E7. cbn in *. destruct s.
-  depelim x2. cbn in *.
-  subst. admit. admit.
+  eapply All2_nth_error_Some in E7; eauto.
+  destruct E7 as [cs [? [XX1 XX2]]].
+  admit. admit.
 
   (* clear - H0 E4. unfold mapi in *. *)
   (* revert n x7 H0 E4. generalize 0 at 3. induction (ind_ctors x2); intros. *)

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -1222,7 +1222,7 @@ Proof.
     clear decl'. intros n [na ty ke ct pr] hb. simpl.
     destruct (decompose_prod_assum [] ty) as [c t] eqn:e1.
     destruct (decompose_prod_assum [] ty.[⇑^0 σ]) as [c' t'] eqn:e2.
-    destruct hb as [indices s arity_eq onAr onConstr onProj sorts].
+    destruct hb as [indices s arity_eq onAr csorts onConstr onProj sorts].
     simpl in *.
     assert (e : ty.[⇑^0 σ] = ty).
     { destruct onAr as [s' h'].
@@ -1231,9 +1231,9 @@ Proof.
     rewrite e in e2. rewrite e1 in e2.
     revert e2. intros [= <- <-].
     rewrite e. f_equal.
-    + apply (Alli_map_id onConstr).
-      intros n1 [[x p] n'] [[s' hty] _].
-      unfold on_pi2. simpl. f_equal. f_equal.
+    + eapply All_map_id. eapply All2_All_left; tea.
+      intros [[x p] n'] y [[?s Hty] [cs Hargs]]. 
+      unfold on_pi2; cbn; f_equal; f_equal.
       eapply typed_inst. all: eauto.
     + destruct (eq_dec pr []) as [hp | hp]. all: subst. all: auto.
       specialize (onProj hp).
@@ -1467,15 +1467,15 @@ Proof.
   destruct hmdecl as [Σ' [wfΣ' decl']].
   red in decl'. destruct decl' as [h ? ? ?].
   eapply Alli_nth_error in h. 2: eassumption.
-  simpl in h. destruct h as [? ? ? ? h ? ?].
+  simpl in h. destruct h as [? ? ? ? ? h ? ?].
   unfold on_constructors in h.
   clear - h wfΣ'.
   induction h.
   - constructor.
   - econstructor.
-    + destruct hd as [[? t] ?].
-      unfold on_constructor in p. cbn in p.
-      destruct p as [[? ht] ?].
+    + destruct x as [[? t] ?].
+      unfold on_constructor in r. cbn in r.
+      destruct r as [[? ht] ?].
       eapply typecheck_closed in ht as [? e]. 2: auto.
       2: eapply typing_wf_local ; eauto.
       move/andP in e. destruct e. assumption.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -548,6 +548,10 @@ Fixpoint instantiate_params_subst params pars s ty :=
     end
   end.
 
+(* If [ty] is [Π params . B] *)
+(* and [⊢ pars : params] *)
+(* then [instantiate_params] is [B{pars}] *)
+
 Definition instantiate_params params pars ty :=
   match instantiate_params_subst (List.rev params) pars [] ty with
   | Some (s, ty) => Some (subst0 s ty)
@@ -651,17 +655,6 @@ Definition universes_decl_of_decl := on_udecl_decl (fun x => x).
 
 (* Definition LevelSet_add_list l := LevelSet.union (LevelSetProp.of_list l). *)
 
-Definition LevelSet_pair x y
-  := LevelSet.add y (LevelSet.singleton x).
-
-Lemma LevelSet_pair_In x y z :
-  LevelSet.In x (LevelSet_pair y z) -> x = y \/ x = z.
-Proof.
-  intro H. apply LevelSetFact.add_iff in H.
-  destruct H; [intuition|].
-  apply LevelSetFact.singleton_1 in H; intuition.
-Qed.
-
 Definition global_levels (Σ : global_env) : LevelSet.t
   := fold_right (fun decl lvls => LevelSet.union (monomorphic_levels_decl decl) lvls)
                 (LevelSet_pair Level.lSet Level.lProp) Σ.
@@ -696,6 +689,9 @@ Definition global_constraints (Σ : global_env) : constraints
                                 (monomorphic_constraints_decl decl) ctrs)
                ConstraintSet.empty Σ.
 
+Definition global_uctx (Σ : global_env) : ContextSet.t
+  := (global_levels Σ, global_constraints Σ).
+
 Definition global_ext_levels (Σ : global_env_ext) : LevelSet.t
   := LevelSet.union (levels_of_udecl (snd Σ)) (global_levels Σ.1).
 
@@ -703,6 +699,10 @@ Definition global_ext_constraints (Σ : global_env_ext) : constraints
   := ConstraintSet.union (constraints_of_udecl (snd Σ))
                          (global_constraints Σ.1).
 Coercion global_ext_constraints : global_env_ext >-> constraints.
+
+Definition global_ext_uctx (Σ : global_env_ext) : ContextSet.t
+  := (global_ext_levels Σ, global_ext_constraints Σ).
+
 
 Lemma prop_global_ext_levels Σ : LevelSet.In Level.prop (global_ext_levels Σ).
 Proof.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -252,9 +252,9 @@ Proof.
     eapply typed_liftn; eauto; eauto. constructor. simpl; lia.
     rewrite H0 in Heq'. rewrite Heq in Heq'. revert Heq'; intros [= <- <-].
     f_equal; auto.
-    apply (Alli_map_id onConstructors).
-    intros n1 [[x p] n']. intros [[s Hty] [cs Hargs]].
-    unfold on_pi2; f_equal; f_equal.
+    eapply All_map_id. eapply All2_All_left; tea.
+    intros [[x p] n'] y [[s Hty] [cs Hargs]]. 
+    unfold on_pi2; cbn; f_equal; f_equal.
     simpl in Hty.
     eapply typed_liftn. 4:eapply Hty. eauto. apply typing_wf_local in Hty; eauto. lia.
     destruct(eq_dec ind_projs []) as [Hp|Hp]. subst; auto. specialize (onProjections Hp).

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -345,35 +345,30 @@ Proof.
   destruct Hdecl as [onI onP onnP]; constructor; eauto.
   - eapply Alli_impl; eauto. intros.
     destruct X. unshelve econstructor; eauto.
-    unfold on_constructors in *. eapply Alli_impl_trans; eauto.
-    intros ik [[id t] ar]. unfold on_constructor, on_type in *; intuition eauto.
-    destruct b. exists x0.
-    -- induction (cshape_args x0); simpl in *; auto.
-       destruct a0 as [na [b|] ty]; simpl in *; intuition eauto.
     -- unfold on_type in *; intuition eauto.
+    -- unfold on_constructors in *. eapply All2_impl; eauto.
+       intros. unfold on_constructor, on_type in *; intuition eauto.
+       destruct b as [cs Hcs]. exists cs.
+       induction (cshape_args cs); simpl in *; auto.
+       destruct a0 as [na [b|] ty]; simpl in *; intuition eauto.
     -- intros Hprojs; destruct onProjections; try constructor; auto.
        eapply Alli_impl; eauto. intros ip [id trm].
        unfold on_projection, on_type; eauto.
-    -- unfold Alli_impl_trans. simpl.
-       revert onConstructors ind_sorts. generalize (ind_ctors x).
-       unfold Alli_rect.
-       unfold check_ind_sorts. destruct universe_family; auto.
-       --- intros ? onCs. depelim onCs; simpl; auto. depelim onCs; simpl; auto.
-           destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
-           destruct o as [? [? ?]]. simpl. auto.
-       --- intros ? onCs. clear onI. induction onCs; simpl; intuition auto.
-           destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
-           destruct p as [? [? ?]]. simpl in *. auto.
-           destruct Hext; subst; simpl; auto.
-           clear H2.
-           eapply leq_universe_subset; eauto.
-           eapply global_ext_constraints_app; tas.
-       --- intros ? onCs. clear onI. induction onCs; simpl; intuition auto.
-           destruct hd as [[? ?] ?]. unfold prod_rect; simpl.
-           destruct p as [? [? ?]]. simpl in *. auto.
-           destruct Hext; subst; simpl; auto. clear H2.
-           eapply leq_universe_subset; eauto.
-           eapply global_ext_constraints_app; tas.
+    -- unfold check_ind_sorts in *. destruct universe_family; auto.
+       --- split; [apply fst in ind_sorts|apply snd in ind_sorts].
+           eapply Forall_impl; tea; cbn.
+           intros. eapply leq_universe_subset; tea.
+           apply weakening_env_global_ext_constraints; tea.
+           destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ' Hext.
+           induction ind_indices; simpl in *; auto.
+           destruct a as [na [b|] ty]; simpl in *; intuition eauto.
+       --- split; [apply fst in ind_sorts|apply snd in ind_sorts].
+           eapply Forall_impl; tea; cbn.
+           intros. eapply leq_universe_subset; tea.
+           apply weakening_env_global_ext_constraints; tea.
+           destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ' Hext.
+           induction ind_indices; simpl in *; auto.
+           destruct a as [na [b|] ty]; simpl in *; intuition eauto.
   - red in onP |- *. eapply All_local_env_impl; eauto.
 Qed.
 
@@ -438,17 +433,23 @@ Proof.
   apply Hidecl.
 Qed.
 
-Lemma declared_constructor_inv `{checker_flags} Σ P mdecl idecl ref cdecl :
-  weaken_env_prop (lift_typing P) ->
-  wf Σ -> Forall_decls_typing P Σ ->
-  declared_constructor Σ mdecl idecl ref cdecl ->
-  on_constructor (lift_typing P) (Σ, ind_universes mdecl) (inductive_mind (fst ref)) mdecl (inductive_ind (fst ref)) idecl (snd ref) cdecl.
+Lemma declared_constructor_inv `{checker_flags} Σ P mdecl idecl ref cdecl
+  (HP : weaken_env_prop (lift_typing P))
+  (wfΣ : wf Σ)
+  (HΣ : Forall_decls_typing P Σ)
+  (Hdecl : declared_constructor Σ mdecl idecl ref cdecl) :
+  ∑ ind_ctor_sort,
+  nth_error (declared_inductive_inv Σ P ref.1 mdecl idecl HP
+                wfΣ HΣ (proj1 Hdecl)).(ind_ctors_sort) ref.2 = Some ind_ctor_sort
+  × on_constructor (lift_typing P) (Σ, ind_universes mdecl) mdecl
+                   (inductive_ind ref.1) idecl cdecl ind_ctor_sort.
 Proof.
   intros.
-  destruct H0 as [Hidecl Hcdecl].
-  eapply declared_inductive_inv in Hidecl; eauto.
-  apply onConstructors in Hidecl.
-  eapply nth_error_alli in Hidecl; eauto.
+  destruct Hdecl as [Hidecl Hcdecl].
+  set (declared_inductive_inv Σ P ref.1 mdecl idecl HP wfΣ HΣ
+                              (proj1 (conj Hidecl Hcdecl))) as HH.
+  clearbody HH. pose proof HH.(onConstructors) as HH'.
+  eapply All2_nth_error_Some in Hcdecl; tea.
 Qed.
 
 Lemma declared_projection_inv `{checker_flags} Σ P mdecl idecl ref pdecl :
@@ -528,16 +529,26 @@ Proof.
   apply (declared_inductive_inv _ _ _ mdecl idecl weaken_env_prop_typing wfΣ wfΣ Hdecl).
 Qed.
 
-Lemma on_declared_constructor `{checker_flags} {Σ ref mdecl idecl cdecl} :
-  wf Σ ->
-  declared_constructor Σ mdecl idecl ref cdecl ->
-  on_inductive (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind (fst ref)) mdecl *
-  on_ind_body (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind (fst ref)) mdecl (inductive_ind (fst ref)) idecl *
-  on_constructor (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind (fst ref)) mdecl (inductive_ind (fst ref)) idecl (snd ref) cdecl.
+Lemma on_declared_constructor `{checker_flags} {Σ ref mdecl idecl cdecl}
+  (wfΣ : wf Σ)
+  (Hdecl : declared_constructor Σ mdecl idecl ref cdecl) :
+  on_inductive (lift_typing typing) (Σ, ind_universes mdecl)
+               (inductive_mind (fst ref)) mdecl *
+  on_ind_body (lift_typing typing) (Σ, ind_universes mdecl)
+              (inductive_mind (fst ref)) mdecl (inductive_ind (fst ref)) idecl *
+  ∑ ind_ctor_sort,
+     nth_error
+      (ind_ctors_sort
+         (declared_inductive_inv Σ typing ref.1 mdecl idecl weaken_env_prop_typing
+            wfΣ wfΣ (proj1 Hdecl))) ref.2 = Some ind_ctor_sort
+    ×  on_constructor (lift_typing typing) (Σ, ind_universes mdecl)
+                 mdecl (inductive_ind (fst ref))
+                 idecl cdecl ind_ctor_sort.
 Proof.
-  intros wfΣ Hdecl.
-  split. destruct Hdecl as [Hidecl Hcdecl]. now apply on_declared_inductive in Hidecl.
-  apply (declared_constructor_inv _ _ mdecl idecl ref cdecl weaken_env_prop_typing wfΣ wfΣ Hdecl).
+  split. destruct Hdecl as [Hidecl Hcdecl].
+  now apply on_declared_inductive in Hidecl.
+  apply (declared_constructor_inv _ _ mdecl idecl ref cdecl
+                                  weaken_env_prop_typing wfΣ wfΣ Hdecl).
 Qed.
 
 Lemma on_declared_projection `{checker_flags} {Σ ref mdecl idecl pdecl} :

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -28,12 +28,6 @@ Module PSR := PCUICSafeReduce.
  *)
 
 
-Definition global_uctx (Σ : global_env) : ContextSet.t
-  := (global_levels Σ, global_constraints Σ).
-
-Definition global_ext_uctx (Σ : global_env_ext) : ContextSet.t
-  := (global_ext_levels Σ, global_ext_constraints Σ).
-
 Definition wf_global_uctx_invariants {cf:checker_flags} Σ
   : ∥ wf Σ ∥ -> global_uctx_invariants (global_uctx Σ).
 Proof.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -24,9 +24,6 @@ Add Search Blacklist "_graph_mut".
   substitution are costly here. No universe checking or conversion is done
   in particular. *)
 
-Definition global_ext_uctx (Σ : global_env_ext) : ContextSet.t
-  := (global_ext_levels Σ, global_ext_constraints Σ).
-
 Section TypeOf.
   Context {cf : checker_flags}.
   Context (Σ : global_env_ext).

--- a/template-coq/theories/config.v
+++ b/template-coq/theories/config.v
@@ -8,24 +8,30 @@ Class checker_flags := {
   allow_cofix : bool ;
 
   (* Prop <= Type iff [true] *)
-  prop_sub_type : bool
+  prop_sub_type : bool ;
+
+  (* If sort of indices are taken in account for the sort of inductive types *)
+  indices_matter : bool
 }.
 
 (* Should correspond to Coq *)
 Local Instance default_checker_flags : checker_flags := {|
   check_univs := true ;
   allow_cofix := true ;
-  prop_sub_type := true
+  prop_sub_type := true;
+  indices_matter := false
 |}.
 
 Local Instance type_in_type : checker_flags := {|
   check_univs := false ;
   allow_cofix := true ;
-  prop_sub_type := true
+  prop_sub_type := true;
+  indices_matter := false
 |}.
 
 Local Instance extraction_checker_flags : checker_flags := {|
   check_univs := true ;
   allow_cofix := false ;
-  prop_sub_type := false
+  prop_sub_type := false;
+  indices_matter := false
 |}.


### PR DESCRIPTION
I move `cshape_args_univ` in an outer list to simplify the dependencies
and remove inductions on `Alli`s ... 

I need this to write the typechecker (the typing judgments are squashed but not the universes).