### PR TITLE
Tacking prop_sub_type in account in leq_universe

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -408,15 +408,15 @@ Proof.
 Qed.
 
 Lemma is_prop_sort_sup:
-  forall x1 x2 : universe, is_prop_sort (Universe.sup x1 x2) -> is_prop_sort x2.
+  forall x1 x2 : universe, Universe.is_prop (Universe.sup x1 x2) -> Universe.is_prop x2.
 Proof.
   induction x1; cbn; intros.
-  - inv H.
-  - inv H.
+  - apply andb_true_iff in H; apply H.
+  - apply IHx1. apply andb_true_iff in H. apply H.
 Qed.
 
 Lemma is_prop_sort_prod x2 x3 :
-  is_prop_sort (Universe.sort_of_product x2 x3) -> is_prop_sort x3.
+  Universe.is_prop (Universe.sort_of_product x2 x3) -> Universe.is_prop x3.
 Proof.
   intros. unfold Universe.sort_of_product in *. destruct ?; eauto.
   eapply is_prop_sort_sup in H. eauto.
@@ -424,9 +424,9 @@ Qed.
 
 Lemma sort_typing_spine:
   forall (Σ : global_env_ext) (Γ : context) (L : list term) (u : universe) (x x0 : term),
-    wf Σ ->
-    is_prop_sort u ->
-    typing_spine Σ Γ x L x0 -> Σ;;; Γ |- x : tSort u -> ∑ u', Σ;;; Γ |- x0 : tSort u' × is_prop_sort u'.
+    wf_ext Σ ->
+    Universe.is_prop u ->
+    typing_spine Σ Γ x L x0 -> Σ;;; Γ |- x : tSort u -> ∑ u', Σ;;; Γ |- x0 : tSort u' × Universe.is_prop u'.
 Proof.
   intros Σ Γ L u x x0 ? ? t1 c0.
   revert u H c0.
@@ -437,9 +437,9 @@ Proof.
     eapply subject_reduction in c0. 3:eauto. 2:eauto.
     eapply inversion_Prod in c0 as (? & ? & ? & ? & ?) ; auto.
     eapply PCUICConversion.cumul_Sort_inv in c0.
-    eapply leq_universe_prop in c0 as []; cbn; eauto.
-
-    eapply is_prop_sort_prod in H0. eapply IHt1. exact H0.
+    eapply leq_universe_prop in c0; cbn; eauto.
+    eapply is_prop_sort_prod in c0. 
+    eapply IHt1. exact c0.
     change (tSort x3) with ((tSort x3) {0 := hd}).
     eapply PCUICSubstitution.substitution0. 2:eauto. eauto.
     econstructor. eassumption. 2: now destruct c. right; eauto.
@@ -459,7 +459,7 @@ Proof.
 Qed.
 
 Lemma Is_type_app (Σ : global_env_ext) Γ t L T :
-  wf Σ ->
+  wf_ext Σ ->
   wf_local Σ Γ ->
   Σ ;;; Γ |- mkApps t L : T ->
   isErasable Σ Γ t ->
@@ -495,10 +495,11 @@ Proof.
     eapply cumul_prop2 in c0; eauto.
     econstructor. exists x0. split. eapply type_mkApps. 2:eassumption. eassumption. right.
     eapply sort_typing_spine in t1; eauto.
+  - eauto.
 Qed.
 
 Lemma Is_type_lambda (Σ : global_env_ext) Γ na T1 t :
-  wf Σ ->
+  wf_ext Σ ->
   wf_local Σ Γ ->
   isErasable Σ Γ (tLambda na T1 t) ->
   ∥isErasable Σ (vass na T1 :: Γ) t∥.
@@ -513,12 +514,9 @@ Proof.
   - sq. eapply cumul_prop1 in c; eauto.
     eapply inversion_Prod in c as (? & ? & ? & ? & ?) ; auto.
     eapply cumul_Sort_inv in c.
-    eapply leq_universe_prop in c as []; cbn; eauto.
+    eapply leq_universe_prop in c; cbn; eauto.
     eexists. split. eassumption. right. eexists. split. eassumption.
-    unfold Universe.sort_of_product in H.
-    destruct ?; eauto.
-
-    eapply is_prop_sort_sup; eauto.
+    now apply is_prop_sort_prod in c.
   - auto.
 Qed.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -36,12 +36,11 @@ Proof.
 Qed.
 
 Lemma is_prop_subst_instance:
-  forall (u : universe_instance) (x0 : universe), is_prop_sort x0 -> is_prop_sort (UnivSubst.subst_instance_univ u x0).
+  forall (u : universe_instance) (x0 : universe), Universe.is_prop x0 -> Universe.is_prop (UnivSubst.subst_instance_univ u x0).
 Proof.
