### PR TITLE
[WIP] Refactor conversion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,6 +355,10 @@ pcuic/src/pCUICUtils.mli
 /erasure/src/pCUICSafeRetyping.mli
 /erasure/src/safeErasureFunction.ml
 /erasure/src/safeErasureFunction.mli
+erasure/src/pCUICConversion.ml
+erasure/src/pCUICConversion.mli
+erasure/src/pCUICReduction.ml
+erasure/src/pCUICReduction.mli
 
 template-coq/gen-src/cRelationClasses.mli.rej
 .DS_Store

--- a/checker/_CoqProject.in
+++ b/checker/_CoqProject.in
@@ -7,6 +7,8 @@ theories/wGraph.v
 theories/uGraph.v
 theories/LibHypsNaming.v
 theories/WfInv.v
+theories/Reduction.v
+theories/Conversion.v
 theories/Typing.v
 theories/TypingWf.v
 theories/Generation.v

--- a/checker/_PluginProject.in
+++ b/checker/_PluginProject.in
@@ -17,6 +17,10 @@ src/signature.ml
 # src/logic1.ml
 src/init.mli
 src/init.ml
+# src/relation0.ml
+# src/relation0.mli
+# src/relation_Properties.ml
+# src/relation_Properties.mli
 
 src/liftSubst.ml
 src/liftSubst.mli
@@ -28,6 +32,10 @@ src/environmentTyping.ml
 src/environmentTyping.mli
 src/retyping0.ml
 src/retyping0.mli
+src/reduction0.mli
+src/reduction0.ml
+src/conversion0.mli
+src/conversion0.ml
 src/typing0.ml
 src/typing0.mli
 src/typingWf.ml

--- a/checker/src/metacoq_checker_plugin.mlpack
+++ b/checker/src/metacoq_checker_plugin.mlpack
@@ -5,6 +5,8 @@ WGraph
 Monad_utils
 UGraph0
 EnvironmentTyping
+Reduction0
+Conversion0
 Typing0
 Checker0
 Retyping0

--- a/checker/theories/Closed.v
+++ b/checker/theories/Closed.v
@@ -322,9 +322,9 @@ Proof.
   - intuition auto. solve_all. unfold test_snd. simpl in *.
     toProp; eauto.
     apply closedn_mkApps; auto.
-    rewrite forallb_app. simpl. rewrite H3.
+    rewrite forallb_app. simpl. rewrite H2.
     rewrite forallb_skipn; auto.
-    now apply closedn_mkApps_inv in H7.
+    now apply closedn_mkApps_inv in H6.
 
   - intuition auto.
     apply closedn_subst0.

