### PR TITLE
Removing axioms introduced by #302

### DIFF
--- a/checker/theories/uGraph.v
+++ b/checker/theories/uGraph.v
@@ -1,4 +1,4 @@
-Require Import Nat Bool String BinInt List Relations Lia.
+Require Import Nat Bool String BinInt List Relations Lia ssrbool.
 Require Import MSetFacts MSetProperties.
 From MetaCoq.Template Require Import utils config Universes monad_utils.
 From MetaCoq.Checker Require Import wGraph.
@@ -733,7 +733,7 @@ Proof.
     2:{ split. intros [[l [H1 H2]]|H]. exists l. split; tas.
         apply InA_In_eq, VSetFact.elements_iff in H1; tas.
         now apply EdgeSetFact.empty_iff in H.
-        intros [l [H1 H2]]. left. exists l. split. 
+        intros [l [H1 H2]]. left. exists l. split.
         apply InA_In_eq, VSetFact.elements_1; tas. tas. }
     rewrite VSet.fold_spec. generalize EdgeSet.empty.
     induction (VSet.elements uctx.1).
@@ -1321,6 +1321,13 @@ Section CheckLeq.
     || Universe.equal u1 u2
     || (try_leqb_universe_n 0 u1 u2 && try_leqb_universe_n 0 u2 u1).
 
+  Lemma check_eqb_universe_refl :
+    forall u, check_eqb_universe u u.
+  Proof.
+    intro u. unfold check_eqb_universe.
+    rewrite Universe.equal_refl.
+    rewrite ssrbool.orbT. reflexivity.
+  Qed.
 
   Definition check_gc_constraint (gc : good_constraint) :=
     negb check_univs || match gc with
@@ -1425,7 +1432,7 @@ Section CheckLeq2.
     destruct (gc_of_constraints uctx.2) as [ctrs|].
     symmetry; exact HG. contradiction HG.
   Qed.
-  
+
 
   Definition level_declared l := LevelSet.In l uctx.1.
 

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -163,6 +163,16 @@ Proof.
   subst. constructor. reflexivity.
 Defined.
 
+Lemma eq_prod_refl :
+  forall A B (eqA : A -> A -> bool) (eqB : B -> B -> bool),
+    (forall a, eqA a a) ->
+    (forall b, eqB b b) ->
+    forall p, eq_prod eqA eqB p p.
+Proof.
+  intros A B eqA eqB eqA_refl eqB_refl [a b].
+  simpl. rewrite eqA_refl. apply eqB_refl.
+Qed.
+
 Definition eq_bool b1 b2 : bool :=
   if b1 then b2 else negb b2.
 