-  intros u x0 i. destruct x0; cbn in *; try congruence.
-  unfold is_prop_sort in *. unfold Universe.level in *.
-  destruct t. destruct t; cbn in *; try congruence.
-  destruct b; cbn in *; try congruence.
+  induction x0; intro Hx0.
+  destruct a as [[] []]; cbn in *; congruence.
+  destruct a as [[] []]; cbn in *; try congruence; auto.
 Qed.
 
 
@@ -934,7 +933,7 @@ Proof.
              intros. eapply (X2 x2 (S n)). eassumption.
         }
 
-        eapply eval_box_apps. eauto. eauto. eapply wf_ext_wf. eauto. eauto.
+        eapply eval_box_apps. eauto. eauto. tas. eauto. eauto.
         eapply subject_reduction. eauto. exact Hty.
         eapply PCUICReduction.red_mkApps. now eapply wcbeval_red.
         eapply All_All2_refl.
@@ -1060,7 +1059,7 @@ Proof.
              intros. eapply (X2 x2 (S n)). eassumption.
         }
 
-        eapply eval_box_apps. eauto. eauto. eapply wf_ext_wf. eauto. eauto.
+        eapply eval_box_apps. eauto. eauto. tas. eauto. eauto.
         eapply subject_reduction. eauto. exact Hty.
         eapply PCUICReduction.red_mkApps. now eapply wcbeval_red.
         eapply All_All2_refl.

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -11,7 +11,7 @@ Import MonadNotation.
 
 Local Existing Instance extraction_checker_flags.
 
-Definition isErasable Σ Γ t := ∑ T, Σ ;;; Γ |- t : T × (isArity T + (∑ u, (Σ ;;; Γ |- T : tSort u) * is_prop_sort u))%type.
+Definition isErasable Σ Γ t := ∑ T, Σ ;;; Γ |- t : T × (isArity T + (∑ u, (Σ ;;; Γ |- T : tSort u) * Universe.is_prop u))%type.
 
 Module E := EAst.
 Local Notation Ret t := t.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -199,7 +199,7 @@ Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ex
     ret (left _)
   else mlet (K; _) <- @type_of extraction_checker_flags Sigma _ _ Gamma T _ ;;
        mlet (u;_) <- @reduce_to_sort _ Sigma _ Gamma K _ ;;
-      match is_prop_sort u with true => ret (left _) | false => ret (right _) end
+      match Universe.is_prop u with true => ret (left _) | false => ret (right _) end
 .
 Next Obligation. sq; eauto. Qed.
 Next Obligation.
@@ -268,8 +268,8 @@ Next Obligation.
     eapply invert_red_sort in r.
     eapply invert_red_sort in r1. subst. inv r1.
 
-    eapply leq_universe_prop in l0 as []; cbn; eauto.
-    eapply leq_universe_prop in l as []; cbn; eauto.
+    eapply leq_universe_prop in l0; cbn; eauto.
+    eapply leq_universe_prop' in l; cbn; eauto.
     eauto using typing_wf_local.
 Qed.
 
@@ -281,7 +281,7 @@ Qed.
 (*     ret (left _) *)
 (*   else mlet (K; _) <-  @make_graph_and_infer _ _ HΣ Gamma HΓ T ;; *)
 (*        mlet (u;_) <- @reduce_to_sort _ Sigma _ Gamma K _ ;; *)
-(*       match is_prop_sort u with true => ret (left _) | false => ret (right _) end *)
+(*       match Universe.is_prop u with true => ret (left _) | false => ret (right _) end *)
 (* . *)
 (* Next Obligation. sq; eauto. Qed. *)
 (* Next Obligation. *)
@@ -368,7 +368,7 @@ Section Erase.
                                   E.dbody := dbody' |})) defs.
     Next Obligation.
       clear erase.
