### PR TITLE
Fix and prove Is_conv_to_Arity_inv

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -474,7 +474,7 @@ Proof.
     destruct c1 as (? & ? & ?). destruct H as [].
     eapply PCUICCumulativity.red_cumul_inv in X.
 
-    eapply invert_cumul_arity_l in H0 as (? & ? & ?). 2:eauto. 2:eauto. 2: eapply PCUICConversion.cumul_trans; eauto.
+    eapply invert_cumul_arity_l in H0 as (? & ? & ?). 2: eapply PCUICConversion.cumul_trans; eauto.
     destruct H.
     eapply typing_spine_red in t1. 2:{ eapply PCUICCumulativity.All_All2_refl.
                                                   clear. induction L; eauto. }

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -337,7 +337,7 @@ Next Obligation.
   edestruct (red_confluence wfΣ X X0) as (? & ? & ?); eauto.
   eapply invert_red_prod in r0 as (? & ? & [] & ?); eauto. subst.
 
-  eapply invert_cumul_arity_l in H2. 2:eauto. 3: eapply PCUICCumulativity.red_cumul. 3:eauto. 2:eauto.
+  eapply invert_cumul_arity_l in H2. 2: eapply PCUICCumulativity.red_cumul. 2:eauto.
   destruct H2 as (? & ? & ?). sq.
 
   eapply invert_red_prod in X2 as (? & ? & [] & ?); eauto. subst. cbn in *.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -363,8 +363,11 @@ Next Obligation.
 Qed.
 Next Obligation.
   Hint Constructors squash. destruct HΣ.
-  eapply Is_conv_to_Arity_inv in H as [(? & ? & ? & ?) | (? & ?)]; eauto.
-Qed.
+  eapply Is_conv_to_Arity_inv in H
+    as [ (? & ? & ? & ?) | [ (? & ? & ? & ? & ?) | (? & ?) ] ].
+  all: eauto.
+(* Qed. *)
+Admitted.
 
 End fix_sigma.
 

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -149,7 +149,7 @@ Next Obligation.
   edestruct (red_confluence wfΣ X0 X) as (? & ? & ?); eauto.
   eapply invert_red_prod in r as (? & ? & [] & ?); eauto. subst.
 
-  eapply invert_cumul_arity_l in H2. 2:eauto. 3: eapply PCUICCumulativity.red_cumul. 3:eauto. 2:eauto.
+  eapply invert_cumul_arity_l in H2. 2: eapply PCUICCumulativity.red_cumul. 2:eauto.
   destruct H2 as (? & ? & ?). sq.
 
   eapply invert_red_prod in X2 as (? & ? & [] & ?); eauto. subst. cbn in *.
@@ -445,7 +445,7 @@ Section Erase.
                                 ret (E.tCoFix mfix' n)
     }.
   Next Obligation. todo "monad_map enhancement for erasing lists". Qed.
-  Next Obligation. 
+  Next Obligation.
     destruct Ht.
     destruct HΣ.
     eapply inversion_Lambda in X as (? & ? & ? & ? & ?) ; auto.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -181,6 +181,30 @@ Section Principality.
       red1 Σ Γ u v ->
       isArity u ->
       isArity v.
+  Proof.
+    intros Γ u v h a.
+    induction u in Γ, v, h, a |- *. all: try contradiction.
+    - dependent destruction h.
+      apply (f_equal nApp) in H as eq. simpl in eq.
+      rewrite nApp_mkApps in eq. simpl in eq.
+      destruct args. 2: discriminate.
+      simpl in H. discriminate.
+    - dependent destruction h.
+      + apply (f_equal nApp) in H as eq. simpl in eq.
+        rewrite nApp_mkApps in eq. simpl in eq.
+        destruct args. 2: discriminate.
+        simpl in H. discriminate.
+      + assumption.
+      + simpl in *. eapply IHu2. all: eassumption.
+    - dependent destruction h.
+      + simpl in *. admit.
+      + apply (f_equal nApp) in H as eq. simpl in eq.
+        rewrite nApp_mkApps in eq. simpl in eq.
+        destruct args. 2: discriminate.
+        simpl in H. discriminate.
+      + assumption.
+      + assumption.
+      + simpl in *. eapply IHu3. all: eassumption.
   Admitted.
 
   Lemma invert_cumul_arity_r :

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -221,12 +221,11 @@ Section Principality.
 
   Lemma invert_cumul_arity_r :
     forall (Γ : context) (C : term) T,
