### PR TITLE
Conversion well-order modulo universes

### DIFF
--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -6,7 +6,7 @@ From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICTyping
-     PCUICReduction.
+     PCUICReduction PCUICEquality.
 From Equations Require Import Equations.
 
 Require Import Equations.Prop.DepElim.
@@ -16,7 +16,7 @@ Local Set Keyed Unification.
 Import MonadNotation.
 
 (* A choice is a local position.
-     We redefine positions in a non dependent way to make it more practical.
+   We define positions in a non dependent way to make it more practical.
  *)
 Inductive choice :=
 | app_l
@@ -86,6 +86,22 @@ Definition dprod_r na A B (p : pos B) : pos (tProd na A B) :=
 
 Definition dlet_in na A b t (p : pos t) : pos (tLetIn na A b t) :=
   exist (let_in :: ` p) (proj2_sig p).
+
+Lemma eq_term_valid_pos :
+  forall {u v p Re Rle},
+    validpos u p ->
+    eq_term_upto_univ Re Rle u v ->
+    validpos v p.
+Proof.
+  intros u v p Re Rle vp e.
+  induction p as [| c p ih ] in u, v, Re, Rle, vp, e |- *.
+  - reflexivity.
+  - destruct c, u. all: try discriminate.
+    all: solve [
+      dependent destruction e ; simpl ;
+      eapply ih ; eauto
+    ].
+Qed.
 
 Inductive positionR : position -> position -> Prop :=
 | positionR_app_lr p q : positionR (app_r :: p) (app_l :: q)

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -87,7 +87,7 @@ Definition dprod_r na A B (p : pos B) : pos (tProd na A B) :=
 Definition dlet_in na A b t (p : pos t) : pos (tLetIn na A b t) :=
   exist (let_in :: ` p) (proj2_sig p).
 
-Lemma eq_term_valid_pos :
+Lemma eq_term_upto_valid_pos :
   forall {u v p Re Rle},
     validpos u p ->
     eq_term_upto_univ Re Rle u v ->
@@ -101,6 +101,16 @@ Proof.
       dependent destruction e ; simpl ;
       eapply ih ; eauto
     ].
