### PR TITLE
Repairing TemplateCoq to PCUIC (Updating typing rules)

### DIFF
--- a/checker/theories/Closed.v
+++ b/checker/theories/Closed.v
@@ -1,7 +1,8 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
-From MetaCoq.Template Require Import config utils Ast AstUtils Induction utils LiftSubst.
+From MetaCoq.Template Require Import config utils Ast AstUtils Induction utils
+  LiftSubst UnivSubst.
 From MetaCoq.Checker Require Import Typing TypingWf WeakeningEnv.
 Require Import ssreflect ssrbool.
 Require Import Equations.Prop.DepElim.
@@ -445,4 +446,21 @@ Proof.
   case: d => na [body|] ty; rewrite /closed_decl /=.
   move/andP => [cb cty] k' lek'. do 2 rewrite (@closed_upwards k) //.
   move=> cty k' lek'; rewrite (@closed_upwards k) //.
+Qed.
+
+Lemma rev_subst_instance_context u Γ :
+  List.rev (subst_instance_context u Γ) = subst_instance_context u (List.rev Γ).
+Proof.
+  unfold subst_instance_context, map_context.
+  now rewrite map_rev.
+Qed.
+
+Lemma closedn_subst_instance_context k Γ u :
+  closedn_ctx k (subst_instance_context u Γ) = closedn_ctx k Γ.
+Proof.
+  unfold closedn_ctx; f_equal.
+  rewrite rev_subst_instance_context.
+  rewrite mapi_map. apply mapi_ext.
+  intros n [? [] ?]; unfold closed_decl; cbn.
+  all: now rewrite !closedn_subst_instance_constr.
 Qed.

--- a/checker/theories/Substitution.v
+++ b/checker/theories/Substitution.v
@@ -1720,7 +1720,7 @@ Theorem substitution `{checker_flags} Σ Γ Γ' s Δ (t : term) T :
   Σ ;;; Γ ,,, Γ' ,,, Δ |- t : T ->
   wf_local Σ (Γ ,,, subst_context s 0 Δ) ->
   Σ ;;; Γ ,,, subst_context s 0 Δ |- subst s #|Δ| t : subst s #|Δ| T.
-(* Proof.
+Proof.
   intros HΣ Hs Ht.
   pose proof (typing_wf_local Ht).
   generalize_eqs Ht. intros eqw. rewrite <- eqw in X.
@@ -1831,10 +1831,11 @@ Theorem substitution `{checker_flags} Σ Γ Γ' s Δ (t : term) T :
 
   - eapply refine_type. econstructor; eauto.
     symmetry.
-    apply on_declared_constructor in isdecl as [_ onc]; auto.
-    eapply on_constructor_closed_wf in onc as [clty wfty]; auto.
+    destruct (on_declared_constructor wfΣ isdecl) as [? [cs [? onc]]].
+    eapply on_constructor_closed_wf in onc as [clty wty]; auto.
     unfold type_of_constructor.