-      wf_local Σ Γ ->
       isArity T ->
       Σ;;; Γ |- C <= T ->
       Is_conv_to_Arity Σ Γ C.
   Proof.
-    intros Γ C T hwf a h.
+    intros Γ C T a h.
     induction h.
     - eapply eq_term_upto_univ_conv_arity_r. all: eassumption.
     - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
@@ -238,6 +237,26 @@ Section Principality.
         * assumption.
       + assumption.
     - eapply IHh. eapply isArity_red1. all: eassumption.
+  Qed.
+
+  Lemma invert_cumul_arity_l :
+    forall (Γ : context) (C : term) T,
+      isArity C ->
+      Σ;;; Γ |- C <= T ->
+      Is_conv_to_Arity Σ Γ T.
+  Proof.
+    intros Γ C T a h.
+    induction h.
+    - eapply eq_term_upto_univ_conv_arity_l. all: eassumption.
+    - eapply IHh. eapply isArity_red1. all: eassumption.
+    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
+      exists v'. split.
+      + constructor. eapply red_trans.
+        * eapply trans_red.
+          -- constructor.
+          -- eassumption.
+        * assumption.
+      + assumption.
   Qed.
 
   Lemma invert_cumul_prod_l Γ C na A B :
@@ -256,27 +275,6 @@ Section Principality.
     - eapply cumul_trans with B'; eauto.
       now eapply red_cumul.
       now constructor; apply leqvv'2.
-  Qed.
-
-  Lemma invert_cumul_arity_l :
-    forall (Γ : context) (C : term) T,
-      wf_local Σ Γ ->
-      isArity C ->
-      Σ;;; Γ |- C <= T ->
-      Is_conv_to_Arity Σ Γ T.
-  Proof.
-    intros Γ C T hwf a h.
-    induction h.
-    - eapply eq_term_upto_univ_conv_arity_l. all: eassumption.
-    - eapply IHh. eapply isArity_red1. all: eassumption.
-    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
-      exists v'. split.
-      + constructor. eapply red_trans.
-        * eapply trans_red.
-          -- constructor.
-          -- eassumption.
-        * assumption.
-      + assumption.
   Qed.
 
   Lemma invert_red_letin Γ C na d ty b :

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -176,6 +176,18 @@ Section Principality.
       + simpl. assumption.
   Qed.
 
+  Lemma isArity_subst :
+    forall u v k,
+      isArity u ->
+      isArity (u { k := v }).
+  Proof.
+    intros u v k h.
+    induction u in v, k, h |- *. all: try contradiction.
+    - simpl. constructor.
+    - simpl in *. eapply IHu2. assumption.
+    - simpl in *. eapply IHu3. assumption.
+  Qed.
+
   Lemma isArity_red1 :
     forall Γ u v,
       red1 Σ Γ u v ->
@@ -197,7 +209,7 @@ Section Principality.
       + assumption.
       + simpl in *. eapply IHu2. all: eassumption.
     - dependent destruction h.
-      + simpl in *. admit.
+      + simpl in *. apply isArity_subst. assumption.
       + apply (f_equal nApp) in H as eq. simpl in eq.
         rewrite nApp_mkApps in eq. simpl in eq.
         destruct args. 2: discriminate.
@@ -205,7 +217,7 @@ Section Principality.
       + assumption.
       + assumption.
       + simpl in *. eapply IHu3. all: eassumption.
-  Admitted.
+  Qed.
 
   Lemma invert_cumul_arity_r :
     forall (Γ : context) (C : term) T,

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -28,12 +28,23 @@ Section Principality.
   Context (Σ : global_env_ext).
   Context (wfΣ : wf Σ).
 