+Qed.
+
+Lemma eq_term_valid_pos :
+  forall `{cf : checker_flags} {G u v p},
+    validpos u p ->
+    eq_term G u v ->
+    validpos v p.
+Proof.
+  intros cf G u v p vp e.
+  eapply eq_term_upto_valid_pos. all: eauto.
 Qed.
 
 Inductive positionR : position -> position -> Prop :=

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -83,7 +83,7 @@ Notation "x ⊩ R1 ⨶ R2" :=
 Notation "R1 ⊗ R2" :=
   (lexprod R1 R2) (at level 20, right associativity).
 
-Notation "x ⊨ R1 / e ; coe ⨶ R2" :=
+Notation "x ⊨ e \ R1 'by' coe ⨷ R2" :=
   (dlexmod R1 e coe (fun x => R2)) (at level 20, right associativity).
 
 Lemma acc_dlexprod :

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -186,6 +186,10 @@ forall A B (leA : A -> A -> Prop) (eA : A -> A -> Prop) coe leB,
   (forall x, well_founded (leB x)) ->
   (forall x x' y, eA x x' -> leA y x' -> leA y x) ->
   (forall x, exists e : eA x x, forall y, coe _ _ e y = y) ->
+  (forall x x' x'' e e' y y',
+    leB x' (coe x'' x' e' y') (coe x x' e y) ->
+    exists e'', leB x (coe _ _ e'' y') y
+  ) ->
   forall x,
     Acc leA x ->
     forall y,
@@ -193,7 +197,7 @@ forall A B (leA : A -> A -> Prop) (eA : A -> A -> Prop) coe leB,
       forall x' (e : eA x x'),
         Acc (@dlexmod A B leA eA coe leB) (x'; coe _ _ e y).
 Proof.
-  intros A B leA eA coe leB hw hA hcoe.
+  intros A B leA eA coe leB hw hA hcoe hleB.
   induction 1 as [x hx ih1].
   induction 1 as [y hy ih2].
   intros x' e.
@@ -205,11 +209,20 @@ Proof.
     + eapply hA. all: eauto.
     + apply hw.
   - simpl in *.
-    (* specialize (hcoe x'') as [e' he'].
-    rewrite <- (he' y''). *)
+    specialize ih2 with (x' := x'').
+    assert (e1 : eA x x'') by admit.
+    assert (e2 : eA x'' x) by admit.
+    replace y'' with (coe x x'' e1 (coe x'' x e2 y'')) by admit.
+    (* TODO: Replace y'' by coe of coe *)
+    (* specialize (hcoe x'') as [e' he']. *)
+    (* rewrite <- (he' y''). *)
+    (* Incorrect hleB
+       might need trans/sym for eA
+    *)
+    (* apply hleB in H as [e' h']. *)
+
     eapply ih2.
-    (* + eassumption.
-    + *)
+    (* Need relation on sym/trans *)
 Abort.
 
 Section Lemmata.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -142,9 +142,14 @@ Qed.
 
 Derive Signature for dlexmod.
 
+(* We should somehow ask that leA is stable under eA
+   maybe for leB we can for the dependecy to be a subset type
+   this is the way we're going to use it anyway.
+*)
 Lemma acc_dlexmod :
 forall A B leA eA coe leB,
   (forall x, well_founded (leB x)) ->
+  (* (forall x x' (e : eA x x'), (* Preserves leB or something... *)) *)
   forall x,
     Acc leA x ->
     forall y,
@@ -161,6 +166,9 @@ intros [x' y'] h. dependent destruction h.
   + assumption.
   + apply hw.
 - simpl in *.
+  eapply ih2.
+  + eassumption.
+  +
   (* Maybe in the definition the bias should be on the other x
      or again induction on forall x ~ x'
   *)
@@ -173,6 +181,39 @@ intros [x' y'] h. dependent destruction h.
 Qed. *)
 Abort.
 
+Lemma acc_dlexmod :
+forall A B leA (eA : A -> A -> Prop) coe leB,
+  (forall x, well_founded (leB x)) ->
+  (* We will need to know that coe x x "refl" y is y
+     or at least that leB preserved that,
+     maybe only to instantiate this.
+  *)
+  forall x,
+    Acc leA x ->
+    forall y,
+      Acc (leB x) y ->
+      forall x' (e : eA x x'),
+        Acc (@dlexmod A B leA eA coe leB) (x'; coe _ _ e y).
+Proof.
+intros A B leA eA coe leB hw.
+induction 1 as [x hx ih1].
+induction 1 as [y hy ih2].
+intros x' e.
+constructor.
+intros [x'' y''] h. dependent destruction h.
+- (* Here we need to know leA is preserved by eA.
+     Maybe only have something similar to Acc_cored_cored'
+     as an assumption...
+     We can postpone eA in H to get the desired result.
+  *)
+  eapply ih1.
+  (* + assumption.
+  + apply hw.
+- simpl in *.
+  eapply ih2.
+  + eassumption.
+  + *)
+Abort.
 
 Section Lemmata.
   Context {cf : checker_flags}.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -182,12 +182,10 @@ Qed. *)
 Abort.
 
 Lemma acc_dlexmod :
-forall A B leA (eA : A -> A -> Prop) coe leB,
+forall A B (leA : A -> A -> Prop) (eA : A -> A -> Prop) coe leB,
   (forall x, well_founded (leB x)) ->
-  (* We will need to know that coe x x "refl" y is y
-     or at least that leB preserved that,
-     maybe only to instantiate this.
-  *)
+  (forall x x' y, eA x x' -> leA y x' -> leA y x) ->
+  (forall x, exists e : eA x x, forall y, coe _ _ e y = y) ->
   forall x,
     Acc leA x ->
     forall y,
@@ -195,24 +193,23 @@ forall A B leA (eA : A -> A -> Prop) coe leB,
       forall x' (e : eA x x'),
         Acc (@dlexmod A B leA eA coe leB) (x'; coe _ _ e y).
 Proof.
-intros A B leA eA coe leB hw.
-induction 1 as [x hx ih1].
-induction 1 as [y hy ih2].
-intros x' e.
-constructor.
-intros [x'' y''] h. dependent destruction h.
-- (* Here we need to know leA is preserved by eA.
-     Maybe only have something similar to Acc_cored_cored'
-     as an assumption...
-     We can postpone eA in H to get the desired result.
-  *)
-  eapply ih1.
-  (* + assumption.
-  + apply hw.
-- simpl in *.
-  eapply ih2.
-  + eassumption.
-  + *)
+  intros A B leA eA coe leB hw hA hcoe.
+  induction 1 as [x hx ih1].
+  induction 1 as [y hy ih2].
+  intros x' e.
+  constructor.
+  intros [x'' y''] h. dependent destruction h.
+  - specialize (hcoe x'') as [e' he'].
+    rewrite <- (he' y'').
+    eapply ih1.
+    + eapply hA. all: eauto.
+    + apply hw.
+  - simpl in *.
+    (* specialize (hcoe x'') as [e' he'].
+    rewrite <- (he' y''). *)
+    eapply ih2.
+    (* + eassumption.
+    + *)
 Abort.
 
 Section Lemmata.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -279,6 +279,31 @@ Section Lemmata.
     - assumption.
   Qed.
 
+  Lemma eq_term_upto_univ_zipp :
+    forall Re u v π,
+      Reflexive Re ->
+      eq_term_upto_univ Re Re u v ->
+      eq_term_upto_univ Re Re (zipp u π) (zipp v π).
+  Proof.
+    intros Re u v π he h.
+    unfold zipp.
+    case_eq (decompose_stack π). intros l ρ e.
+    eapply eq_term_upto_univ_mkApps.
+    - assumption.
+    - apply All2_same. intro. reflexivity.
+  Qed.
+
+  Lemma eq_term_zipp :
+    forall (Σ : global_env_ext) u v π,
+      eq_term (global_ext_constraints Σ) u v ->
+      eq_term (global_ext_constraints Σ) (zipp u π) (zipp v π).
+  Proof.
+    intros Σ u v π h.
+    eapply eq_term_upto_univ_zipp.
+    - intro. eapply eq_universe_refl.
+    - assumption.
+  Qed.
+
   Lemma eq_term_upto_univ_zipx :
     forall Re Γ u v π,
       Reflexive Re ->

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -142,69 +142,30 @@ Qed.
 
 Derive Signature for dlexmod.
 
-(* We should somehow ask that leA is stable under eA
-   maybe for leB we can for the dependecy to be a subset type
-   this is the way we're going to use it anyway.
-*)
 Lemma acc_dlexmod :
-forall A B leA eA coe leB,
-  (forall x, well_founded (leB x)) ->
-  (* (forall x x' (e : eA x x'), (* Preserves leB or something... *)) *)
-  forall x,
-    Acc leA x ->
-    forall y,
-      Acc (leB x) y ->
-      Acc (@dlexmod A B leA eA coe leB) (x;y).
-Proof.
-intros A B leA eA coe leB hw.
-induction 1 as [x hx ih1].
-intros y.
-induction 1 as [y hy ih2].
-constructor.
-intros [x' y'] h. dependent destruction h.
-- eapply ih1.
-  + assumption.
-  + apply hw.
-- simpl in *.
-  eapply ih2.
-  + eassumption.
-  +
-  (* Maybe in the definition the bias should be on the other x
-     or again induction on forall x ~ x'
-  *)
-
-(* intro hB. rewrite <- H0.
-  pose proof (projT2_eq H1) as p2.
-  set (projT1_eq H1) as p1 in *; cbn in p1.
-  destruct p1; cbn in p2; destruct p2.
-  eapply ih2. assumption.
-Qed. *)
-Abort.
-
-Lemma acc_dlexmod :
-forall A B (leA : A -> A -> Prop) (eA : A -> A -> Prop)
-       (coe : forall x x', eA x x' -> B x -> B x')
-       (leB : forall x : A, B x -> B x -> Prop)
-       (sym : forall x y, eA x y -> eA y x)
-       (trans : forall x y z, eA x y -> eA y z -> eA x z),
-  (forall x, well_founded (leB x)) ->
-  (forall x x' y, eA x x' -> leA y x' -> leA y x) ->
-  (forall x, exists e : eA x x, forall y, coe _ _ e y = y) ->
-  (forall x x' y e, coe x x' (sym _ _ e) (coe _ _ e y) = y) ->
-  (forall x0 x1 x2 e1 e2 y,
-    coe _ _ (trans x0 x1 x2 e1 e2) y =
-    coe _ _ e2 (coe _ _ e1 y)
-  ) ->
-  (forall x x' e y y',
-    leB _ y (coe x x' e y') ->
-    leB _ (coe _ _ (sym _ _ e) y) y'
-  ) ->
-  forall x,
-    Acc leA x ->
-    forall y,
-      Acc (leB x) y ->
-      forall x' (e : eA x x'),
-        Acc (@dlexmod A B leA eA coe leB) (x'; coe _ _ e y).
+  forall A B (leA : A -> A -> Prop) (eA : A -> A -> Prop)
+        (coe : forall x x', eA x x' -> B x -> B x')
+        (leB : forall x : A, B x -> B x -> Prop)
+        (sym : forall x y, eA x y -> eA y x)
+        (trans : forall x y z, eA x y -> eA y z -> eA x z),
+    (forall x, well_founded (leB x)) ->
+    (forall x x' y, eA x x' -> leA y x' -> leA y x) ->
+    (forall x, exists e : eA x x, forall y, coe _ _ e y = y) ->
+    (forall x x' y e, coe x x' (sym _ _ e) (coe _ _ e y) = y) ->
+    (forall x0 x1 x2 e1 e2 y,
+      coe _ _ (trans x0 x1 x2 e1 e2) y =
+      coe _ _ e2 (coe _ _ e1 y)
+    ) ->
+    (forall x x' e y y',
+      leB _ y (coe x x' e y') ->
+      leB _ (coe _ _ (sym _ _ e) y) y'
+    ) ->
+    forall x,
+      Acc leA x ->
+      forall y,
+        Acc (leB x) y ->
+        forall x' (e : eA x x'),
+          Acc (@dlexmod A B leA eA coe leB) (x'; coe _ _ e y).
 Proof.
   intros A B leA eA coe leB sym trans hw hA hcoe coesym coetrans lesym.
   induction 1 as [x hx ih1].
@@ -227,6 +188,35 @@ Proof.
     rewrite coetrans.
     eapply lesym.
     assumption.
+Qed.
+
+Lemma dlexmod_Acc :
+  forall A B (leA : A -> A -> Prop) (eA : A -> A -> Prop)
+    (coe : forall x x', eA x x' -> B x -> B x')
+    (leB : forall x : A, B x -> B x -> Prop)
+    (sym : forall x y, eA x y -> eA y x)
+    (trans : forall x y z, eA x y -> eA y z -> eA x z),
+    (forall x, well_founded (leB x)) ->
+    (forall x x' y, eA x x' -> leA y x' -> leA y x) ->
+    (forall x, exists e : eA x x, forall y, coe _ _ e y = y) ->
+    (forall x x' y e, coe x x' (sym _ _ e) (coe _ _ e y) = y) ->
+    (forall x0 x1 x2 e1 e2 y,
+      coe _ _ (trans x0 x1 x2 e1 e2) y =
+      coe _ _ e2 (coe _ _ e1 y)
+    ) ->
+    (forall x x' e y y',
+      leB _ y (coe x x' e y') ->
+      leB _ (coe _ _ (sym _ _ e) y) y'
+    ) ->
+    forall x y,
+      Acc leA x ->
+      Acc (@dlexmod A B leA eA coe leB) (x ; y).
+Proof.
+  intros A B leA eA coe leB sym trans hB ? hcoe ? ? ? x y h.
+  specialize (hcoe x) as h'. destruct h' as [e he].
+  rewrite <- (he y).
+  eapply acc_dlexmod. all: eauto.
+  apply hB.
 Qed.
 
 Section Lemmata.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -246,7 +246,7 @@ Section Conversion.
 
   (* Alternative definition of R_aux, to replace it eventually *)
   (* Definition R_aux' Γ :=
-    t ⊨ cored' Σ Γ / eq_term ; ? ⨶ @posR t ⊗ ... *)
+    t ⊨ cored' Σ Γ / eq_term Σ ; ? ⨶ @posR t ⊗ ... *)
   (* Several things:
      - We need to show valid_pos is preserved by eq_term
      - We need to use eq_term for cored' and not just upto_names

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -244,6 +244,22 @@ Section Conversion.
     eapply H0. all: assumption.
   Qed.
 
+  (* Alternative definition of R_aux, to replace it eventually *)
+  (* Definition R_aux' Γ :=
+    t ⊨ cored' Σ Γ / eq_term ; ? ⨶ @posR t ⊗ ... *)
+  (* Several things:
+     - We need to show valid_pos is preserved by eq_term
+     - We need to use eq_term for cored' and not just upto_names
+     - Which of eq_term/leq_term? We want to account for both...
+
+     => Probably just eq_term
+     => This might only be interesting in cases like tCase where we
+     compare stuff with nl_eq,
+     for stacks we might want to keep both terms in the end
+     (no more zipc_replace!) and instead carry the information
+     that they are eq or leq.
+  *)
+
   Definition R_aux Γ :=
     t ⊩ cored' Σ Γ ⨶ @posR t ⊗ w ⊩ wcored Γ ⨶ @posR (` w) ⊗ stateR.
 