-      destruct (wf_ext_is_graph HΣ) as [].
+      destruct (wf_ext_is_graph (todo "FIXME prop_sub_type") HΣ) as [].
       apply Checked. todo "well-typed fix body".
     Defined.
       (* epose proof ((fix check_types (mfix : mfixpoint term) acc (Hacc : ∥ wf_local_rel Σ Γ acc ∥) {struct mfix} *)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -507,16 +507,18 @@ Section Conversion.
   Definition eqb_term :=
     eqb_term_upto_univ (check_eqb_universe G) (check_eqb_universe G).
 
+  Context (Hcf : prop_sub_type).
+
   Lemma leqb_term_spec t u :
     leqb_term t u ->
     leq_term (global_ext_constraints Σ) t u.
   Proof.
     pose proof hΣ'.
     apply eqb_term_upto_univ_impl.
-    intros u1 u2; eapply (check_eqb_universe_spec G (global_ext_uctx Σ)); tas.
+    intros u1 u2; eapply (check_eqb_universe_spec Hcf G (global_ext_uctx Σ)); tas.
     now eapply wf_ext_global_uctx_invariants.
     now eapply global_ext_uctx_consistent.
-    intros u1 u2; eapply (check_leqb_universe_spec G (global_ext_uctx Σ)); tas.
+    intros u1 u2; eapply (check_leqb_universe_spec Hcf G (global_ext_uctx Σ)); tas.
     now eapply wf_ext_global_uctx_invariants.
     now eapply global_ext_uctx_consistent.
   Qed.
@@ -527,10 +529,10 @@ Section Conversion.
   Proof.
     pose proof hΣ'.
     apply eqb_term_upto_univ_impl.
-    intros u1 u2; eapply (check_eqb_universe_spec G (global_ext_uctx Σ)); tas.
+    intros u1 u2; eapply (check_eqb_universe_spec Hcf G (global_ext_uctx Σ)); tas.
     now eapply wf_ext_global_uctx_invariants.
     now eapply global_ext_uctx_consistent.
-    intros u1 u2; eapply (check_eqb_universe_spec G (global_ext_uctx Σ)); tas.
+    intros u1 u2; eapply (check_eqb_universe_spec Hcf G (global_ext_uctx Σ)); tas.
     now eapply wf_ext_global_uctx_invariants.
     now eapply global_ext_uctx_consistent.
   Qed.
@@ -1430,7 +1432,7 @@ Section Conversion.
     unfold eqb_universe_instance in e.
     eapply forallb2_Forall2 in e.
     eapply Forall2_impl. 1: eassumption.
-    intros. eapply (check_eqb_universe_spec G (global_ext_uctx Σ)).
+    intros. eapply (check_eqb_universe_spec Hcf G (global_ext_uctx Σ)).
     all: auto.
     - eapply wf_ext_global_uctx_invariants.
       eapply hΣ'.

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -14,9 +14,9 @@ Import MonadNotation.
 
 Existing Instance envcheck_monad.
 
-Program Definition infer_template_program {cf : checker_flags} (p : Ast.program) φ Hφ
+Program Definition infer_template_program {cf : checker_flags} (Hcf : prop_sub_type = true) (p : Ast.program) φ Hφ
   : EnvCheck (∑ A, ∥ (trans_global_decls (List.rev p.1), φ) ;;; [] |- trans p.2 : A ∥) :=
-  p <- typecheck_program (cf:=cf) (trans_global_decls p.1, trans p.2) φ Hφ ;;
+  p <- typecheck_program Hcf (trans_global_decls p.1, trans p.2) φ Hφ ;;
   ret (p.π1 ; _).
 
 Next Obligation.
@@ -112,10 +112,10 @@ Definition fix_program_universes (p : Ast.program) : Ast.program :=
   let '(Σ, t) := p in
   (fix_global_env_universes Σ, t).
 
-Program Definition infer_and_print_template_program {cf : checker_flags} (p : Ast.program) φ Hφ
+Program Definition infer_and_print_template_program {cf : checker_flags} (Hcf : prop_sub_type = true) (p : Ast.program) φ Hφ
   : string + string :=
   let p := fix_program_universes p in
-  match infer_template_program (cf:=cf) p φ Hφ return string + string with
+  match infer_template_program Hcf p φ Hφ return string + string with
   | CorrectDecl t =>
     inl ("Environment is well-formed and " ++ string_of_term (trans p.2) ++
          " has type: " ++ string_of_term t.π1)

--- a/test-suite/add_constructor.v
+++ b/test-suite/add_constructor.v
@@ -83,7 +83,7 @@ Inductive tm :=
 | lam : tm -> tm
 | app : tm -> tm -> tm.
 
-Run TemplateProgram (add_constructor <%tm%> "letin" <% (fun tm' => tm' -> tm' -> tm') %>).
+Run TemplateProgram (add_constructor <% tm %> "letin" <% fun tm' => tm' -> tm' -> tm' %>).
 
 Print tm'.
 (* Inductive tm' : Type := *)


### PR DESCRIPTION
Take the prop_sub_type properly in account.

I forgave to do the implementation, for the moment uGraph only suppose prop_sub_type = true.

It introduces a weird inconcictency (the "FIXME prop_sub_type").

It compiles, except the end of ErasureFunction.v.