--- a/checker/theories/Conversion.v
+++ b/checker/theories/Conversion.v
@@ -1,0 +1,248 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia.
+
+From MetaCoq.Template Require Import config utils Ast AstUtils Induction LiftSubst UnivSubst EnvironmentTyping.
+From MetaCoq.Checker Require Import LibHypsNaming Reflect Reduction.
+
+From Equations Require Import Equations.
+Require Import Equations.Prop.DepElim.
+Require Import ssreflect.
+
+(* Type-valued relations. *)
+Require Import CRelationClasses.
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+
+(** ** Term equality and cumulativity *)
+
+(* ** Syntactic equality up-to universes
+
+  We shouldn't look at printing annotations nor casts.
+  It is however not possible to write a structurally recursive definition
+  for syntactic equality up-to casts due to the [tApp (tCast f _ _) args] case.
+  We hence implement first an equality which considers casts and do a stripping
+  phase of casts before checking equality. *)
+
+
+Inductive eq_term_upto_univ (Re Rle : universe -> universe -> Prop) : term -> term -> Prop :=
+| eq_Rel n  :
+    eq_term_upto_univ Re Rle (tRel n) (tRel n)
+
+| eq_Evar e args args' :
+    Forall2 (eq_term_upto_univ Re Re) args args' ->
+    eq_term_upto_univ Re Rle (tEvar e args) (tEvar e args')
+
+| eq_Var id :
+    eq_term_upto_univ Re Rle (tVar id) (tVar id)
+
+| eq_Sort s s' :
+    Rle s s' ->
+    eq_term_upto_univ Re Rle (tSort s) (tSort s')
+
+| eq_Cast f f' k T T' :
+    eq_term_upto_univ Re Re f f' ->
+    eq_term_upto_univ Re Re T T' ->
+    eq_term_upto_univ Re Rle (tCast f k T) (tCast f' k T')
+
+| eq_App t t' args args' :
+    eq_term_upto_univ Re Rle t t' ->
+    Forall2 (eq_term_upto_univ Re Re) args args' ->
+    eq_term_upto_univ Re Rle (tApp t args) (tApp t' args')
+
+| eq_Const c u u' :
+    Forall2 Rle (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ Re Rle (tConst c u) (tConst c u')
+
+| eq_Ind i u u' :
+    Forall2 Rle (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ Re Rle (tInd i u) (tInd i u')
+
+| eq_Construct i k u u' :
+    Forall2 Rle (List.map Universe.make u) (List.map Universe.make u') ->
+    eq_term_upto_univ Re Rle (tConstruct i k u) (tConstruct i k u')
+
+| eq_Lambda na na' ty ty' t t' :
+    eq_term_upto_univ Re Re ty ty' ->
+    eq_term_upto_univ Re Rle t t' ->
+    eq_term_upto_univ Re Rle (tLambda na ty t) (tLambda na' ty' t')
+
+| eq_Prod na na' a a' b b' :
+    eq_term_upto_univ Re Re a a' ->
+    eq_term_upto_univ Re Rle b b' ->
+    eq_term_upto_univ Re Rle (tProd na a b) (tProd na' a' b')
+
+| eq_LetIn na na' ty ty' t t' u u' :
+    eq_term_upto_univ Re Re ty ty' ->
+    eq_term_upto_univ Re Re t t' ->
+    eq_term_upto_univ Re Rle u u' ->
+    eq_term_upto_univ Re Rle (tLetIn na ty t u) (tLetIn na' ty' t' u')
+
+| eq_Case ind par p p' c c' brs brs' :
+    eq_term_upto_univ Re Re p p' ->
+    eq_term_upto_univ Re Re c c' ->
+    Forall2 (fun x y =>
+      fst x = fst y /\
+      eq_term_upto_univ Re Re (snd x) (snd y)
+    ) brs brs' ->
+    eq_term_upto_univ Re Rle (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
+
+| eq_Proj p c c' :
+    eq_term_upto_univ Re Re c c' ->
+    eq_term_upto_univ Re Rle (tProj p c) (tProj p c')
+
+| eq_Fix mfix mfix' idx :
+    Forall2 (fun x y =>
+      eq_term_upto_univ Re Re x.(dtype) y.(dtype) /\
+      eq_term_upto_univ Re Re x.(dbody) y.(dbody) /\
+      x.(rarg) = y.(rarg)
+    ) mfix mfix' ->
+    eq_term_upto_univ Re Rle (tFix mfix idx) (tFix mfix' idx)
+
+| eq_CoFix mfix mfix' idx :
+    Forall2 (fun x y =>
+      eq_term_upto_univ Re Re x.(dtype) y.(dtype) /\
+      eq_term_upto_univ Re Re x.(dbody) y.(dbody) /\
+      x.(rarg) = y.(rarg)
+    ) mfix mfix' ->
+    eq_term_upto_univ Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
+
+Definition eq_term `{checker_flags} φ :=
+  eq_term_upto_univ (eq_universe φ) (eq_universe φ).
+
+(* ** Syntactic cumulativity up-to universes
+
+  We shouldn't look at printing annotations *)
+
+Definition leq_term `{checker_flags} φ :=
+  eq_term_upto_univ (eq_universe φ) (leq_universe φ).
+
+Fixpoint strip_casts t :=
+  match t with
+  | tEvar ev args => tEvar ev (List.map strip_casts args)
+  | tLambda na T M => tLambda na (strip_casts T) (strip_casts M)
+  | tApp u v => mkApps (strip_casts u) (List.map (strip_casts) v)
+  | tProd na A B => tProd na (strip_casts A) (strip_casts B)
+  | tCast c kind t => strip_casts c
+  | tLetIn na b t b' => tLetIn na (strip_casts b) (strip_casts t) (strip_casts b')
+  | tCase ind p c brs =>
+    let brs' := List.map (on_snd (strip_casts)) brs in
+    tCase ind (strip_casts p) (strip_casts c) brs'
+  | tProj p c => tProj p (strip_casts c)
+  | tFix mfix idx =>
+    let mfix' := List.map (map_def strip_casts strip_casts) mfix in
+    tFix mfix' idx
+  | tCoFix mfix idx =>
+    let mfix' := List.map (map_def strip_casts strip_casts) mfix in
+    tCoFix mfix' idx
+  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => t
+  end.
+
+Definition eq_term_nocast `{checker_flags} (φ : constraints) (t u : term) :=
+  eq_term φ (strip_casts t) (strip_casts u).
+
+Definition leq_term_nocast `{checker_flags} (φ : constraints) (t u : term) :=
+  leq_term φ (strip_casts t) (strip_casts u).
+
+(** ** Cumulativity and Conversion ** *)
+
+Reserved Notation " Σ ;;; Γ |- t <= u " (at level 50, Γ, t, u at next level).
+Reserved Notation " Σ ;;; Γ |- t = u " (at level 50, Γ, t, u at next level).
+
+Inductive cumul `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| cumul_refl t u : leq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t <= u
+| cumul_red_l t u v : red1 Σ.1 Γ t v -> Σ ;;; Γ |- v <= u -> Σ ;;; Γ |- t <= u
+| cumul_red_r t u v : Σ ;;; Γ |- t <= v -> red1 Σ.1 Γ u v -> Σ ;;; Γ |- t <= u
+where " Σ ;;; Γ |- t <= u " := (cumul Σ Γ t u) : type_scope.
+
+
+Inductive conv `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| conv_refl t u : eq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t = u
+| conv_red_l t u v : red1 Σ Γ t v -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- t = u
+| conv_red_r t u v : Σ ;;; Γ |- t = v -> red1 (fst Σ) Γ u v -> Σ ;;; Γ |- t = u
+where " Σ ;;; Γ |- t = u " := (@conv _ Σ Γ t u) : type_scope.
+
+
+Lemma cumul_alt {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- t <= u <~> ∑ v v', red Σ Γ t v × red Σ Γ u v' × leq_term Σ v v'.
+Proof.
+  split.
+  { induction 1. exists t, u. intuition auto; constructor.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step. }
+  { intros [v [v' [redv [redv' Hleq]]]]. apply red_alt in redv.
+    apply red_alt in redv'.
+    apply clos_rt_rt1n in redv.
+    apply clos_rt_rt1n in redv'.
+    induction redv. induction redv'. constructor; auto.
+    econstructor 3; eauto.
+    econstructor 2; eauto. }
+Qed.
+
+
+Lemma conv_alt {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- t = u <~> ∑ v v', red Σ Γ t v × red Σ Γ u v' × eq_term Σ v v'.
+Proof.
+  split.
+  { induction 1. exists t, u. intuition auto; constructor.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step. }
+  { intros [v [v' [redv [redv' Hleq]]]]. apply red_alt in redv.
+    apply red_alt in redv'.
+    apply clos_rt_rt1n in redv.
+    apply clos_rt_rt1n in redv'.
+    induction redv. induction redv'. constructor; auto.
+    econstructor 3; eauto.
+    econstructor 2; eauto. }
+Qed.
+
+
+
+
+(** ** Context conversion ** *)
+
+Inductive context_relation
+          (P : context -> context -> context_decl -> context_decl -> Type)
+          : forall (Γ Γ' : context), Type :=
+| ctx_rel_nil : context_relation P nil nil
+| ctx_rel_vass na na' T U Γ Γ' :
+    context_relation P Γ Γ' ->
+    P Γ Γ' (vass na T) (vass na' U) ->
+    context_relation P (vass na T :: Γ) (vass na' U :: Γ')
+| ctx_rel_def na na' t T u U Γ Γ' :
+    context_relation P Γ Γ' ->
+    P Γ Γ' (vdef na t T) (vdef na' u U) ->
+    context_relation P (vdef na t T :: Γ) (vdef na' u U :: Γ').
+Derive Signature for context_relation.
+Arguments context_relation P Γ Γ' : clear implicits.
+
+Section ConvContext.
+
+  Context {cf:checker_flags} (Σ : global_env_ext).
+
+  Inductive conv_decls (Γ Γ' : context) : forall (x y : context_decl), Type :=
+  | conv_vass na na' T T' :
+      (* isType Σ Γ' T' -> *)
+      Σ ;;; Γ |- T = T' ->
+      conv_decls Γ Γ' (vass na T) (vass na' T')
+
+  | conv_vdef_type na na' b T T' :
+      (* isType Σ Γ' T' -> *)
+      Σ ;;; Γ |- T = T' ->
+      conv_decls Γ Γ' (vdef na b T) (vdef na' b T')
+
+  | conv_vdef_body na na' b b' T T' :
+      (* isType Σ Γ' T' -> *)
+      (* Σ ;;; Γ' |- b' : T' -> *)
+      Σ ;;; Γ |- b = b' ->
+      Σ ;;; Γ |- T = T' ->
+      conv_decls Γ Γ' (vdef na b T) (vdef na' b' T').
+
+End ConvContext.
+
+Notation conv_context Σ Γ Γ' := (context_relation (conv_decls Σ) Γ Γ').

--- a/checker/theories/Extraction.v
+++ b/checker/theories/Extraction.v
@@ -18,7 +18,8 @@ Extract Constant utils.ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt".
 
 Extraction Blacklist config uGraph Universes Ast String List Nat Int
-           UnivSubst Typing Checker Retyping OrderedType Logic Common Equality.
+           Reduction Conversion
+           UnivSubst Typing Checker Retyping OrderedType Logic (* Logic0 *) Common Equality.
 Set Warnings "-extraction-opaque-accessed".
 
 Require Export MetaCoq.Template.Ast.
@@ -48,9 +49,12 @@ Extraction Inline Equations.Init.pr2.
 Extraction Inline Equations.Init.hidebody.
 Extraction Inline Equations.Prop.DepElim.solution_left.
 
+(* Extraction Library Logic. *)
 Extraction Library Signature.
 Extraction Library Classes.
+(* Extraction Library Relation_Properties. *)
 Extraction Library ssreflect.
+(* Extraction Library Relation. *)
 Extraction Library CMorphisms.
 
 (** From checker *)
@@ -59,6 +63,8 @@ Extraction Library Reflect.
 Extraction Library LiftSubst.
 Extraction Library UnivSubst.
 Extraction Library monad_utils.
+Extraction Library Reduction.
+Extraction Library Conversion.
 Extraction Library Typing.
 Extraction Library TypingWf.
 Extraction Library wGraph.

--- a/checker/theories/Reduction.v
+++ b/checker/theories/Reduction.v
@@ -1,0 +1,480 @@
+
+From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia.
+
+From MetaCoq.Template Require Import config utils Ast AstUtils Induction LiftSubst UnivSubst EnvironmentTyping.
+From MetaCoq.Checker Require Import LibHypsNaming Reflect.
+
+From Equations Require Import Equations.
+Require Import Equations.Prop.DepElim.
+Require Import ssreflect.
+
+(* Type-valued relations. *)
+Require Import CRelationClasses.
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+
+Module TemplateLookup := Lookup TemplateTerm TemplateEnvironment.
+Include TemplateLookup.
+
+(** ** Reduction *)
+
+(** *** Helper functions for reduction *)
+
+Definition fix_subst (l : mfixpoint term) :=
+  let fix aux n :=
+      match n with
+      | 0 => []
+      | S n => tFix l n :: aux n
+      end
+  in aux (List.length l).
+
+Definition unfold_fix (mfix : mfixpoint term) (idx : nat) :=
+  match List.nth_error mfix idx with
+  | Some d => Some (d.(rarg), subst0 (fix_subst mfix) d.(dbody))
+  | None => None
+  end.
+
+Definition cofix_subst (l : mfixpoint term) :=
+  let fix aux n :=
+      match n with
+      | 0 => []
+      | S n => tCoFix l n :: aux n
+      end
+  in aux (List.length l).
+
+Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
+  match List.nth_error mfix idx with
+  | Some d => Some (d.(rarg), subst0 (cofix_subst mfix) d.(dbody))
+  | None => None
+  end.
+
+Definition isConstruct_app t :=
+  match fst (decompose_app t) with
+  | tConstruct _ _ _ => true
+  | _ => false
+  end.
+
+Definition is_constructor n ts :=
+  match List.nth_error ts n with
+  | Some a => isConstruct_app a
+  | None => false
+  end.
+
+Lemma fix_subst_length mfix : #|fix_subst mfix| = #|mfix|.
+Proof.
+  unfold fix_subst. generalize (tFix mfix). intros.
+  induction mfix; simpl; auto.
+Qed.
+
+Lemma cofix_subst_length mfix : #|cofix_subst mfix| = #|mfix|.
+Proof.
+  unfold cofix_subst. generalize (tCoFix mfix). intros.
+  induction mfix; simpl; auto.
+Qed.
+
+Definition fix_context (m : mfixpoint term) : context :=
+  List.rev (mapi (fun i d => vass d.(dname) (lift0 i d.(dtype))) m).
+
+Lemma fix_context_length mfix : #|fix_context mfix| = #|mfix|.
+Proof. unfold fix_context. now rewrite List.rev_length mapi_length. Qed.
+
+Definition tDummy := tVar "".
+
+Definition iota_red npar c args brs :=
+  (mkApps (snd (List.nth c brs (0, tDummy))) (List.skipn npar args)).
+
+
+(** *** One step strong beta-zeta-iota-fix-delta reduction
+
+  Inspired by the reduction relation from Coq in Coq [Barras'99].
+*)
+
+Local Open Scope type_scope.
+Arguments OnOne2 {A} P%type l l'.
+
+Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
+(** Reductions *)
+(** Beta *)
+| red_beta na t b a l :
+    red1 Σ Γ (tApp (tLambda na t b) (a :: l)) (mkApps (subst10 a b) l)
+
+(** Let *)
+| red_zeta na b t b' :
+    red1 Σ Γ (tLetIn na b t b') (subst10 b b')
+
+| red_rel i body :
+    option_map decl_body (nth_error Γ i) = Some (Some body) ->
+    red1 Σ Γ (tRel i) (lift0 (S i) body)
+
+(** Case *)
+| red_iota ind pars c u args p brs :
+    red1 Σ Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs)
+         (iota_red pars c args brs)
+
+(** Fix unfolding, with guard *)
+| red_fix mfix idx args narg fn :
+    unfold_fix mfix idx = Some (narg, fn) ->
+    is_constructor narg args = true ->
+    red1 Σ Γ (tApp (tFix mfix idx) args) (tApp fn args)
+
+(** CoFix-case unfolding *)
+| red_cofix_case ip p mfix idx args narg fn brs :
+    unfold_cofix mfix idx = Some (narg, fn) ->
+    red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
+         (tCase ip p (mkApps fn args) brs)
+
+(** CoFix-proj unfolding *)
+| red_cofix_proj p mfix idx args narg fn :
+    unfold_cofix mfix idx = Some (narg, fn) ->
+    red1 Σ Γ (tProj p (mkApps (tCoFix mfix idx) args))
+         (tProj p (mkApps fn args))
+(* FIXME: We should really be dual to Fix: ask directly
+   for the constructor, applied, and project the argument:
+
+    unfold_cofix mfix idx = Some (narg, mkApps (tConstruct ind c u) args') ->
+    nth_error args' (pars + narg) = Some arg ->
+    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tCoFix mfix idx) args))
+             (mkApps arg args)
+
+    Otherwise confluence fails, AFAICT.
+
+    (tProj (i, pars, narg) (mkApps fn args))
+*)
+(** Constant unfolding *)
+| red_delta c decl body (isdecl : declared_constant Σ c decl) u :
+    decl.(cst_body) = Some body ->
+    red1 Σ Γ (tConst c u) (subst_instance_constr u body)
+
+(** Proj *)
+| red_proj i pars narg args k u arg:
+    nth_error args (pars + narg) = Some arg ->
+    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg
+
+
+| abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
+| abs_red_r na M M' N : red1 Σ (Γ ,, vass na N) M M' -> red1 Σ Γ (tLambda na N M) (tLambda na N M')
+
+| letin_red_def na b t b' r : red1 Σ Γ b r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na r t b')
+| letin_red_ty na b t b' r : red1 Σ Γ t r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b r b')
+| letin_red_body na b t b' r : red1 Σ (Γ ,, vdef na b t) b' r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b t r)
+
+| case_red_pred ind p p' c brs : red1 Σ Γ p p' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p' c brs)
+| case_red_discr ind p c c' brs : red1 Σ Γ c c' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c' brs)
+| case_red_brs ind p c brs brs' : OnOne2 (fun x y => red1 Σ Γ (snd x) (snd y)) brs brs' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c brs')
+
+| proj_red p c c' : red1 Σ Γ c c' -> red1 Σ Γ (tProj p c) (tProj p c')
+
+| app_red_l M1 N1 M2 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tApp M1 M2) (mkApps N1 M2)
+| app_red_r M2 N2 M1 : OnOne2 (red1 Σ Γ) M2 N2 -> red1 Σ Γ (tApp M1 M2) (tApp M1 N2)
+
+| prod_red_l na M1 M2 N1 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tProd na M1 M2) (tProd na N1 M2)
+| prod_red_r na M2 N2 M1 : red1 Σ (Γ ,, vass na M1) M2 N2 ->
+                               red1 Σ Γ (tProd na M1 M2) (tProd na M1 N2)
+
+| evar_red ev l l' : OnOne2 (red1 Σ Γ) l l' -> red1 Σ Γ (tEvar ev l) (tEvar ev l')
+
+| cast_red_l M1 k M2 N1 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tCast M1 k M2) (tCast N1 k M2)
+| cast_red_r M2 k N2 M1 : red1 Σ Γ M2 N2 -> red1 Σ Γ (tCast M1 k M2) (tCast M1 k N2)
+| cast_red M1 k M2 : red1 Σ Γ (tCast M1 k M2) M1
+
+| fix_red_ty mfix0 mfix1 idx :
+    OnOne2 (fun d0 d1 => red1 Σ Γ (dtype d0) (dtype d1) * (dbody d0 = dbody d1))%type mfix0 mfix1 ->
+    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
+
+| fix_red_body mfix0 mfix1 idx :
+    OnOne2 (fun d0 d1 => red1 Σ (Γ ,,, fix_context mfix0) (dbody d0) (dbody d1) * (dtype d0 = dtype d1))
+           mfix0 mfix1 ->
+    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
+
+| cofix_red_ty mfix0 mfix1 idx :
+    OnOne2 (fun d0 d1 => red1 Σ Γ (dtype d0) (dtype d1) * (dbody d0 = dbody d1))%type mfix0 mfix1 ->
+    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)
+
+| cofix_red_body mfix0 mfix1 idx :
+    OnOne2 (fun d0 d1 => red1 Σ (Γ ,,, fix_context mfix0) (dbody d0) (dbody d1) * (dtype d0 = dtype d1))%type mfix0 mfix1 ->
+    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx).
+
+Lemma red1_ind_all :
+  forall (Σ : global_env) (P : context -> term -> term -> Type),
+       (forall (Γ : context) (na : name) (t b a : term) (l : list term),
+        P Γ (tApp (tLambda na t b) (a :: l)) (mkApps (b {0 := a}) l)) ->
+       (forall (Γ : context) (na : name) (b t b' : term), P Γ (tLetIn na b t b') (b' {0 := b})) ->
+
+       (forall (Γ : context) (i : nat) (body : term),
+        option_map decl_body (nth_error Γ i) = Some (Some body) -> P Γ (tRel i) ((lift0 (S i)) body)) ->
+
+       (forall (Γ : context) (ind : inductive) (pars c : nat) (u : universe_instance) (args : list term)
+          (p : term) (brs : list (nat * term)),
+        P Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs) (iota_red pars c args brs)) ->
+
+       (forall (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
+        unfold_fix mfix idx = Some (narg, fn) ->
+        is_constructor narg args = true -> P Γ (tApp (tFix mfix idx) args) (tApp fn args)) ->
+       (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
+          (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
+        unfold_cofix mfix idx = Some (narg, fn) ->
+        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
+
+       (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
+          (narg : nat) (fn : term),
+        unfold_cofix mfix idx = Some (narg, fn) -> P Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
+
+       (forall (Γ : context) (c : ident) (decl : constant_body) (body : term),
+        declared_constant Σ c decl ->
+        forall u : universe_instance, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
+
+       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (k : nat) (u : universe_instance)
+         (arg : term),
+           nth_error args (pars + narg) = Some arg ->
+           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg) ->
+
+       (forall (Γ : context) (na : name) (M M' N : term),
+        red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->
+
+       (forall (Γ : context) (na : name) (M M' N : term),
+        red1 Σ (Γ,, vass na N) M M' -> P (Γ,, vass na N) M M' -> P Γ (tLambda na N M) (tLambda na N M')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ Γ b r -> P Γ b r -> P Γ (tLetIn na b t b') (tLetIn na r t b')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ Γ t r -> P Γ t r -> P Γ (tLetIn na b t b') (tLetIn na b r b')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ (Γ,, vdef na b t) b' r -> P (Γ,, vdef na b t) b' r -> P Γ (tLetIn na b t b') (tLetIn na b t r)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p p' c : term) (brs : list (nat * term)),
+        red1 Σ Γ p p' -> P Γ p p' -> P Γ (tCase ind p c brs) (tCase ind p' c brs)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p c c' : term) (brs : list (nat * term)),
+        red1 Σ Γ c c' -> P Γ c c' -> P Γ (tCase ind p c brs) (tCase ind p c' brs)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p c : term) (brs brs' : list (nat * term)),
+           OnOne2 (fun x y : nat * term => red1 Σ Γ (snd x) (snd y) * P Γ (snd x) (snd y)) brs brs' ->
+           P Γ (tCase ind p c brs) (tCase ind p c brs')) ->
+
+       (forall (Γ : context) (p : projection) (c c' : term), red1 Σ Γ c c' -> P Γ c c' -> P Γ (tProj p c) (tProj p c')) ->
+
+       (forall (Γ : context) (M1 N1 : term) (M2 : list term), red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tApp M1 M2) (mkApps N1 M2)) ->
+
+       (forall (Γ : context) (M2 N2 : list term) (M1 : term), OnOne2 (fun x y => red1 Σ Γ x y * P Γ x y)%type M2 N2 -> P Γ (tApp M1 M2) (tApp M1 N2)) ->
+
+       (forall (Γ : context) (na : name) (M1 M2 N1 : term),
+        red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tProd na M1 M2) (tProd na N1 M2)) ->
+
+       (forall (Γ : context) (na : name) (M2 N2 M1 : term),
+        red1 Σ (Γ,, vass na M1) M2 N2 -> P (Γ,, vass na M1) M2 N2 -> P Γ (tProd na M1 M2) (tProd na M1 N2)) ->
+
+       (forall (Γ : context) (ev : nat) (l l' : list term), OnOne2 (fun x y => red1 Σ Γ x y * P Γ x y) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
+
+       (forall (Γ : context) (M1 : term) (k : cast_kind) (M2 N1 : term),
+        red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tCast M1 k M2) (tCast N1 k M2)) ->
+
+       (forall (Γ : context) (M2 : term) (k : cast_kind) (N2 M1 : term),
+        red1 Σ Γ M2 N2 -> P Γ M2 N2 -> P Γ (tCast M1 k M2) (tCast M1 k N2)) ->
+
+       (forall (Γ : context) (M1 : term) (k : cast_kind) (M2 : term),
+           P Γ (tCast M1 k M2) M1) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (fun d0 d1 : def term => red1 Σ Γ (dtype d0) (dtype d1) * (dbody d0 = dbody d1) * P Γ (dtype d0) (dtype d1)) mfix0 mfix1 ->
+        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (fun d0 d1 : def term =>
+                  red1 Σ (Γ ,,, fix_context mfix0) (dbody d0) (dbody d1) * (dtype d0 = dtype d1) *
+                  P (Γ ,,, fix_context mfix0) (dbody d0) (dbody d1)) mfix0 mfix1 ->
+        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (fun d0 d1 : def term => red1 Σ Γ (dtype d0) (dtype d1) * (dbody d0 = dbody d1) *
+                                        P Γ (dtype d0) (dtype d1)) mfix0 mfix1 ->
+        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (fun d0 d1 : def term => red1 Σ (Γ ,,, fix_context mfix0) (dbody d0) (dbody d1) * (dtype d0 = dtype d1) * P (Γ ,,, fix_context mfix0) (dbody d0) (dbody d1)) mfix0 mfix1 ->
+        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
+
+       forall (Γ : context) (t t0 : term), red1 Σ Γ t t0 -> P Γ t t0.
+Proof.
+  intros. rename X29 into Xlast. revert Γ t t0 Xlast.
+  fix aux 4. intros Γ t T.
+  move aux at top.
+  destruct 1; match goal with
+              | |- P _ (tFix _ _) (tFix _ _) => idtac
+              | |- P _ (tCoFix _ _) (tCoFix _ _) => idtac
+              | |- P _ (tApp (tFix _ _) _) _ => idtac
+              | |- P _ (tCase _ _ (mkApps (tCoFix _ _) _) _) _ => idtac
+              | |- P _ (tProj _ (mkApps (tCoFix _ _) _)) _ => idtac
+              | H : _ |- _ => eapply H; eauto
+              end.
+  - eapply X3; eauto.
+  - eapply X4; eauto.
+  - eapply X5; eauto.
+
+  - revert brs brs' o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    constructor. split; auto.
+    constructor. auto.
+
+  - revert M2 N2 o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    constructor. split; auto.
+    constructor. auto.
+
+  - revert l l' o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    constructor. split; auto.
+    constructor. auto.
+
+  - eapply X25.
+    revert mfix0 mfix1 o; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+
+  - eapply X26.
+    revert o. generalize (fix_context mfix0). intros c H28.
+    revert mfix0 mfix1 H28; fix auxl 3; intros l l' Hl;
+    destruct Hl; constructor; try split; auto; intuition.
+
+  - eapply X27.
+    revert mfix0 mfix1 o; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+
+  - eapply X28.
+    revert o. generalize (fix_context mfix0). intros c H28.
+    revert mfix0 mfix1 H28; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+Defined.
+
+(** *** Reduction
+
+  The reflexive-transitive closure of 1-step reduction. *)
+
+Inductive red Σ Γ M : term -> Type :=
+| refl_red : red Σ Γ M M
+| trans_red : forall (P : term) N, red Σ Γ M P -> red1 Σ Γ P N -> red Σ Γ M N.
+
+
+(** Simple lemmas about reduction *)
+
+Lemma red1_red (Σ : global_env) Γ t u : red1 Σ Γ t u -> red Σ Γ t u.
+Proof. econstructor; eauto. constructor. Qed.
+Hint Resolve red1_red refl_red.
+
+Lemma red_step Σ Γ t u v : red1 Σ Γ t u -> red Σ Γ u v -> red Σ Γ t v.
+Proof.
+  induction 2. econstructor; auto.
+  econstructor 2; eauto.
+Qed.
+
+
+(* I can't reuse Equations' one because of an extraction bug ? *)
+
+Section Reflexive_Transitive_Closure.
+  Context {A : Type} (R : crelation A).
+
+  (** Definition by direct reflexive-transitive closure *)
+
+  Inductive clos_refl_trans (x:A) : A -> Type :=
+  | rt_step (y:A) : R x y -> clos_refl_trans x y
+  | rt_refl : clos_refl_trans x x
+  | rt_trans (y z:A) :
+      clos_refl_trans x y -> clos_refl_trans y z -> clos_refl_trans x z.
+
+  (** Alternative definition by transitive extension on the left *)
+
+  Inductive clos_refl_trans_1n (x: A) : A -> Type :=
+  | rt1n_refl : clos_refl_trans_1n x x
+  | rt1n_trans (y z:A) :
+      R x y -> clos_refl_trans_1n y z -> clos_refl_trans_1n x z.
+
+  (** Alternative definition by transitive extension on the right *)
+
+  Inductive clos_refl_trans_n1 (x: A) : A -> Type :=
+  | rtn1_refl : clos_refl_trans_n1 x x
+  | rtn1_trans (y z:A) :
+      R y z -> clos_refl_trans_n1 x y -> clos_refl_trans_n1 x z.
+
+  Lemma clos_rt1n_rt : forall x y,
+      clos_refl_trans_1n x y -> clos_refl_trans x y.
+  Proof.
+    induction 1.
+    constructor 2.
+    constructor 3 with y; auto.
+    constructor 1; auto.
+  Qed.
+
+  Lemma clos_rt1n_step : forall x y, R x y -> clos_refl_trans_1n x y.
+  Proof.
+    intros x y H.
+    right with y;[assumption|left].
+  Qed.
+
+  Lemma clos_rt_rt1n : forall x y,
+      clos_refl_trans x y -> clos_refl_trans_1n x y.
+  Proof.
+    induction 1.
+    apply clos_rt1n_step; assumption.
+    left.
+    generalize IHX2; clear IHX2;
+      induction IHX1; auto.
+
+    right with y; auto.
+    eapply IHIHX1; auto.
+    apply clos_rt1n_rt; auto.
+  Qed.
+
+
+  Lemma clos_rtn1_rt : forall x y,
+      clos_refl_trans_n1 x y -> clos_refl_trans x y.
+  Proof.
+    induction 1.
+    constructor 2.
+    constructor 3 with y; auto.
+    constructor 1; assumption.
+  Qed.
+
+  Lemma clos_rtn1_step : forall x y, R x y -> clos_refl_trans_n1 x y.
+  Proof.
+    intros x y H.
+    right with x;[assumption|left].
+  Qed.
+
+  Lemma clos_rt_rtn1 :  forall x y,
+      clos_refl_trans x y -> clos_refl_trans_n1 x y.
+  Proof.
+    induction 1.
+    apply clos_rtn1_step; auto.
+    left.
+    elim IHX2; auto.
+    intros.
+    right with y0; auto.
+  Qed.
+
+End Reflexive_Transitive_Closure.
+
+Lemma red_alt Σ Γ t u : red Σ Γ t u <~> clos_refl_trans (red1 Σ Γ) t u.
+Proof.
+  split.
+  - intros H. apply clos_rtn1_rt.
+    induction H. constructor.
+    econstructor; tea.
+  - intros H. apply clos_rt_rtn1 in H.
+    induction H; econstructor; eauto.
+Qed.
+
+
+Lemma red_trans Σ Γ t u v : red Σ Γ t u -> red Σ Γ u v -> red Σ Γ t v.
+Proof.
+  intros. apply red_alt. apply red_alt in X. apply red_alt in X0. now econstructor 3.
+Defined.
+
+Instance red_Transitive Σ Γ : Transitive (red Σ Γ).
+Proof. refine (red_trans _ _). Qed.
+
+Instance red_Reflexive Σ Γ : Reflexive (red Σ Γ)
+  := refl_red _ _.

--- a/checker/theories/Substitution.v
+++ b/checker/theories/Substitution.v
@@ -1656,26 +1656,27 @@ Lemma subst_check_correct_arity:
       φ idecl ind u (subst_context s k indctx) (firstn npar (map (subst s k) args))
       (subst_context s k pctx).
 Proof.
-  intros cf φ ind u npar args idecl indctx pctx s k.
-  unfold check_correct_arity.
-  inversion_clear 1.
-  rewrite subst_context_snoc. constructor.
-  - apply All2_Forall2, Forall2_length in H1. destruct H1.
-    apply (subst_eq_decl _ s (#|indctx| + k)) in H0.
-    unfold subst_decl, map_decl in H0; cbn in H0.
-    assert (XX : subst s (#|indctx| + k) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|subst_context s k indctx|) (firstn npar (map (subst s k) args)) ++ to_extended_list (subst_context s k indctx)) );
-      [|now rewrite XX in H0].
-    clear H0.
-    rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app.
-    rewrite -> firstn_map.
-    rewrite !map_map_compose. cbn. f_equal.
-    + eapply map_ext.
-      intros. unfold compose. rewrite commut_lift_subst_rec. lia.
-      rewrite subst_context_length. f_equal. lia.
-    + rewrite /to_extended_list to_extended_list_k_subst.
-      rewrite <- (to_extended_list_k_map_subst s). reflexivity. lia.
-  - now apply subst_eq_context.
-Qed.
+(*   intros cf φ ind u npar args idecl indctx pctx s k. *)
+(*   unfold check_correct_arity. *)
+(*   inversion_clear 1. *)
+(*   rewrite subst_context_snoc. constructor. *)
+(*   - apply All2_Forall2, Forall2_length in H1. destruct H1. *)
+(*     apply (subst_eq_decl _ s (#|indctx| + k)) in H0. *)
+(*     unfold subst_decl, map_decl in H0; cbn in H0. *)
+(*     assert (XX : subst s (#|indctx| + k) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|subst_context s k indctx|) (firstn npar (map (subst s k) args)) ++ to_extended_list (subst_context s k indctx)) ); *)
+(*       [|now rewrite XX in H0]. *)
+(*     clear H0. *)
+(*     rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app. *)
+(*     rewrite -> firstn_map. *)
+(*     rewrite !map_map_compose. cbn. f_equal. *)
+(*     + eapply map_ext. *)
+(*       intros. unfold compose. rewrite commut_lift_subst_rec. lia. *)
+(*       rewrite subst_context_length. f_equal. lia. *)
+(*     + rewrite /to_extended_list to_extended_list_k_subst. *)
+(*       rewrite <- (to_extended_list_k_map_subst s). reflexivity. lia. *)
+(*   - now apply subst_eq_context. *)
+(* Qed. *)
+Admitted.
 
 Lemma subs_wf `{checker_flags} Σ Γ s Δ : wf Σ.1 -> subs Σ Γ s Δ -> All Ast.wf s.
 Proof.
@@ -1838,26 +1839,26 @@ Proof.
     eapply closed_upwards; eauto. lia.
 
   - rewrite subst_mkApps map_app map_skipn.
-    specialize (X2 Γ Γ' Δ s sub eq_refl wfsubs).
-    specialize (X4 Γ Γ' Δ s sub eq_refl wfsubs).
+    specialize (X3 Γ Γ' Δ s sub eq_refl wfsubs).
+    specialize (X5 Γ Γ' Δ s sub eq_refl wfsubs).
     simpl. econstructor.
     4:{ eapply subst_types_of_case in H1.
         simpl in H1. subst pars. rewrite firstn_map. eapply H1; eauto.
         all:eauto.
         -- now apply subs_wf in sub.
         -- subst pars. eapply All_firstn.
-           apply typing_wf in X3 as [_ X3]; eauto.
-           now (apply (Forall_All); apply wf_mkApps_inv in X3).
+           apply typing_wf in X4 as [_ X4]; eauto.
+           now (apply (Forall_All); apply wf_mkApps_inv in X4).
         -- eapply typing_wf in X1; wf.
         -- eapply on_declared_inductive in isdecl as [Hmdecl Hidecl]; auto.
            apply onArity in Hidecl as [s' Hty]. now eapply typing_wf in Hty; eauto. }
     -- eauto.
     -- eauto.
     -- eauto.
-    -- revert H2. subst pars.
+    -- revert X2. subst pars.
        apply subst_check_correct_arity.
     -- destruct idecl; simpl in *; auto.
-    -- now rewrite !subst_mkApps in X4.
+    -- now rewrite !subst_mkApps in X5.
     -- solve_all.
 
   - specialize (X2 Γ Γ' Δ s sub eq_refl wfsubs).

--- a/checker/theories/TypingWf.v
+++ b/checker/theories/TypingWf.v
@@ -430,7 +430,7 @@ Proof.
     apply wf_subst; auto with wf. apply wf_subst_instance_constr.
     eapply declared_constructor_wf; eauto.
   - split. wf. constructor; eauto. solve_all.
-    apply wf_mkApps. wf. solve_all. apply wf_mkApps_inv in H7. solve_all.
+    apply wf_mkApps. wf. solve_all. apply wf_mkApps_inv in H6. solve_all.
     apply All_app_inv; solve_all. now apply All_skipn.
   - split. wf. apply wf_subst. solve_all. constructor. wf.
     apply wf_mkApps_inv in H2. apply All_rev. solve_all.

--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -960,25 +960,26 @@ Lemma lift_check_correct_arity:
       φ idecl ind u (lift_context #|Γ''| #|Γ'| indctx) (firstn npar (map (lift #|Γ''| #|Γ'|) args))
       (lift_context #|Γ''| #|Γ'| pctx).
 Proof.
-  intros cf φ Γ' ind u npar args idecl Γ'' indctx pctx.
-  unfold check_correct_arity. intro H.
-  inversion H; subst. simpl. rewrite lift_context_snoc0.
-  constructor.
-  - apply All2_Forall2, Forall2_length in H4. destruct H4.
-    clear -H2. apply (lift_eq_decl _ #|Γ''| (#|indctx| + #|Γ'|)) in H2.
-    unfold lift_decl, map_decl in H2; cbn in H2.
-    assert (XX : lift #|Γ''| (#|indctx| + #|Γ'|) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|lift_context #|Γ''| #|Γ'| indctx|) (firstn npar (map (lift #|Γ''| #|Γ'|) args)) ++ to_extended_list (lift_context #|Γ''| #|Γ'| indctx)));
-      [|now rewrite XX in H2].
+(*   intros cf φ Γ' ind u npar args idecl Γ'' indctx pctx. *)
+(*   unfold check_correct_arity. intro H. *)
+(*   inversion H; subst. simpl. rewrite lift_context_snoc0. *)
+(*   constructor. *)
+(*   - apply All2_Forall2, Forall2_length in H3. destruct H4. *)
+(*     clear -H2. apply (lift_eq_decl _ #|Γ''| (#|indctx| + #|Γ'|)) in H2. *)
+(*     unfold lift_decl, map_decl in H2; cbn in H2. *)
+(*     assert (XX : lift #|Γ''| (#|indctx| + #|Γ'|) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|lift_context #|Γ''| #|Γ'| indctx|) (firstn npar (map (lift #|Γ''| #|Γ'|) args)) ++ to_extended_list (lift_context #|Γ''| #|Γ'| indctx))); *)
+(*       [|now rewrite XX in H2]. *)
 
-    rewrite -> lift_mkApps, map_app.
-    rewrite -> firstn_map. rewrite -> to_extended_list_lift.
-    erewrite <- (to_extended_list_map_lift #|Γ''|).
-    rewrite -> lift_context_length.
-    rewrite -> !map_map_compose. f_equal. f_equal. apply map_ext.
-    intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). omega.
-    f_equal. omega.
-  - now apply lift_eq_context.
-Qed.
+(*     rewrite -> lift_mkApps, map_app. *)
+(*     rewrite -> firstn_map. rewrite -> to_extended_list_lift. *)
+(*     erewrite <- (to_extended_list_map_lift #|Γ''|). *)
+(*     rewrite -> lift_context_length. *)
+(*     rewrite -> !map_map_compose. f_equal. f_equal. apply map_ext. *)
+(*     intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). omega. *)
+(*     f_equal. omega. *)
+(*   - now apply lift_eq_context. *)
+(* Qed. *)
+Admitted.
 
 Lemma wf_ind_type `{checker_flags} Σ mdecl ind idecl :
   wf Σ -> declared_inductive Σ mdecl ind idecl -> Ast.wf (ind_type idecl).
@@ -1116,7 +1117,7 @@ Proof.
     -- erewrite -> lift_declared_inductive; eauto.
     -- auto.
     -- auto.
-    -- revert H1.
+    -- revert X2.
       subst pars.
       erewrite lift_declared_inductive; eauto.
       apply lift_check_correct_arity.

--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -276,12 +276,11 @@ Proof.
   eapply eq_decl_subset; eassumption. assumption.
 Qed.
 
-Lemma check_correct_arity_subset {cf:checker_flags} φ φ' decl ind u ctx pars pctx
-  : ConstraintSet.Subset φ φ' -> check_correct_arity φ decl ind u ctx pars pctx
-    -> check_correct_arity φ' decl ind u ctx pars pctx.
+Lemma check_correct_arity_extends {cf:checker_flags} Σ Σ' φ decl ind u ctx pars pctx
+  : extends Σ Σ' -> check_correct_arity (Σ, φ) decl ind u ctx pars pctx
+    -> check_correct_arity (Σ', φ) decl ind u ctx pars pctx.
 Proof.
-  apply eq_context_subset.
-Qed.
+Admitted.
 
 Lemma weakening_env_consistent_instance {cf:checker_flags} :
   forall Σ Σ' φ ctrs u,
@@ -325,8 +324,7 @@ Proof.
     induction X1. constructor. econstructor; eauto with extends.
     eapply weakening_env_cumul in cumul; eauto.
   - econstructor; eauto 2 with extends.
-    + eapply check_correct_arity_subset; tea.
-      apply weakening_env_global_ext_constraints; tas.
+    + destruct Σ; eapply check_correct_arity_extends; tea.
     + close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
     eapply All_local_env_impl. eapply X.

--- a/checker/theories/kernel/Checker.v
+++ b/checker/theories/kernel/Checker.v
@@ -839,7 +839,7 @@ Lemma lookup_constant_type_is_declared Σ cst u T :
            subst_instance_constr u decl.(cst_type) = fst T }.
 Proof.
   unfold lookup_constant_type_cstrs, lookup_env, declared_constant.
-  destruct Typing.lookup_env eqn:Hlook; try discriminate.
+  destruct lookup_env eqn:Hlook; try discriminate.
   destruct g eqn:Hg; intros; try discriminate. destruct c.
   injection H as eq. subst T. rewrite (lookup_env_id Hlook). simpl.
   eexists. split; eauto.

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -57,8 +57,8 @@ src/pCUICNormal.ml
 # src/pCUICWeakeningEnv.mli
 # src/pCUICWeakening.mli
 # src/pCUICWeakening.ml
-# src/pCUICReduction.mli
-# src/pCUICReduction.ml
+src/pCUICReduction.mli
+src/pCUICReduction.ml
 # src/pCUICSubstitution.ml
 # src/pCUICSubstitution.mli
 # src/pCUICNameless.mli
@@ -67,8 +67,8 @@ src/pCUICNormal.ml
 # src/pCUICGeneration.ml
 # src/pCUICContextConversion.mli
 # src/pCUICContextConversion.ml
-# src/pCUICConversion.mli
-# src/pCUICConversion.ml
+src/pCUICConversion.mli
+src/pCUICConversion.ml
 src/pCUICSafeLemmata.mli
 src/pCUICSafeLemmata.ml
 src/templateToPCUIC.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -22,6 +22,7 @@ PCUICEquality
 PCUICTyping
 PCUICInduction
 PCUICReduction
+PCUICConversion
 PCUICNormal
 PCUICPosition
 PCUICChecker

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -1,7 +1,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR PCUICNormal PCUICSafeLemmata PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination PCUICEquality PCUICContextConversion PCUICConversion.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR PCUICNormal PCUICSafeLemmata PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination PCUICEquality PCUICContextConversion PCUICConversion PCUICConfluence PCUICConversionLemmas.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker.
 
 From MetaCoq.Erasure Require EAst ELiftSubst ETyping EWcbvEval Extract.
@@ -124,11 +124,11 @@ Lemma typing_spine_red :
 Proof.
   intros Σ Γ args args' X wf T x x0 t0 c x1 c0 ?. revert args' X.
   dependent induction t0; intros.
-  - inv X. econstructor. eauto. eapply PCUICConversion.cumul_trans. assumption.
-    eauto. eapply PCUICConversion.cumul_trans. assumption. eauto. eauto.
+  - inv X. econstructor. eauto. eapply cumul_trans. assumption.
+    eauto. eapply cumul_trans. assumption. eauto. eauto.
   - inv X. econstructor.
     + eauto.
-    + eapply PCUICConversion.cumul_trans ; eauto.
+    + eapply cumul_trans ; eauto.
     + eapply subject_reduction; eauto.
     + eapply IHt0; eauto.
       eapply PCUICCumulativity.red_cumul_inv.
@@ -314,7 +314,6 @@ Proof.
   induction Γ; try econstructor.
   intros wfΣ wfΓ; depelim wfΓ; econstructor; eauto;
   constructor; auto.
-  - constructor; eapply cumul_refl; reflexivity.
 Qed.
 
 Lemma context_conversion_red1 (Σ : global_env_ext) Γ Γ' s t : wf Σ -> (* Σ ;;; Γ' |- t : T -> *)
@@ -453,7 +452,7 @@ Proof.
     eapply invert_cumul_prod_r in c as (? & ? & ? & [] & ?); eauto.
     eapply subject_reduction in c0. 3:eauto. 2:eauto.
     eapply inversion_Prod in c0 as (? & ? & ? & ? & ?) ; auto.
-    eapply PCUICConversion.cumul_Sort_inv in c0.
+    eapply cumul_Sort_inv in c0.
     eapply leq_universe_prop in c0 as []; cbn; eauto.
 
     eapply is_prop_sort_prod in H0. eapply IHt1. exact H0.
@@ -491,7 +490,7 @@ Proof.
     destruct c1 as (? & ? & ?). destruct H as [].
     eapply PCUICCumulativity.red_cumul_inv in X.
 
-    eapply invert_cumul_arity_l in H0 as (? & ? & ?). 2: eapply PCUICConversion.cumul_trans; eauto.
+    eapply invert_cumul_arity_l in H0 as (? & ? & ?). 2: eapply cumul_trans; eauto.
     destruct H.
     eapply typing_spine_red in t1. 2:{ eapply PCUICCumulativity.All_All2_refl.
                                                   clear. induction L; eauto. }

--- a/erasure/theories/EInversion.v
+++ b/erasure/theories/EInversion.v
@@ -23,7 +23,7 @@ Local Existing Instance default_checker_flags.
 Lemma type_Case_inv (Σ : global_env_ext) (hΣ : wf Σ.1) Γ ind npar p c brs T :
   Σ;;; Γ |- PCUICAst.tCase (ind, npar) p c brs : T ->
   { '(u, args, mdecl, idecl, pty, indctx, pctx, ps, btys) : _ &
-         (PCUICTyping.declared_inductive (fst Σ) mdecl ind idecl) *
+         (PCUICReduction.declared_inductive (fst Σ) mdecl ind idecl) *
          (PCUICAst.ind_npars mdecl = npar) *
          let pars := firstn npar args in
          (Σ;;; Γ |- p : pty) *
@@ -37,13 +37,13 @@ Proof.
   intros. dependent induction X.
   - unshelve eexists.
     + repeat refine (_,_). all:shelve.
-    + cbn. subst pars. intuition eauto.
+    + cbn. subst pars. intuition eauto. reflexivity.
   - edestruct (IHX hΣ _ _ _ _ _ eq_refl) as [ [[[[[[[[]]]]]]]] ].
     repeat match goal with [ H : _ * _ |- _ ] => destruct H end.
     unshelve eexists.
     + repeat refine (_, _). all:shelve.
     + cbn. intuition eauto.
-      all: eapply PCUICConversion.cumul_trans; eauto.
+      all: eapply PCUICConfluence.cumul_trans; eauto.
 Qed.
 
 Notation type_Construct_inv := PCUICInversion.inversion_Construct.

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -55,7 +55,7 @@ Lemma Informative_extends:
   forall (Σ : global_env_ext) (ind : inductive)
     (mdecl : PCUICAst.mutual_inductive_body) (idecl : PCUICAst.one_inductive_body),
 
-    PCUICTyping.declared_inductive (fst Σ) mdecl ind idecl ->
+    PCUICReduction.declared_inductive (fst Σ) mdecl ind idecl ->
     forall (Σ' : global_env) (u0 : universe_instance),
       wf Σ' ->
       extends Σ Σ' ->
@@ -68,7 +68,7 @@ Proof.
 
   eapply weakening_env_declared_inductive in H; eauto.
   destruct H, H1.
-  unfold PCUICTyping.declared_minductive in *.
+  unfold PCUICReduction.declared_minductive in *.
 
   eapply extends_lookup in H1; eauto.
   rewrite H1 in H. inversion H. subst. clear H.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -349,7 +349,7 @@ Next Obligation.
 
      eapply conv_context_refl; eauto. econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
 
   ++ sq. etransitivity. eassumption.
 
@@ -359,7 +359,7 @@ Next Obligation.
 
      econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
 Qed.
 Next Obligation.
   Hint Constructors squash. destruct HΣ.
@@ -419,8 +419,6 @@ Next Obligation.
        eapply type_reduction in X0; eauto.
 
        eapply principal_typing in c0 as (? & ? & ? & ?). 2:eauto. 2:{ exact X0. }
-
-       eapply cumul_prop1 in c; eauto.
 
        destruct (invert_cumul_sort_r _ _ _ _ c0) as (? & ? & ?).
        destruct (invert_cumul_sort_r _ _ _ _ c1) as (? & ? & ?).

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -300,7 +300,7 @@ Lemma subslet_fix_subst `{cf : checker_flags} Σ mfix1 T n :
   wf Σ.1 ->
   Σ ;;; [] |- tFix mfix1 n : T ->
   (* wf_local Σ (PCUICLiftSubst.fix_context mfix1) -> *)
-  subslet Σ [] (PCUICTyping.fix_subst mfix1) (PCUICLiftSubst.fix_context mfix1).
+  subslet Σ [] (fix_subst mfix1) (PCUICLiftSubst.fix_context mfix1).
 Proof.
   intro hΣ.
   unfold fix_subst, PCUICLiftSubst.fix_context.
@@ -343,8 +343,6 @@ Proof.
   - cbn; eauto.
   - destruct a. destruct decl_body.
     + cbn. econstructor. inv X0. eauto. econstructor.
-      depelim X0.
-      eapply PCUICCumulativity.conv_alt_refl; reflexivity.
-    + cbn. econstructor. inv X0. eauto. econstructor.
-      eapply PCUICCumulativity.conv_alt_refl; reflexivity.
+      depelim X0. reflexivity.
+    + cbn. econstructor. inv X0. eauto. econstructor. reflexivity.
 Qed.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -170,7 +170,7 @@ Next Obligation.
 
      eapply conv_context_refl; eauto. econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
   ++ sq. etransitivity. eassumption.
 
      eapply context_conversion_red; eauto. econstructor.
@@ -179,7 +179,7 @@ Next Obligation.
 
      econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
 Qed.
 
 Next Obligation.
@@ -255,11 +255,9 @@ Next Obligation.
     eapply cumul_prop1 in c; eauto.
     eapply cumul_prop2 in c0; eauto.
 
-    eapply type_reduction in X0; eauto.
+    eapply type_reduction in X0; eauto using typing_wf_local.
 
     eapply principal_typing in c0 as (? & ? & ? & ?). 2:eauto. 2:{ exact X0. }
-
-    eapply cumul_prop1 in c; eauto.
 
     destruct (invert_cumul_sort_r _ _ _ _ c0) as (? & ? & ?).
     destruct (invert_cumul_sort_r _ _ _ _ c1) as (? & ? & ?).
@@ -270,7 +268,6 @@ Next Obligation.
 
     eapply leq_universe_prop in l0 as []; cbn; eauto.
     eapply leq_universe_prop in l as []; cbn; eauto.
-    eauto using typing_wf_local.
 Qed.
 
 (* Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (HΓ : ∥wf_local Sigma Gamma∥) (t : PCUICAst.term) : *)

--- a/erasure/theories/SafeTemplateErasure.v
+++ b/erasure/theories/SafeTemplateErasure.v
@@ -60,9 +60,9 @@ Program Fixpoint check_wf_env_only_univs (Σ : global_env)
   | nil => ret (init_graph; _)
   | d :: Σ =>
     G <- check_wf_env_only_univs Σ ;;
-    check_fresh (PCUICTyping.global_decl_ident d) Σ ;;
+    check_fresh (PCUICReduction.global_decl_ident d) Σ ;;
     let udecl := universes_decl_of_decl d in
-    uctx <- check_udecl (PCUICTyping.global_decl_ident d) Σ _ G.π1 (proj1 G.π2) udecl ;;
+    uctx <- check_udecl (PCUICReduction.global_decl_ident d) Σ _ G.π1 (proj1 G.π2) udecl ;;
     let G' := add_uctx uctx.π1 G.π1 in
     assume_wf_decl (Σ, udecl) _ _ G' _ d ;;
     match udecl with

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -39,6 +39,7 @@ theories/PCUICCheckerCompleteness.v
 theories/PCUICRetyping.v
 theories/PCUICElimination.v
 theories/PCUICSN.v
+theories/PCUICConversionLemmas.v
 
 theories/PCUICSigmaCalculus.v
 

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -392,9 +392,9 @@ Proof.
     + solve_all. unfold test_snd. simpl in *.
       toProp; eauto.
     + apply closedn_mkApps; auto.
-      rewrite forallb_app. simpl. rewrite H3.
+      rewrite forallb_app. simpl. rewrite H2.
       rewrite forallb_skipn; auto.
-      now apply closedn_mkApps_inv in H7.
+      now apply closedn_mkApps_inv in H6.
 
   - intuition auto.
     apply closedn_subst0.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -670,7 +670,9 @@ Proof.
   - econstructor; pcuic.
     eapply forall_Γ'1; repeat (constructor; pcuic). reflexivity.
   - econstructor; pcuic. intuition auto. eapply isdecl. eapply isdecl.
-    eauto. solve_all.
+    2: solve_all.
+    unfold check_correct_arity in X2. clear -X2.
+    exact (todo "convconv").
   - econstructor; pcuic.
     eapply All_local_env_app_inv. split; auto.
     eapply All_local_env_app in X. subst types.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -3,952 +3,109 @@ From Equations Require Import Equations.
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
 From MetaCoq.Template Require Import config utils AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
-     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening
-     PCUICSubstitution
-     PCUICReduction PCUICCumulativity PCUICConfluence PCUICParallelReductionConfluence
-     PCUICEquality PCUICContextConversion.
-Require Import ssreflect ssrbool.
-Require Import String.
-From MetaCoq Require Import LibHypsNaming.
-Local Open Scope string_scope.
-Set Asymmetric Patterns.
-Require Import CRelationClasses.
+     PCUICLiftSubst PCUICUnivSubst PCUICReduction PCUICEquality.
+
 Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
-Require Import Equations.Prop.DepElim.
 
-Ltac tc := try typeclasses eauto 10.
-Hint Resolve eq_universe_leq_universe' : pcuic.
 
-Derive Signature for cumul assumption_context.
+(** ** Cumulativity and Conversion ** *)
 
-Instance cumul_trans {cf:checker_flags} (Σ : global_env_ext) Γ :
-  wf Σ -> Transitive (cumul Σ Γ).
+Reserved Notation " Σ ;;; Γ |- t <= u " (at level 50, Γ, t, u at next level).
+Reserved Notation " Σ ;;; Γ |- t = u " (at level 50, Γ, t, u at next level).
+
+Inductive cumul `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| cumul_refl t u : leq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t <= u
+| cumul_red_l t u v : red1 Σ.1 Γ t v -> Σ ;;; Γ |- v <= u -> Σ ;;; Γ |- t <= u
+| cumul_red_r t u v : Σ ;;; Γ |- t <= v -> red1 Σ.1 Γ u v -> Σ ;;; Γ |- t <= u
+where " Σ ;;; Γ |- t <= u " := (cumul Σ Γ t u) : type_scope.
+
+
+Inductive conv `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| conv_refl t u : eq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t = u
+| conv_red_l t u v : red1 Σ Γ t v -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- t = u
+| conv_red_r t u v : Σ ;;; Γ |- t = v -> red1 (fst Σ) Γ u v -> Σ ;;; Γ |- t = u
+where " Σ ;;; Γ |- t = u " := (@conv _ Σ Γ t u) : type_scope.
+
+
+Lemma cumul_alt {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- t <= u <~> ∑ v v', red Σ Γ t v × red Σ Γ u v' × leq_term Σ v v'.
 Proof.
-  intros wfΣ t u v X X0.
-  eapply cumul_alt in X as [v' [v'' [[redl redr] eq]]].
-  eapply cumul_alt in X0 as [w [w' [[redl' redr'] eq']]].
-  destruct (red_confluence wfΣ redr redl') as [nf [nfl nfr]].
-  eapply cumul_alt.
-  eapply red_eq_term_upto_univ_r in eq; tc;eauto with pcuic.
-  destruct eq as [v'0 [red'0 eq2]].
-  eapply red_eq_term_upto_univ_l in eq'; tc;eauto with pcuic.
-  destruct eq' as [v'1 [red'1 eq1]].
-  exists v'0, v'1.
-  split. split; auto.
-  transitivity v'; auto.
-  transitivity w'; auto.
-  eapply leq_term_trans with nf; eauto.
+  split.
+  { induction 1. exists t, u. intuition auto; constructor.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step. }
+  { intros [v [v' [redv [redv' Hleq]]]]. apply red_alt in redv.
+    apply red_alt in redv'.
+    apply clos_rt_rt1n in redv.
+    apply clos_rt_rt1n in redv'.
+    induction redv. induction redv'. constructor; auto.
+    econstructor 3; eauto.
+    econstructor 2; eauto. }
 Qed.
 
-Instance conv_trans {cf:checker_flags} (Σ : global_env_ext) Γ :
-  wf Σ -> Transitive (PCUICTyping.conv Σ Γ).
+
+Lemma conv_alt {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- t = u <~> ∑ v v', red Σ Γ t v × red Σ Γ u v' × eq_term Σ v v'.
 Proof.
-  intros wfΣ t u v tu uv.
-  split. eapply cumul_trans with u. auto. apply tu. apply uv.
-  eapply cumul_trans with u. auto. apply uv. apply tu.
+  split.
+  { induction 1. exists t, u. intuition auto; constructor.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step.
+    destruct IHX as (v' & v'' & redv & redv' & leqv).
+    exists v', v''. intuition auto. now eapply red_step. }
+  { intros [v [v' [redv [redv' Hleq]]]]. apply red_alt in redv.
+    apply red_alt in redv'.
+    apply clos_rt_rt1n in redv.
+    apply clos_rt_rt1n in redv'.
+    induction redv. induction redv'. constructor; auto.
+    econstructor 3; eauto.
+    econstructor 2; eauto. }
 Qed.
 
-Instance conv_sym {cf:checker_flags} (Σ : global_env_ext) Γ :
-  wf Σ -> Symmetric (PCUICTyping.conv Σ Γ).
-Proof.
-  intros wfΣ t u tu. split; apply tu.
-Qed.
 
-Instance conv_alt_reflexive {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} Γ : Reflexive (conv_alt Σ Γ).
-Proof. intros x. eapply conv_alt_refl, eq_term_refl. Qed.
 
-Instance conv_alt_symmetric {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} Γ : Symmetric (conv_alt Σ Γ).
-Proof. intros x y. eapply conv_alt_sym. auto. Qed.
 
-Instance conv_alt_transitive {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} Γ : Transitive (conv_alt Σ Γ).
-Proof. intros x y z. eapply conv_alt_trans. auto. Qed.
-
-Instance cumul_reflexive {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} Γ : Reflexive (cumul Σ Γ).
-Proof. intros x. eapply cumul_refl'. Qed.
-
-Instance cumul_transitive {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} Γ : Transitive (cumul Σ Γ).
-Proof. intros x y z. eapply cumul_trans. auto. Qed.
-
-Existing Class wf.
-
-Lemma congr_cumul_prod : forall `{checker_flags} Σ Γ na na' M1 M2 N1 N2,
-    Σ ;;; Γ |- M1 == N1 ->
-    Σ ;;; (Γ ,, vass na M1) |- M2 <= N2 ->
-    Σ ;;; Γ |- (tProd na M1 M2) <= (tProd na' N1 N2).
-Proof.
-  intros.
-Admitted.
-
-(* Should follow from context conversion + invariants on T and U *)
-(* Lemma conv_conv_alt `{cf : checker_flags} {Σ : global_env_ext} (wfΣ : wf Σ) Γ T U : *)
-(*   Σ ;;; Γ |- T = U -> Σ ;;; Γ |- T == U. *)
-(* Proof. *)
-(* Admitted. *)
-
-Lemma cumul_Sort_inv {cf:checker_flags} Σ Γ s s' :
-  Σ ;;; Γ |- tSort s <= tSort s' -> leq_universe (global_ext_constraints Σ) s s'.
-Proof.
-  intros H; depind H; auto.
-  - now inversion l.
-  - depelim r. solve_discr.
-  - depelim r. solve_discr.
-Qed.
-
-Lemma cumul_Sort_Prod_inv {cf:checker_flags} Σ Γ s na dom codom :
-  Σ ;;; Γ |- tSort s <= tProd na dom codom -> False.
-Proof.
-  intros H; depind H; auto.
-  - now inversion l.
-  - depelim r. solve_discr.
-  - depelim r. solve_discr. eapply IHcumul. reflexivity.
-    eapply IHcumul. reflexivity.
-Qed.
-
-Lemma cumul_Sort_l_inv {cf:checker_flags} Σ Γ s T :
-  Σ ;;; Γ |- tSort s <= T ->
-  ∑ s', red Σ Γ T (tSort s') * leq_universe Σ s s'.
-Proof.
-  intros H; depind H; auto.
-  - now inversion l.
-  - depelim r. solve_discr.
-  - destruct IHcumul as [s' [redv leq]].
-    exists s'. split; auto. now eapply red_step with v.
-Qed.
-
-Lemma cumul_Sort_r_inv {cf:checker_flags} Σ Γ s T :
-  Σ ;;; Γ |- T <= tSort s ->
-  ∑ s', red Σ Γ T (tSort s') * leq_universe Σ s' s.
-Proof.
-  intros H; depind H; auto.
-  - now inversion l.
-  - destruct IHcumul as [s' [redv leq]].
-    exists s'. split; auto. now eapply red_step with v.
-  - depelim r. solve_discr.
-Qed.
-
-Lemma cumul_LetIn_l_inv {cf:checker_flags} (Σ : global_env_ext) Γ na b B codom T :
-  wf Σ ->
-  Σ ;;; Γ |- tLetIn na b B codom <= T ->
-  ∑ codom', red Σ Γ T codom' *
-                     (Σ ;;; Γ |- codom {0 := b} <= codom').
-Proof.
-  intros wfΣ H; depind H; auto.
-  - inv l. eexists (u' {0 := t'}); intuition eauto. eapply red1_red. constructor.
-    transitivity (codom {0 := t'}).
-    { constructor. eapply eq_term_upto_univ_subst; trivial. auto with pcuic. reflexivity. }
-    constructor. now eapply subst_leq_term.
-  - depelim r.
-    * exists u; intuition auto.
-    * solve_discr.
-    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [codom' [reddom' leq]].
-      exists codom'; intuition auto.
-      transitivity (codom {0 := r}); eauto.
-      eapply red_cumul. eapply (red_red Σ _ [vdef na b B] []) => //. constructor. now eapply red1_red.
-      constructor. rewrite -{1}(subst_empty 0 b). repeat constructor.
-    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [codom' [reddom' leq]].
-      exists codom'; intuition auto.
-    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [codom' [reddom' leq]].
-      exists codom'; intuition auto.
-      eapply transitivity; [|eassumption].
-      eapply red_cumul.
-      rewrite -{1 2}(subst_empty 0 b).
-      eapply (untyped_substitution_red _ _ [vdef na b B] []); auto. repeat constructor.
-  - specialize (IHcumul wfΣ).
-    destruct IHcumul as [codom' [reddom' leq]] => //.
-    exists codom'; intuition auto.
-    now eapply red_step with v.
-Qed.
-
-Lemma cumul_LetIn_r_inv {cf:checker_flags} (Σ : global_env_ext) Γ na b B codom T :
-  wf Σ ->
-  Σ ;;; Γ |- T <= tLetIn na b B codom ->
-  ∑ codom', red Σ Γ T codom' *
-                     (Σ ;;; Γ |- codom' <= codom {0 := b}).
-Proof.
-  intros wfΣ H; depind H; auto.
-  - inv l. eexists (u {0 := t0}); intuition eauto. eapply red1_red. constructor.
-    transitivity (codom {0 := t0}).
-    { constructor. eapply eq_term_upto_univ_subst; trivial. auto with pcuic. reflexivity. }
-    constructor. eapply eq_term_upto_univ_subst; auto with pcuic. reflexivity.
-  - specialize (IHcumul wfΣ).
-    destruct IHcumul as [codom' [reddom' leq]] => //.
-    exists codom'; intuition auto.
-    now eapply red_step with v.
-  - depelim r.
-    * eexists ; intuition eauto.
-    * solve_discr.
-    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [codom' [reddom' leq]].
-      exists codom'; intuition auto.
-      transitivity (codom {0 := r}); eauto.
-      eapply red_cumul_inv. eapply (red_red Σ _ [vdef na b B] []) => //. constructor. now eapply red1_red.
-      constructor. rewrite -{1}(subst_empty 0 b). repeat constructor.
-    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [codom' [reddom' leq]].
-      exists codom'; intuition auto.
-    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [codom' [reddom' leq]].
-      exists codom'; intuition auto.
-      eapply transitivity; [eassumption|].
-      eapply red_cumul_inv.
-      rewrite -{1 2}(subst_empty 0 b).
-      eapply (untyped_substitution_red _ _ [vdef na b B] []); auto. repeat constructor.
-Qed.
-
-Lemma cumul_Prod_l_inv {cf:checker_flags} (Σ : global_env_ext) Γ na dom codom T :
-  wf Σ ->
-  Σ ;;; Γ |- tProd na dom codom <= T ->
-  ∑ na' dom' codom', red Σ Γ T (tProd na' dom' codom') *
-                     (Σ ;;; Γ |- dom == dom') * (Σ ;;; Γ ,, vass na dom |- codom <= codom').
-Proof.
-  intros wfΣ H; depind H; auto.
-  - inv l. exists na', a', b'; intuition eauto; constructor; auto.
-  - depelim r. solve_discr.
-    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [na' [dom' [codom' [[reddom' eqdom'] leq]]]].
-      exists na', dom', codom'; intuition auto.
-      transitivity N1; eauto.
-      eapply cumul_conv_ctx; eauto. constructor; auto with pcuic.
-      constructor. symmetry; eapply red_conv_alt; auto.
-
-    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [na' [dom' [codom' [[reddom' eqdom'] leq]]]].
-      exists na', dom', codom'; intuition auto.
-      transitivity N2; eauto. eapply red_cumul; auto.
-  - destruct IHcumul as [na' [dom' [codom' [[reddom' eqdom'] leq]]]] => //.
-    exists na', dom', codom'; intuition auto.
-    now eapply red_step with v.
-Qed.
-
-Lemma cumul_Prod_r_inv {cf:checker_flags} (Σ : global_env_ext) Γ na' dom' codom' T :
-  wf Σ ->
-  Σ ;;; Γ |- T <= tProd na' dom' codom' ->
-  ∑ na dom codom, red Σ Γ T (tProd na dom codom) *
-                     (Σ ;;; Γ |- dom == dom') * (Σ ;;; Γ ,, vass na' dom' |- codom <= codom').
-Proof.
-  intros wfΣ H; depind H; auto.
-  - inv l. exists na, a, b; intuition eauto; constructor; auto.
-  - destruct IHcumul as [na [dom [codom [[reddom' eqdom'] leq]]]] => //.
-    exists na, dom, codom; intuition auto.
-    now eapply red_step with v.
-  - depelim r. solve_discr.
-    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [na [dom [codom [[reddom' eqdom'] leq]]]].
-      eexists _, _, _; intuition eauto.
-      transitivity N1; eauto. symmetry; apply red_conv_alt; auto.
-      eapply cumul_conv_ctx; eauto. constructor; auto with pcuic.
-      constructor. symmetry. eapply red_conv_alt; auto.
-
-    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
-      destruct IHcumul as [na [dom [codom [[reddom' eqdom'] leq]]]].
-      eexists _, _, _; intuition eauto.
-      transitivity N2; eauto. eapply red_cumul_inv; auto.
-Qed.
-
-Lemma cumul_Prod_Sort_inv {cf:checker_flags} Σ Γ s na dom codom :
-  Σ ;;; Γ |- tProd na dom codom <= tSort s -> False.
-Proof.
-  intros H; depind H; auto.
-  - now inversion l.
-  - depelim r. solve_discr. eapply IHcumul; reflexivity.
-    eapply IHcumul; reflexivity.
-  - depelim r. solve_discr.
-Qed.
-
-Lemma cumul_Prod_Prod_inv {cf:checker_flags} (Σ : global_env_ext) Γ na na' dom dom' codom codom' : wf Σ ->
-  Σ ;;; Γ |- tProd na dom codom <= tProd na' dom' codom' ->
-   ((Σ ;;; Γ |- dom == dom') * (Σ ;;; Γ ,, vass na' dom' |- codom <= codom'))%type.
-Proof.
-  intros wfΣ H; depind H; auto.
-  - inv l. split; auto; constructor; auto.
-  - depelim r. solve_discr.
-    destruct (IHcumul na na' N1 _ _ _ wfΣ eq_refl).
-    split; auto. transitivity N1=> //. now eapply red_conv_alt, red1_red.
-    destruct (IHcumul na na' _ _ N2 _ wfΣ eq_refl).
-    split; auto. eapply cumul_trans. auto. 2:eauto.
-    eapply cumul_conv_ctx; eauto. eapply red_cumul; eauto.
-    constructor; auto with pcuic.
-  - depelim r. solve_discr.
-    destruct (IHcumul na na' _ _ _ _ wfΣ eq_refl).
-    split; auto. transitivity N1 => //. symmetry => //.
-    now eapply red_conv_alt, red1_red.
-    eapply cumul_red_ctx_inv. auto. eauto. constructor. eapply All2_local_env_red_refl. red.
-    now eapply red1_red.
-    destruct (IHcumul na na' _ _ _ _ wfΣ eq_refl).
-    split; auto.
-    eapply cumul_trans with N2; auto.
-    eapply red1_red, red_conv in r. apply r.
-Qed.
-
-Lemma assumption_context_app Γ Γ' :
-  assumption_context (Γ' ,,, Γ) ->
-  assumption_context Γ * assumption_context Γ'.
-Proof.
-  induction Γ; simpl; split; try constructor; auto. depelim H. constructor; auto. now eapply IHΓ.
-  depelim H. now eapply IHΓ.
-Qed.
-
-Lemma it_mkProd_or_LetIn_ass_inv {cf : checker_flags} (Σ : global_env_ext) Γ ctx ctx' s s' :
-  wf Σ ->
-  assumption_context ctx ->
-  assumption_context ctx' ->
-  Σ ;;; Γ |- it_mkProd_or_LetIn ctx (tSort s) <= it_mkProd_or_LetIn ctx' (tSort s') ->
-  conv_context Σ ctx ctx' * leq_term Σ (tSort s) (tSort s').
-Proof.
-  intros wfΣ.
-  revert Γ ctx' s s'.
-  induction ctx using rev_ind.
-  intros. destruct ctx' using rev_ind. simpl in X.
-  - eapply cumul_Sort_inv in X. split; constructor; auto.
-  - destruct x as [na [b|] ty]. elimtype False.
-    apply assumption_context_app in H0.
-    destruct H0. inv a0.
-    rewrite it_mkProd_or_LetIn_app in X.
-    apply assumption_context_app in H0 as [H0 _].
-    specialize (IHctx' H0).
-    simpl in IHctx'. simpl in X. unfold mkProd_or_LetIn in X. simpl in X.
-    eapply cumul_Sort_Prod_inv in X. depelim X.
-  - intros.
-    rewrite it_mkProd_or_LetIn_app in X.
-    simpl in X.
-    eapply assumption_context_app in H as [H H'].
-    destruct x as [na [b|] ty]. elimtype False. inv H'.
-    rewrite /mkProd_or_LetIn /= in X.
-    destruct ctx' using rev_ind.
-    simpl in X.
-    now eapply cumul_Prod_Sort_inv in X.
-    eapply assumption_context_app in H0 as [H0 Hx].
-    destruct x as [na' [b'|] ty']; [elimtype False; inv Hx|].
-    rewrite it_mkProd_or_LetIn_app in X.
-    rewrite /= /mkProd_or_LetIn /= in X.
-    eapply cumul_Prod_Prod_inv in X as [Hdom Hcodom]; auto.
-    specialize (IHctx (Γ ,, vass na' ty') l0 s s' H H0 Hcodom). clear IHctx'.
-    intuition auto.
-Admitted.
-
-(** Injectivity of products, the essential property of cumulativity needed for subject reduction. *)
-Lemma cumul_Prod_inv {cf:checker_flags} Σ Γ na na' A B A' B' :
-  wf Σ.1 -> wf_local Σ Γ ->
-  Σ ;;; Γ |- tProd na A B <= tProd na' A' B' ->
-   ((Σ ;;; Γ |- A == A') * (Σ ;;; Γ ,, vass na' A' |- B <= B'))%type.
-Proof.
-  intros wfΣ wfΓ H; depind H.
-  - depelim l.
-    split; auto.
-    now constructor.
-    now constructor.
-
-  - depelim r. solve_discr.
-    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
-    intuition auto.
-    econstructor 2; eauto.
-
-    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
-    intuition auto. apply cumul_trans with N2. auto.
-    eapply cumul_conv_ctx; eauto.
-
-    econstructor 2. eauto. constructor. reflexivity.
-    constructor. now apply conv_ctx_refl.
-    constructor; auto.
-    auto.
-
-  - depelim r. solve_discr.
-    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
-    intuition auto. econstructor 3. 2:eauto. auto.
-    eapply cumul_conv_ctx in b. eauto. auto. constructor. eapply conv_ctx_refl. auto.
-    constructor. eapply conv_alt_sym; auto.
-
-    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
-    intuition auto. apply cumul_trans with N2. auto. auto.
-    eapply cumul_red_r; eauto.
-Qed.
-
-Lemma tProd_it_mkProd_or_LetIn na A B ctx s :
-  tProd na A B = it_mkProd_or_LetIn ctx (tSort s) ->
-  { ctx' & ctx = (ctx' ++ [vass na A])%list /\
-           destArity [] B = Some (ctx', s) }.
-Proof.
-  intros. exists (removelast ctx).
-  revert na A B s H.
-  induction ctx using rev_ind; intros; noconf H.
-  rewrite it_mkProd_or_LetIn_app in H. simpl in H.
-  destruct x as [na' [b'|] ty']; noconf H; simpl in *.
-  rewrite removelast_app. congruence. simpl. rewrite app_nil_r. intuition auto.
-  rewrite destArity_it_mkProd_or_LetIn. simpl. now rewrite app_context_nil_l.
-Qed.
-
-Section Inversions.
-  Context {cf : checker_flags}.
-  Context (Σ : global_env_ext) (wfΣ : wf Σ).
-
-  Lemma conv_trans_reg : forall Γ u v w,
-      Σ ;;; Γ |- u = v ->
-                 Σ ;;; Γ |- v = w ->
-                            Σ ;;; Γ |- u = w.
-  Proof.
-    intros Γ u v w h1 h2.
-    destruct h1, h2. constructor ; eapply cumul_trans ; eassumption.
-  Qed.
-
-  Lemma cumul_App_r {Γ f u v} :
-    Σ ;;; Γ |- u == v ->
-    Σ ;;; Γ |- tApp f u <= tApp f v.
-  Proof.
-    intros h.
-    induction h.
-    - eapply cumul_refl. constructor.
-      + apply leq_term_refl.
-      + assumption.
-    -  eapply cumul_red_l ; try eassumption.
-       econstructor. assumption.
-    - eapply cumul_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_App_r {Γ f x y} :
-    Σ ;;; Γ |- x == y ->
-    Σ ;;; Γ |- tApp f x == tApp f y.
-  Proof.
-    intros h.
-    induction h.
-    - constructor. constructor.
-      + apply eq_term_refl.
-      + assumption.
-    - eapply conv_alt_red_l ; eauto.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; eauto.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_Prod_l:
-    forall {Γ na na' A1 A2 B},
-      Σ ;;; Γ |- A1 == A2 ->
-      Σ ;;; Γ |- tProd na A1 B == tProd na' A2 B.
-  Proof.
-    intros Γ na na' A1 A2 B h.
-    induction h.
-    - constructor. constructor.
-      + assumption.
-      + apply eq_term_refl.
-    - eapply conv_alt_red_l ; eauto.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; eauto.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_Prod_r  :
-    forall {Γ na A B1 B2},
-      Σ ;;; Γ ,, vass na A |- B1 == B2 ->
-      Σ ;;; Γ |- tProd na A B1 == tProd na A B2.
-  Proof.
-    intros Γ na A B1 B2 h.
-    induction h.
-    - constructor. constructor.
-      + apply eq_term_refl.
-      + assumption.
-    - eapply conv_alt_red_l ; eauto.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; eauto.
-      econstructor. assumption.
-  Qed.
-
-  Lemma cumul_Prod_r :
-    forall {Γ na A B1 B2},
-      Σ ;;; Γ ,, vass na A |- B1 <= B2 ->
-      Σ ;;; Γ |- tProd na A B1 <= tProd na A B2.
-  Proof.
-    intros Γ na A B1 B2 h.
-    induction h.
-    - eapply cumul_refl. constructor.
-      + apply eq_term_refl.
-      + assumption.
-    - eapply cumul_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply cumul_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_cumul_l :
-    forall Γ u v,
-      Σ ;;; Γ |- u == v ->
-      Σ ;;; Γ |- u <= v.
-  Proof.
-    intros Γ u v h. now eapply conv_alt_cumul.
-  Qed.
-
-  Lemma conv_refl' :
-    forall leq Γ t,
-      conv leq Σ Γ t t.
-  Proof.
-    intros leq Γ t.
-    destruct leq.
-    - cbn. constructor. apply conv_alt_refl. reflexivity.
-    - cbn. constructor. apply cumul_refl'.
-  Qed.
-
-  Lemma conv_conv :
-    forall {Γ leq u v},
-      ∥ Σ ;;; Γ |- u == v ∥ ->
-      conv leq Σ Γ u v.
-  Proof.
-    intros Γ leq u v h.
-    destruct leq.
-    - assumption.
-    - destruct h. cbn.
-      constructor. now eapply conv_alt_cumul.
-  Qed.
-
-  Lemma eq_term_conv :
-    forall {Γ u v},
-      eq_term (global_ext_constraints Σ) u v ->
-      Σ ;;; Γ |- u = v.
-  Proof.
-    intros Γ u v e.
-    constructor.
-    - eapply cumul_refl.
-      eapply eq_term_leq_term. assumption.
-    - eapply cumul_refl.
-      eapply eq_term_leq_term.
-      eapply eq_term_sym.
-      assumption.
-  Qed.
-
-  Global Instance conv_trans' :
-    forall leq Γ, Transitive (conv leq Σ Γ).
-  Proof.
-    intros leq Γ u v w h1 h2.
-    destruct leq.
-    - cbn in *. destruct h1, h2. constructor.
-      eapply conv_alt_trans ; eassumption.
-    - cbn in *. destruct h1, h2. constructor. eapply cumul_trans ; eassumption.
-  Qed.
-
-  Lemma red_conv_l :
-    forall leq Γ u v,
-      red (fst Σ) Γ u v ->
-      conv leq Σ Γ u v.
-  Proof.
-    intros leq Γ u v h.
-    induction h.
-    - apply conv_refl'.
-    - eapply conv_trans' ; try eassumption.
-      destruct leq.
-      + simpl. destruct IHh. constructor.
-        eapply conv_alt_red_l; eauto.
-      + simpl. constructor.
-        eapply cumul_red_l.
-        * eassumption.
-        * eapply cumul_refl'.
-  Qed.
-
-  Lemma red_conv_r :
-    forall leq Γ u v,
-      red (fst Σ) Γ u v ->
-      conv leq Σ Γ v u.
-  Proof.
-    intros leq Γ u v h.
-    induction h.
-    - apply conv_refl'.
-    - eapply conv_trans' ; try eassumption.
-      destruct leq.
-      + simpl. destruct IHh. constructor.
-        eapply conv_alt_red_r; eauto.
-      + simpl. constructor.
-        eapply cumul_red_r.
-        * eapply cumul_refl'.
-        * assumption.
-  Qed.
-
-  Lemma conv_Prod leq Γ na1 na2 A1 A2 B1 B2 :
-      Σ ;;; Γ |- A1 == A2 ->
-      conv leq Σ (Γ,, vass na1 A1) B1 B2 ->
-      conv leq Σ Γ (tProd na1 A1 B1) (tProd na2 A2 B2).
-  Proof.
-    intros h1 h2; destruct leq.
-    - simpl in *. destruct h2 as [h2]. constructor.
-      eapply conv_alt_trans => //.
-      + eapply conv_Prod_r. eassumption.
-      + eapply conv_Prod_l. eassumption.
-    - simpl in *. destruct h2 as [h2]. constructor.
-      eapply cumul_trans. auto.
-      + eapply cumul_Prod_r. eassumption.
-      + eapply conv_cumul_l. eapply conv_Prod_l. assumption.
-  Qed.
-
-  Lemma cumul_Case_c :
-    forall Γ indn p brs u v,
-      Σ ;;; Γ |- u == v ->
-      Σ ;;; Γ |- tCase indn p u brs <= tCase indn p v brs.
-  Proof.
-    intros Γ [ind n] p brs u v h.
-    induction h.
-    - constructor. constructor.
-      + eapply eq_term_refl.
-      + assumption.
-      + eapply All2_same.
-        intros. split ; eauto.
-        reflexivity.
-    - eapply cumul_red_l ; eauto.
-      constructor. assumption.
-    - eapply cumul_red_r ; eauto.
-      constructor. assumption.
-  Qed.
-
-  Lemma cumul_Proj_c :
-    forall Γ p u v,
-      Σ ;;; Γ |- u == v ->
-      Σ ;;; Γ |- tProj p u <= tProj p v.
-  Proof.
-    intros Γ p u v h.
-    induction h.
-    - eapply cumul_refl. constructor. assumption.
-    - eapply cumul_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply cumul_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_App_l :
-    forall {Γ f g x},
-      Σ ;;; Γ |- f == g ->
-      Σ ;;; Γ |- tApp f x == tApp g x.
-  Proof.
-    intros Γ f g x h.
-    induction h.
-    - constructor. constructor.
-      + assumption.
-      + apply eq_term_refl.
-    - eapply conv_alt_red_l ; eauto.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; eauto.
-      econstructor. assumption.
-  Qed.
-
-  Lemma App_conv :
-    forall Γ t1 t2 u1 u2,
-      Σ ;;; Γ |- t1 == t2 ->
-      Σ ;;; Γ |- u1 == u2 ->
-      Σ ;;; Γ |- tApp t1 u1 == tApp t2 u2.
-  Proof.
-    intros. etransitivity.
-    eapply conv_App_l; tea.
-    eapply conv_App_r; tea.
-  Qed.
-
-  Lemma conv_Case_c :
-    forall Γ indn p brs u v,
-      Σ ;;; Γ |- u == v ->
-      Σ ;;; Γ |- tCase indn p u brs == tCase indn p v brs.
-  Proof.
-    intros Γ [ind n] p brs u v h.
-    induction h.
-    - constructor. constructor.
-      + eapply eq_term_refl.
-      + assumption.
-      + eapply All2_same.
-        intros. split ; eauto. reflexivity.
-    - eapply conv_alt_red_l ; eauto.
-      constructor. assumption.
-    - eapply conv_alt_red_r ; eauto.
-      constructor. assumption.
-  Qed.
-
-  Lemma conv_Proj_c :
-    forall Γ p u v,
-      Σ ;;; Γ |- u == v ->
-      Σ ;;; Γ |- tProj p u == tProj p v.
-  Proof.
-    intros Γ p u v h.
-    induction h.
-    - eapply conv_alt_refl. constructor. assumption.
-    - eapply conv_alt_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_Lambda_l :
-    forall Γ na A b na' A',
-      Σ ;;; Γ |- A == A' ->
-      Σ ;;; Γ |- tLambda na A b == tLambda na' A' b.
-  Proof.
-    intros Γ na A b na' A' h.
-    induction h.
-    - eapply conv_alt_refl. constructor.
-      + assumption.
-      + eapply eq_term_refl.
-    - eapply conv_alt_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma conv_Lambda_r :
-    forall Γ na A b b',
-      Σ ;;; Γ,, vass na A |- b == b' ->
-      Σ ;;; Γ |- tLambda na A b == tLambda na A b'.
-  Proof.
-    intros Γ na A b b' h.
-    induction h.
-    - eapply conv_alt_refl. constructor.
-      + eapply eq_term_refl.
-      + assumption.
-    - eapply conv_alt_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply conv_alt_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma cumul_LetIn_bo :
-    forall Γ na ty t u u',
-      Σ ;;; Γ ,, vdef na ty t |- u <= u' ->
-      Σ ;;; Γ |- tLetIn na ty t u <= tLetIn na ty t u'.
-  Proof.
-    intros Γ na ty t u u' h.
-    induction h.
-    - eapply cumul_refl. constructor.
-      all: try eapply eq_term_refl.
-      assumption.
-    - eapply cumul_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply cumul_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma cumul_Lambda_r :
-    forall Γ na A b b',
-      Σ ;;; Γ,, vass na A |- b <= b' ->
-      Σ ;;; Γ |- tLambda na A b <= tLambda na A b'.
-  Proof.
-    intros Γ na A b b' h.
-    induction h.
-    - eapply cumul_refl. constructor.
-      + eapply eq_term_refl.
-      + assumption.
-    - eapply cumul_red_l ; try eassumption.
-      econstructor. assumption.
-    - eapply cumul_red_r ; try eassumption.
-      econstructor. assumption.
-  Qed.
-
-  Lemma cumul_it_mkLambda_or_LetIn :
-    forall Δ Γ u v,
-      Σ ;;; (Δ ,,, Γ) |- u <= v ->
-      Σ ;;; Δ |- it_mkLambda_or_LetIn Γ u <= it_mkLambda_or_LetIn Γ v.
-  Proof.
-    intros Δ Γ u v h. revert Δ u v h.
-    induction Γ as [| [na [b|] A] Γ ih ] ; intros Δ u v h.
-    - assumption.
-    - simpl. cbn. eapply ih.
-      eapply cumul_LetIn_bo. assumption.
-    - simpl. cbn. eapply ih.
-      eapply cumul_Lambda_r. assumption.
-  Qed.
-
-  Lemma cumul_it_mkProd_or_LetIn :
-    forall Δ Γ B B',
-      Σ ;;; (Δ ,,, Γ) |- B <= B' ->
-      Σ ;;; Δ |- it_mkProd_or_LetIn Γ B <= it_mkProd_or_LetIn Γ B'.
-  Proof.
-    intros Δ Γ B B' h.
-    induction Γ as [| [na [b|] A] Γ ih ] in Δ, B, B', h |- *.
-    - assumption.
-    - simpl. cbn. eapply ih.
-      eapply cumul_LetIn_bo. assumption.
-    - simpl. cbn. eapply ih.
-      eapply cumul_Prod_r. assumption.
-  Qed.
-
-  Lemma mkApps_conv_weak :
-    forall Γ u1 u2 l,
-      Σ ;;; Γ |- u1 == u2 ->
-      Σ ;;; Γ |- mkApps u1 l == mkApps u2 l.
-  Proof.
-    intros Γ u1 u2 l. induction l in u1, u2 |- *; cbn. trivial.
-    intros X. apply IHl. now apply conv_App_l.
-  Qed.
-
-
-  Lemma context_relation_length P Γ Γ' :
-    context_relation P Γ Γ' -> #|Γ| = #|Γ'|.
-  Proof.
-    induction 1; cbn; congruence.
-  Qed.
-
-
-  Lemma conv_Lambda leq Γ na1 na2 A1 A2 t1 t2 :
-      Σ ;;; Γ |- A1 == A2 ->
-      conv leq Σ (Γ ,, vass na1 A1) t1 t2 ->
-      conv leq Σ Γ (tLambda na1 A1 t1) (tLambda na2 A2 t2).
-  Proof.
-    intros X H. destruct leq; cbn in *; sq.
-    - etransitivity. eapply conv_Lambda_r; tea.
-      now eapply conv_Lambda_l.
-    - etransitivity. eapply cumul_Lambda_r; tea.
-      eapply conv_cumul_l, conv_Lambda_l; tea.
-  Qed.
-
-  Lemma conva_LetIn_tm Γ na na' ty t t' u :
-      Σ ;;; Γ |- t == t' ->
-      Σ ;;; Γ |- tLetIn na t ty u == tLetIn na' t' ty u.
-  Proof.
-    induction 1.
-    - constructor 1. constructor; try reflexivity.
-      assumption.
-    - econstructor 2; tea. now constructor.
-    - econstructor 3; tea. now constructor.
-  Qed.
-
-  Lemma conva_LetIn_ty Γ na na' ty ty' t u :
-      Σ ;;; Γ |- ty == ty' ->
-      Σ ;;; Γ |- tLetIn na t ty u == tLetIn na' t ty' u.
-  Proof.
-    induction 1.
-    - constructor 1. constructor; try reflexivity.
-      assumption.
-    - econstructor 2; tea. now constructor.
-    - econstructor 3; tea. now constructor.
-  Qed.
-
-  Lemma conva_LetIn_bo Γ na ty t u u' :
-      Σ ;;; Γ ,, vdef na ty t |- u == u' ->
-      Σ ;;; Γ |- tLetIn na ty t u == tLetIn na ty t u'.
-  Proof.
-    induction 1.
-    - constructor 1. now constructor. 
-    - econstructor 2; tea. now constructor.
-    - econstructor 3; tea. now constructor.
-  Qed.
-
-  Lemma conv_LetIn leq Γ na1 na2 t1 t2 A1 A2 u1 u2 :
-      Σ;;; Γ |- t1 == t2 ->
-      Σ;;; Γ |- A1 == A2 ->
-      conv leq Σ (Γ ,, vdef na1 t1 A1) u1 u2 ->
-      conv leq Σ Γ (tLetIn na1 t1 A1 u1) (tLetIn na2 t2 A2 u2).
-  Proof.
-    intros X H H'. destruct leq; cbn in *; sq.
-    - etransitivity. eapply conva_LetIn_bo; tea.
-      etransitivity. eapply conva_LetIn_tm; tea.
-      eapply conva_LetIn_ty with (na := na1); tea.
-    - etransitivity. eapply cumul_LetIn_bo; tea.
-      etransitivity. eapply conv_cumul_l, conva_LetIn_tm; tea.
-      eapply conv_cumul_l, conva_LetIn_ty with (na := na1); tea.
-  Qed.
-
-  Lemma conv_conv_ctx leq Γ Γ' T U :
-    conv leq Σ Γ T U ->
-    conv_context Σ Γ Γ' ->
-    conv leq Σ Γ' T U.
-  Proof.
-    destruct leq; cbn; intros; sq.
-    eapply conv_alt_conv_ctx; eassumption.
-    eapply cumul_conv_ctx; eassumption.
-  Qed.
-
-
-  Lemma it_mkLambda_or_LetIn_conv' leq Γ Δ1 Δ2 t1 t2 :
-      conv_context Σ (Γ ,,, Δ1) (Γ ,,, Δ2) ->
-      conv leq Σ (Γ ,,, Δ1) t1 t2 ->
-      conv leq Σ Γ (it_mkLambda_or_LetIn Δ1 t1) (it_mkLambda_or_LetIn Δ2 t2).
-  Proof.
-    induction Δ1 in Δ2, t1, t2 |- *; intros X Y.
-    - apply context_relation_length in X.
-      destruct Δ2; cbn in *; [trivial|].
-      rewrite app_length in X; lia.
-    - apply context_relation_length in X as X'.
-      destruct Δ2 as [|c Δ2]; simpl in *; [rewrite app_length in X'; lia|].
-      dependent destruction X.
-      + eapply IHΔ1; tas; cbn.
-        inv c0. eapply conv_Lambda; tea.
-      + eapply IHΔ1; tas; cbn.
-        inversion c0; subst; eapply conv_LetIn; auto.
-  Qed.
-
-  Lemma it_mkLambda_or_LetIn_conv Γ Δ1 Δ2 t1 t2 :
-      conv_context Σ (Γ ,,, Δ1) (Γ ,,, Δ2) ->
-      Σ ;;; Γ ,,, Δ1 |- t1 == t2 ->
-      Σ ;;; Γ |- it_mkLambda_or_LetIn Δ1 t1 == it_mkLambda_or_LetIn Δ2 t2.
-  Proof.
-    induction Δ1 in Δ2, t1, t2 |- *; intros X Y.
-    - apply context_relation_length in X.
-      destruct Δ2; cbn in *; [trivial|].
-      exfalso. rewrite app_length in X; lia.
-    - apply context_relation_length in X as X'.
-      destruct Δ2 as [|c Δ2]; simpl in *; [exfalso; rewrite app_length in X'; lia|].
-      dependent destruction X.
-      + eapply IHΔ1; tas; cbn.
-        inv c0. etransitivity. eapply conv_Lambda_r; tea.
-        now eapply conv_Lambda_l.
-      + eapply IHΔ1; tas; cbn.
-        etransitivity. eapply conva_LetIn_bo; tea. inv c0.
-        eapply conva_LetIn_ty; tea.
-        etransitivity. eapply conva_LetIn_tm; tea.
-        eapply conva_LetIn_ty with (na := na); tea.
-  Qed.
-
-  Lemma red_lambda_inv Γ na A1 b1 T :
-    red Σ Γ (tLambda na A1 b1) T ->
-    ∑ A2 b2, (T = tLambda na A2 b2) *
-             red Σ Γ A1 A2 * red Σ (Γ ,, vass na A1) b1 b2.
-  Proof.
-    intros.
-    eapply red_alt in X. eapply clos_rt_rt1n_iff in X.
-    depind X.
-    - eexists _, _; intuition eauto.
-    - depelim r; solve_discr; specialize (IHX _ _ _ _ eq_refl);
-      destruct IHX as [A2 [B2 [[-> ?] ?]]].
-      * eexists _, _; intuition eauto.
-        now eapply red_step with M'.
-        eapply PCUICConfluence.red_red_ctx; eauto.
-        constructor; auto. eapply All2_local_env_red_refl.
-        red. auto.
-      * eexists _, _; intuition eauto.
-        now eapply red_step with M'.
-  Qed.
-
-  Lemma Lambda_conv_inv :
-    forall leq Γ na1 na2 A1 A2 b1 b2,
-      wf_local Σ Γ ->
-      conv leq Σ Γ (tLambda na1 A1 b1) (tLambda na2 A2 b2) ->
-      ∥ Σ ;;; Γ |- A1 == A2 ∥ /\ conv leq Σ (Γ ,, vass na1 A1) b1 b2.
-  Proof.
-    intros * wfΓ.
-    destruct leq; simpl in *.
-    - destruct 1.
-      eapply conv_alt_red in X as [l [r [[redl redr] eq]]].
-      eapply red_lambda_inv in redl as [A1' [b1' [[-> ?] ?]]].
-      eapply red_lambda_inv in redr as [A2' [b2' [[-> ?] ?]]].
-      depelim eq. assert (Σ ;;; Γ |- A1 == A2).
-      { eapply conv_alt_trans with A1'; auto.
-        eapply conv_alt_trans with A2'; auto.
-        constructor. assumption.
-        apply conv_alt_sym; auto. }
-      split; constructor; auto.
-      eapply conv_alt_trans with b1'; auto.
-      eapply conv_alt_trans with b2'; auto.
-      constructor; auto.
-      apply conv_alt_sym; auto.
-      eapply conv_alt_conv_ctx; eauto.
-      constructor; auto. reflexivity. constructor. now apply conv_alt_sym.
-    - destruct 1.
-      eapply cumul_alt in X as [l [r [[redl redr] eq]]].
-      eapply red_lambda_inv in redl as [A1' [b1' [[-> ?] ?]]].
-      eapply red_lambda_inv in redr as [A2' [b2' [[-> ?] ?]]].
-      depelim eq. assert (Σ ;;; Γ |- A1 == A2).
-      { eapply conv_alt_trans with A1'; auto.
-        eapply conv_alt_trans with A2'; auto.
-        constructor. assumption.
-        apply conv_alt_sym; auto. }
-      split; constructor; auto.
-      eapply red_cumul_cumul; tea.
-      eapply cumul_trans with b2'; auto.
-      constructor; auto.
-      eapply cumul_conv_ctx; tas. eapply red_cumul_cumul_inv; tea.
-      reflexivity. symmetry in X.
-      constructor. reflexivity. now constructor.
-  Qed.
-
-End Inversions.
+(** ** Context conversion ** *)
+
+Inductive context_relation
+          (P : context -> context -> context_decl -> context_decl -> Type)
+          : forall (Γ Γ' : context), Type :=
+| ctx_rel_nil : context_relation P nil nil
+| ctx_rel_vass na na' T U Γ Γ' :
+    context_relation P Γ Γ' ->
+    P Γ Γ' (vass na T) (vass na' U) ->
+    context_relation P (vass na T :: Γ) (vass na' U :: Γ')
+| ctx_rel_def na na' t T u U Γ Γ' :
+    context_relation P Γ Γ' ->
+    P Γ Γ' (vdef na t T) (vdef na' u U) ->
+    context_relation P (vdef na t T :: Γ) (vdef na' u U :: Γ').
+Derive Signature for context_relation.
+Arguments context_relation P Γ Γ' : clear implicits.
+
+Section ConvContext.
+
+  Context {cf:checker_flags} (Σ : global_env_ext).
+
+  Inductive conv_decls (Γ Γ' : context) : forall (x y : context_decl), Type :=
+  | conv_vass na na' T T' :
+      (* isType Σ Γ' T' -> *)
+      Σ ;;; Γ |- T = T' ->
+      conv_decls Γ Γ' (vass na T) (vass na' T')
+
+  | conv_vdef_type na na' b T T' :
+      (* isType Σ Γ' T' -> *)
+      Σ ;;; Γ |- T = T' ->
+      conv_decls Γ Γ' (vdef na b T) (vdef na' b T')
+
+  | conv_vdef_body na na' b b' T T' :
+      (* isType Σ Γ' T' -> *)
+      (* Σ ;;; Γ' |- b' : T' -> *)
+      Σ ;;; Γ |- b = b' ->
+      Σ ;;; Γ |- T = T' ->
+      conv_decls Γ Γ' (vdef na b T) (vdef na' b' T').
+
+End ConvContext.
+
+Notation conv_context Σ Γ Γ' := (context_relation (conv_decls Σ) Γ Γ').

--- a/pcuic/theories/PCUICConversionLemmas.v
+++ b/pcuic/theories/PCUICConversionLemmas.v
@@ -1,0 +1,888 @@
+(* Distributed under the terms of the MIT license.   *)
+From Equations Require Import Equations.
+From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From MetaCoq.Template Require Import config utils AstUtils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
+     PCUICLiftSubst PCUICUnivSubst PCUICEquality
+     PCUICTyping PCUICWeakeningEnv PCUICWeakening PCUICSubstitution
+     PCUICCumulativity PCUICConfluence PCUICParallelReductionConfluence
+     PCUICEquality PCUICContextConversion.
+
+Require Import ssreflect ssrbool.
+Require Import String.
+From MetaCoq Require Import LibHypsNaming.
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Require Import CRelationClasses.
+Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
+Require Import Equations.Prop.DepElim.
+
+Ltac tc := try typeclasses eauto 10.
+(* Hint Resolve eq_universe_leq_universe' : pcuic. *)
+
+
+Derive Signature for cumul.
+
+Lemma congr_cumul_prod : forall `{checker_flags} Σ Γ na na' M1 M2 N1 N2,
+    Σ ;;; Γ |- M1 = N1 ->
+    Σ ;;; (Γ ,, vass na M1) |- M2 <= N2 ->
+    Σ ;;; Γ |- (tProd na M1 M2) <= (tProd na' N1 N2).
+Proof.
+  intros.
+Admitted.
+
+(* Should follow from context conversion + invariants on T and U *)
+(* Lemma conv_conv_alt `{cf : checker_flags} {Σ : global_env_ext} (wfΣ : wf Σ) Γ T U : *)
+(*   Σ ;;; Γ |- T = U -> Σ ;;; Γ |- T == U. *)
+(* Proof. *)
+(* Admitted. *)
+
+Lemma cumul_Sort_inv {cf:checker_flags} Σ Γ s s' :
+  Σ ;;; Γ |- tSort s <= tSort s' -> leq_universe (global_ext_constraints Σ) s s'.
+Proof.
+  intros H; depind H; auto.
+  - now inversion l.
+  - depelim r. solve_discr.
+  - depelim r. solve_discr.
+Qed.
+
+Lemma cumul_Sort_Prod_inv {cf:checker_flags} Σ Γ s na dom codom :
+  Σ ;;; Γ |- tSort s <= tProd na dom codom -> False.
+Proof.
+  intros H; depind H; auto.
+  - now inversion l.
+  - depelim r. solve_discr.
+  - depelim r. solve_discr. eapply IHcumul. reflexivity.
+    eapply IHcumul. reflexivity.
+Qed.
+
+Lemma cumul_Sort_l_inv {cf:checker_flags} Σ Γ s T :
+  Σ ;;; Γ |- tSort s <= T ->
+  ∑ s', red Σ Γ T (tSort s') * leq_universe Σ s s'.
+Proof.
+  intros H; depind H; auto.
+  - now inversion l.
+  - depelim r. solve_discr.
+  - destruct IHcumul as [s' [redv leq]].
+    exists s'. split; auto. now eapply red_step with v.
+Qed.
+
+Lemma cumul_Sort_r_inv {cf:checker_flags} Σ Γ s T :
+  Σ ;;; Γ |- T <= tSort s ->
+  ∑ s', red Σ Γ T (tSort s') * leq_universe Σ s' s.
+Proof.
+  intros H; depind H; auto.
+  - now inversion l.
+  - destruct IHcumul as [s' [redv leq]].
+    exists s'. split; auto. now eapply red_step with v.
+  - depelim r. solve_discr.
+Qed.
+
+Lemma cumul_LetIn_l_inv {cf:checker_flags} (Σ : global_env_ext) Γ na b B codom T :
+  wf Σ ->
+  Σ ;;; Γ |- tLetIn na b B codom <= T ->
+  ∑ codom', red Σ Γ T codom' *
+                     (Σ ;;; Γ |- codom {0 := b} <= codom').
+Proof.
+  intros wfΣ H; depind H; auto.
+  - inv l. eexists (u' {0 := t'}); intuition eauto. eapply red1_red. constructor.
+    transitivity (codom {0 := t'}).
+    { constructor. eapply eq_term_upto_univ_subst; trivial. auto with pcuic. reflexivity. }
+    constructor. now eapply subst_leq_term.
+  - depelim r.
+    * exists u; intuition auto.
+    * solve_discr.
+    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [codom' [reddom' leq]].
+      exists codom'; intuition auto.
+      transitivity (codom {0 := r}); eauto.
+      eapply red_cumul. eapply (red_red Σ _ [vdef na b B] []) => //. constructor. now eapply red1_red.
+      constructor. rewrite -{1}(subst_empty 0 b). repeat constructor.
+    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [codom' [reddom' leq]].
+      exists codom'; intuition auto.
+    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [codom' [reddom' leq]].
+      exists codom'; intuition auto.
+      eapply transitivity; [|eassumption].
+      eapply red_cumul.
+      rewrite -{1 2}(subst_empty 0 b).
+      eapply (untyped_substitution_red _ _ [vdef na b B] []); auto. repeat constructor.
+  - specialize (IHcumul wfΣ).
+    destruct IHcumul as [codom' [reddom' leq]] => //.
+    exists codom'; intuition auto.
+    now eapply red_step with v.
+Qed.
+
+Lemma cumul_LetIn_r_inv {cf:checker_flags} (Σ : global_env_ext) Γ na b B codom T :
+  wf Σ ->
+  Σ ;;; Γ |- T <= tLetIn na b B codom ->
+  ∑ codom', red Σ Γ T codom' *
+                     (Σ ;;; Γ |- codom' <= codom {0 := b}).
+Proof.
+  intros wfΣ H; depind H; auto.
+  - inv l. eexists (u {0 := t0}); intuition eauto. eapply red1_red. constructor.
+    transitivity (codom {0 := t0}).
+    { constructor. eapply eq_term_upto_univ_subst; trivial. auto with pcuic. reflexivity. }
+    constructor. eapply eq_term_upto_univ_subst; auto with pcuic. reflexivity.
+  - specialize (IHcumul wfΣ).
+    destruct IHcumul as [codom' [reddom' leq]] => //.
+    exists codom'; intuition auto.
+    now eapply red_step with v.
+  - depelim r.
+    * eexists ; intuition eauto.
+    * solve_discr.
+    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [codom' [reddom' leq]].
+      exists codom'; intuition auto.
+      transitivity (codom {0 := r}); eauto.
+      eapply red_cumul_inv. eapply (red_red Σ _ [vdef na b B] []) => //. constructor. now eapply red1_red.
+      constructor. rewrite -{1}(subst_empty 0 b). repeat constructor.
+    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [codom' [reddom' leq]].
+      exists codom'; intuition auto.
+    * specialize (IHcumul _ _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [codom' [reddom' leq]].
+      exists codom'; intuition auto.
+      eapply transitivity; [eassumption|].
+      eapply red_cumul_inv.
+      rewrite -{1 2}(subst_empty 0 b).
+      eapply (untyped_substitution_red _ _ [vdef na b B] []); auto. repeat constructor.
+Qed.
+
+Lemma cumul_Prod_l_inv {cf:checker_flags} (Σ : global_env_ext) Γ na dom codom T :
+  wf Σ ->
+  Σ ;;; Γ |- tProd na dom codom <= T ->
+  ∑ na' dom' codom', red Σ Γ T (tProd na' dom' codom') *
+                     (Σ ;;; Γ |- dom = dom') * (Σ ;;; Γ ,, vass na dom |- codom <= codom').
+Proof.
+  intros wfΣ H; depind H; auto.
+  - inv l. exists na', a', b'; intuition eauto; constructor; auto.
+  - depelim r. solve_discr.
+    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [na' [dom' [codom' [[reddom' eqdom'] leq]]]].
+      exists na', dom', codom'; intuition auto.
+      transitivity N1; eauto. now econstructor 2.
+      eapply cumul_conv_ctx; eauto. constructor. reflexivity.
+      constructor. symmetry; eapply red_conv; auto.
+
+    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [na' [dom' [codom' [[reddom' eqdom'] leq]]]].
+      exists na', dom', codom'; intuition auto.
+      transitivity N2; eauto. eapply red_cumul; auto.
+  - destruct IHcumul as [na' [dom' [codom' [[reddom' eqdom'] leq]]]] => //.
+    exists na', dom', codom'; intuition auto.
+    now eapply red_step with v.
+Qed.
+
+Lemma cumul_Prod_r_inv {cf:checker_flags} (Σ : global_env_ext) Γ na' dom' codom' T :
+  wf Σ ->
+  Σ ;;; Γ |- T <= tProd na' dom' codom' ->
+  ∑ na dom codom, red Σ Γ T (tProd na dom codom) *
+                     (Σ ;;; Γ |- dom = dom') * (Σ ;;; Γ ,, vass na' dom' |- codom <= codom').
+Proof.
+  intros wfΣ H; depind H; auto.
+  - inv l. exists na, a, b; intuition eauto; constructor; auto.
+  - destruct IHcumul as [na [dom [codom [[reddom' eqdom'] leq]]]] => //.
+    exists na, dom, codom; intuition auto.
+    now eapply red_step with v.
+  - depelim r. solve_discr.
+    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [na [dom [codom [[reddom' eqdom'] leq]]]].
+      eexists _, _, _; intuition eauto.
+      transitivity N1; eauto. symmetry; apply red_conv; auto.
+      eapply cumul_conv_ctx; eauto. constructor. reflexivity.
+      constructor. symmetry. eapply red_conv; auto.
+
+    * specialize (IHcumul _ _ _ _ wfΣ eq_refl).
+      destruct IHcumul as [na [dom [codom [[reddom' eqdom'] leq]]]].
+      eexists _, _, _; intuition eauto.
+      transitivity N2; eauto. eapply red_cumul_inv; auto.
+Qed.
+
+Lemma cumul_Prod_Sort_inv {cf:checker_flags} Σ Γ s na dom codom :
+  Σ ;;; Γ |- tProd na dom codom <= tSort s -> False.
+Proof.
+  intros H; depind H; auto.
+  - now inversion l.
+  - depelim r. solve_discr. eapply IHcumul; reflexivity.
+    eapply IHcumul; reflexivity.
+  - depelim r. solve_discr.
+Qed.
+
+Lemma cumul_Prod_Prod_inv {cf:checker_flags} (Σ : global_env_ext) Γ na na' dom dom' codom codom' : wf Σ ->
+  Σ ;;; Γ |- tProd na dom codom <= tProd na' dom' codom' ->
+   ((Σ ;;; Γ |- dom = dom') * (Σ ;;; Γ ,, vass na' dom' |- codom <= codom'))%type.
+Proof.
+  intros wfΣ H; depind H; auto.
+  - inv l. split; auto; constructor; auto.
+  - depelim r. solve_discr.
+    destruct (IHcumul na na' N1 _ _ _ wfΣ eq_refl).
+    split; auto. transitivity N1=> //. now eapply red_conv, red1_red.
+    destruct (IHcumul na na' _ _ N2 _ wfΣ eq_refl).
+    split; auto. eapply cumul_trans. auto. 2:eauto.
+    eapply cumul_conv_ctx; eauto. eapply red_cumul; eauto.
+    constructor. reflexivity. auto with pcuic.
+  - depelim r. solve_discr.
+    destruct (IHcumul na na' _ _ _ _ wfΣ eq_refl).
+    split; auto. transitivity N1 => //. symmetry => //.
+    now eapply red_conv, red1_red.
+    eapply cumul_red_ctx_inv. auto. eauto. constructor. eapply All2_local_env_red_refl. red.
+    now eapply red1_red.
+    destruct (IHcumul na na' _ _ _ _ wfΣ eq_refl).
+    split; auto.
+    eapply cumul_trans with N2; auto.
+    (* eapply red1_red, red_conv in r. apply conv_cumul_inv. , r. *)
+(* Qed. *)
+Admitted.
+
+Lemma assumption_context_app Γ Γ' :
+  assumption_context (Γ' ,,, Γ) ->
+  assumption_context Γ * assumption_context Γ'.
+Proof.
+  induction Γ; simpl; split; try constructor; auto. depelim H. constructor; auto. now eapply IHΓ.
+  depelim H. now eapply IHΓ.
+Qed.
+
+Lemma it_mkProd_or_LetIn_ass_inv {cf : checker_flags} (Σ : global_env_ext) Γ ctx ctx' s s' :
+  wf Σ ->
+  assumption_context ctx ->
+  assumption_context ctx' ->
+  Σ ;;; Γ |- it_mkProd_or_LetIn ctx (tSort s) <= it_mkProd_or_LetIn ctx' (tSort s') ->
+  conv_context Σ ctx ctx' * leq_term Σ (tSort s) (tSort s').
+Proof.
+  intros wfΣ.
+  revert Γ ctx' s s'.
+  induction ctx using rev_ind.
+  intros. destruct ctx' using rev_ind. simpl in X.
+  - eapply cumul_Sort_inv in X. split; constructor; auto.
+  - destruct x as [na [b|] ty]. elimtype False.
+    apply assumption_context_app in H0.
+    destruct H0. inv a0.
+    rewrite it_mkProd_or_LetIn_app in X.
+    apply assumption_context_app in H0 as [H0 _].
+    specialize (IHctx' H0).
+    simpl in IHctx'. simpl in X. unfold mkProd_or_LetIn in X. simpl in X.
+    eapply cumul_Sort_Prod_inv in X. depelim X.
+  - intros.
+    rewrite it_mkProd_or_LetIn_app in X.
+    simpl in X.
+    eapply assumption_context_app in H as [H H'].
+    destruct x as [na [b|] ty]. elimtype False. inv H'.
+    rewrite /mkProd_or_LetIn /= in X.
+    destruct ctx' using rev_ind.
+    simpl in X.
+    now eapply cumul_Prod_Sort_inv in X.
+    eapply assumption_context_app in H0 as [H0 Hx].
+    destruct x as [na' [b'|] ty']; [elimtype False; inv Hx|].
+    rewrite it_mkProd_or_LetIn_app in X.
+    rewrite /= /mkProd_or_LetIn /= in X.
+    eapply cumul_Prod_Prod_inv in X as [Hdom Hcodom]; auto.
+    specialize (IHctx (Γ ,, vass na' ty') l0 s s' H H0 Hcodom). clear IHctx'.
+    intuition auto.
+Admitted.
+
+(** Injectivity of products, the essential property of cumulativity needed for subject reduction. *)
+Lemma cumul_Prod_inv {cf:checker_flags} Σ Γ na na' A B A' B' :
+  wf Σ.1 -> wf_local Σ Γ ->
+  Σ ;;; Γ |- tProd na A B <= tProd na' A' B' ->
+   ((Σ ;;; Γ |- A = A') * (Σ ;;; Γ ,, vass na' A' |- B <= B'))%type.
+Proof.
+  intros wfΣ wfΓ H; depind H.
+  - depelim l.
+    split; auto.
+    now constructor.
+    now constructor.
+
+  - depelim r. solve_discr.
+    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
+    intuition auto.
+    econstructor 2; eauto.
+
+    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
+    intuition auto. apply cumul_trans with N2. auto.
+    eapply cumul_conv_ctx; eauto.
+
+    econstructor 2. eauto. constructor. reflexivity.
+    constructor. now apply conv_ctx_refl.
+    constructor; auto.
+    auto.
+
+  - depelim r. solve_discr.
+    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
+    intuition auto. econstructor 3. 2:eauto. auto.
+    eapply cumul_conv_ctx in b. eauto. auto. constructor. eapply conv_ctx_refl. auto.
+    constructor. econstructor 3; tea. reflexivity.
+
+    specialize (IHcumul _ _ _ _ _ _ wfΣ wfΓ eq_refl).
+    intuition auto. apply cumul_trans with N2. auto. auto.
+    eapply cumul_red_r; eauto. reflexivity.
+Qed.
+
+Lemma tProd_it_mkProd_or_LetIn na A B ctx s :
+  tProd na A B = it_mkProd_or_LetIn ctx (tSort s) ->
+  { ctx' & ctx = (ctx' ++ [vass na A])%list /\
+           destArity [] B = Some (ctx', s) }.
+Proof.
+  intros. exists (removelast ctx).
+  revert na A B s H.
+  induction ctx using rev_ind; intros; noconf H.
+  rewrite it_mkProd_or_LetIn_app in H. simpl in H.
+  destruct x as [na' [b'|] ty']; noconf H; simpl in *.
+  rewrite removelast_app. congruence. simpl. rewrite app_nil_r. intuition auto.
+  rewrite destArity_it_mkProd_or_LetIn. simpl. now rewrite app_context_nil_l.
+Qed.
+
+Section Inversions.
+  Context {cf : checker_flags}.
+  Context (Σ : global_env_ext) (wfΣ : wf Σ).
+
+  Lemma cumul_App_r {Γ f u v} :
+    Σ ;;; Γ |- u = v ->
+    Σ ;;; Γ |- tApp f u <= tApp f v.
+  Proof.
+    intros h.
+    induction h.
+    - eapply cumul_refl. constructor.
+      + apply leq_term_refl.
+      + assumption.
+    -  eapply cumul_red_l ; try eassumption.
+       econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma conv_App_r {Γ f x y} :
+    Σ ;;; Γ |- x = y ->
+    Σ ;;; Γ |- tApp f x = tApp f y.
+  Proof.
+    intros h.
+    induction h.
+    - constructor. constructor.
+      + apply eq_term_refl.
+      + assumption.
+    - eapply conv_red_l ; eauto.
+      econstructor. assumption.
+    - eapply conv_red_r ; eauto.
+      econstructor. assumption.
+  Qed.
+
+  Lemma conv_Prod_l:
+    forall {Γ na na' A1 A2 B},
+      Σ ;;; Γ |- A1 = A2 ->
+      Σ ;;; Γ |- tProd na A1 B = tProd na' A2 B.
+  Proof.
+    intros Γ na na' A1 A2 B h.
+    induction h.
+    - constructor. constructor.
+      + assumption.
+      + apply eq_term_refl.
+    - eapply conv_red_l ; eauto.
+      econstructor. assumption.
+    - eapply conv_red_r ; eauto.
+      econstructor. assumption.
+  Qed.
+
+  Lemma conv_Prod_r  :
+    forall {Γ na A B1 B2},
+      Σ ;;; Γ ,, vass na A |- B1 = B2 ->
+      Σ ;;; Γ |- tProd na A B1 = tProd na A B2.
+  Proof.
+    intros Γ na A B1 B2 h.
+    induction h.
+    - constructor. constructor.
+      + apply eq_term_refl.
+      + assumption.
+    - eapply conv_red_l ; eauto.
+      econstructor. assumption.
+    - eapply conv_red_r ; eauto.
+      econstructor. assumption.
+  Qed.
+
+  Lemma cumul_Prod_r :
+    forall {Γ na A B1 B2},
+      Σ ;;; Γ ,, vass na A |- B1 <= B2 ->
+      Σ ;;; Γ |- tProd na A B1 <= tProd na A B2.
+  Proof.
+    intros Γ na A B1 B2 h.
+    induction h.
+    - eapply cumul_refl. constructor.
+      + apply eq_term_refl.
+      + assumption.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Global Instance conv_cum_refl :
+    forall leq Γ, RelationClasses.Reflexive (conv_cum leq Σ Γ).
+  Proof.
+    intros leq Γ t.
+    destruct leq; now constructor.
+  Qed.
+
+  Global Instance conv_cum_trans :
+    forall leq Γ, RelationClasses.Transitive (conv_cum leq Σ Γ).
+  Proof.
+    intros leq Γ u v w h1 h2.
+    destruct leq.
+    - cbn in *. destruct h1, h2. constructor.
+      eapply conv_trans ; eassumption.
+    - cbn in *. destruct h1, h2. constructor. eapply cumul_trans ; eassumption.
+  Qed.
+
+  Lemma red_conv_cum_l :
+    forall leq Γ u v,
+      red (fst Σ) Γ u v ->
+      conv_cum leq Σ Γ u v.
+  Proof.
+    intros leq Γ u v h.
+    induction h.
+    - reflexivity.
+    - etransitivity; tea.
+      destruct leq.
+      + simpl. destruct IHh. constructor.
+        eapply conv_red_l; eauto. reflexivity.
+      + simpl. constructor.
+        now eapply cumul_red_l.
+  Qed.
+
+  Lemma red_conv_cum_r :
+    forall leq Γ u v,
+      red (fst Σ) Γ u v ->
+      conv_cum leq Σ Γ v u.
+  Proof.
+    intros leq Γ u v h.
+    induction h.
+    - reflexivity.
+    - etransitivity; tea.
+      destruct leq.
+      + simpl. destruct IHh. constructor.
+        eapply conv_red_r; eauto. reflexivity.
+      + simpl. constructor.
+        now eapply cumul_red_r.
+  Qed.
+
+  Lemma conv_cum_Prod leq Γ na1 na2 A1 A2 B1 B2 :
+      Σ ;;; Γ |- A1 = A2 ->
+      conv_cum leq Σ (Γ,, vass na1 A1) B1 B2 ->
+      conv_cum leq Σ Γ (tProd na1 A1 B1) (tProd na2 A2 B2).
+  Proof.
+    intros h1 h2; destruct leq.
+    - simpl in *. destruct h2 as [h2]. constructor.
+      eapply conv_trans => //.
+      + eapply conv_Prod_r. eassumption.
+      + eapply conv_Prod_l. eassumption.
+    - simpl in *. destruct h2 as [h2]. constructor.
+      eapply cumul_trans. auto.
+      + eapply cumul_Prod_r. eassumption.
+      + eapply conv_cumul. eapply conv_Prod_l. assumption.
+  Qed.
+
+  Lemma cumul_Case_c :
+    forall Γ indn p brs u v,
+      Σ ;;; Γ |- u = v ->
+      Σ ;;; Γ |- tCase indn p u brs <= tCase indn p v brs.
+  Proof.
+    intros Γ [ind n] p brs u v h.
+    induction h.
+    - constructor. constructor.
+      + eapply eq_term_refl.
+      + assumption.
+      + eapply All2_same.
+        intros. split ; eauto.
+        reflexivity.
+    - eapply cumul_red_l ; eauto.
+      constructor. assumption.
+    - eapply cumul_red_r ; eauto.
+      constructor. assumption.
+  Qed.
+
+  Lemma cumul_Proj_c :
+    forall Γ p u v,
+      Σ ;;; Γ |- u = v ->
+      Σ ;;; Γ |- tProj p u <= tProj p v.
+  Proof.
+    intros Γ p u v h.
+    induction h.
+    - eapply cumul_refl. constructor. assumption.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma conv_App_l :
+    forall {Γ f g x},
+      Σ ;;; Γ |- f = g ->
+      Σ ;;; Γ |- tApp f x = tApp g x.
+  Proof.
+    intros Γ f g x h.
+    induction h.
+    - constructor. constructor.
+      + assumption.
+      + apply eq_term_refl.
+    - eapply conv_red_l ; eauto.
+      econstructor. assumption.
+    - eapply conv_red_r ; eauto.
+      econstructor. assumption.
+  Qed.
+
+  Lemma App_conv :
+    forall Γ t1 t2 u1 u2,
+      Σ ;;; Γ |- t1 = t2 ->
+      Σ ;;; Γ |- u1 = u2 ->
+      Σ ;;; Γ |- tApp t1 u1 = tApp t2 u2.
+  Proof.
+    intros. etransitivity.
+    eapply conv_App_l; tea.
+    eapply conv_App_r; tea.
+  Qed.
+
+  Lemma conv_Case_c :
+    forall Γ indn p brs u v,
+      Σ ;;; Γ |- u = v ->
+      Σ ;;; Γ |- tCase indn p u brs = tCase indn p v brs.
+  Proof.
+    intros Γ [ind n] p brs u v h.
+    induction h.
+    - constructor. constructor.
+      + eapply eq_term_refl.
+      + assumption.
+      + eapply All2_same.
+        intros. split ; eauto. reflexivity.
+    - eapply conv_red_l ; eauto.
+      constructor. assumption.
+    - eapply conv_red_r ; eauto.
+      constructor. assumption.
+  Qed.
+
+  Lemma conv_Proj_c :
+    forall Γ p u v,
+      Σ ;;; Γ |- u = v ->
+      Σ ;;; Γ |- tProj p u = tProj p v.
+  Proof.
+    intros Γ p u v h.
+    induction h.
+    - eapply conv_refl. constructor. assumption.
+    - eapply conv_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply conv_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma conv_Lambda_l :
+    forall Γ na A b na' A',
+      Σ ;;; Γ |- A = A' ->
+      Σ ;;; Γ |- tLambda na A b = tLambda na' A' b.
+  Proof.
+    intros Γ na A b na' A' h.
+    induction h.
+    - eapply conv_refl. constructor.
+      + assumption.
+      + eapply eq_term_refl.
+    - eapply conv_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply conv_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma conv_Lambda_r :
+    forall Γ na A b b',
+      Σ ;;; Γ,, vass na A |- b = b' ->
+      Σ ;;; Γ |- tLambda na A b = tLambda na A b'.
+  Proof.
+    intros Γ na A b b' h.
+    induction h.
+    - eapply conv_refl. constructor.
+      + eapply eq_term_refl.
+      + assumption.
+    - eapply conv_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply conv_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma cumul_LetIn_bo :
+    forall Γ na ty t u u',
+      Σ ;;; Γ ,, vdef na ty t |- u <= u' ->
+      Σ ;;; Γ |- tLetIn na ty t u <= tLetIn na ty t u'.
+  Proof.
+    intros Γ na ty t u u' h.
+    induction h.
+    - eapply cumul_refl. constructor.
+      all: try eapply eq_term_refl.
+      assumption.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma cumul_Lambda_r :
+    forall Γ na A b b',
+      Σ ;;; Γ,, vass na A |- b <= b' ->
+      Σ ;;; Γ |- tLambda na A b <= tLambda na A b'.
+  Proof.
+    intros Γ na A b b' h.
+    induction h.
+    - eapply cumul_refl. constructor.
+      + eapply eq_term_refl.
+      + assumption.
+    - eapply cumul_red_l ; try eassumption.
+      econstructor. assumption.
+    - eapply cumul_red_r ; try eassumption.
+      econstructor. assumption.
+  Qed.
+
+  Lemma cumul_it_mkLambda_or_LetIn :
+    forall Δ Γ u v,
+      Σ ;;; (Δ ,,, Γ) |- u <= v ->
+      Σ ;;; Δ |- it_mkLambda_or_LetIn Γ u <= it_mkLambda_or_LetIn Γ v.
+  Proof.
+    intros Δ Γ u v h. revert Δ u v h.
+    induction Γ as [| [na [b|] A] Γ ih ] ; intros Δ u v h.
+    - assumption.
+    - simpl. cbn. eapply ih.
+      eapply cumul_LetIn_bo. assumption.
+    - simpl. cbn. eapply ih.
+      eapply cumul_Lambda_r. assumption.
+  Qed.
+
+  Lemma cumul_it_mkProd_or_LetIn :
+    forall Δ Γ B B',
+      Σ ;;; (Δ ,,, Γ) |- B <= B' ->
+      Σ ;;; Δ |- it_mkProd_or_LetIn Γ B <= it_mkProd_or_LetIn Γ B'.
+  Proof.
+    intros Δ Γ B B' h.
+    induction Γ as [| [na [b|] A] Γ ih ] in Δ, B, B', h |- *.
+    - assumption.
+    - simpl. cbn. eapply ih.
+      eapply cumul_LetIn_bo. assumption.
+    - simpl. cbn. eapply ih.
+      eapply cumul_Prod_r. assumption.
+  Qed.
+
+  Lemma mkApps_conv_weak :
+    forall Γ u1 u2 l,
+      Σ ;;; Γ |- u1 = u2 ->
+      Σ ;;; Γ |- mkApps u1 l = mkApps u2 l.
+  Proof.
+    intros Γ u1 u2 l. induction l in u1, u2 |- *; cbn. trivial.
+    intros X. apply IHl. now apply conv_App_l.
+  Qed.
+
+
+  Lemma context_relation_length P Γ Γ' :
+    context_relation P Γ Γ' -> #|Γ| = #|Γ'|.
+  Proof.
+    induction 1; cbn; congruence.
+  Qed.
+
+
+  Lemma conv_cum_Lambda leq Γ na1 na2 A1 A2 t1 t2 :
+      Σ ;;; Γ |- A1 = A2 ->
+      conv_cum leq Σ (Γ ,, vass na1 A1) t1 t2 ->
+      conv_cum leq Σ Γ (tLambda na1 A1 t1) (tLambda na2 A2 t2).
+  Proof.
+    intros X H. destruct leq; cbn in *; sq.
+    - etransitivity. eapply conv_Lambda_r; tea.
+      now eapply conv_Lambda_l.
+    - etransitivity. eapply cumul_Lambda_r; tea.
+      eapply conv_cumul, conv_Lambda_l; tea.
+  Qed.
+
+  Lemma conv_LetIn_tm Γ na na' ty t t' u :
+      Σ ;;; Γ |- t = t' ->
+      Σ ;;; Γ |- tLetIn na t ty u = tLetIn na' t' ty u.
+  Proof.
+    induction 1.
+    - constructor 1. constructor; try reflexivity.
+      assumption.
+    - econstructor 2; tea. now constructor.
+    - econstructor 3; tea. now constructor.
+  Qed.
+
+  Lemma conv_LetIn_ty Γ na na' ty ty' t u :
+      Σ ;;; Γ |- ty = ty' ->
+      Σ ;;; Γ |- tLetIn na t ty u = tLetIn na' t ty' u.
+  Proof.
+    induction 1.
+    - constructor 1. constructor; try reflexivity.
+      assumption.
+    - econstructor 2; tea. now constructor.
+    - econstructor 3; tea. now constructor.
+  Qed.
+
+  Lemma conv_LetIn_bo Γ na ty t u u' :
+      Σ ;;; Γ ,, vdef na ty t |- u = u' ->
+      Σ ;;; Γ |- tLetIn na ty t u = tLetIn na ty t u'.
+  Proof.
+    induction 1.
+    - constructor 1. now constructor. 
+    - econstructor 2; tea. now constructor.
+    - econstructor 3; tea. now constructor.
+  Qed.
+
+  Lemma conv_cum_LetIn leq Γ na1 na2 t1 t2 A1 A2 u1 u2 :
+      Σ;;; Γ |- t1 = t2 ->
+      Σ;;; Γ |- A1 = A2 ->
+      conv_cum leq Σ (Γ ,, vdef na1 t1 A1) u1 u2 ->
+      conv_cum leq Σ Γ (tLetIn na1 t1 A1 u1) (tLetIn na2 t2 A2 u2).
+  Proof.
+    intros X H H'. destruct leq; cbn in *; sq.
+    - etransitivity. eapply conv_LetIn_bo; tea.
+      etransitivity. eapply conv_LetIn_tm; tea.
+      eapply conv_LetIn_ty with (na := na1); tea.
+    - etransitivity. eapply cumul_LetIn_bo; tea.
+      etransitivity. eapply conv_cumul, conv_LetIn_tm; tea.
+      eapply conv_cumul, conv_LetIn_ty with (na := na1); tea.
+  Qed.
+
+  Lemma conv_cum_conv_ctx leq Γ Γ' T U :
+    conv_cum leq Σ Γ T U ->
+    conv_context Σ Γ Γ' ->
+    conv_cum leq Σ Γ' T U.
+  Proof.
+    destruct leq; cbn; intros; sq.
+    eapply conv_conv_ctx; eassumption.
+    eapply cumul_conv_ctx; eassumption.
+  Qed.
+
+
+  Lemma it_mkLambda_or_LetIn_conv_cum leq Γ Δ1 Δ2 t1 t2 :
+      conv_context Σ (Γ ,,, Δ1) (Γ ,,, Δ2) ->
+      conv_cum leq Σ (Γ ,,, Δ1) t1 t2 ->
+      conv_cum leq Σ Γ (it_mkLambda_or_LetIn Δ1 t1) (it_mkLambda_or_LetIn Δ2 t2).
+  Proof.
+    induction Δ1 in Δ2, t1, t2 |- *; intros X Y.
+    - apply context_relation_length in X.
+      destruct Δ2; cbn in *; [trivial|].
+      rewrite app_length in X; lia.
+    - apply context_relation_length in X as X'.
+      destruct Δ2 as [|c Δ2]; simpl in *; [rewrite app_length in X'; lia|].
+      dependent destruction X.
+      + eapply IHΔ1; tas; cbn.
+        inv c0. eapply conv_cum_Lambda; tea.
+      + eapply IHΔ1; tas; cbn.
+        inversion c0; subst; eapply conv_cum_LetIn; auto. reflexivity.
+  Qed.
+
+  Lemma conv_it_mkProd_or_LetIn :
+    forall Δ Γ B B',
+      Σ ;;; (Δ ,,, Γ) |- B = B' ->
+      Σ ;;; Δ |- it_mkProd_or_LetIn Γ B = it_mkProd_or_LetIn Γ B'.
+  Proof.
+    intros Δ Γ B B' h.
+    induction Γ as [| [na [b|] A] Γ ih ] in Δ, B, B', h |- *.
+    - assumption.
+    - simpl. cbn. eapply ih.
+      eapply conv_LetIn_bo. assumption.
+    - simpl. cbn. eapply ih.
+      eapply conv_Prod_r. assumption.
+  Qed.
+
+  Lemma it_mkLambda_or_LetIn_conv Γ Δ1 Δ2 t1 t2 :
+      conv_context Σ (Γ ,,, Δ1) (Γ ,,, Δ2) ->
+      Σ ;;; Γ ,,, Δ1 |- t1 = t2 ->
+      Σ ;;; Γ |- it_mkLambda_or_LetIn Δ1 t1 = it_mkLambda_or_LetIn Δ2 t2.
+  Proof.
+    induction Δ1 in Δ2, t1, t2 |- *; intros X Y.
+    - apply context_relation_length in X.
+      destruct Δ2; cbn in *; [trivial|].
+      exfalso. rewrite app_length in X; lia.
+    - apply context_relation_length in X as X'.
+      destruct Δ2 as [|c Δ2]; simpl in *; [exfalso; rewrite app_length in X'; lia|].
+      dependent destruction X.
+      + eapply IHΔ1; tas; cbn.
+        inv c0. etransitivity. eapply conv_Lambda_r; tea.
+        now eapply conv_Lambda_l.
+      + eapply IHΔ1; tas; cbn.
+        etransitivity. eapply conv_LetIn_bo; tea. inv c0.
+        eapply conv_LetIn_ty; tea.
+        etransitivity. eapply conv_LetIn_tm; tea.
+        eapply conv_LetIn_ty with (na := na); tea.
+  Qed.
+
+  Lemma conv_it_mkLambda_or_LetIn :
+    forall Δ Γ B B',
+      Σ ;;; (Δ ,,, Γ) |- B = B' ->
+      Σ ;;; Δ |- it_mkLambda_or_LetIn Γ B = it_mkLambda_or_LetIn Γ B'.
+  Proof.
+    intros Δ Γ B B' h.
+    induction Γ as [| [na [b|] A] Γ ih ] in Δ, B, B', h |- *.
+    - assumption.
+    - simpl. cbn. eapply ih.
+      eapply conv_LetIn_bo. assumption.
+    - simpl. cbn. eapply ih.
+      eapply conv_Lambda_r. assumption.
+  Qed.
+
+  Lemma red_lambda_inv Γ na A1 b1 T :
+    red Σ Γ (tLambda na A1 b1) T ->
+    ∑ A2 b2, (T = tLambda na A2 b2) *
+             red Σ Γ A1 A2 * red Σ (Γ ,, vass na A1) b1 b2.
+  Proof.
+    intros.
+    eapply red_alt in X. eapply clos_rt_rt1n_iff in X.
+    depind X.
+    - eexists _, _; intuition eauto.
+    - depelim r; solve_discr; specialize (IHX _ _ _ _ eq_refl);
+      destruct IHX as [A2 [B2 [[-> ?] ?]]].
+      * eexists _, _; intuition eauto.
+        now eapply red_step with M'.
+        eapply PCUICConfluence.red_red_ctx; eauto.
+        constructor; auto. eapply All2_local_env_red_refl.
+        red. auto.
+      * eexists _, _; intuition eauto.
+        now eapply red_step with M'.
+  Qed.
+
+  Lemma Lambda_conv_cum_inv :
+    forall leq Γ na1 na2 A1 A2 b1 b2,
+      wf_local Σ Γ ->
+      conv_cum leq Σ Γ (tLambda na1 A1 b1) (tLambda na2 A2 b2) ->
+      ∥ Σ ;;; Γ |- A1 = A2 ∥ /\ conv_cum leq Σ (Γ ,, vass na1 A1) b1 b2.
+  Proof.
+    intros * wfΓ.
+    destruct leq; simpl in *.
+    - destruct 1.
+      eapply conv_alt in X as [l [r [redl [redr eq]]]].
+      eapply red_lambda_inv in redl as [A1' [b1' [[-> ?] ?]]].
+      eapply red_lambda_inv in redr as [A2' [b2' [[-> ?] ?]]].
+      depelim eq. assert (Σ ;;; Γ |- A1 = A2).
+      { eapply conv_trans with A1'; auto.
+        now apply red_conv.
+        eapply conv_trans with A2'; auto.
+        constructor. assumption.
+        symmetry; now apply red_conv. }
+      split; constructor; auto.
+      eapply conv_trans with b1'; auto.
+      now apply red_conv.
+      eapply conv_trans with b2'; auto.
+      constructor; auto.
+      apply conv_sym; auto.
+      eapply conv_conv_ctx; eauto.
+      now apply red_conv.
+      constructor; auto. reflexivity. constructor. now apply conv_sym.
+    - destruct 1.
+      eapply cumul_alt in X as [l [r [redl [redr eq]]]].
+      eapply red_lambda_inv in redl as [A1' [b1' [[-> ?] ?]]].
+      eapply red_lambda_inv in redr as [A2' [b2' [[-> ?] ?]]].
+      depelim eq. assert (Σ ;;; Γ |- A1 = A2).
+      { eapply conv_trans with A1'; auto.
+        now apply red_conv.
+        eapply conv_trans with A2'; auto.
+        constructor. assumption.
+        symmetry; now apply red_conv. }
+      split; constructor; auto.
+      eapply red_cumul_cumul; tea.
+      eapply cumul_trans with b2'; auto.
+      constructor; auto.
+      eapply cumul_conv_ctx; tas. eapply red_cumul_cumul_inv; tea.
+      reflexivity. symmetry in X.
+      constructor. reflexivity. now constructor.
+  Qed.
+
+End Inversions.

--- a/pcuic/theories/PCUICConversionLemmas.v
+++ b/pcuic/theories/PCUICConversionLemmas.v
@@ -674,12 +674,6 @@ Section Inversions.
   Qed.
 
 
-  Lemma context_relation_length P Γ Γ' :
-    context_relation P Γ Γ' -> #|Γ| = #|Γ'|.
-  Proof.
-    induction 1; cbn; congruence.
-  Qed.
-
 
   Lemma conv_cum_Lambda leq Γ na1 na2 A1 A2 t1 t2 :
       Σ ;;; Γ |- A1 = A2 ->

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -14,33 +14,15 @@ Require Import CRelationClasses.
 Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
 Require Import Equations.Prop.DepElim.
 
-Reserved Notation " Σ ;;; Γ |- t == u " (at level 50, Γ, t, u at next level).
 
-Lemma cumul_alt `{cf : checker_flags} Σ Γ t u :
-  Σ ;;; Γ |- t <= u <~> { v & { v' & (red Σ Γ t v * red Σ Γ u v' * leq_term (global_ext_constraints Σ) v v')%type } }.
+Instance cumul_refl' {cf:checker_flags} Σ Γ : Reflexive (cumul Σ Γ).
 Proof.
-  split.
-  { induction 1. exists t, u. intuition auto; constructor.
-    destruct IHX as (v' & v'' & (redv & redv') & leqv).
-    exists v', v''. intuition auto. now eapply red_step.
-    destruct IHX as (v' & v'' & (redv & redv') & leqv).
-    exists v', v''. intuition auto. now eapply red_step. }
-  { intros [v [v' [[redv redv'] Hleq]]]. apply red_alt in redv. apply red_alt in redv'.
-    apply clos_rt_rt1n in redv.
-    apply clos_rt_rt1n in redv'.
-    induction redv. induction redv'. constructor; auto.
-    econstructor 3; eauto.
-    econstructor 2; eauto. }
+  intro; constructor. reflexivity.
 Qed.
 
-Lemma cumul_refl' {cf : checker_flags} Σ Γ t : Σ ;;; Γ |- t <= t.
+Instance conv_refl' {cf:checker_flags} Σ Γ : Reflexive (conv Σ Γ).
 Proof.
-  eapply cumul_alt. exists t, t; intuition eauto. eapply leq_term_refl.
-Qed.
-
-Lemma conv_refl' {cf : checker_flags} Σ Γ t : Σ ;;; Γ |- t = t.
-Proof.
-  split; apply cumul_refl'.
+  intro; constructor. reflexivity.
 Qed.
 
 Lemma red_cumul `{cf : checker_flags} {Σ : global_env_ext} {Γ t u} :
@@ -48,7 +30,7 @@ Lemma red_cumul `{cf : checker_flags} {Σ : global_env_ext} {Γ t u} :
   Σ ;;; Γ |- t <= u.
 Proof.
   intros. apply red_alt in X. apply clos_rt_rt1n in X.
-  induction X. apply cumul_refl'.
+  induction X. reflexivity.
   econstructor 2; eauto.
 Qed.
 
@@ -57,7 +39,7 @@ Lemma red_cumul_inv `{cf : checker_flags} {Σ : global_env_ext} {Γ t u} :
   Σ ;;; Γ |- u <= t.
 Proof.
   intros. apply red_alt in X. apply clos_rt_rt1n in X.
-  induction X. apply cumul_refl'.
+  induction X. reflexivity.
   econstructor 3; eauto.
 Qed.
 
@@ -77,14 +59,44 @@ Proof.
   econstructor 3. eapply IHX. eauto. eauto.
 Qed.
 
-Lemma red_conv {cf:checker_flags} (Σ : global_env_ext) Γ t u : red Σ Γ t u -> Σ ;;; Γ |- t = u.
+Lemma red_conv {cf:checker_flags} (Σ : global_env_ext) Γ t u :
+  red Σ Γ t u -> Σ ;;; Γ |- t = u.
 Proof.
-  intros. split; [apply red_cumul|apply red_cumul_inv]; auto.
+  intros. apply red_alt in X. apply clos_rt_rt1n in X.
+  induction X. reflexivity.
+  econstructor 2; eauto.
+Qed.
+
+Lemma conv_cumul2 {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- t = u -> (Σ ;;; Γ |- t <= u) * (Σ ;;; Γ |- u <= t).
+Proof.
+  induction 1.
+  - split; constructor; now apply eq_term_leq_term.
+  - destruct IHX as [H1 H2]. split.
+    * econstructor 2; eassumption.
+    * econstructor 3; eassumption.
+  - destruct IHX as [H1 H2]. split.
+    * econstructor 3; eassumption.
+    * econstructor 2; eassumption.
 Qed.
 
 Lemma conv_cumul {cf:checker_flags} Σ Γ t u :
-  Σ ;;; Γ |- t = u -> (Σ ;;; Γ |- t <= u) * (Σ ;;; Γ |- u <= t).
-Proof. trivial. Qed.
+  Σ ;;; Γ |- t = u -> Σ ;;; Γ |- t <= u.
+Proof.
+  intro H; now apply conv_cumul2 in H.
+Qed.
+
+Lemma conv_cumul_inv {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- u = t -> Σ ;;; Γ |- t <= u.
+Proof.
+  intro H; now apply conv_cumul2 in H.
+Qed.
+
+Lemma cumul2_conv {cf:checker_flags} Σ Γ t u :
+  (Σ ;;; Γ |- t <= u) * (Σ ;;; Γ |- u <= t) -> Σ ;;; Γ |- t = u.
+Proof.
+Admitted.
+
 
 (* todo: move *)
 Lemma All_All2_refl {A : Type} {R} {l : list A} : All (fun x : A => R x x) l -> All2 R l l.
@@ -126,27 +138,8 @@ Proof.
   - cbn. apply IHl. constructor; try assumption. assumption.
 Qed.
 
-Inductive conv_alt `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
-| conv_alt_refl t u : eq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t == u
-| conv_alt_red_l t u v : red1 Σ Γ t v -> Σ ;;; Γ |- v == u -> Σ ;;; Γ |- t == u
-| conv_alt_red_r t u v : Σ ;;; Γ |- t == v -> red1 (fst Σ) Γ u v -> Σ ;;; Γ |- t == u
-where " Σ ;;; Γ |- t == u " := (@conv_alt _ Σ Γ t u) : type_scope.
-
-Lemma red_conv_alt `{cf : checker_flags} Σ Γ t u :
-  red (fst Σ) Γ t u ->
-  Σ ;;; Γ |- t == u.
-Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
-  induction X. constructor. apply eq_term_refl.
-  apply clos_rt_rt1n_iff in X. apply red_alt in X.
-  econstructor 2; eauto.
-Qed.
-Hint Resolve red_conv_alt.
-
-Hint Resolve leq_term_refl cumul_refl' : core.
-
 Lemma red_conv_conv `{cf : checker_flags} Σ Γ t u v :
-  red (fst Σ) Γ t u -> Σ ;;; Γ |- u == v -> Σ ;;; Γ |- t == v.
+  red (fst Σ) Γ t u -> Σ ;;; Γ |- u = v -> Σ ;;; Γ |- t = v.
 Proof.
   intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
   induction X; auto.
@@ -154,82 +147,49 @@ Proof.
 Qed.
 
 Lemma red_conv_conv_inv `{cf : checker_flags} Σ Γ t u v :
-  red (fst Σ) Γ t u -> Σ ;;; Γ |- v == u -> Σ ;;; Γ |- v == t.
+  red (fst Σ) Γ t u -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- v = t.
 Proof.
   intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
   induction X; auto.
   now econstructor 3; [eapply IHX|]; eauto.
 Qed.
 
-Lemma conv_alt_sym `{cf : checker_flags} (Σ : global_env_ext) Γ t u :
-  wf Σ ->
-  Σ ;;; Γ |- t == u -> Σ ;;; Γ |- u == t.
+Instance conv_sym `{cf : checker_flags} (Σ : global_env_ext) Γ : Symmetric (conv Σ Γ).
 Proof.
-  intros wfΣ X.
-  induction X.
+  intros t u; induction 1.
   - eapply eq_term_sym in e; now constructor.
   - eapply red_conv_conv_inv. eapply red1_red in r. eauto. eauto.
   - eapply red_conv_conv. eapply red1_red in r. eauto. eauto.
-Qed.
-
-Lemma conv_alt_red {cf : checker_flags} {Σ : global_env_ext} {Γ : context} {t u : term} :
-  Σ;;; Γ |- t == u <~> (∑ v v' : term, (red Σ Γ t v × red Σ Γ u v') × eq_term (global_ext_constraints Σ) v v').
-Proof.
-  split. induction 1. exists t, u; intuition auto.
-  destruct IHX as [? [? [? ?]]].
-  exists x, x0; intuition auto. eapply red_step; eauto.
-  destruct IHX as [? [? [? ?]]].
-  exists x, x0; intuition auto. eapply red_step; eauto.
-  intros.
-  destruct X as [? [? [[? ?] ?]]].
-  eapply red_conv_conv; eauto.
-  eapply red_conv_conv_inv; eauto. now constructor.
-Qed.
-
-Lemma conv_alt_cumul `{cf : checker_flags} (Σ : global_env_ext) Γ t u : wf Σ ->
-  Σ ;;; Γ |- t == u -> Σ ;;; Γ |- t <= u.
-Proof.
-  intros wfΣ H.
-  apply conv_alt_red in H as [v [v' [[l r] eq]]].
-  apply cumul_alt.
-  exists v, v'; intuition auto. now eapply eq_term_leq_term.
-Qed.
-
-Lemma conv_alt_conv `{cf : checker_flags} (Σ : global_env_ext) Γ t u : wf Σ ->
-  Σ ;;; Γ |- t == u -> Σ ;;; Γ |- t = u.
-Proof.
-  intros wfΣ H. split. now apply conv_alt_cumul.
-  apply conv_alt_sym in H; auto. now apply conv_alt_cumul.
 Qed.
 
 Inductive conv_pb :=
 | Conv
 | Cumul.
 
-Definition conv `{cf : checker_flags} leq Σ Γ u v :=
+Definition conv_cum `{cf : checker_flags} leq Σ Γ u v :=
   match leq with
-  | Conv => ∥ Σ ;;; Γ |- u == v ∥
+  | Conv => ∥ Σ ;;; Γ |- u = v ∥
   | Cumul => ∥ Σ ;;; Γ |- u <= v ∥
   end.
 
-Lemma conv_conv_l `{cf : checker_flags} :
+Lemma conv_conv_cum_l `{cf : checker_flags} :
   forall (Σ : global_env_ext) leq Γ u v, wf Σ ->
-      Σ ;;; Γ |- u == v ->
-      conv leq Σ Γ u v.
+      Σ ;;; Γ |- u = v ->
+      conv_cum leq Σ Γ u v.
 Proof.
   intros Σ [] Γ u v h.
   - cbn. constructor. assumption.
-  - cbn. constructor. now apply conv_alt_cumul.
+  - cbn. constructor. now apply conv_cumul.
 Qed.
 
-Lemma conv_conv_r `{cf : checker_flags} :
+Lemma conv_conv_cum_r `{cf : checker_flags} :
   forall (Σ : global_env_ext) leq Γ u v, wf Σ ->
-      Σ ;;; Γ |- u == v ->
-      conv leq Σ Γ v u.
+      Σ ;;; Γ |- u = v ->
+      conv_cum leq Σ Γ v u.
 Proof.
   intros Σ [] Γ u v wfΣ h.
-  - cbn. constructor. apply conv_alt_sym; auto.
-  - cbn. constructor. apply conv_alt_cumul. auto. now apply conv_alt_sym.
+  - cbn. constructor. apply conv_sym; auto.
+  - cbn. constructor. apply conv_cumul. auto. now apply conv_sym.
 Qed.
 
 Lemma cumul_App_l `{cf : checker_flags} :

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -4,7 +4,8 @@ From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening
-     PCUICSubstitution PCUICClosed PCUICCumulativity PCUICConversion PCUICGeneration.
+     PCUICSubstitution PCUICClosed PCUICCumulativity PCUICConversionLemmas
+     PCUICConfluence PCUICGeneration.
 Require Import ssreflect ssrbool.
 Require Import String.
 From MetaCoq Require Import LibHypsNaming.
@@ -49,13 +50,13 @@ Section Inversion.
     dependent induction h ; [
       repeat insum ;
       repeat intimes ;
-      [ first [ eassumption | reflexivity ] .. | eapply cumul_refl' ]
+      [ first [ eassumption | reflexivity ] .. | reflexivity ]
     | repeat outsum ;
       repeat outtimes ;
       repeat insum ;
       repeat intimes ;
       [ first [ eassumption | reflexivity ] ..
-      | eapply cumul_trans ; eassumption ]
+      | etransitivity ; eassumption ]
     ].
 
   Derive Signature for typing.
@@ -258,7 +259,7 @@ Section Inversion.
   Proof.
     intros Γ Δ t T h.
     induction Δ as [| [na [b|] A] Δ ih ] in Γ, t, h |- *.
-    - eexists. split ; eauto.
+    - eexists. split ; eauto. reflexivity.
     - simpl. apply ih in h. cbn in h.
       destruct h as [B [h c]].
       apply inversion_LetIn in h as hh.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -189,7 +189,7 @@ Section Inversion.
         Σ ;;; Γ |- p : pty ×
         types_of_case ind mdecl idecl pars u p pty =
         Some (indctx, pctx, ps, btys) ×
-        check_correct_arity (global_ext_constraints Σ)
+        check_correct_arity Σ Γ
         idecl ind u indctx pars pctx ×
         existsb (leb_sort_family (universe_family ps)) (ind_kelim idecl) ×
         Σ ;;; Γ |- c : mkApps (tInd ind u) args ×

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -1124,20 +1124,21 @@ Proof.
         now rewrite <- subst_instance_context_nlctx.
         apply nl_subst_instance_constr.
     + clear -H1. unfold check_correct_arity in *.
-      rewrite global_ext_constraints_nlg.
-      inversion H1; subst. cbn. constructor.
-      * clear -H2. destruct H2 as [H1 H2]; cbn in *.
-        destruct y as [? [?|] ?]; cbn in *; [contradiction|].
-        split; cbn; tas. apply nl_eq_term in H2.
-        refine (eq_rect _ (fun d => eq_term _ d _) H2 _ _).
-        clear. rewrite nl_mkApps, map_app, firstn_map, !map_map.
-        f_equal. rewrite nl_to_extended_list. f_equal.
-        apply map_ext. intro; rewrite nl_lift; cbn.
-        unfold nlctx; now rewrite map_length.
-      * eapply All2_map, All2_impl; tea.
-        apply nl_eq_decl'.
+      admit.
+      (* rewrite global_ext_constraints_nlg. *)
+      (* inversion H1; subst. cbn. constructor. *)
+      (* * clear -H2. destruct H2 as [H1 H2]; cbn in *. *)
+      (*   destruct y as [? [?|] ?]; cbn in *; [contradiction|]. *)
+      (*   split; cbn; tas. apply nl_eq_term in H2. *)
+      (*   refine (eq_rect _ (fun d => eq_term _ d _) H2 _ _). *)
+      (*   clear. rewrite nl_mkApps, map_app, firstn_map, !map_map. *)
+      (*   f_equal. rewrite nl_to_extended_list. f_equal. *)
+      (*   apply map_ext. intro; rewrite nl_lift; cbn. *)
+      (*   unfold nlctx; now rewrite map_length. *)
+      (* * eapply All2_map, All2_impl; tea. *)
+      (*   apply nl_eq_decl'. *)
     + rewrite nl_mkApps in *; eassumption.
-    + clear -X5. eapply All2_map, All2_impl; tea. cbn.
+    + clear -X6. eapply All2_map, All2_impl; tea. cbn.
       clear. intros x y [[[? ?] ?] ?]. intuition eauto.
   - destruct pdecl as [pdecl1 pdecl2]; simpl.
     rewrite map_rev.
@@ -1200,7 +1201,7 @@ Proof.
         eapply nlg_wf_local. eassumption.
       * destruct s as [? [? ?]]; eauto.
     + now apply nl_cumul.
-Qed.
+Admitted.
 
 Corollary reflect_nleq_term :
   forall t t',

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -1,11 +1,11 @@
 (* Distributed under the terms of the MIT license.   *)
 Require Import ssreflect ssrbool.
-From MetaCoq Require Import LibHypsNaming.
+From MetaCoq Require Import LibHypsNaming Environment EnvironmentTyping.
 From Equations Require Import Equations.
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega Utf8 String Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
-     PCUICLiftSubst PCUICUnivSubst PCUICTyping.
+     PCUICLiftSubst PCUICUnivSubst.
 
 Require Import Equations.Prop.DepElim.
 
@@ -15,6 +15,344 @@ Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
 
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
+
+
+(** ** Environment lookup *)
+
+Module PCUICLookup := Lookup PCUICTerm PCUICEnvironment.
+Include PCUICLookup.
+
+
+(** ** Reduction *)
+
+(** *** Helper functions for reduction *)
+
+Definition fix_subst (l : mfixpoint term) :=
+  let fix aux n :=
+      match n with
+      | 0 => []
+      | S n => tFix l n :: aux n
+      end
+  in aux (List.length l).
+
+Definition unfold_fix (mfix : mfixpoint term) (idx : nat) :=
+  match List.nth_error mfix idx with
+  | Some d =>
+    if isLambda d.(dbody) then
+      Some (d.(rarg), subst0 (fix_subst mfix) d.(dbody))
+    else None (* We don't unfold ill-formed fixpoints, which would
+                 render confluence unprovable, creating an infinite
+                 number of critical pairs between unfoldings of fixpoints.
+                 e.g. [fix f := f] is not allowed. *)
+  | None => None
+  end.
+
+Definition cofix_subst (l : mfixpoint term) :=
+  let fix aux n :=
+      match n with
+      | 0 => []
+      | S n => tCoFix l n :: aux n
+      end
+  in aux (List.length l).
+
+Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
+  match List.nth_error mfix idx with
+  | Some d => Some (d.(rarg), subst0 (cofix_subst mfix) d.(dbody))
+  | None => None
+  end.
+
+Definition is_constructor n ts :=
+  match List.nth_error ts n with
+  | Some a => isConstruct_app a
+  | None => false
+  end.
+
+Lemma fix_subst_length mfix : #|fix_subst mfix| = #|mfix|.
+Proof.
+  unfold fix_subst. generalize (tFix mfix). intros.
+  induction mfix; simpl; auto.
+Qed.
+
+Lemma cofix_subst_length mfix : #|cofix_subst mfix| = #|mfix|.
+Proof.
+  unfold cofix_subst. generalize (tCoFix mfix). intros.
+  induction mfix; simpl; auto.
+Qed.
+
+Lemma fix_context_length mfix : #|fix_context mfix| = #|mfix|.
+Proof. unfold fix_context. now rewrite List.rev_length mapi_length. Qed.
+
+Definition tDummy := tVar "".
+
+Definition iota_red npar c args brs :=
+  (mkApps (snd (List.nth c brs (0, tDummy))) (List.skipn npar args)).
+
+
+(** *** One step strong beta-zeta-iota-fix-delta reduction
+
+  Inspired by the reduction relation from Coq in Coq [Barras'99].
+*)
+
+Local Open Scope type_scope.
+Arguments OnOne2 {A} P%type l l'.
+
+Notation on_Trel_eq R f g :=
+  (fun x y => (R (f x) (f y) * (g x = g y)))%type.
+
+Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
+(** Reductions *)
+(** Beta *)
+| red_beta na t b a :
+    red1 Σ Γ (tApp (tLambda na t b) a) (subst10 a b)
+
+(** Let *)
+| red_zeta na b t b' :
+    red1 Σ Γ (tLetIn na b t b') (subst10 b b')
+
+| red_rel i body :
+    option_map decl_body (nth_error Γ i) = Some (Some body) ->
+    red1 Σ Γ (tRel i) (lift0 (S i) body)
+
+(** Case *)
+| red_iota ind pars c u args p brs :
+    red1 Σ Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs)
+         (iota_red pars c args brs)
+
+(** Fix unfolding, with guard *)
+| red_fix mfix idx args narg fn :
+    unfold_fix mfix idx = Some (narg, fn) ->
+    is_constructor narg args = true ->
+    red1 Σ Γ (mkApps (tFix mfix idx) args) (mkApps fn args)
+
+(** CoFix-case unfolding *)
+| red_cofix_case ip p mfix idx args narg fn brs :
+    unfold_cofix mfix idx = Some (narg, fn) ->
+    red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
+         (tCase ip p (mkApps fn args) brs)
+
+(** CoFix-proj unfolding *)
+| red_cofix_proj p mfix idx args narg fn :
+    unfold_cofix mfix idx = Some (narg, fn) ->
+    red1 Σ Γ (tProj p (mkApps (tCoFix mfix idx) args))
+         (tProj p (mkApps fn args))
+
+(** Constant unfolding *)
+| red_delta c decl body (isdecl : declared_constant Σ c decl) u :
+    decl.(cst_body) = Some body ->
+    red1 Σ Γ (tConst c u) (subst_instance_constr u body)
+
+(** Proj *)
+| red_proj i pars narg args k u arg:
+    nth_error args (pars + narg) = Some arg ->
+    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg
+
+
+| abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
+| abs_red_r na M M' N : red1 Σ (Γ ,, vass na N) M M' -> red1 Σ Γ (tLambda na N M) (tLambda na N M')
+
+| letin_red_def na b t b' r : red1 Σ Γ b r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na r t b')
+| letin_red_ty na b t b' r : red1 Σ Γ t r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b r b')
+| letin_red_body na b t b' r : red1 Σ (Γ ,, vdef na b t) b' r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b t r)
+
+| case_red_pred ind p p' c brs : red1 Σ Γ p p' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p' c brs)
+| case_red_discr ind p c c' brs : red1 Σ Γ c c' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c' brs)
+| case_red_brs ind p c brs brs' : OnOne2 (on_Trel_eq (red1 Σ Γ) snd fst) brs brs' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c brs')
+
+| proj_red p c c' : red1 Σ Γ c c' -> red1 Σ Γ (tProj p c) (tProj p c')
+
+| app_red_l M1 N1 M2 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tApp M1 M2) (tApp N1 M2)
+| app_red_r M2 N2 M1 : red1 Σ Γ M2 N2 -> red1 Σ Γ (tApp M1 M2) (tApp M1 N2)
+
+| prod_red_l na M1 M2 N1 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tProd na M1 M2) (tProd na N1 M2)
+| prod_red_r na M2 N2 M1 : red1 Σ (Γ ,, vass na M1) M2 N2 ->
+                               red1 Σ Γ (tProd na M1 M2) (tProd na M1 N2)
+
+| evar_red ev l l' : OnOne2 (red1 Σ Γ) l l' -> red1 Σ Γ (tEvar ev l) (tEvar ev l')
+
+| fix_red_ty mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
+
+| fix_red_body mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x)))
+           mfix0 mfix1 ->
+    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
+
+| cofix_red_ty mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)
+
+| cofix_red_body mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
+    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx).
+
+Lemma red1_ind_all :
+  forall (Σ : global_env) (P : context -> term -> term -> Type),
+
+       (forall (Γ : context) (na : name) (t b a : term),
+        P Γ (tApp (tLambda na t b) a) (b {0 := a})) ->
+
+       (forall (Γ : context) (na : name) (b t b' : term), P Γ (tLetIn na b t b') (b' {0 := b})) ->
+
+       (forall (Γ : context) (i : nat) (body : term),
+        option_map decl_body (nth_error Γ i) = Some (Some body) -> P Γ (tRel i) ((lift0 (S i)) body)) ->
+
+       (forall (Γ : context) (ind : inductive) (pars c : nat) (u : universe_instance) (args : list term)
+          (p : term) (brs : list (nat * term)),
+        P Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs) (iota_red pars c args brs)) ->
+
+       (forall (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
+        unfold_fix mfix idx = Some (narg, fn) ->
+        is_constructor narg args = true -> P Γ (mkApps (tFix mfix idx) args) (mkApps fn args)) ->
+
+       (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
+          (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
+        unfold_cofix mfix idx = Some (narg, fn) ->
+        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
+
+       (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
+          (narg : nat) (fn : term),
+        unfold_cofix mfix idx = Some (narg, fn) -> P Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
+
+       (forall (Γ : context) (c : ident) (decl : constant_body) (body : term),
+        declared_constant Σ c decl ->
+        forall u : universe_instance, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
+
+       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (k : nat) (u : universe_instance)
+         (arg : term),
+           nth_error args (pars + narg) = Some arg ->
+           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg) ->
+
+       (forall (Γ : context) (na : name) (M M' N : term),
+        red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->
+
+       (forall (Γ : context) (na : name) (M M' N : term),
+        red1 Σ (Γ,, vass na N) M M' -> P (Γ,, vass na N) M M' -> P Γ (tLambda na N M) (tLambda na N M')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ Γ b r -> P Γ b r -> P Γ (tLetIn na b t b') (tLetIn na r t b')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ Γ t r -> P Γ t r -> P Γ (tLetIn na b t b') (tLetIn na b r b')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ (Γ,, vdef na b t) b' r -> P (Γ,, vdef na b t) b' r -> P Γ (tLetIn na b t b') (tLetIn na b t r)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p p' c : term) (brs : list (nat * term)),
+        red1 Σ Γ p p' -> P Γ p p' -> P Γ (tCase ind p c brs) (tCase ind p' c brs)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p c c' : term) (brs : list (nat * term)),
+        red1 Σ Γ c c' -> P Γ c c' -> P Γ (tCase ind p c brs) (tCase ind p c' brs)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p c : term) (brs brs' : list (nat * term)),
+           OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) snd fst) brs brs' ->
+           P Γ (tCase ind p c brs) (tCase ind p c brs')) ->
+
+       (forall (Γ : context) (p : projection) (c c' : term), red1 Σ Γ c c' -> P Γ c c' ->
+                                                             P Γ (tProj p c) (tProj p c')) ->
+
+       (forall (Γ : context) (M1 N1 : term) (M2 : term), red1 Σ Γ M1 N1 -> P Γ M1 N1 ->
+                                                         P Γ (tApp M1 M2) (tApp N1 M2)) ->
+
+       (forall (Γ : context) (M2 N2 : term) (M1 : term), red1 Σ Γ M2 N2 -> P Γ M2 N2 ->
+                                                         P Γ (tApp M1 M2) (tApp M1 N2)) ->
+
+       (forall (Γ : context) (na : name) (M1 M2 N1 : term),
+        red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tProd na M1 M2) (tProd na N1 M2)) ->
+
+       (forall (Γ : context) (na : name) (M2 N2 M1 : term),
+        red1 Σ (Γ,, vass na M1) M2 N2 -> P (Γ,, vass na M1) M2 N2 -> P Γ (tProd na M1 M2) (tProd na M1 N2)) ->
+
+       (forall (Γ : context) (ev : nat) (l l' : list term),
+           OnOne2 (Trel_conj (red1 Σ Γ) (P Γ)) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
+                                      (P (Γ ,,, fix_context mfix0))) dbody
+                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
+        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
+                                      (P (Γ ,,, fix_context mfix0))) dbody
+                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
+        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
+
+       forall (Γ : context) (t t0 : term), red1 Σ Γ t t0 -> P Γ t t0.
+Proof.
+  intros. rename X26 into Xlast. revert Γ t t0 Xlast.
+  fix aux 4. intros Γ t T.
+  move aux at top.
+  destruct 1; match goal with
+              | |- P _ (tFix _ _) (tFix _ _) => idtac
+              | |- P _ (tCoFix _ _) (tCoFix _ _) => idtac
+              | |- P _ (mkApps (tFix _ _) _) _ => idtac
+              | |- P _ (tCase _ _ (mkApps (tCoFix _ _) _) _) _ => idtac
+              | |- P _ (tProj _ (mkApps (tCoFix _ _) _)) _ => idtac
+              | H : _ |- _ => eapply H; eauto
+              end.
+  - eapply X3; eauto.
+  - eapply X4; eauto.
+  - eapply X5; eauto.
+
+  - revert brs brs' o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    constructor. intuition auto. constructor. intuition auto.
+
+  - revert l l' o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    constructor. split; auto.
+    constructor. auto.
+
+  - eapply X22.
+    revert mfix0 mfix1 o; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+
+  - eapply X23.
+    revert o. generalize (fix_context mfix0). intros c Xnew.
+    revert mfix0 mfix1 Xnew; fix auxl 3; intros l l' Hl;
+    destruct Hl; constructor; try split; auto; intuition.
+
+  - eapply X24.
+    revert mfix0 mfix1 o.
+    fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+
+  - eapply X25.
+    revert o. generalize (fix_context mfix0). intros c new.
+    revert mfix0 mfix1 new; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+Defined.
+
+
+(** *** Reduction
+
+  The reflexive-transitive closure of 1-step reduction. *)
+
+Inductive red Σ Γ M : term -> Type :=
+| refl_red : red Σ Γ M M
+| trans_red : forall (P : term) N, red Σ Γ M P -> red1 Σ Γ P N -> red Σ Γ M N.
+
+Fixpoint subst_app (t : term) (us : list term) : term :=
+  match t, us with
+  | tLambda _ A t, u :: us => subst_app (t {0 := u}) us
+  | _, [] => t
+  | _, _ => mkApps t us
+  end.
+
+
+
+
 
 (** * Parallel reduction and confluence *)
 
@@ -63,6 +401,7 @@ Proof. refine (red_trans _ _). Qed.
 
 Instance red_Reflexive Σ Γ : Reflexive (red Σ Γ)
   := refl_red _ _.
+
 
 (** Generic method to show that a relation is closed by congruence using
     a notion of one-hole context. *)
@@ -1059,7 +1398,7 @@ Section ReductionCongruence.
           intros y z e. cbn in e. inversion e. eauto.
         } subst.
         constructor.
-      - set (f := fun x : term => (x, ())) in *.
+      - set (f := fun x : term => (x, tt)) in *.
         set (g := (fun '(x, _) => x) : term × unit -> term).
         assert (el :  forall l, l = map f (map g l)).
         { clear. intros l. induction l.

--- a/pcuic/theories/PCUICRetyping.v
+++ b/pcuic/theories/PCUICRetyping.v
@@ -2,7 +2,7 @@
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
 From MetaCoq.Template Require Import config monad_utils utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICChecker PCUICConversion PCUICCumulativity.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICChecker PCUICConfluence PCUICConversionLemmas PCUICCumulativity.
 Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -206,7 +206,7 @@ Section TypeOf.
       inversion eq. subst. clear eq.
       split.
       + econstructor ; eassumption.
-      + eapply cumul_refl'.
+      + reflexivity.
     - cbn in eq. inversion eq. subst. clear eq.
       split.
       + (* Proving Typeᵢ : Typeᵢ₊₁ shouldn't be hard... *)
@@ -228,11 +228,11 @@ Section TypeOf.
     - go eq. split.
       + econstructor ; try eassumption ; try ih ; try cih.
       + eapply congr_cumul_prod.
-        * eapply conv_alt_refl. reflexivity.
+        * reflexivity.
         * ih.
     - go eq. split.
       + econstructor ; try eassumption ; try ih ; try cih.
-      + eapply congr_cumul_letin. all: try eapply cumul_refl'.
+      + eapply congr_cumul_letin. all: try reflexivity.
         ih.
     - go eq. split.
       + econstructor ; try eassumption ; try ih ; try cih.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -528,6 +528,9 @@ Section SRContext.
              constructor. eauto.
              exists tu.π1. eauto. cbn. eauto.
     - econstructor; tea; eauto.
+      (* unfold check_correct_arity in *. *)
+      (* etransitivity. *)
+      exact (todo "convconv").
       eapply All2_impl; tea; cbn.
       intros; utils.rdestruct; eauto.
     - assert (XX: red1_ctx Σ.1 (Γ ,,, fix_context mfix) (Γ' ,,, fix_context mfix))

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -11,7 +11,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICSubstitution PCUICClosed PCUICCumulativity PCUICGeneration PCUICReduction
      PCUICParallelReduction PCUICEquality PCUICAlpha
      PCUICValidity PCUICParallelReductionConfluence PCUICConfluence
-     PCUICContextConversion PCUICUnivSubstitution
+     PCUICContextConversion PCUICUnivSubstitution PCUICConversionLemmas
      PCUICConversion PCUICInversion PCUICPrincipality.
 
 Require Import ssreflect ssrbool.
@@ -46,7 +46,7 @@ Lemma type_mkApps_inv {cf:checker_flags} (Σ : global_env_ext) Γ f u T : wf Σ 
 Proof.
   intros wfΣ; induction u in f, T |- *. simpl. intros.
   { exists T, T. intuition auto. constructor. eapply validity; auto.
-    now eapply typing_wf_local. eauto. eapply cumul_refl'. }
+    now eapply typing_wf_local. eauto. all: eapply cumul_refl'. }
   intros Hf. simpl in Hf.
   destruct u. simpl in Hf.
   - eapply inversion_App in Hf as [na' [A' [B' [Hf' [Ha HA''']]]]].
@@ -111,7 +111,7 @@ Proof.
                          rewrite Hi. f_equal. lia.
     + subst types. rewrite simpl_subst_k.
       * now rewrite fix_context_length fix_subst_length.
-      * auto.
+      * reflexivity.
   - destruct (IHtyping wfΣ) as [T' [rarg [f [[unf fty] Hcumul]]]].
     exists T', rarg, f. intuition auto.
     + eapply cumul_trans; eauto.
@@ -158,13 +158,13 @@ Proof.
   - (* Prod *)
     constructor; eauto.
     eapply (context_conversion _ wfΣ _ _ _ _ typeb).
-    constructor; auto with pcuic.
+    constructor; auto with pcuic. reflexivity.
     constructor; auto. exists s1; auto.
 
   - (* Lambda *)
     eapply type_Cumul. eapply type_Lambda; eauto.
     eapply (context_conversion _ wfΣ _ _ _ _ typeb).
-    constructor; auto with pcuic.
+    constructor; auto with pcuic. reflexivity.
     constructor; auto. exists s1; auto.
     assert (Σ ;;; Γ |- tLambda n t b : tProd n t bty). econstructor; eauto.
     edestruct (validity _ wfΣ _ wfΓ _ _ X0). apply i.
@@ -184,7 +184,8 @@ Proof.
     eapply type_Cumul.
     econstructor; eauto.
     eapply (context_conversion _ wfΣ _ _ _ _ typeb').
-    constructor. auto with pcuic. constructor; eauto. constructor; auto.
+    constructor. auto with pcuic. reflexivity.
+    constructor; eauto. constructor; auto.
     now exists s1. red. auto.
     assert (Σ ;;; Γ |- tLetIn n b b_ty b' : tLetIn n b b_ty b'_ty). econstructor; eauto.
     edestruct (validity _ wfΣ _ wfΓ _ _ X0). apply i.
@@ -198,7 +199,8 @@ Proof.
     eapply type_Cumul. eauto. right; exists s1; auto.
     apply red_cumul; eauto.
     eapply (context_conversion _ wfΣ _ _ _ _ typeb').
-    constructor. auto with pcuic. constructor; eauto. constructor; auto.
+    constructor. auto with pcuic. reflexivity.
+    constructor; eauto. constructor; auto.
     exists s1; auto. red; eauto.
     eapply type_Cumul. eauto. right. exists s1; auto. eapply red_cumul. now eapply red1_red.
     assert (Σ ;;; Γ |- tLetIn n b b_ty b' : tLetIn n b b_ty b'_ty). econstructor; eauto.
@@ -215,7 +217,7 @@ Proof.
 
     eapply type_Cumul; eauto.
     unshelve eapply (context_conversion _ wfΣ _ _ _ _ Hb); eauto with wf.
-    constructor. auto with pcuic. constructor ; eauto.
+    constructor. auto with pcuic. reflexivity. constructor ; eauto.
     constructor; auto with pcuic. red; eauto.
     admit.
     clear -wfΣ i.
@@ -347,7 +349,7 @@ Section SRContext.
     intros Σ Γ t u hΣ h.
     induction h.
     - eapply cumul_refl'.
-    - eapply PCUICConversion.cumul_trans ; try eassumption.
+    - eapply cumul_trans ; try eassumption.
       eapply cumul_red_l.
       + eassumption.
       + eapply cumul_refl'.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1440,7 +1440,7 @@ Lemma type_Case' {cf:checker_flags} Σ Γ ind u npar p c brs args :
     forall pty, Σ ;;; Γ |- p : pty ->
     forall indctx pctx ps btys, types_of_case ind mdecl idecl pars u p pty
                            = Some (indctx, pctx, ps, btys) ->
-    check_correct_arity (global_ext_constraints Σ) idecl ind u indctx pars pctx ->
+    check_correct_arity Σ Γ idecl ind u indctx pars pctx ->
     existsb (leb_sort_family (universe_family ps)) idecl.(ind_kelim) ->
     Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
     All2 (fun x y => (fst x = fst y) × (Σ ;;; Γ |- snd x : snd y)) brs btys ->

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1588,35 +1588,35 @@ Proof.
   now apply IHl.
 Qed.
 
-Lemma subst_check_correct_arity:
-  forall (cf : checker_flags) φ (ind : inductive) (u : universe_instance)
-         (npar : nat) (args : list term) (idecl : one_inductive_body)
-         (indctx pctx : list context_decl) s k,
-    check_correct_arity φ idecl ind u indctx (firstn npar args) pctx ->
-    check_correct_arity
-      φ idecl ind u (subst_context s k indctx) (firstn npar (map (subst s k) args))
-      (subst_context s k pctx).
-Proof.
-  intros cf Σ ind u npar args idecl indctx pctx s k.
-  unfold check_correct_arity.
-  inversion_clear 1.
-  rewrite subst_context_snoc. constructor.
-  - apply All2_length in H1. destruct H1.
-    apply (subst_eq_decl _ s (#|indctx| + k)) in H0.
-    unfold subst_decl, map_decl in H0; cbn in H0.
-    assert (XX : subst s (#|indctx| + k) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|subst_context s k indctx|) (firstn npar (map (subst s k) args)) ++ to_extended_list (subst_context s k indctx)) );
-      [|now rewrite XX in H0].
-    clear H0.
-    rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app.
-    rewrite -> firstn_map.
-    rewrite !map_map_compose. cbn. f_equal.
-    + eapply map_ext.
-      intros. unfold compose. rewrite commut_lift_subst_rec. lia.
-      rewrite subst_context_length. f_equal. lia.
-    + rewrite /to_extended_list to_extended_list_k_subst.
-      rewrite <- (to_extended_list_k_map_subst s). reflexivity. lia.
-  - now apply subst_eq_context.
-Qed.
+(* Lemma subst_check_correct_arity Σ: *)
+(*   forall (cf : checker_flags) φ (ind : inductive) (u : universe_instance) *)
+(*          (npar : nat) (args : list term) (idecl : one_inductive_body) *)
+(*          (indctx pctx : list context_decl) s k, *)
+(*     check_correct_arity Σ φ idecl ind u indctx (firstn npar args) pctx -> *)
+(*     check_correct_arity Σ *)
+(*       φ idecl ind u (subst_context s k indctx) (firstn npar (map (subst s k) args)) *)
+(*       (subst_context s k pctx). *)
+(* Proof. *)
+(*   intros cf  ind u npar args idecl indctx pctx s k. *)
+(*   unfold check_correct_arity. *)
+(*   inversion_clear 1. *)
+(*   rewrite subst_context_snoc. constructor. *)
+(*   - apply All2_length in H1. destruct H1. *)
+(*     apply (subst_eq_decl _ s (#|indctx| + k)) in H0. *)
+(*     unfold subst_decl, map_decl in H0; cbn in H0. *)
+(*     assert (XX : subst s (#|indctx| + k) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|subst_context s k indctx|) (firstn npar (map (subst s k) args)) ++ to_extended_list (subst_context s k indctx)) ); *)
+(*       [|now rewrite XX in H0]. *)
+(*     clear H0. *)
+(*     rewrite -> subst_mkApps; simpl. f_equal. rewrite map_app. *)
+(*     rewrite -> firstn_map. *)
+(*     rewrite !map_map_compose. cbn. f_equal. *)
+(*     + eapply map_ext. *)
+(*       intros. unfold compose. rewrite commut_lift_subst_rec. lia. *)
+(*       rewrite subst_context_length. f_equal. lia. *)
+(*     + rewrite /to_extended_list to_extended_list_k_subst. *)
+(*       rewrite <- (to_extended_list_k_map_subst s). reflexivity. lia. *)
+(*   - now apply subst_eq_context. *)
+(* Qed. *)
 
 Lemma substitution_red `{cf : checker_flags} (Σ : global_env_ext) Γ Δ Γ' s M N :
   wf Σ -> subslet Σ Γ s Δ -> wf_local Σ Γ ->
@@ -2079,8 +2079,8 @@ Proof.
     apply subst_closedn; eauto. eapply closed_upwards; eauto. lia.
 
   - rewrite subst_mkApps map_app map_skipn.
-    specialize (X2 Γ Γ' Δ s sub eq_refl wfsubs).
-    specialize (X4 Γ Γ' Δ s sub eq_refl wfsubs).
+    specialize (X3 Γ Γ' Δ s sub eq_refl wfsubs).
+    specialize (X5 Γ Γ' Δ s sub eq_refl wfsubs).
     simpl. econstructor.
     4:{ eapply subst_types_of_case in H0.
         simpl in H1. subst pars. rewrite firstn_map. eapply H0; eauto.
@@ -2089,9 +2089,10 @@ Proof.
     -- eauto.
     -- eauto.
     -- revert H1. subst pars.
-       apply subst_check_correct_arity.
+       (* apply subst_check_correct_arity. *)
+       exact (todo "convconv").
     -- destruct idecl; simpl in *; auto.
-    -- now rewrite !subst_mkApps in X4.
+    -- now rewrite !subst_mkApps in X5.
     -- solve_all.
 
   - specialize (X2 Γ Γ' Δ s sub eq_refl wfsubs).

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -276,12 +276,12 @@ Qed.
 
 Reserved Notation " Σ ;;; Γ |- t : T " (at level 50, Γ, t, T at next level).
 
-Definition check_correct_arity `{checker_flags} φ decl ind u ctx pars pctx :=
+Definition check_correct_arity `{checker_flags} Σ Γ decl ind u ctx pars pctx :=
   let inddecl :=
       {| decl_name := nNamed decl.(ind_name);
          decl_body := None;
          decl_type := mkApps (tInd ind u) (map (lift0 #|ctx|) pars ++ to_extended_list ctx) |}
-  in eq_context φ (inddecl :: ctx) pctx.
+  in conv_context Σ (Γ ,,, ctx ,, inddecl) (Γ ,,, pctx).
 
 (** ** Typing relation *)
 
@@ -399,7 +399,7 @@ Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term ->
     let pars := List.firstn npar args in
     forall pty, Σ ;;; Γ |- p : pty ->
     forall indctx pctx ps btys, types_of_case ind mdecl idecl pars u p pty = Some (indctx, pctx, ps, btys) ->
-    check_correct_arity (global_ext_constraints Σ) idecl ind u indctx pars pctx ->
+    check_correct_arity Σ Γ idecl ind u indctx pars pctx ->
     existsb (leb_sort_family (universe_family ps)) idecl.(ind_kelim) ->
     Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
     All2 (fun x y => (fst x = fst y) * (Σ ;;; Γ |- snd x : snd y) * (Σ ;;; Γ |- snd y : tSort ps)) brs btys ->
@@ -728,7 +728,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
         forall (pty : term), Σ ;;; Γ |- p : pty ->
         forall indctx pctx ps btys,
         types_of_case ind mdecl idecl pars u p pty = Some (indctx, pctx, ps, btys) ->
-        check_correct_arity (global_ext_constraints Σ) idecl ind u indctx pars pctx ->
+        check_correct_arity Σ Γ idecl ind u indctx pars pctx ->
         existsb (leb_sort_family (universe_family ps)) (ind_kelim idecl) ->
         P Σ Γ p pty ->
         Σ;;; Γ |- c : mkApps (tInd ind u) args ->

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -1,10 +1,10 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia.
-From MetaCoq.Template Require Import config utils Universes BasicAst AstUtils
-UnivSubst EnvironmentTyping.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
-PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils.
+From MetaCoq.Template Require Import config utils Universes BasicAst AstUtils UnivSubst EnvironmentTyping.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICReflect
+                          PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils.
+From MetaCoq.PCUIC Require Export PCUICReduction PCUICConversion.
 
 From MetaCoq Require Export LibHypsNaming.
 
@@ -17,6 +17,7 @@ Set Asymmetric Patterns.
 
 From Equations Require Import Equations.
 Require Import Equations.Prop.DepElim.
+
 
 (** * Typing derivations
 
@@ -66,9 +67,6 @@ Proof.
   - rewrite IHtl app_length. simpl. lia.
 Qed.
 
-Module PCUICLookup := Lookup PCUICTerm PCUICEnvironment.
-Include PCUICLookup.
-
 (** Inductive substitution, to produce a constructors' type *)
 Definition inds ind u (l : list one_inductive_body) :=
   let fix aux n :=
@@ -93,333 +91,6 @@ Qed.
 Definition type_of_constructor mdecl (cdecl : ident * term * nat) (c : inductive * nat) (u : list Level.t) :=
   let mind := inductive_mind (fst c) in
   subst0 (inds mind u mdecl.(ind_bodies)) (subst_instance_constr u (snd (fst cdecl))).
-
-(** ** Reduction *)
-
-(** *** Helper functions for reduction *)
-
-Definition fix_subst (l : mfixpoint term) :=
-  let fix aux n :=
-      match n with
-      | 0 => []
-      | S n => tFix l n :: aux n
-      end
-  in aux (List.length l).
-
-Definition unfold_fix (mfix : mfixpoint term) (idx : nat) :=
-  match List.nth_error mfix idx with
-  | Some d =>
-    if isLambda d.(dbody) then
-      Some (d.(rarg), subst0 (fix_subst mfix) d.(dbody))
-    else None (* We don't unfold ill-formed fixpoints, which would
-                 render confluence unprovable, creating an infinite
-                 number of critical pairs between unfoldings of fixpoints.
-                 e.g. [fix f := f] is not allowed. *)
-  | None => None
-  end.
-
-Definition cofix_subst (l : mfixpoint term) :=
-  let fix aux n :=
-      match n with
-      | 0 => []
-      | S n => tCoFix l n :: aux n
-      end
-  in aux (List.length l).
-
-Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
-  match List.nth_error mfix idx with
-  | Some d => Some (d.(rarg), subst0 (cofix_subst mfix) d.(dbody))
-  | None => None
-  end.
-
-Definition is_constructor n ts :=
-  match List.nth_error ts n with
-  | Some a => isConstruct_app a
-  | None => false
-  end.
-
-Lemma fix_subst_length mfix : #|fix_subst mfix| = #|mfix|.
-Proof.
-  unfold fix_subst. generalize (tFix mfix). intros.
-  induction mfix; simpl; auto.
-Qed.
-
-Lemma cofix_subst_length mfix : #|cofix_subst mfix| = #|mfix|.
-Proof.
-  unfold cofix_subst. generalize (tCoFix mfix). intros.
-  induction mfix; simpl; auto.
-Qed.
-
-Lemma fix_context_length mfix : #|fix_context mfix| = #|mfix|.
-Proof. unfold fix_context. now rewrite List.rev_length mapi_length. Qed.
-
-Definition tDummy := tVar "".
-
-Definition iota_red npar c args brs :=
-  (mkApps (snd (List.nth c brs (0, tDummy))) (List.skipn npar args)).
-
-
-(** *** One step strong beta-zeta-iota-fix-delta reduction
-
-  Inspired by the reduction relation from Coq in Coq [Barras'99].
-*)
-
-Local Open Scope type_scope.
-Arguments OnOne2 {A} P%type l l'.
-
-Notation on_Trel_eq R f g :=
-  (fun x y => (R (f x) (f y) * (g x = g y)))%type.
-
-Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
-(** Reductions *)
-(** Beta *)
-| red_beta na t b a :
-    red1 Σ Γ (tApp (tLambda na t b) a) (subst10 a b)
-
-(** Let *)
-| red_zeta na b t b' :
-    red1 Σ Γ (tLetIn na b t b') (subst10 b b')
-
-| red_rel i body :
-    option_map decl_body (nth_error Γ i) = Some (Some body) ->
-    red1 Σ Γ (tRel i) (lift0 (S i) body)
-
-(** Case *)
-| red_iota ind pars c u args p brs :
-    red1 Σ Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs)
-         (iota_red pars c args brs)
-
-(** Fix unfolding, with guard *)
-| red_fix mfix idx args narg fn :
-    unfold_fix mfix idx = Some (narg, fn) ->
-    is_constructor narg args = true ->
-    red1 Σ Γ (mkApps (tFix mfix idx) args) (mkApps fn args)
-
-(** CoFix-case unfolding *)
-| red_cofix_case ip p mfix idx args narg fn brs :
-    unfold_cofix mfix idx = Some (narg, fn) ->
-    red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
-         (tCase ip p (mkApps fn args) brs)
-
-(** CoFix-proj unfolding *)
-| red_cofix_proj p mfix idx args narg fn :
-    unfold_cofix mfix idx = Some (narg, fn) ->
-    red1 Σ Γ (tProj p (mkApps (tCoFix mfix idx) args))
-         (tProj p (mkApps fn args))
-
-(** Constant unfolding *)
-| red_delta c decl body (isdecl : declared_constant Σ c decl) u :
-    decl.(cst_body) = Some body ->
-    red1 Σ Γ (tConst c u) (subst_instance_constr u body)
-
-(** Proj *)
-| red_proj i pars narg args k u arg:
-    nth_error args (pars + narg) = Some arg ->
-    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg
-
-
-| abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
-| abs_red_r na M M' N : red1 Σ (Γ ,, vass na N) M M' -> red1 Σ Γ (tLambda na N M) (tLambda na N M')
-
-| letin_red_def na b t b' r : red1 Σ Γ b r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na r t b')
-| letin_red_ty na b t b' r : red1 Σ Γ t r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b r b')
-| letin_red_body na b t b' r : red1 Σ (Γ ,, vdef na b t) b' r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b t r)
-
-| case_red_pred ind p p' c brs : red1 Σ Γ p p' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p' c brs)
-| case_red_discr ind p c c' brs : red1 Σ Γ c c' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c' brs)
-| case_red_brs ind p c brs brs' : OnOne2 (on_Trel_eq (red1 Σ Γ) snd fst) brs brs' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c brs')
-
-| proj_red p c c' : red1 Σ Γ c c' -> red1 Σ Γ (tProj p c) (tProj p c')
-
-| app_red_l M1 N1 M2 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tApp M1 M2) (tApp N1 M2)
-| app_red_r M2 N2 M1 : red1 Σ Γ M2 N2 -> red1 Σ Γ (tApp M1 M2) (tApp M1 N2)
-
-| prod_red_l na M1 M2 N1 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tProd na M1 M2) (tProd na N1 M2)
-| prod_red_r na M2 N2 M1 : red1 Σ (Γ ,, vass na M1) M2 N2 ->
-                               red1 Σ Γ (tProd na M1 M2) (tProd na M1 N2)
-
-| evar_red ev l l' : OnOne2 (red1 Σ Γ) l l' -> red1 Σ Γ (tEvar ev l) (tEvar ev l')
-
-| fix_red_ty mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
-
-| fix_red_body mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x)))
-           mfix0 mfix1 ->
-    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
-
-| cofix_red_ty mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)
-
-| cofix_red_body mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
-    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx).
-
-Lemma red1_ind_all :
-  forall (Σ : global_env) (P : context -> term -> term -> Type),
-
-       (forall (Γ : context) (na : name) (t b a : term),
-        P Γ (tApp (tLambda na t b) a) (b {0 := a})) ->
-
-       (forall (Γ : context) (na : name) (b t b' : term), P Γ (tLetIn na b t b') (b' {0 := b})) ->
-
-       (forall (Γ : context) (i : nat) (body : term),
-        option_map decl_body (nth_error Γ i) = Some (Some body) -> P Γ (tRel i) ((lift0 (S i)) body)) ->
-
-       (forall (Γ : context) (ind : inductive) (pars c : nat) (u : universe_instance) (args : list term)
-          (p : term) (brs : list (nat * term)),
-        P Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs) (iota_red pars c args brs)) ->
-
-       (forall (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
-        unfold_fix mfix idx = Some (narg, fn) ->
-        is_constructor narg args = true -> P Γ (mkApps (tFix mfix idx) args) (mkApps fn args)) ->
-
-       (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
-          (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
-        unfold_cofix mfix idx = Some (narg, fn) ->
-        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
-
-       (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
-          (narg : nat) (fn : term),
-        unfold_cofix mfix idx = Some (narg, fn) -> P Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
-
-       (forall (Γ : context) (c : ident) (decl : constant_body) (body : term),
-        declared_constant Σ c decl ->
-        forall u : universe_instance, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
-
-       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (k : nat) (u : universe_instance)
-         (arg : term),
-           nth_error args (pars + narg) = Some arg ->
-           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg) ->
-
-       (forall (Γ : context) (na : name) (M M' N : term),
-        red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->
-
-       (forall (Γ : context) (na : name) (M M' N : term),
-        red1 Σ (Γ,, vass na N) M M' -> P (Γ,, vass na N) M M' -> P Γ (tLambda na N M) (tLambda na N M')) ->
-
-       (forall (Γ : context) (na : name) (b t b' r : term),
-        red1 Σ Γ b r -> P Γ b r -> P Γ (tLetIn na b t b') (tLetIn na r t b')) ->
-
-       (forall (Γ : context) (na : name) (b t b' r : term),
-        red1 Σ Γ t r -> P Γ t r -> P Γ (tLetIn na b t b') (tLetIn na b r b')) ->
-
-       (forall (Γ : context) (na : name) (b t b' r : term),
-        red1 Σ (Γ,, vdef na b t) b' r -> P (Γ,, vdef na b t) b' r -> P Γ (tLetIn na b t b') (tLetIn na b t r)) ->
-
-       (forall (Γ : context) (ind : inductive * nat) (p p' c : term) (brs : list (nat * term)),
-        red1 Σ Γ p p' -> P Γ p p' -> P Γ (tCase ind p c brs) (tCase ind p' c brs)) ->
-
-       (forall (Γ : context) (ind : inductive * nat) (p c c' : term) (brs : list (nat * term)),
-        red1 Σ Γ c c' -> P Γ c c' -> P Γ (tCase ind p c brs) (tCase ind p c' brs)) ->
-
-       (forall (Γ : context) (ind : inductive * nat) (p c : term) (brs brs' : list (nat * term)),
-           OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) snd fst) brs brs' ->
-           P Γ (tCase ind p c brs) (tCase ind p c brs')) ->
-
-       (forall (Γ : context) (p : projection) (c c' : term), red1 Σ Γ c c' -> P Γ c c' ->
-                                                             P Γ (tProj p c) (tProj p c')) ->
-
-       (forall (Γ : context) (M1 N1 : term) (M2 : term), red1 Σ Γ M1 N1 -> P Γ M1 N1 ->
-                                                         P Γ (tApp M1 M2) (tApp N1 M2)) ->
-
-       (forall (Γ : context) (M2 N2 : term) (M1 : term), red1 Σ Γ M2 N2 -> P Γ M2 N2 ->
-                                                         P Γ (tApp M1 M2) (tApp M1 N2)) ->
-
-       (forall (Γ : context) (na : name) (M1 M2 N1 : term),
-        red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tProd na M1 M2) (tProd na N1 M2)) ->
-
-       (forall (Γ : context) (na : name) (M2 N2 M1 : term),
-        red1 Σ (Γ,, vass na M1) M2 N2 -> P (Γ,, vass na M1) M2 N2 -> P Γ (tProd na M1 M2) (tProd na M1 N2)) ->
-
-       (forall (Γ : context) (ev : nat) (l l' : list term),
-           OnOne2 (Trel_conj (red1 Σ Γ) (P Γ)) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
-                                      (P (Γ ,,, fix_context mfix0))) dbody
-                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
-        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
-                                      (P (Γ ,,, fix_context mfix0))) dbody
-                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
-        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
-
-       forall (Γ : context) (t t0 : term), red1 Σ Γ t t0 -> P Γ t t0.
-Proof.
-  intros. rename X26 into Xlast. revert Γ t t0 Xlast.
-  fix aux 4. intros Γ t T.
-  move aux at top.
-  destruct 1; match goal with
-              | |- P _ (tFix _ _) (tFix _ _) => idtac
-              | |- P _ (tCoFix _ _) (tCoFix _ _) => idtac
-              | |- P _ (mkApps (tFix _ _) _) _ => idtac
-              | |- P _ (tCase _ _ (mkApps (tCoFix _ _) _) _) _ => idtac
-              | |- P _ (tProj _ (mkApps (tCoFix _ _) _)) _ => idtac
-              | H : _ |- _ => eapply H; eauto
-              end.
-  - eapply X3; eauto.
-  - eapply X4; eauto.
-  - eapply X5; eauto.
-
-  - revert brs brs' o.
-    fix auxl 3.
-    intros l l' Hl. destruct Hl.
-    constructor. intuition auto. constructor. intuition auto.
-
-  - revert l l' o.
-    fix auxl 3.
-    intros l l' Hl. destruct Hl.
-    constructor. split; auto.
-    constructor. auto.
-
-  - eapply X22.
-    revert mfix0 mfix1 o; fix auxl 3; intros l l' Hl; destruct Hl;
-      constructor; try split; auto; intuition.
-
-  - eapply X23.
-    revert o. generalize (fix_context mfix0). intros c Xnew.
-    revert mfix0 mfix1 Xnew; fix auxl 3; intros l l' Hl;
-    destruct Hl; constructor; try split; auto; intuition.
-
-  - eapply X24.
-    revert mfix0 mfix1 o.
-    fix auxl 3; intros l l' Hl; destruct Hl;
-      constructor; try split; auto; intuition.
-
-  - eapply X25.
-    revert o. generalize (fix_context mfix0). intros c new.
-    revert mfix0 mfix1 new; fix auxl 3; intros l l' Hl; destruct Hl;
-      constructor; try split; auto; intuition.
-Defined.
-
-
-(** *** Reduction
-
-  The reflexive-transitive closure of 1-step reduction. *)
-
-Inductive red Σ Γ M : term -> Type :=
-| refl_red : red Σ Γ M M
-| trans_red : forall (P : term) N, red Σ Γ M P -> red1 Σ Γ P N -> red Σ Γ M N.
-
-Fixpoint subst_app (t : term) (us : list term) : term :=
-  match t, us with
-  | tLambda _ A t, u :: us => subst_app (t {0 := u}) us
-  | _, [] => t
-  | _, _ => mkApps t us
-  end.
 
 
 (** ** Utilities for typing *)
@@ -604,26 +275,6 @@ Qed.
 
 
 Reserved Notation " Σ ;;; Γ |- t : T " (at level 50, Γ, t, T at next level).
-Reserved Notation " Σ ;;; Γ |- t <= u " (at level 50, Γ, t, u at next level).
-
-(** ** Cumulativity *)
-
-Inductive cumul `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
-| cumul_refl t u : leq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t <= u
-| cumul_red_l t u v : red1 Σ.1 Γ t v -> Σ ;;; Γ |- v <= u -> Σ ;;; Γ |- t <= u
-| cumul_red_r t u v : Σ ;;; Γ |- t <= v -> red1 Σ.1 Γ u v -> Σ ;;; Γ |- t <= u
-
-where " Σ ;;; Γ |- t <= u " := (cumul Σ Γ t u) : type_scope.
-
-(** *** Conversion
-
-   Defined as cumulativity in both directions.
- *)
-
-Definition conv `{checker_flags} Σ Γ T U : Type :=
-  (Σ ;;; Γ |- T <= U) * (Σ ;;; Γ |- U <= T).
-
-Notation " Σ ;;; Γ |- t = u " := (conv Σ Γ t u) (at level 50, Γ, t, u at next level) : type_scope.
 
 Definition check_correct_arity `{checker_flags} φ decl ind u ctx pars pctx :=
   let inddecl :=
@@ -641,7 +292,8 @@ Section WfArity.
   Context (typing : forall (Σ : global_env_ext) (Γ : context), term -> term -> Type).
 
   Definition isWfArity Σ (Γ : context) T :=
-    { ctx & { s & (destArity [] T = Some (ctx, s)) * All_local_env (lift_typing typing Σ) (Γ ,,, ctx) } }.
+    ∑ ctx s, destArity [] T = Some (ctx, s)
+             × All_local_env (lift_typing typing Σ) (Γ ,,, ctx).
 
   Context (property : forall (Σ : global_env_ext) (Γ : context),
               All_local_env (lift_typing typing Σ) Γ ->

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -1124,15 +1124,16 @@ Proof.
         now rewrite map_option_out_map_option_map, E3.
     + clear -X2 X HSub wfΣ' H2. destruct HSub as [_ HSub]; cbn in *.
       eapply consistent_instance_valid_constraints in H2 as H2'; aa; simpl in *.
-      eapply eq_context_subst_instance in X2; aa.
-      refine (transport (fun c => eq_context _ c _) _ X2). clear.
-      cbn. f_equal. unfold map_decl; cbn. f_equal.
-      rewrite subst_instance_constr_mkApps. f_equal.
-      rewrite !map_app. f_equal.
-      * rewrite firstn_map, !map_map. eapply map_ext.
-        rewrite subst_instance_context_length.
-        intro; symmetry; apply lift_subst_instance_constr.
-      * apply subst_instance_to_extended_list.
+      exact (todo "convconv").
+      (* eapply eq_context_subst_instance in X2; aa. *)
+      (* refine (transport (fun c => eq_context _ c _) _ X2). clear. *)
+      (* cbn. f_equal. unfold map_decl; cbn. f_equal. *)
+      (* rewrite subst_instance_constr_mkApps. f_equal. *)
+      (* rewrite !map_app. f_equal. *)
+      (* * rewrite firstn_map, !map_map. eapply map_ext. *)
+      (*   rewrite subst_instance_context_length. *)
+      (*   intro; symmetry; apply lift_subst_instance_constr. *)
+      (* * apply subst_instance_to_extended_list. *)
     + clear -H1 H2.
       induction (ind_kelim idecl) as [|a l]; try discriminate; cbn in *.
       apply* orb_true_iff in H1.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -114,12 +114,13 @@ Section Validity.
       typing_spine Σ Γ T' u U ×
       Σ ;;; Γ |- U <= T.
   Proof.
-    induction u in f, fty, T |- *. simpl. intros. exists T, T. intuition auto. constructor.
-    admit. auto.
-    intros Hf Hty. simpl in Hty.
-    specialize (IHu _ fty _ Hf) as [T' [U' [H' [H'' H''']]]].
-    simpl in Hf.
-    econstructor.
+    induction u in f, fty, T |- *.
+    - simpl. intros. exists T, T. intuition auto; try reflexivity. constructor.
+      admit. reflexivity.
+    - intros Hf Hty. simpl in Hty.
+      specialize (IHu _ fty _ Hf) as [T' [U' [H' [H'' H''']]]].
+      simpl in Hf.
+      econstructor.
 
   Admitted.
   (*   eapply invert_type_App in H' as (fA & fB & fna & Hf). intuition. *)
@@ -337,12 +338,12 @@ Lemma inversion_mkApps :
 Proof.
   intros cf Σ Γ t l T hΣ h.
   induction l in t, T, h |- *.
-  - cbn in h. exists T, T. repeat split ; auto.
+  - cbn in h. exists T, T. repeat split ; auto; try reflexivity.
     constructor.
     + eapply validity' ; eauto.
     + apply cumul_refl'.
   - simpl in h. eapply IHl in h as [C [U [h1 [h2 h3]]]].
-    apply inversion_App in h1 as [na [A [B [ht [ha hc]]]]].
+    apply inversion_App in h1 as [na [A [B [ht [ha hc]]]]]; tas.
     eexists (tProd na A B), _. split ; [| split].
     + assumption.
     + econstructor. 2: eapply cumul_refl'.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -34,17 +34,17 @@ Section Validity.
       clear -wfΣ wfΓ isdecl a b.
       induction b; rewrite ?lift_context_snoc; econstructor; simpl; auto.
       + destruct t0 as [u Hu]. exists u. rewrite Nat.add_0_r.
-        unshelve eapply (weakening_typing Σ (skipn n Γ) Γ0 (firstn n Γ) t _ _ _ (tSort u)); eauto with wf.
+        unshelve eapply (weakening_typing Σ (skipn n Γ) Γ0 (firstn n Γ) t _ _ (tSort u)); eauto with wf.
         apply All_local_env_app_inv. intuition eauto.
       + destruct t0 as [u Hu]. exists u. rewrite Nat.add_0_r.
-        unshelve eapply (weakening_typing Σ (skipn n Γ) Γ0 (firstn n Γ) t _ _ _ (tSort u)); eauto with wf.
+        unshelve eapply (weakening_typing Σ (skipn n Γ) Γ0 (firstn n Γ) t _ _ (tSort u)); eauto with wf.
         apply All_local_env_app_inv. intuition eauto.
       + rewrite Nat.add_0_r.
-        unshelve eapply (weakening_typing Σ (skipn n Γ) Γ0 (firstn n Γ) b _ _ _ t); eauto with wf.
+        unshelve eapply (weakening_typing Σ (skipn n Γ) Γ0 (firstn n Γ) b _ _ t); eauto with wf.
         eapply All_local_env_app_inv. intuition eauto.
     - right. destruct i as [u Hu]. exists u.
       rewrite {3}H.
-      unshelve eapply (weakening_typing Σ (skipn n Γ) [] (firstn n Γ) ty _ _ _ (tSort u)); eauto with wf.
+      unshelve eapply (weakening_typing Σ (skipn n Γ) [] (firstn n Γ) ty _ _ (tSort u)); eauto with wf.
   Qed.
 
   Lemma destArity_it_mkProd_or_LetIn ctx ctx' t :
@@ -252,7 +252,7 @@ Section Validity.
 
     - (* Case *)
       right. red.
-      destruct X2.
+      destruct X3.
       + destruct i as [ctx [s [Heq Hs]]].
         exists s.
         unfold check_correct_arity in *.
@@ -262,7 +262,7 @@ Section Validity.
         simpl in H. subst pty.
         assert (#|args| = #|pctx|). admit. (* WF of case *)
         eapply type_mkApps. eauto.
-        destruct X4. destruct i as [ctx' [s' [Heq' Hs']]].
+        destruct X5. destruct i as [ctx' [s' [Heq' Hs']]].
         elimtype False.
         { clear -Heq'.
           revert Heq'.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -807,7 +807,7 @@ Proof.
 
   - eapply red_mkApps; auto.
 
-  - redt _. eapply red1_red. eapply PCUICTyping.red_cofix_case; eauto. eauto.
+  - redt _. eapply red1_red. eapply PCUICReduction.red_cofix_case; eauto. eauto.
 
   - redt _. 2:eauto.
     redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -122,10 +122,10 @@ Qed.
 Require Import ssreflect.
 
 Lemma forall_decls_declared_constant Σ cst decl :
-  TTy.declared_constant Σ cst decl ->
+  TemplateLookup.declared_constant Σ cst decl ->
   declared_constant (trans_global_decls Σ) cst (trans_constant_body decl).
 Proof.
-  unfold declared_constant, TTy.declared_constant.
+  unfold declared_constant, TemplateLookup.declared_constant.
   induction Σ => //; try discriminate.
   case: a => // /= k b; case: (ident_eq cst k); auto.
   - by move => [=] -> ->.
@@ -133,10 +133,10 @@ Proof.
 Qed.
 
 Lemma forall_decls_declared_minductive Σ cst decl :
-  TTy.declared_minductive Σ cst decl ->
+  TemplateLookup.declared_minductive Σ cst decl ->
   declared_minductive (trans_global_decls Σ) cst (trans_minductive_body decl).
 Proof.
-  unfold declared_minductive, TTy.declared_minductive.
+  unfold declared_minductive, TemplateLookup.declared_minductive.
   induction Σ => //; try discriminate.
   case: a => // /= k b; case: (ident_eq cst k); auto.
   - by discriminate.
@@ -144,10 +144,10 @@ Proof.
 Qed.
 
 Lemma forall_decls_declared_inductive Σ mdecl ind decl :
-  TTy.declared_inductive Σ mdecl ind decl ->
+  TemplateLookup.declared_inductive Σ mdecl ind decl ->
   declared_inductive (trans_global_decls Σ) (trans_minductive_body mdecl) ind (trans_one_ind_body decl).
 Proof.
-  unfold declared_inductive, TTy.declared_inductive.
+  unfold declared_inductive, TemplateLookup.declared_inductive.
   move=> [decl' Hnth].
   pose proof (forall_decls_declared_minductive _ _ _ decl').
   eexists. eauto. destruct decl'; simpl in *.
@@ -156,11 +156,11 @@ Proof.
 Qed.
 
 Lemma forall_decls_declared_constructor Σ cst mdecl idecl decl :
-  TTy.declared_constructor Σ mdecl idecl cst decl ->
+  TemplateLookup.declared_constructor Σ mdecl idecl cst decl ->
   declared_constructor (trans_global_decls Σ) (trans_minductive_body mdecl) (trans_one_ind_body idecl)
                     cst ((fun '(x, y, z) => (x, trans y, z)) decl).
 Proof.
-  unfold declared_constructor, TTy.declared_constructor.
+  unfold declared_constructor, TemplateLookup.declared_constructor.
   move=> [decl' Hnth].
   pose proof (forall_decls_declared_inductive _ _ _ _ decl'). split; auto.
   destruct idecl; simpl.
@@ -168,11 +168,11 @@ Proof.
 Qed.
 
 Lemma forall_decls_declared_projection Σ cst mdecl idecl decl :
-  TTy.declared_projection Σ mdecl idecl cst decl ->
+  TemplateLookup.declared_projection Σ mdecl idecl cst decl ->
   declared_projection (trans_global_decls Σ) (trans_minductive_body mdecl) (trans_one_ind_body idecl)
                     cst ((fun '(x, y) => (x, trans y)) decl).
 Proof.
-  unfold declared_constructor, TTy.declared_constructor.
+  unfold declared_constructor, TemplateLookup.declared_constructor.
   move=> [decl' [Hnth Hnpar]].
   pose proof (forall_decls_declared_inductive _ _ _ _ decl'). split; auto.
   destruct idecl; simpl.
@@ -304,7 +304,7 @@ Lemma trans_types_of_case (Σ : T.global_env) ind mdecl idecl args p u pty indct
   T.wf p -> T.wf pty -> T.wf (T.ind_type idecl) ->
   All Ast.wf args ->
   TTy.wf Σ ->
-  TTy.declared_inductive Σ mdecl ind idecl ->
+  TemplateLookup.declared_inductive Σ mdecl ind idecl ->
   TTy.types_of_case ind mdecl idecl args u p pty = Some (indctx, pctx, ps, btys) ->
   types_of_case ind (trans_minductive_body mdecl) (trans_one_ind_body idecl)
   (map trans args) u (trans p) (trans pty) =
@@ -397,7 +397,7 @@ Proof.
 Qed.
 
 Lemma trans_eq_term ϕ T U :
-  T.wf T -> T.wf U -> TTy.eq_term ϕ T U ->
+  T.wf T -> T.wf U -> Conversion.eq_term ϕ T U ->
   eq_term ϕ (trans T) (trans U).
 Proof.
   intros HT HU H.
@@ -431,7 +431,7 @@ Admitted.
 
 
 Lemma trans_eq_term_list ϕ T U :
-  List.Forall T.wf T -> List.Forall T.wf U -> Forall2 (TTy.eq_term ϕ) T U ->
+  List.Forall T.wf T -> List.Forall T.wf U -> Forall2 (Conversion.eq_term ϕ) T U ->
   All2 (eq_term ϕ) (List.map trans T) (List.map trans U).
 Proof.
 (*   intros H H0 H1. eapply All2_map. *)
@@ -485,7 +485,7 @@ Proof.
 Qed.
 
 Lemma trans_eq_term_upto_univ Re Rle T U :
-  T.wf T -> T.wf U -> TTy.eq_term_upto_univ Re Rle T U ->
+  T.wf T -> T.wf U -> Conversion.eq_term_upto_univ Re Rle T U ->
   eq_term_upto_univ Re Rle (trans T) (trans U).
 Proof.
   intros HT HU H.
@@ -545,7 +545,7 @@ Proof.
 Admitted.
 
 Lemma trans_leq_term ϕ T U :
-  T.wf T -> T.wf U -> TTy.leq_term ϕ T U ->
+  T.wf T -> T.wf U -> Conversion.leq_term ϕ T U ->
   leq_term ϕ (trans T) (trans U).
 Proof.
   intros HT HU H.
@@ -575,10 +575,10 @@ Qed.
 Lemma trans_iota_red pars ind c u args brs :
   T.wf (Template.Ast.mkApps (Template.Ast.tConstruct ind c u) args) ->
   List.Forall (compose T.wf snd) brs ->
-  trans (TTy.iota_red pars c args brs) =
+  trans (Reduction.iota_red pars c args brs) =
   iota_red pars c (List.map trans args) (List.map (on_snd trans) brs).
 Proof.
-  unfold TTy.iota_red, iota_red. intros wfapp wfbrs.
+  unfold Reduction.iota_red, iota_red. intros wfapp wfbrs.
   rewrite trans_mkApps.
 
   - induction wfbrs in c |- *.
@@ -592,20 +592,20 @@ Qed.
 Lemma trans_unfold_fix mfix idx narg fn :
   List.Forall (fun def : def Tterm => T.wf (dtype def) /\ T.wf (dbody def) /\
               T.isLambda (dbody def) = true) mfix ->
-  TTy.unfold_fix mfix idx = Some (narg, fn) ->
+  Reduction.unfold_fix mfix idx = Some (narg, fn) ->
   unfold_fix (map (map_def trans trans) mfix) idx = Some (narg, trans fn).
 Proof.
-  unfold TTy.unfold_fix, unfold_fix. intros wffix.
+  unfold Reduction.unfold_fix, unfold_fix. intros wffix.
   rewrite nth_error_map. destruct (nth_error mfix idx) eqn:Hdef => //.
   intros [= <- <-]. simpl.
   destruct isLambda eqn:isl => //.
   repeat f_equal.
   rewrite trans_subst. clear Hdef.
-  unfold TTy.fix_subst. generalize mfix at 2.
+  unfold Reduction.fix_subst. generalize mfix at 2.
   induction mfix0. constructor. simpl. repeat (constructor; auto).
   apply (nth_error_forall Hdef) in wffix. simpl in wffix; intuition.
   f_equal. clear Hdef.
-  unfold fix_subst, TTy.fix_subst. rewrite map_length.
+  unfold fix_subst, Reduction.fix_subst. rewrite map_length.
   generalize mfix at 1 3.
   induction wffix; trivial.
   simpl; intros mfix. f_equal.
@@ -618,18 +618,18 @@ Qed.
 
 Lemma trans_unfold_cofix mfix idx narg fn :
   List.Forall (fun def : def Tterm => T.wf (dtype def) /\ T.wf (dbody def)) mfix ->
-  TTy.unfold_cofix mfix idx = Some (narg, fn) ->
+  Reduction.unfold_cofix mfix idx = Some (narg, fn) ->
   unfold_cofix (map (map_def trans trans) mfix) idx = Some (narg, trans fn).
 Proof.
-  unfold TTy.unfold_cofix, unfold_cofix. intros wffix.
+  unfold Reduction.unfold_cofix, unfold_cofix. intros wffix.
   rewrite nth_error_map. destruct (nth_error mfix idx) eqn:Hdef.
   intros [= <- <-]. simpl. repeat f_equal.
   rewrite trans_subst. clear Hdef.
-  unfold TTy.cofix_subst. generalize mfix at 2.
+  unfold Reduction.cofix_subst. generalize mfix at 2.
   induction mfix0. constructor. simpl. repeat (constructor; auto).
   apply (nth_error_forall Hdef) in wffix. simpl in wffix; intuition.
   f_equal. clear Hdef.
-  unfold cofix_subst, TTy.cofix_subst. rewrite map_length.
+  unfold cofix_subst, Reduction.cofix_subst. rewrite map_length.
   generalize mfix at 1 3.
   induction wffix; trivial.
   simpl; intros mfix. f_equal.
@@ -640,10 +640,10 @@ Definition isApp t := match t with tApp _ _ => true | _ => false end.
 
 Lemma trans_is_constructor:
   forall (args : list Tterm) (narg : nat),
-    Checker.Typing.is_constructor narg args = true -> is_constructor narg (map trans args) = true.
+    Reduction.is_constructor narg args = true -> is_constructor narg (map trans args) = true.
 Proof.
   intros args narg.
-  unfold Checker.Typing.is_constructor, is_constructor.
+  unfold Reduction.is_constructor, is_constructor.
   rewrite nth_error_map. destruct nth_error. simpl. intros.
   destruct t; try discriminate || reflexivity. simpl in H.
   destruct t; try discriminate || reflexivity.
@@ -666,11 +666,11 @@ Ltac wf_inv H := try apply wf_inv in H; simpl in H; repeat destruct_conjs.
 Lemma trans_red1 Σ Γ T U :
   TTy.on_global_env (fun Σ => wf_decl_pred) Σ ->
   List.Forall wf_decl Γ ->
-  T.wf T -> TTy.red1 Σ Γ T U ->
+  T.wf T -> Reduction.red1 Σ Γ T U ->
   red1 (map trans_global_decl Σ) (trans_local Γ) (trans T) (trans U).
 Proof.
   intros wfΣ wfΓ Hwf.
-  induction 1 using Checker.Typing.red1_ind_all; wf_inv Hwf; simpl in *;
+  induction 1 using Reduction.red1_ind_all; wf_inv Hwf; simpl in *;
     try solve [econstructor; eauto].
 
   - simpl. wf_inv H1. apply Forall_All in H2. inv H2.
@@ -752,7 +752,7 @@ Proof.
     red. rewrite <- !map_dtype. rewrite <- !map_dbody. intuition eauto.
     unfold Template.Ast.app_context, trans_local in b0.
     simpl in a. rewrite -> map_app in b0.
-    unfold app_context. unfold Checker.Typing.fix_context in b0.
+    unfold app_context. unfold Reduction.fix_context in b0.
     rewrite map_rev map_mapi in b0. simpl in b0.
     unfold fix_context. rewrite mapi_map. simpl.
     forward b0.
@@ -781,7 +781,7 @@ Proof.
     red. rewrite <- !map_dtype. rewrite <- !map_dbody. intuition eauto.
     unfold Template.Ast.app_context, trans_local in b0.
     simpl in a. rewrite -> map_app in b0.
-    unfold app_context. unfold Checker.Typing.fix_context in b0.
+    unfold app_context. unfold Reduction.fix_context in b0.
     rewrite map_rev map_mapi in b0. simpl in b0.
     unfold fix_context. rewrite mapi_map. simpl.
     forward b0.
@@ -800,10 +800,10 @@ Proof.
 Admitted.
 
 Lemma global_ext_levels_trans Σ
-  : global_ext_levels (trans_global Σ) = TTy.global_ext_levels Σ.
+  : global_ext_levels (trans_global Σ) = TemplateLookup.global_ext_levels Σ.
 Proof.
   destruct Σ.
-  unfold trans_global, TTy.global_ext_levels, global_ext_levels; simpl.
+  unfold trans_global, TemplateLookup.global_ext_levels, global_ext_levels; simpl.
   f_equal. clear u.
   induction g.
   - reflexivity.
@@ -812,10 +812,10 @@ Proof.
 Qed.
 
 Lemma global_ext_constraints_trans Σ
-  : global_ext_constraints (trans_global Σ) = TTy.global_ext_constraints Σ.
+  : global_ext_constraints (trans_global Σ) = TemplateLookup.global_ext_constraints Σ.
 Proof.
   destruct Σ.
-  unfold trans_global, TTy.global_ext_constraints, global_ext_constraints; simpl.
+  unfold trans_global, TemplateLookup.global_ext_constraints, global_ext_constraints; simpl.
   f_equal. clear u.
   induction g.
   - reflexivity.
@@ -906,21 +906,22 @@ Admitted.
 
 Hint Resolve trans_wf_local : trans.
 
-Lemma check_correct_arity_trans (Σ : T.global_env_ext) idecl ind u indctx npar args pctx :
-  TTy.check_correct_arity (TTy.global_ext_constraints Σ) idecl ind u indctx (firstn npar args) pctx ->
-  check_correct_arity (global_ext_constraints (trans_global Σ)) (trans_one_ind_body idecl) ind u
+Lemma check_correct_arity_trans (Σ : T.global_env_ext) Γ idecl ind u indctx npar args pctx :
+  TTy.check_correct_arity Σ idecl ind u indctx (firstn npar args) pctx ->
+  check_correct_arity (trans_global Σ) (trans_local Γ) (trans_one_ind_body idecl) ind u
                       (trans_local indctx) (firstn npar (map trans args))
                       (trans_local pctx).
 Proof.
   destruct idecl; simpl in *. unfold TTy.check_correct_arity, check_correct_arity in *.
   simpl. (* Types of cases check *)
   clear. simpl. induction pctx; simpl. intros.
-  depelim H. intros H. depelim H. constructor; auto.
-  red. red in e. intuition auto.
-  red. simpl. red in a0. simpl in *. destruct a as [? [?|] ?]; simpl in *; try discriminate; auto.
-  red in a0. simpl in *. destruct a as [? [?|] ?]; simpl in *; try discriminate; try tauto.
-  red. eapply trans_eq_term in b.
-  rewrite trans_mkApps in b. constructor. admit.
+  (* depelim H. intros H. depelim H. constructor; auto. *)
+  (* red. red in e. intuition auto. *)
+  (* red. simpl. red in a0. simpl in *. destruct a as [? [?|] ?]; simpl in *; try discriminate; auto. *)
+  (* red in a0. simpl in *. destruct a as [? [?|] ?]; simpl in *; try discriminate; try tauto. *)
+  (* red. eapply trans_eq_term in b. *)
+  (* rewrite trans_mkApps in b. constructor. admit. *)
+  todo "convconv -> template".
 Admitted.
 
 Axiom fix_guard_trans :
@@ -1018,25 +1019,27 @@ Proof.
        destruct cdecl as [[id t] p]; simpl; auto.
 
   - rewrite trans_mkApps; auto with wf trans. apply typing_wf in X1; intuition auto.
-    solve_all. apply typing_wf in X3; auto. intuition auto.
-    apply wf_mkApps_inv in H4.
+    solve_all. apply typing_wf in X4; auto. intuition auto.
+    apply wf_mkApps_inv in H3.
     apply All_app_inv. apply All_skipn. solve_all. constructor; auto.
     rewrite map_app map_skipn.
     eapply type_Case.
     apply forall_decls_declared_inductive; eauto. destruct mdecl; auto.
-    eapply X2.
+    eapply X3.
     rewrite firstn_map.
     eapply trans_types_of_case; eauto.
     -- eapply typing_wf in X1; intuition auto.
     -- eapply typing_wf in X1; intuition auto.
     -- eapply declared_inductive_wf in isdecl; eauto.
        apply typing_wf_wf; auto.
-    -- eapply typing_wf in X3; intuition auto.
-       eapply wf_mkApps_inv in H4. apply All_firstn. solve_all.
-    -- revert H1. apply check_correct_arity_trans.
+    -- eapply typing_wf in X4; intuition auto.
+       eapply wf_mkApps_inv in H3. apply All_firstn. solve_all.
+    -- revert H1.
+       exact (todo "convcon").
+       (* apply check_correct_arity_trans. *)
     -- destruct idecl; simpl in *; auto.
-    -- rewrite trans_mkApps in X4; auto with wf.
-       eapply typing_wf in X3; auto. intuition. eapply wf_mkApps_inv in H4; auto.
+    -- rewrite trans_mkApps in X5; auto with wf.
+       eapply typing_wf in X4; auto. intuition. eapply wf_mkApps_inv in H3; auto.
     -- apply All2_map. solve_all.
 
   - destruct pdecl as [arity ty]; simpl in *.
@@ -1055,8 +1058,8 @@ Proof.
 
   - eapply refine_type.
     assert (fix_context (map (map_def trans trans) mfix) =
-            trans_local (TTy.fix_context mfix)).
-    { unfold trans_local, TTy.fix_context.
+            trans_local (Reduction.fix_context mfix)).
+    { unfold trans_local, Reduction.fix_context.
       rewrite map_rev map_mapi /fix_context mapi_map.
       f_equal. apply mapi_ext; intros i x.
       simpl. rewrite trans_lift. reflexivity. }
@@ -1078,8 +1081,8 @@ Proof.
 
   - eapply refine_type.
     assert (fix_context (map (map_def trans trans) mfix) =
-            trans_local (TTy.fix_context mfix)).
-    { unfold trans_local, TTy.fix_context.
+            trans_local (Reduction.fix_context mfix)).
+    { unfold trans_local, Reduction.fix_context.
       rewrite map_rev map_mapi /fix_context mapi_map.
       f_equal. apply mapi_ext => i x.
       simpl. rewrite trans_lift. reflexivity. }

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -978,7 +978,7 @@ Proof.
     clear H1 X0 H H0. revert H2.
     induction X1. econstructor; eauto.
     (* Need updated typing_spine in template-coq *) admit.
-    simpl in p.
+    reflexivity. simpl in p.
     destruct (TypingWf.typing_wf _ wfΣ _ _ _ typrod) as [wfAB _].
     intros wfT.
     econstructor; eauto. right. exists s; eauto.

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -55,8 +55,8 @@ src/pCUICNormal.ml
 # src/pCUICWeakeningEnv.mli
 # src/pCUICWeakening.mli
 # src/pCUICWeakening.ml
-# src/pCUICReduction.mli
-# src/pCUICReduction.ml
+src/pCUICReduction.mli
+src/pCUICReduction.ml
 # src/pCUICSubstitution.ml
 # src/pCUICSubstitution.mli
 # src/pCUICNameless.mli
@@ -65,8 +65,8 @@ src/pCUICNormal.ml
 # src/pCUICGeneration.ml
 # src/pCUICContextConversion.mli
 # src/pCUICContextConversion.ml
-# src/pCUICConversion.mli
-# src/pCUICConversion.ml
+src/pCUICConversion.mli
+src/pCUICConversion.ml
 src/pCUICSafeLemmata.mli
 src/pCUICSafeLemmata.ml
 src/templateToPCUIC.mli

--- a/safechecker/src/metacoq_safechecker_plugin.mlpack
+++ b/safechecker/src/metacoq_safechecker_plugin.mlpack
@@ -21,6 +21,7 @@ PCUICEquality
 PCUICTyping
 PCUICInduction
 PCUICReduction
+PCUICConversion
 PCUICNormal
 PCUICPosition
 PCUICChecker

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -2211,7 +2211,7 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_conv_cum_l. 1: assumption.
+    eapply conv_conv_cum_l.
     constructor.
     eapply eqb_term_spec. auto.
   Qed.

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -101,7 +101,7 @@ End FoldMap.
 
 Definition fix_global_env_universes (Σ : Ast.global_env) : Ast.global_env :=
   let fix_decl decl declared :=
-    let '(declu, declcstrs) := Typing.monomorphic_udecl_decl decl in
+    let '(declu, declcstrs) := TemplateLookup.monomorphic_udecl_decl decl in
     let declared := LevelSet.union declu declared in
     let dangling := dangling_universes declared declcstrs in
     (update_universes (LevelSet.union declu dangling, declcstrs) decl, LevelSet.union declared dangling)


### PR DESCRIPTION
Conversion is no longer the cumulativity in both directions. Now [conv] refers to
the old [conv_alt].

Also the second [conv] has been renamed [conv_cum] (it is only used for safe
conversion checker).