@@ -1250,6 +1266,7 @@ Section Conversion.
       False_rect _ _ ;
 
     | prog_view_Const c u c' u' with eq_dec c c' := {
+      (* TODO Not use eq_dec but eq_universe instead *)
       | left eq1 with eq_dec u u' := {
         | left eq2 with isconv_args_raw (tConst c u) π1 π2 aux := {
           | @exist true h := yes ;
@@ -1288,6 +1305,7 @@ Section Conversion.
       | @exist false _ := no
       } ;
 
+    (* TODO Replace nleq_term here by eq_term (x3) *)
     | prog_view_Case ind par p c brs ind' par' p' c' brs'
       with inspect (nleq_term (tCase (ind, par) p c brs) (tCase (ind', par') p' c' brs')) := {
       | @exist true eq1 := isconv_args (tCase (ind, par) p c brs) π1 π2 aux ;
@@ -1303,11 +1321,13 @@ Section Conversion.
         }
       } ;
 
+    (* TODO Replace nleq_term here by eq_term *)
     | prog_view_Proj p c p' c' with inspect (nleq_term (tProj p c) (tProj p' c')) := {
       | @exist true eq1 := isconv_args (tProj p c) π1 π2 aux ;
       | @exist false _ := no
       } ;
 
+    (* TODO Replace nleq_term here by eq_term *)
     | prog_view_Fix mfix idx mfix' idx'
       with inspect (nleq_term (tFix mfix idx) (tFix mfix' idx')) := {
       | @exist true eq1 := isconv_args (tFix mfix idx) π1 π2 aux ;
@@ -1334,6 +1354,7 @@ Section Conversion.
         }
       } ;
 