-    apply subst_closedn; eauto. eapply closed_upwards; eauto. lia.
+    apply subst_closedn. 1: eauto with wf.
+    eapply closed_upwards; eauto. lia.
 
   - rewrite subst_mkApps map_app map_skipn.
     specialize (X2 Γ Γ' Δ s sub eq_refl wfsubs).
@@ -2015,8 +2016,6 @@ Theorem substitution `{checker_flags} Σ Γ Γ' s Δ (t : term) T :
     + right; exists u; intuition eauto.
     + eapply substitution_cumul; eauto.
       now eapply typing_wf in X0.
-Qed. *)
-  todo "substitution"%string.
 Qed.
 
 Theorem substitution_alt `{checker_flags} Σ Γ Γ' s Δ (t : term) T :

--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -325,9 +325,9 @@ Proof.
     induction X1. constructor. econstructor; eauto with extends.
     eapply weakening_env_cumul in cumul; eauto.
   - econstructor; eauto 2 with extends.
-    eapply check_correct_arity_subset; tea.
-    apply weakening_env_global_ext_constraints; tas.
-    close_Forall. intros; intuition eauto with extends.
+    + eapply check_correct_arity_subset; tea.
+      apply weakening_env_global_ext_constraints; tas.
+    + close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
     eapply All_local_env_impl. eapply X.
     clear -wfΣ' extΣ. simpl; intros.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -1307,18 +1307,21 @@ Proof.
        simpl in X14. forward X14; auto. lia. apply X14.
 
     -- eapply X8; eauto.
-       eapply (X14 _ wfΓ _ _ H); eauto. simpl; auto with arith.
-       eapply (X14 _ wfΓ _ _ H); eauto. simpl; auto with arith. simpl in *.
-       eapply (X14 _ wfΓ _ _ H0); eauto. lia.
-       clear X13. revert a wfΓ X14. simpl. clear. intros.
-       induction a; simpl in *. constructor.
-       destruct r as [[? ?] ?]. constructor. intuition eauto.
-       eapply (X14 _ wfΓ _ _ t); eauto. simpl; auto with arith.
-       lia.
-       eapply (X14 _ wfΓ _ _ t0); eauto. simpl; auto with arith.
-       lia.
-       apply IHa. auto. intros.
-       eapply (X14 _ wfΓ0 _ _ Hty). lia.
+       ++ eapply (X14 _ wfΓ _ _ H); eauto. simpl; auto with arith.
+       ++ eapply (X14 _ wfΓ _ _ H); eauto. simpl; auto with arith.
+       ++ simpl in *.
+          eapply (X14 _ wfΓ _ _ H0); eauto. lia.
+       ++ clear X13. revert a wfΓ X14. simpl. clear. intros.
+          induction a; simpl in *.
+          ** constructor.
+          ** destruct r as [[? ?] ?]. constructor.
+             --- intuition eauto.
+                 +++ eapply (X14 _ wfΓ _ _ t); eauto. simpl; auto with arith.
+                     lia.
+                 +++ eapply (X14 _ wfΓ _ _ t0); eauto. simpl; auto with arith.
+                     lia.
+             --- apply IHa. auto. intros.
+                 eapply (X14 _ wfΓ0 _ _ Hty). lia.
 
     -- eapply X9; eauto.
        specialize (X14 [] localenv_nil _ _ (type_Prop _)).

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -305,15 +305,16 @@ Proof.
     rename_all_hyps; try solve [econstructor; eauto 2 with extends].
 
   - econstructor; eauto 2 with extends.
-    eapply check_correct_arity_subset; tea.
-    apply weakening_env_global_ext_constraints; tas.
-    close_Forall. intros; intuition eauto with extends.
+    + eapply check_correct_arity_subset; tea.
+      apply weakening_env_global_ext_constraints; tas.
+    + close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
-    eapply All_local_env_impl. eapply X.
-    clear -wfΣ' extΣ. simpl; intros.
-    unfold lift_typing in *; destruct T; intuition eauto with extends.
-    destruct X as [u [tyu Hu]]. exists u. eauto.
-    eapply All_impl; eauto; simpl; intuition eauto with extends.
+    + eapply All_local_env_impl.
+      * eapply X.
+      * clear -wfΣ' extΣ. simpl; intros.
+        unfold lift_typing in *; destruct T; intuition eauto with extends.
+        destruct X as [u [tyu Hu]]. exists u. eauto.
+    + eapply All_impl; eauto; simpl; intuition eauto with extends.
   - econstructor; eauto with extends. auto.
     eapply All_local_env_impl. eapply X.
     clear -wfΣ' extΣ. simpl; intros.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -1038,8 +1038,6 @@ Proof.
     -- rewrite trans_mkApps in X4; auto with wf.
        eapply typing_wf in X3; auto. intuition. eapply wf_mkApps_inv in H4; auto.
     -- apply All2_map. solve_all.
-       (* TODO Update type_Case for TemplateCoq *)
-       admit.
 
   - destruct pdecl as [arity ty]; simpl in *.
     pose proof (TypingWf.declared_projection_wf _ _ u _ _ _ isdecl).


### PR DESCRIPTION
The translation has been broken for quite some time because changes were made in PCUIC and not in TemplateCoq.
#328 allowed us to close the gap for the definition of environments and their typing.
This PR will focus on the typing rules—mainly that of pattern-matching—and try to address the no longer correct translation.

I rehabilitate the substitution and weakening lemmata, as well as `typing_wf`, modulo some lemma that was also not proven.