@@ -241,7 +251,7 @@ Defined.
 Fixpoint eq_non_empty_list {A : Set} (eqA : A -> A -> bool) (l l' : non_empty_list A) : bool :=
   match l, l' with
   | NEL.sing a, NEL.sing a' => eqA a a'
-  | NEL.cons a l, NEL.cons a' l' => 
+  | NEL.cons a l, NEL.cons a' l' =>
     eqA a a' && eq_non_empty_list eqA l l'
   | _, _ => false
   end.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -508,11 +508,72 @@ Section Conversion.
   Qed.
 
   (* TODO MOVE *)
+  Lemma forallb2_refl :
+    forall A (R : A -> A -> bool),
+      (forall x, R x x) ->
+      forall l, forallb2 R l l.
+  Proof.
+    intros A R R_refl l.
+    induction l.
+    - reflexivity.
+    - simpl. rewrite R_refl. assumption.
+  Qed.
+
+  (* TODO MOVE *)
+  Lemma forallb2_map :
+    forall A B (R : A -> A -> bool) f g (l : list B) (l' : list B),
+      forallb2 (fun x y => R (f x) (g y)) l l' ->
+      forallb2 R (map f l) (map g l').
+  Proof.
+    intros A B R f g l l' h.
+    induction l in l', h |- *.
+    - destruct l'. 2: discriminate. reflexivity.
+    - destruct l'. 1: discriminate. simpl in *.
+      apply andP in h as [e1 e2]. rewrite e1. simpl.
+      eapply IHl. assumption.
+  Qed.
+
+  (* TODO MOVE *)
+  Lemma eq_prod_refl :
+    forall A B (eqA : A -> A -> bool) (eqB : B -> B -> bool),
+      (forall a, eqA a a) ->
+      (forall b, eqB b b) ->
+      forall p, eq_prod eqA eqB p p.
+  Proof.
+    intros A B eqA eqB eqA_refl eqB_refl [a b].
+    simpl. rewrite eqA_refl. apply eqB_refl.
+  Qed.
+
+  (* TODO MOVE *)
   Lemma eqb_term_upto_univ_refl :
     forall (eqb leqb : universe -> universe -> bool) t,
       (forall u, eqb u u) ->
       (forall u, leqb u u) ->
       eqb_term_upto_univ eqb leqb t t.
+  Proof.
+    intros eqb leqb t eqb_refl leqb_refl.
+    induction t using term_forall_list_ind in leqb, leqb_refl |- *.
+    all: simpl.
+    all: rewrite ?Nat.eqb_refl, ?eq_string_refl, ?eq_inductive_refl.
+    all: repeat rewrite eq_prod_refl by (eauto using Nat.eqb_refl, eq_string_refl, eq_inductive_refl).
+    all: repeat lazymatch goal with
+         | ih : forall leqb, _ -> @?P leqb |- _ =>
+           rewrite ih by assumption ; clear ih
+         end.
+    all: simpl.
+    all: try solve [ eauto ].
+    - induction H.
+      + reflexivity.
+      + simpl. rewrite p by assumption. auto.
+    - eapply forallb2_map. eapply forallb2_refl.
+      intro l. eapply eqb_refl.
+    - eapply forallb2_map. eapply forallb2_refl.
+      intro l. eapply eqb_refl.
+    - eapply forallb2_map. eapply forallb2_refl.
+      intro l. eapply eqb_refl.
+    - admit.
+    - admit.
+    -
   Admitted.
 
   Definition leqb_term :=

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1463,13 +1463,15 @@ Section Conversion.
       destArity Γ1 t1 = Some (Δ1, s1) ->
       exists Δ2 s2,
         destArity Γ2 t2 = Some (Δ2, s2) /\
+        ∥ eq_context_upto Re Δ1 Δ2 ∥ /\
         Rle s1 s2.
   Proof.
     intros Re Rle Γ1 Γ2 t1 t2 Δ1 s1 ht hΓ e.
     induction ht in Γ1, Γ2, Δ1, s1, hΓ, e |- *.
     all: try discriminate e.
     - simpl in *. inversion e. subst.
-      eexists _,_. eauto.
+      eexists _,_. intuition eauto.
+      constructor. assumption.
     - simpl in *.
       eapply IHht2 in e as h.
       + eassumption.
@@ -1481,16 +1483,48 @@ Section Conversion.
   Qed.
 
   (* TODO MOVE *)
+  Lemma isWfArity_eq_term_upto_univ :
+    forall Re Rle Γ u v,
+      Reflexive Re ->
+      isWfArity typing Σ Γ u ->
+      eq_term_upto_univ Re Rle u v ->
+      ∥ isWfArity typing Σ Γ v ∥.
+  Proof.
+    intros Re Rle Γ u v Re_refl [Δ [s [e1 e2]]] e.
+    eapply destArity_eq_term_upto_univ in e1 as h.
+    2: eassumption. 2: eapply eq_context_upto_refl. 2: assumption.
+    destruct h as [Δ' [s' [h1 [[h2] h3]]]].
+    constructor. eexists _,_. split.
+    - eassumption.
+    - (* TODO NEED welltyped_eq_term *)
+      admit.
+  Admitted.
+
+  (* TODO MOVE *)
+  Lemma wellformed_eq_term_upto_univ :
+    forall Re Rle Γ u v,
+      Reflexive Re ->
+      wellformed Σ Γ u ->
+      eq_term_upto_univ Re Rle u v ->
+      wellformed Σ Γ v.
+  Proof.
+    intros Re Rle Γ u v Re_refl [h|[h]] e.
+    - left. admit.
+    - right.
+      eapply isWfArity_eq_term_upto_univ. all: eassumption.
+  Admitted.
+
+  (* TODO MOVE *)
   Lemma wellformed_eq_term :
     forall Γ u v,
       wellformed Σ Γ u ->
       eq_term Σ u v ->
       wellformed Σ Γ v.
   Proof.
-    intros Γ u v [h|[[Δ [s [e1 e2]]]]] e.
-    - left. admit.
-    - right. constructor.
-  Admitted.
+    intros Γ u v h e.
+    eapply wellformed_eq_term_upto_univ. all: try eassumption.
+    eapply eq_universe_refl.
+  Qed.
 
   Equations(noeqns) _isconv_prog (Γ : context) (leq : conv_pb)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1456,11 +1456,40 @@ Section Conversion.
   Qed.
 
   (* TODO MOVE *)
+  Lemma destArity_eq_term_upto_univ :
+    forall Re Rle Γ1 Γ2 t1 t2 Δ1 s1,
+      eq_term_upto_univ Re Rle t1 t2 ->
+      eq_context_upto Re Γ1 Γ2 ->
+      destArity Γ1 t1 = Some (Δ1, s1) ->
+      exists Δ2 s2,
+        destArity Γ2 t2 = Some (Δ2, s2) /\
+        Rle s1 s2.
+  Proof.
+    intros Re Rle Γ1 Γ2 t1 t2 Δ1 s1 ht hΓ e.
+    induction ht in Γ1, Γ2, Δ1, s1, hΓ, e |- *.
+    all: try discriminate e.
+    - simpl in *. inversion e. subst.
+      eexists _,_. eauto.
+    - simpl in *.
+      eapply IHht2 in e as h.
+      + eassumption.
+      + constructor. all: auto.
+    - simpl in *.
+      eapply IHht3 in e as h.
+      + eassumption.
+      + constructor. all: assumption.
+  Qed.
+
+  (* TODO MOVE *)
   Lemma wellformed_eq_term :
     forall Γ u v,
       wellformed Σ Γ u ->
       eq_term Σ u v ->
       wellformed Σ Γ v.
+  Proof.
+    intros Γ u v [h|[[Δ [s [e1 e2]]]]] e.
+    - left. admit.
+    - right. constructor.
   Admitted.
 
   Equations(noeqns) _isconv_prog (Γ : context) (leq : conv_pb)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -630,9 +630,65 @@ Section Conversion.
     intro t. eapply eqb_term_upto_univ_refl.
   Admitted.
 
+  (* TODO MOVE *)
+  Lemma NEL_forallb2_refl :
+    forall (A : Set) (R : A -> A -> bool),
+      (forall x, R x x) ->
+      forall l, NEL.forallb2 R l l.
+  Proof.
+    intros A R R_refl l.
+    induction l.
+    - simpl. apply R_refl.
+    - simpl. rewrite R_refl. assumption.
+  Qed.
+
+  (* TODO MOVE *)
+  Lemma Level_equal_refl :
+    forall l, Level.equal l l.
+  Proof.
+    intros [].
+    all: unfold Level.equal.
+    all: simpl.
+    1-2: reflexivity.
+    - rewrite (ssreflect.iffRL (string_compare_eq s s)). all: auto.
+    - rewrite Nat.compare_refl. reflexivity.
+  Qed.
+
+  (* TODO MOVE *)
+  Lemma Universe_Expr_equal_refl :
+    forall e, Universe.Expr.equal e e.
+  Proof.
+    intro e. destruct e as [[] b]. all: simpl.
+    - reflexivity.
+    - apply eqb_reflx.
+    - rewrite eqb_reflx. rewrite Level_equal_refl. reflexivity.
+    - rewrite Level_equal_refl, eqb_reflx. reflexivity.
+  Qed.
+
+  (* TODO MOVE *)
+  Lemma universe_equal_refl :
+    forall u, Universe.equal u u.
+  Proof.
+    intro u. unfold Universe.equal. eapply NEL_forallb2_refl.
+    apply Universe_Expr_equal_refl.
+  Qed.
+
+  (* TODO MOVE *)
+  Lemma check_eqb_universe_refl :
+    forall u, check_eqb_universe G u u.
+  Proof.
+    intro u. unfold check_eqb_universe.
+    rewrite universe_equal_refl.
+    rewrite ssrbool.orbT. reflexivity.
+  Qed.
+
+  (* TODO MOVE *)
   Lemma eqb_term_refl :
     forall t, eqb_term t t.
-  Admitted.
+  Proof.
+    intro t. eapply eqb_term_upto_univ_refl.
+    all: apply check_eqb_universe_refl.
+  Qed.
 
   Fixpoint eqb_ctx (Γ Δ : context) : bool :=
     match Γ, Δ with

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -507,89 +507,6 @@ Section Conversion.
     eapply R_aux_stateR. all: simpl. all: auto.
   Qed.
 
-  (* TODO MOVE *)
-  Lemma forallb2_refl :
-    forall A (R : A -> A -> bool),
-      (forall x, R x x) ->
-      forall l, forallb2 R l l.
-  Proof.
-    intros A R R_refl l.
-    induction l.
-    - reflexivity.
-    - simpl. rewrite R_refl. assumption.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma forallb2_map :
-    forall A B (R : A -> A -> bool) f g (l : list B) (l' : list B),
-      forallb2 (fun x y => R (f x) (g y)) l l' ->
-      forallb2 R (map f l) (map g l').
-  Proof.
-    intros A B R f g l l' h.
-    induction l in l', h |- *.
-    - destruct l'. 2: discriminate. reflexivity.
-    - destruct l'. 1: discriminate. simpl in *.
-      apply andP in h as [e1 e2]. rewrite e1. simpl.
-      eapply IHl. assumption.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma eq_prod_refl :
-    forall A B (eqA : A -> A -> bool) (eqB : B -> B -> bool),
-      (forall a, eqA a a) ->
-      (forall b, eqB b b) ->
-      forall p, eq_prod eqA eqB p p.
-  Proof.
-    intros A B eqA eqB eqA_refl eqB_refl [a b].
-    simpl. rewrite eqA_refl. apply eqB_refl.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma eqb_term_upto_univ_refl :
-    forall (eqb leqb : universe -> universe -> bool) t,
-      (forall u, eqb u u) ->
-      (forall u, leqb u u) ->
-      eqb_term_upto_univ eqb leqb t t.
-  Proof.
-    intros eqb leqb t eqb_refl leqb_refl.
-    induction t using term_forall_list_ind in leqb, leqb_refl |- *.
-    all: simpl.
-    all: rewrite ?Nat.eqb_refl, ?eq_string_refl, ?eq_inductive_refl.
-    all: repeat rewrite eq_prod_refl
-          by (eauto using eq_prod_refl, Nat.eqb_refl, eq_string_refl, eq_inductive_refl).
-    all: repeat lazymatch goal with
-         | ih : forall leqb, _ -> @?P leqb |- _ =>
-           rewrite ih by assumption ; clear ih
-         end.
-    all: simpl.
-    all: try solve [ eauto ].
-    - induction H.
-      + reflexivity.
-      + simpl. rewrite p by assumption. auto.
-    - eapply forallb2_map. eapply forallb2_refl.
-      intro l. eapply eqb_refl.
-    - eapply forallb2_map. eapply forallb2_refl.
-      intro l. eapply eqb_refl.
-    - eapply forallb2_map. eapply forallb2_refl.
-      intro l. eapply eqb_refl.
-    - induction X.
-      + reflexivity.
-      + simpl. rewrite Nat.eqb_refl. rewrite p0 by assumption.
-        assumption.
-    - induction X.
-      + reflexivity.
-      + simpl. rewrite Nat.eqb_refl.
-        destruct p as [e1 e2].
-        rewrite e1 by assumption. rewrite e2 by assumption.
-        assumption.
-    - induction X.
-      + reflexivity.
-      + simpl. rewrite Nat.eqb_refl.
-        destruct p as [e1 e2].
-        rewrite e1 by assumption. rewrite e2 by assumption.
-        assumption.
-  Qed.
-
   Definition leqb_term :=
     eqb_term_upto_univ (check_eqb_universe G) (check_leqb_universe G).
 
@@ -624,65 +541,6 @@ Section Conversion.
     now eapply global_ext_uctx_consistent.
   Qed.
 
-  Lemma leqb_term_refl :
-    forall t, leqb_term t t.
-  Proof.
-    intro t. eapply eqb_term_upto_univ_refl.
-  Admitted.
-
-  (* TODO MOVE *)
-  Lemma NEL_forallb2_refl :
-    forall (A : Set) (R : A -> A -> bool),
-      (forall x, R x x) ->
-      forall l, NEL.forallb2 R l l.
-  Proof.
-    intros A R R_refl l.
-    induction l.
-    - simpl. apply R_refl.
-    - simpl. rewrite R_refl. assumption.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma Level_equal_refl :
-    forall l, Level.equal l l.
-  Proof.
-    intros [].
-    all: unfold Level.equal.
-    all: simpl.
-    1-2: reflexivity.
-    - rewrite (ssreflect.iffRL (string_compare_eq s s)). all: auto.
-    - rewrite Nat.compare_refl. reflexivity.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma Universe_Expr_equal_refl :
-    forall e, Universe.Expr.equal e e.
-  Proof.
-    intro e. destruct e as [[] b]. all: simpl.
-    - reflexivity.
-    - apply eqb_reflx.
-    - rewrite eqb_reflx. rewrite Level_equal_refl. reflexivity.
-    - rewrite Level_equal_refl, eqb_reflx. reflexivity.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma universe_equal_refl :
-    forall u, Universe.equal u u.
-  Proof.
-    intro u. unfold Universe.equal. eapply NEL_forallb2_refl.
-    apply Universe_Expr_equal_refl.
-  Qed.
-
-  (* TODO MOVE *)
-  Lemma check_eqb_universe_refl :
-    forall u, check_eqb_universe G u u.
-  Proof.
-    intro u. unfold check_eqb_universe.
-    rewrite universe_equal_refl.
-    rewrite ssrbool.orbT. reflexivity.
-  Qed.
-
-  (* TODO MOVE *)
   Lemma eqb_term_refl :
     forall t, eqb_term t t.
   Proof.
@@ -1586,7 +1444,7 @@ Section Conversion.
       eapply hΣ'.
   Qed.
 
-  (* TODO MOVE *)
+  (* TODO (RE)MOVE *)
   Lemma destArity_eq_term_upto_univ :
     forall Re Rle Γ1 Γ2 t1 t2 Δ1 s1,
       eq_term_upto_univ Re Rle t1 t2 ->
@@ -1612,50 +1470,6 @@ Section Conversion.
       + eassumption.
       + constructor. all: assumption.
   Qed.
-
-  (* TODO MOVE *)
-  Lemma isWfArity_eq_term_upto_univ :
-    forall Re Rle Γ u v,
-      Reflexive Re ->
-      isWfArity typing Σ Γ u ->
-      eq_term_upto_univ Re Rle u v ->
-      ∥ isWfArity typing Σ Γ v ∥.
-  Proof.
-    intros Re Rle Γ u v Re_refl [Δ [s [e1 e2]]] e.
-    eapply destArity_eq_term_upto_univ in e1 as h.
-    2: eassumption. 2: eapply eq_context_upto_refl. 2: assumption.
-    destruct h as [Δ' [s' [h1 [[h2] h3]]]].
-    constructor. eexists _,_. split.
-    - eassumption.
-    - (* TODO NEED welltyped_eq_term *)
-      admit.
-  Admitted.
-
-  (* TODO MOVE *)
-  (* Lemma wellformed_eq_term_upto_univ :
-    forall Re Rle Γ u v,
-      Reflexive Re ->
-      wellformed Σ Γ u ->
-      eq_term_upto_univ Re Rle u v ->
-      wellformed Σ Γ v.
-  Proof.
-    intros Re Rle Γ u v Re_refl [h|[h]] e.
-    - left. admit.
-    - right.
-      eapply isWfArity_eq_term_upto_univ. all: eassumption.
-  Admitted.
-
-  (* TODO MOVE *)
-  Lemma wellformed_eq_term :
-    forall Γ u v,
-      wellformed Σ Γ u ->
-      eq_term Σ u v ->
-      wellformed Σ Γ v.
-  Proof.
-    intros Γ u v h e.
-    eapply wellformed_eq_term_upto_univ. all: try eassumption.
-    eapply eq_universe_refl.
-  Qed. *)
 
   Equations(noeqns) _isconv_prog (Γ : context) (leq : conv_pb)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -555,7 +555,8 @@ Section Conversion.
     induction t using term_forall_list_ind in leqb, leqb_refl |- *.
     all: simpl.
     all: rewrite ?Nat.eqb_refl, ?eq_string_refl, ?eq_inductive_refl.
-    all: repeat rewrite eq_prod_refl by (eauto using Nat.eqb_refl, eq_string_refl, eq_inductive_refl).
+    all: repeat rewrite eq_prod_refl
+          by (eauto using eq_prod_refl, Nat.eqb_refl, eq_string_refl, eq_inductive_refl).
     all: repeat lazymatch goal with
          | ih : forall leqb, _ -> @?P leqb |- _ =>
            rewrite ih by assumption ; clear ih
@@ -571,10 +572,23 @@ Section Conversion.
       intro l. eapply eqb_refl.
     - eapply forallb2_map. eapply forallb2_refl.
       intro l. eapply eqb_refl.
-    - admit.
-    - admit.
-    -
-  Admitted.
+    - induction X.
+      + reflexivity.
+      + simpl. rewrite Nat.eqb_refl. rewrite p0 by assumption.
+        assumption.
+    - induction X.
+      + reflexivity.
+      + simpl. rewrite Nat.eqb_refl.
+        destruct p as [e1 e2].
+        rewrite e1 by assumption. rewrite e2 by assumption.
+        assumption.
+    - induction X.
+      + reflexivity.
+      + simpl. rewrite Nat.eqb_refl.
+        destruct p as [e1 e2].
+        rewrite e1 by assumption. rewrite e2 by assumption.
+        assumption.
+  Qed.
 
   Definition leqb_term :=
     eqb_term_upto_univ (check_eqb_universe G) (check_leqb_universe G).

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1546,7 +1546,7 @@ Section Conversion.
           | @exist false _ with inspect (lookup_env Σ c) := {
             | @exist (Some (ConstantDecl n {| cst_body := Some body |})) eq3 :=
               isconv_red leq (subst_instance_constr u body) π1
-                             (subst_instance_constr u body) π2 aux ;
+                             (subst_instance_constr u' body) π2 aux ;
             (* Inductive or not found *)
             | @exist _ _ := no
             }
@@ -1660,17 +1660,10 @@ Section Conversion.
       eapply red_const. eassumption.
   Qed.
   Next Obligation.
-    eapply wellformed_eq_term.
-    - eapply red_wellformed ; auto.
-      + exact h2.
-      + constructor. eapply red_zipc.
-        eapply red_const. eassumption.
-    - eapply eq_term_zipc.
-      eapply eq_term_sym.
-      eapply eq_term_upto_univ_subst_instance_constr.
-      + intro. eapply eq_universe_refl.
-      + apply leq_term_SubstUnivPreserving.
-      + eapply eqb_universe_instance_spec. auto.
+    eapply red_wellformed ; auto.
+    - exact h2.
+    - constructor. eapply red_zipc.
+      eapply red_const. eassumption.
   Qed.
   Next Obligation.
     eapply R_cored. simpl.
@@ -1687,15 +1680,9 @@ Section Conversion.
       eapply red_zipp.
       eapply red_const. eassumption.
     - eapply conv_trans' ; try eassumption.
-      eapply conv_trans'.
-      + assumption.
-      + eapply red_conv_r ; try assumption.
-        eapply red_zipp.
-        eapply red_const. eassumption.
-      + eapply conv_conv. 1: auto.
-        constructor. constructor.
-        eapply eq_term_zipp. constructor.
-        eapply eqb_universe_instance_spec. auto.
+      eapply red_conv_r ; try assumption.
+      eapply red_zipp.
+      eapply red_const. eassumption.
   Qed.
 
   (* tLambda *)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -2302,7 +2302,11 @@ Section Conversion.
     - destruct ht as [ht].
       constructor. apply App_conv. all: assumption.
     - destruct ht as [ht]. constructor.
-  Admitted.
+      eapply cumul_trans.
+      + assumption.
+      + eapply cumul_App_l. eassumption.
+      + eapply cumul_App_r. assumption.
+  Qed.
 
   Definition Aux' Γ t1 args1 l1 π1 t2 π2 h2 :=
     forall u1 u2 ca1 a1 ρ2

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1501,7 +1501,7 @@ Section Conversion.
   Admitted.
 
   (* TODO MOVE *)
-  Lemma wellformed_eq_term_upto_univ :
+  (* Lemma wellformed_eq_term_upto_univ :
     forall Re Rle Γ u v,
       Reflexive Re ->
       wellformed Σ Γ u ->
@@ -1524,7 +1524,7 @@ Section Conversion.
     intros Γ u v h e.
     eapply wellformed_eq_term_upto_univ. all: try eassumption.
     eapply eq_universe_refl.
-  Qed.
+  Qed. *)
 
   Equations(noeqns) _isconv_prog (Γ : context) (leq : conv_pb)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -59,6 +59,18 @@ Module Level.
 
   Definition equal (l1 l2 : Level.t) : bool
     := match compare l1 l2 with Eq => true | _ => false end.
+
+  Lemma equal_refl :
+    forall l, equal l l.
+  Proof.
+    intros [].
+    all: unfold equal.
+    all: simpl.
+    1-2: reflexivity.
+    - rewrite (ssreflect.iffRL (string_compare_eq s s)). all: auto.
+    - rewrite Nat.compare_refl. reflexivity.
+  Qed.
+
 End Level.
 
 Module LevelDecidableType.
@@ -132,6 +144,17 @@ Module Universe.
     Definition prop : t := (Level.prop, false).
     Definition set : t := (Level.set, false).
     Definition type1 : t := (Level.set, true).
+
+    Lemma equal_refl :
+      forall e, equal e e.
+    Proof.
+      intro e. destruct e as [[] b]. all: simpl.
+      - reflexivity.
+      - apply eqb_reflx.
+      - rewrite eqb_reflx. rewrite Level.equal_refl. reflexivity.
+      - rewrite Level.equal_refl, eqb_reflx. reflexivity.
+    Qed.
+
   End Expr.
 
   Definition t : Set := non_empty_list Expr.t.
@@ -205,6 +228,13 @@ Module Universe.
     (* Prop impredicativity *)
     if Universe.is_prop rangsort then rangsort
     else Universe.sup domsort rangsort.
+
+  Lemma equal_refl :
+    forall u, equal u u.
+  Proof.
+    intro u. unfold equal. eapply NEL.forallb2_refl.
+    apply Expr.equal_refl.
+  Qed.
 
 End Universe.
 

--- a/template-coq/theories/utils.v
+++ b/template-coq/theories/utils.v
@@ -231,7 +231,32 @@ Section Forallb2.
     | [], [] => true
     | _, _ => false
     end.
+
 End Forallb2.
+
+Lemma forallb2_refl :
+  forall A (R : A -> A -> bool),
+    (forall x, R x x) ->
+    forall l, forallb2 R l l.
+Proof.
+  intros A R R_refl l.
+  induction l.
+  - reflexivity.
+  - simpl. rewrite R_refl. assumption.
+Qed.
+
+Lemma forallb2_map :
+  forall A B (R : A -> A -> bool) f g (l : list B) (l' : list B),
+    forallb2 (fun x y => R (f x) (g y)) l l' ->
+    forallb2 R (map f l) (map g l').
+Proof.
+  intros A B R f g l l' h.
+  induction l in l', h |- *.
+  - destruct l'. 2: discriminate. reflexivity.
+  - destruct l'. 1: discriminate. simpl in *.
+    apply andP in h as [e1 e2]. rewrite e1. simpl.
+    eapply IHl. assumption.
+Qed.
 
 Program Fixpoint safe_nth {A} (l : list A) (n : nat | n < List.length l) : A :=
   match l with
@@ -2316,6 +2341,17 @@ Module NEL.
     induction l; cbn; rewrite ?H; congruence.
   Defined.
 
+  Lemma forallb2_refl :
+    forall (A : Set) (R : A -> A -> bool),
+      (forall x, R x x) ->
+      forall l, forallb2 R l l.
+  Proof.
+    intros A R R_refl l.
+    induction l.
+    - simpl. apply R_refl.
+    - simpl. rewrite R_refl. assumption.
+  Qed.
+
 End NEL.
 
 Definition non_empty_list := NEL.t.
@@ -2756,7 +2792,7 @@ Qed.
 Lemma forallb_impl {A} (p q : pred A) l :
   (forall x, In x l -> p x -> q x) -> forallb p l -> forallb q l.
 Proof.
-  intros H0 H1. eapply forallb_forall. intros x H2. 
+  intros H0 H1. eapply forallb_forall. intros x H2.
   eapply forallb_forall in H1; tea.
   now eapply H0.
 Qed.


### PR DESCRIPTION
As the aftermath of #302, we added new axioms.
- [X] Removing `wellformed_eq_term` by tweaking things so it's no longer needed.
- [X] Prove `App_conv'`.
- [x] Prove `eqb_term_refl`.