+    (* TODO Replace nleq_term here by eq_term *)
     | prog_view_CoFix mfix idx mfix' idx'
       with inspect (nleq_term (tCoFix mfix idx) (tCoFix mfix' idx')) := {
       | @exist true eq1 := isconv_args (tCoFix mfix idx) π1 π2 aux ;

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -284,17 +284,28 @@ Section Conversion.
       Acc (R_aux' Γ) (t ; p).
   Proof.
     intros Γ t p (* w q s *) ht.
-    (* eapply dlexprod_Acc.
-    - intro u. eapply Subterm.wf_lexprod.
-      + intro. eapply posR_Acc.
-      + intros [w' q']. eapply dlexprod_Acc.
-        * intros [t' h']. eapply Subterm.wf_lexprod.
-          -- intro. eapply posR_Acc.
-          -- intro. eapply stateR_Acc.
-        * eapply wcored_wf.
-    - destruct hΣ as [hΣ'].
-      eapply normalisation_upto. all: assumption.
-  Qed. *)
+    unshelve eapply dlexmod_Acc.
+    - intros x y [e]. constructor. eapply eq_term_sym. assumption.
+    - intros x y z [e1] [e2]. constructor. eapply eq_term_trans. all: eauto.
+    - admit.
+    - intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]].
+      eexists _,_. intuition eauto.
+      + constructor. assumption.
+      + constructor. eapply eq_term_trans. all: eauto.
+    - intros x. exists (sq (eq_term_refl _ _)). intros [q h].
+      unfold eq_term_pos. simpl. f_equal.
+      eapply uip.
+    - intros x x' [q h] [e].
+      unfold eq_term_pos. simpl. f_equal.
+      eapply uip.
+    - intros x y z e1 e2 [q h].
+      unfold eq_term_pos. simpl. f_equal.
+      eapply uip.
+    - intros x x' [e] [q h] [q' h'] hl.
+      unfold posR in *.
+      simpl in *.
+      assumption.
+    - eapply normalisation_upto. all: assumption.
   Abort.
 
   Definition R_aux Γ :=

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -244,13 +244,26 @@ Section Conversion.
     eapply H0. all: assumption.
   Qed.
 
+  Definition eqt u v :=
+    ∥ eq_term Σ u v ∥.
+
+  Lemma eq_term_valid_pos :
+    forall {u v p},
+      validpos u p ->
+      eqt u v ->
+      validpos v p.
+  Proof.
+    intros u v p vp [e].
+    eapply eq_term_valid_pos. all: eauto.
+  Qed.
+
   (* Can be generalised *)
-  Definition eq_term_pos {u v} (e : eq_term Σ u v) (p : pos u) : pos v :=
+  Definition eq_term_pos u v (e : eqt u v) (p : pos u) : pos v :=
     exist (` p) (eq_term_valid_pos (proj2_sig p) e).
 
   (* Alternative definition of R_aux, to replace it eventually *)
-  (* Definition R_aux' Γ :=
-    t ⊨ cored' Σ Γ / eq_term Σ ; ? ⨶ @posR t ⊗ ... *)
+  Definition R_aux' Γ :=
+    t ⊨ eqt \ cored' Σ Γ by eq_term_pos ⨷ @posR t.
   (* Several things:
      - We need to show valid_pos is preserved by eq_term
      - We need to use eq_term for cored' and not just upto_names

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -263,7 +263,7 @@ Section Conversion.
 
   (* Alternative definition of R_aux, to replace it eventually *)
   Definition R_aux' Γ :=
-    t ⊨ eqt \ cored' Σ Γ by eq_term_pos ⨷ @posR t.
+    t ⊨ eqt \ cored' Σ Γ by eq_term_pos ⨷ @posR t. (* ⊗ w ⊨ *)
   (* Several things:
      - We need to show valid_pos is preserved by eq_term
      - We need to use eq_term for cored' and not just upto_names
@@ -276,6 +276,26 @@ Section Conversion.
      (no more zipc_replace!) and instead carry the information
      that they are eq or leq.
   *)
+
+  Lemma R_aux'_Acc :
+    forall Γ t p (* w q s *),
+      wellformed Σ Γ t ->
+      (* Acc (R_aux' Γ) (t ; (p, (w ; (q, s)))). *)
+      Acc (R_aux' Γ) (t ; p).
+  Proof.
+    intros Γ t p (* w q s *) ht.
+    (* eapply dlexprod_Acc.
+    - intro u. eapply Subterm.wf_lexprod.
+      + intro. eapply posR_Acc.
+      + intros [w' q']. eapply dlexprod_Acc.
+        * intros [t' h']. eapply Subterm.wf_lexprod.
+          -- intro. eapply posR_Acc.
+          -- intro. eapply stateR_Acc.
+        * eapply wcored_wf.
+    - destruct hΣ as [hΣ'].
+      eapply normalisation_upto. all: assumption.
+  Qed. *)
+  Abort.
 
   Definition R_aux Γ :=
     t ⊩ cored' Σ Γ ⨶ @posR t ⊗ w ⊩ wcored Γ ⨶ @posR (` w) ⊗ stateR.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1518,6 +1518,14 @@ Section Conversion.
       eapply hΣ'.
   Qed.
 
+  (* TODO MOVE *)
+  Lemma wellformed_eq_term :
+    forall Γ u v,
+      wellformed Σ Γ u ->
+      eq_term Σ u v ->
+      wellformed Σ Γ v.
+  Admitted.
+
   Equations(noeqns) _isconv_prog (Γ : context) (leq : conv_pb)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)
             (t2 : term) (π2 : stack) (h2 : wtp Γ t2 π2)