-  Definition Is_conv_to_Arity Σ Γ T := exists T', ∥red Σ Γ T T'∥ /\ isArity T'.
- 
-  Lemma Is_conv_to_Arity_inv Γ T :
-    Is_conv_to_Arity Σ Γ T ->
-    (exists na A B, ∥red Σ Γ T (tProd na A B)∥) \/ (exists u, ∥red Σ Γ T (tSort u)∥).
-  Admitted.
+  Definition Is_conv_to_Arity Σ Γ T :=
+    exists T', ∥ red Σ Γ T T' ∥ /\ isArity T'.
+
+  Lemma Is_conv_to_Arity_inv :
+    forall Γ T,
+      Is_conv_to_Arity Σ Γ T ->
+      (exists na A B, ∥ red Σ Γ T (tProd na A B) ∥) \/
+      (exists na b B t, ∥ red Σ Γ T (tLetIn na b B t) ∥) \/
+      (exists u, ∥ red Σ Γ T (tSort u) ∥).
+  Proof.
+    intros Γ T [T' [r a]].
+    destruct T'.
+    all: try contradiction.
+    - right. right. eexists. eassumption.
+    - left. eexists _, _, _. eassumption.
+    - right. left. eexists _, _, _, _. eassumption.
+  Qed.
 
   Lemma invert_red_sort Γ u v :
     red Σ Γ (tSort u) v -> v = tSort u.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -258,27 +258,26 @@ Section Principality.
       now constructor; apply leqvv'2.
   Qed.
 
-  Lemma invert_cumul_arity_l (Γ : context) (C : term) T :
-    wf_local Σ Γ ->
-    isArity C ->
-    Σ;;; Γ |- C <= T -> Is_conv_to_Arity Σ Γ T.
+  Lemma invert_cumul_arity_l :
+    forall (Γ : context) (C : term) T,
+      wf_local Σ Γ ->
+      isArity C ->
+      Σ;;; Γ |- C <= T ->
+      Is_conv_to_Arity Σ Γ T.
   Proof.
-    revert Γ T; induction C; cbn in *; intros Γ T wfΓ ? ?; try tauto.
-    - eapply invert_cumul_sort_l in X as (? & ? & ?).
-      exists (tSort x). split; sq; eauto.
-    - eapply invert_cumul_prod_l in X as (? & ? & ? & [] & ?); eauto.
-      eapply IHC2 in c0 as (? & ? & ?); eauto. sq.
-
-      exists (tProd x x0 x2). split; sq; cbn; eauto.
-      etransitivity. eauto.
-      eapply PCUICReduction.red_prod_r.
-
-      (*   eapply context_conversion_red. eauto. 2:eauto. *)
-      (*   econstructor. eapply conv_context_refl; eauto.  *)
-
-      (*   econstructor. 2:eauto. 2:econstructor; eauto. 2:cbn. admit. admit. *)
-      (* - eapply invert_cumul_letin_l in X; eauto. *)
-  Admitted.                       (* invert_cumul_arity_l *)
+    intros Γ C T hwf a h.
+    induction h.
+    - eapply eq_term_upto_univ_conv_arity_l. all: eassumption.
+    - eapply IHh. eapply isArity_red1. all: eassumption.
+    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
+      exists v'. split.
+      + constructor. eapply red_trans.
+        * eapply trans_red.
+          -- constructor.
+          -- eassumption.
+        * assumption.
+      + assumption.
+  Qed.
 
   Lemma invert_red_letin Γ C na d ty b :
     red Σ.1 Γ (tLetIn na d ty b) C ->


### PR DESCRIPTION
This PR is about the admitted lemmata on airty needed by erasure.

- [X] `PCUICPrincipality.Is_conv_to_Arity_inv`
- [x] `PCUICPrincipality.invert_cumul_arity_r`
- [x] `PCUICPrincipality.invert_cumul_arity_l`

Regarding `PCUICPrincipality.Is_conv_to_Arity_inv`, I proved it by fixing its statement , so @yforster, I'm sorry but you will have to adapt your proof a bit.

For the other two I also removed useless hypotheses but I updated erasure properly. ;)