### PR TITLE
template-coq: Copied definition of option to avoid introducing universe-constrains

### DIFF
--- a/template-coq/src/constr_quoted.ml
+++ b/template-coq/src/constr_quoted.ml
@@ -198,6 +198,9 @@ struct
   let pkg_specif = ["Coq";"Init";"Specif"]
   let texistT = resolve_symbol pkg_specif "existT"
   let texistT_typed_term = r_template_monad_p "existT_typed_term"
+                 
+  let cMySome = resolve_symbol pkg_template_monad "mySome"
+  let cMyNone = resolve_symbol pkg_template_monad "myNone"
 
   let constr_equall h t = Constr.equal h (Lazy.force t)
 

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -461,9 +461,9 @@ let rec run_template_program_rec ?(intactic=false) (k : Environ.env * Evd.evar_m
         | None -> evm, typ in
       try
         let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
-        k (env, evm, constr_mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
+        k (env, evm, constr_mkApp (cMySome, [| typ; EConstr.to_constr evm t|]))
       with
-        Not_found -> k (env, evm, constr_mkApp (cNone, [|typ|]))
+        Not_found -> k (env, evm, constr_mkApp (cMyNone, [|typ|]))
     end
   | TmInferInstanceTerm typ ->
     let evm,typ = denote_term evm (reduce_all env evm typ) in

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -16,6 +16,10 @@ Record typed_term : Type := existT_typed_term
 ; my_projT2 : my_projT1
 }.
 
+Monomorphic Inductive myOption (A : Type) : Type := mySome : A -> myOption A | myNone : myOption A.
+
+Arguments Some {A} a.
+Arguments None {A}.
 
 Record TMInstance@{t u r} :=
 { TemplateMonad : Type@{t} -> Type@{r}

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -55,7 +55,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 
 (* Typeclass registration and querying for an instance *)
 | tmExistingInstance : qualid -> TemplateMonad unit
-| tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
+| tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (myOption A)
 .
 
 Polymorphic Definition tmDefinitionRed


### PR DESCRIPTION
The use of option inside the Template-Coq-monad introduces universe constrains between the type returned by the monad and the universe in which the parameter of option lives. Copying option fixes this.