@@ -1632,7 +1640,10 @@ Section Conversion.
 
   (* tConst *)
   Next Obligation.
-  Admitted.
+    eapply wellformed_eq_term. 1: eassumption.
+    eapply eq_term_zipc. eapply eq_term_sym.
+    constructor. eapply eqb_universe_instance_spec. auto.
+  Qed.
   Next Obligation.
     unshelve eapply R_stateR.
     all: try reflexivity.
@@ -1655,12 +1666,18 @@ Section Conversion.
       eapply red_const. eassumption.
   Qed.
   Next Obligation.
-    (* eapply red_wellformed ; auto.
-    - exact h2.
-    - constructor. eapply red_zipc.
-      eapply red_const. eassumption.
-  Qed. *)
-  Admitted.
+    eapply wellformed_eq_term.
+    - eapply red_wellformed ; auto.
+      + exact h2.
+      + constructor. eapply red_zipc.
+        eapply red_const. eassumption.
+    - eapply eq_term_zipc.
+      eapply eq_term_sym.
+      eapply eq_term_upto_univ_subst_instance_constr.
+      + intro. eapply eq_universe_refl.
+      + apply leq_term_SubstUnivPreserving.
+      + eapply eqb_universe_instance_spec. auto.
+  Qed.
   Next Obligation.
     eapply R_cored. simpl.
     eapply cored_zipc.
@@ -1784,16 +1801,12 @@ Section Conversion.
 
   (* tCase *)
   Next Obligation.
-    (* TODO NEED wellformed upto eq_term *)
-    (* symmetry in eq1.
-    eapply wellformed_alpha ; [ assumption .. | exact h2 |].
-    eapply eq_term_upto_univ_sym. all: auto.
-    eapply eq_term_upto_univ_zipc. all: auto.
-    eapply elimT.
-    - eapply reflect_upto_names.
-    - assumption.
-  Qed. *)
-  Admitted.
+    eapply wellformed_eq_term.
+    - exact h2.
+    - eapply eq_term_sym.
+      eapply eq_term_zipc.
+      eapply eqb_term_spec. auto.
+  Qed.
   Next Obligation.
     unshelve eapply R_stateR.
     all: try reflexivity. all: simpl.
@@ -1964,17 +1977,12 @@ Section Conversion.
 
   (* tProj *)
   Next Obligation.
-    (* TODO NEED *)
-    (* destruct hΣ as [wΣ].
-    eapply wellformed_alpha ; try assumption.
+    eapply wellformed_eq_term.
     - exact h2.
-    - apply eq_term_upto_univ_sym ; auto.
-      eapply eq_term_upto_univ_zipc ; auto.
-      eapply elimT.
-      + eapply reflect_upto_names.
-      + symmetry. assumption.
-  Qed. *)
-  Admitted.
+    - eapply eq_term_sym.
+      eapply eq_term_zipc.
+      eapply eqb_term_spec. auto.
+  Qed.
   Next Obligation.
     unshelve eapply R_stateR.
     all: try reflexivity.
@@ -1996,16 +2004,12 @@ Section Conversion.
 
   (* tFix *)
   Next Obligation.
-    (* destruct hΣ as [wΣ].
-    eapply wellformed_alpha ; try assumption.
+    eapply wellformed_eq_term.
     - exact h2.
-    - apply eq_term_upto_univ_sym ; auto.
-      eapply eq_term_upto_univ_zipc ; auto.
-      eapply elimT.
-      + eapply reflect_upto_names.
-      + symmetry. assumption.
-  Qed. *)
-  Admitted.
+    - eapply eq_term_sym.
+      eapply eq_term_zipc.
+      eapply eqb_term_spec. auto.
+  Qed.
   Next Obligation.
     unshelve eapply R_stateR.
     all: try reflexivity.
@@ -2330,16 +2334,12 @@ Section Conversion.
 
   (* tCoFix *)
   Next Obligation.
-    (* destruct hΣ as [wΣ].
-    eapply wellformed_alpha ; try assumption.
+    eapply wellformed_eq_term.
     - exact h2.
-    - apply eq_term_upto_univ_sym ; auto.
-      eapply eq_term_upto_univ_zipc ; auto.
-      eapply elimT.
-      + eapply reflect_upto_names.
-      + symmetry. assumption.
-  Qed. *)
-  Admitted.
+    - eapply eq_term_sym.
+      eapply eq_term_zipc.
+      eapply eqb_term_spec. auto.
+  Qed.
   Next Obligation.
     unshelve eapply R_stateR.
     all: try reflexivity.
@@ -3184,16 +3184,12 @@ Section Conversion.
     - eapply conv_context_sym. all: auto.
   Qed.
   Next Obligation.
-    (* destruct hΣ as [wΣ].
-    eapply wellformed_alpha ; try assumption.
+    eapply wellformed_eq_term.
     - exact h2.
-    - apply eq_term_upto_univ_sym ; auto.
-      eapply eq_term_upto_univ_zipc ; auto.
-      eapply elimT.
-      + eapply reflect_upto_names.
-      + symmetry. assumption.
-  Qed. *)
-  Admitted.
+    - eapply eq_term_sym.
+      eapply eq_term_zipc.
+      eapply eqb_term_spec. auto.
+  Qed.
   Next Obligation.
     eapply R_stateR. all: simpl. all: try reflexivity.
     - eapply eq_term_zipc.
@@ -3213,29 +3209,18 @@ Section Conversion.
       eapply eqb_term_spec. eauto.
   Qed.
   Next Obligation.
-    (* case_eq (eqb_term (zipp t1 π1) (zipp t2 π2)). 2: auto.
-    intro e.
-    apply eqb_term_spec in e.
-    constructor. constructor. assumption.
-  Qed. *)
-  Admitted.
-  Next Obligation.
-    (* destruct hΣ as [wΣ].
-    eapply wellformed_alpha ; try assumption.
+    eapply wellformed_eq_term.
     - exact h2.
-    - apply eq_term_upto_univ_sym ; auto.
-      eapply eq_term_upto_univ_zipc ; auto.
-      eapply elimT.
-      + eapply reflect_upto_names.
-      + symmetry. assumption.
-  Qed. *)
-  Admitted.
-  (* Next Obligation.
+    - eapply eq_term_sym.
+      eapply eq_term_zipc.
+      eapply eqb_term_spec. auto.
+  Qed.
+  Next Obligation.
     eapply R_stateR. all: simpl. all: try reflexivity.
     - eapply eq_term_zipc.
       eapply eqb_term_spec. eauto.
     - constructor.
-  Qed. *)
+  Qed.
   Next Obligation.
     destruct b. 2: auto.
     destruct h as [h].

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -318,7 +318,41 @@ Section Conversion.
     unshelve eapply dlexmod_Acc.
     - intros x y [e]. constructor. eapply eq_term_sym. assumption.
     - intros x y z [e1] [e2]. constructor. eapply eq_term_trans. all: eauto.
-    - admit.
+    - intro u. eapply Subterm.wf_lexprod.
+      + intro. eapply posR_Acc.
+      + intros [w' q'].
+        unshelve eapply dlexmod_Acc.
+        * intros x y [e]. constructor. eapply eq_term_sym. assumption.
+        * intros x y z [e1] [e2]. constructor. eapply eq_term_trans. all: eauto.
+        * intros [t' h']. eapply Subterm.wf_lexprod.
+          -- intro. eapply posR_Acc.
+          -- intro. eapply stateR_Acc.
+        * intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]].
+          eexists _,_. intuition eauto.
+          -- constructor. assumption.
+          -- constructor. eapply eq_term_trans. all: eauto.
+        * intros x. exists (sq (eq_term_refl _ _)). intros [[q'' h] ?].
+          unfold R_aux'_obligations_obligation_2.
+          simpl. f_equal. f_equal.
+          eapply uip.
+        * intros x x' [[q'' h] ?] [e].
+          unfold R_aux'_obligations_obligation_2.
+          simpl. f_equal. f_equal.
+          eapply uip.
+        * intros x y z e1 e2 [[q'' h] ?].
+          unfold R_aux'_obligations_obligation_2.
+          simpl. f_equal. f_equal.
+          eapply uip.
+        * intros [t1 ht1] [t2 ht2] [e] [[q1 hq1] s1] [[q2 hq2] s2] h.
+          simpl in *.
+          dependent destruction h.
+          -- left. unfold posR in *. simpl in *. assumption.
+          -- match goal with
+             | |- context [ exist q1 ?hq1 ] =>
+               assert (ee : hq1 = hq2) by eapply uip
+             end.
+            rewrite ee. right. clear ee. assumption.
+        * eapply wcored_wf.
     - intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]].
       eexists _,_. intuition eauto.
       + constructor. assumption.
@@ -356,7 +390,7 @@ Section Conversion.
              simpl in *. assumption.
           -- right. assumption.
     - eapply normalisation_upto. all: assumption.
-  Abort.
+  Qed.
 
   Definition R_aux Γ :=
     t ⊩ cored' Σ Γ ⨶ @posR t ⊗ w ⊩ wcored Γ ⨶ @posR (` w) ⊗ stateR.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -244,6 +244,10 @@ Section Conversion.
     eapply H0. all: assumption.
   Qed.
 
+  (* Can be generalised *)
+  Definition eq_term_pos {u v} (e : eq_term Σ u v) (p : pos u) : pos v :=
+    exist (` p) (eq_term_valid_pos (proj2_sig p) e).
+
   (* Alternative definition of R_aux, to replace it eventually *)
   (* Definition R_aux' Γ :=
     t ⊨ cored' Σ Γ / eq_term Σ ; ? ⨶ @posR t ⊗ ... *)


### PR DESCRIPTION
This replaces the order used for conversion by a new one, using _dependent lexicographic order modulo an equivalence relation_.
The algorithms becomes more complete thanks to it.
There is however the new need of a few lemmata, that are yet to be proven.