### PR TITLE
Bye bye check correct arity

### DIFF
--- a/checker/theories/TypingWf.v
+++ b/checker/theories/TypingWf.v
@@ -104,8 +104,10 @@ Proof.
   unfold unfold_fix in Hf. inv Hwf.
   destruct nth_error eqn:eqnth; try congruence.
   pose proof (nth_error_forall eqnth H). simpl in H0.
+  destruct H0 as [ _ [ wfd islamd ] ].
+  rewrite islamd in Hf.
   injection Hf. intros <- <-.
-  destruct H0 as [ _ [ wfd islamd ] ]. apply (isLambda_subst (fix_subst mfix) 0) in islamd.
+  apply (isLambda_subst (fix_subst mfix) 0) in islamd.
   apply isLambda_isApp in islamd. split; try congruence.
   apply wf_subst; auto. clear wfd islamd Hf eqnth.
   assert(forall n, Ast.wf (tFix mfix n)). constructor; auto.

--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -1060,11 +1060,11 @@ Proof.
     7:{ cbn. rewrite -> firstn_map.
         erewrite lift_build_branches_type; tea.
         rewrite map_option_out_map_option_map.
-        erewrite heq_map_option_out. reflexivity. }
+        subst params. erewrite heq_map_option_out. reflexivity. }
     all: eauto.
     -- erewrite -> lift_declared_inductive; eauto.
     -- simpl. erewrite firstn_map, lift_build_case_predicate_type; tea.
-       erewrite heq_build_case_predicate_type; reflexivity.
+       subst params. erewrite heq_build_case_predicate_type; reflexivity.
     -- destruct idecl; simpl in *; auto.
     -- now rewrite -> !lift_mkApps in IHc.
     -- solve_all.

--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -282,13 +282,6 @@ Proof.
   eapply eq_decl_subset; eassumption. assumption.
 Qed.
 
-Lemma check_correct_arity_subset {cf:checker_flags} φ φ' decl ind u ctx pars pctx
-  : ConstraintSet.Subset φ φ' -> check_correct_arity φ decl ind u ctx pars pctx
-    -> check_correct_arity φ' decl ind u ctx pars pctx.
-Proof.
-  apply eq_context_subset.
-Qed.
-
 Lemma weakening_env_consistent_instance {cf:checker_flags} :
   forall Σ Σ' φ ctrs u,
     extends Σ Σ' ->
@@ -331,9 +324,7 @@ Proof.
     induction X1. constructor. econstructor; eauto with extends.
     eapply weakening_env_cumul in cumul; eauto.
   - econstructor; eauto 2 with extends.
-    + eapply check_correct_arity_subset; tea.
-      apply weakening_env_global_ext_constraints; tas.
-    + close_Forall. intros; intuition eauto with extends.
+    close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
     eapply All_local_env_impl. eapply X.
     clear -wfΣ' extΣ. simpl; intros.

--- a/erasure/theories/EInversion.v
+++ b/erasure/theories/EInversion.v
@@ -20,31 +20,6 @@ Local Existing Instance default_checker_flags.
 
 (** ** Inversion on eval *)
 
-Lemma type_Case_inv (Σ : global_env_ext) (hΣ : wf Σ.1) Γ ind npar p c brs T :
-  Σ;;; Γ |- PCUICAst.tCase (ind, npar) p c brs : T ->
-  { '(u, args, mdecl, idecl, pty, indctx, pctx, ps, btys) : _ &
-         (PCUICTyping.declared_inductive (fst Σ) mdecl ind idecl) *
-         (PCUICAst.ind_npars mdecl = npar) *
-         let pars := firstn npar args in
-         (Σ;;; Γ |- p : pty) *
-         (types_of_case ind mdecl idecl pars u p pty = Some (indctx, pctx, ps, btys)) *
-         (check_correct_arity (global_ext_constraints Σ) idecl ind u indctx pars pctx) *
-         (existsb (leb_sort_family (universe_family ps)) (PCUICAst.ind_kelim idecl)) *
-         (Σ;;; Γ |- c : PCUICAst.mkApps (tInd ind u) args) *
-         (All2 (fun x y : nat * PCUICAst.term => ((fst x = fst y) * (Σ;;; Γ |- snd x : snd y)) * (Σ ;;; Γ |- snd y : tSort ps)) brs btys) *
-         (Σ ;;; Γ |- PCUICAst.mkApps p (skipn npar args ++ [c])  <= T)}%type.
-Proof.
-  intros. dependent induction X.
-  - unshelve eexists.
-    + repeat refine (_,_). all:shelve.
-    + cbn. subst pars. intuition eauto.
-  - edestruct (IHX hΣ _ _ _ _ _ eq_refl) as [ [[[[[[[[]]]]]]]] ].
-    repeat match goal with [ H : _ * _ |- _ ] => destruct H end.
-    unshelve eexists.
-    + repeat refine (_, _). all:shelve.
-    + cbn. intuition eauto.
-      all: eapply PCUICConversion.cumul_trans; eauto.
-Qed.
 
 Notation type_Construct_inv := PCUICInversion.inversion_Construct.
 Notation type_tFix_inv := PCUICInversion.inversion_Fix.

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -362,7 +362,7 @@ Proof.
   - depelim H5.
     + cbn. econstructor.
       * eauto.
-      * eapply H4; eauto.
+      * eapply H3; eauto.
       * eapply All2_map.
         eapply All2_impl_In; eauto.
         intros. destruct H11, x, y. cbn in *. subst. split; eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -593,149 +593,154 @@ Proof.
   - destruct Σ as (Σ, univs).
     cbn in H.
     eapply extr_env_axiom_free'0 in H. congruence.
-  - assert (Hty' := Hty).
-    assert (Σ ;;; [] |- tCase (ind, pars) p discr brs ▷ res) by eauto.
-    eapply inversion_Case in Hty' as (u' & args' & mdecl & idecl & pty & indctx & pctx & ps & btys & ? & ? & ? & ? & ? & ? & ? & ? & ?).
-    assert (Σ ;;; [] |- mkApps (tConstruct ind c u) args :  mkApps (tInd ind u') args').
-    eapply subject_reduction_eval; eauto.
-    eapply type_mkApps_inv in X0 as (? & ? & [] & ?); eauto.
-    eapply inversion_Construct in t1 as (mdecl' & idecl' & cdecl & ? & ? & ? & ?).
-    assert (d1 := d0).
-    destruct d0.
 
-    edestruct (declared_inductive_inj H1 d). subst.
+  (* - assert (Hty' := Hty). *)
+  (*   assert (Σ ;;; [] |- tCase (ind, pars) p discr brs ▷ res) by eauto. *)
+  (* eapply inversion_Case in Hty' as [u' [args' [mdecl [idecl [ps [pty [btys *)
+  (*                                  [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]. *)
+  (*   assert (Σ ;;; [] |- mkApps (tConstruct ind c u) args :  mkApps (tInd ind u') args'). *)
+  (*   eapply subject_reduction_eval; eauto. *)
+  (*   eapply type_mkApps_inv in X0 as (? & ? & [] & ?); eauto. *)
+  (*   eapply inversion_Construct in t1 as (mdecl' & idecl' & cdecl & ? & ? & ? & ?). *)
+  (*   assert (d1 := d0). *)
+  (*   destruct d0. *)
 
-    pose proof (length_of_btys e0).
+  (*   edestruct (declared_inductive_inj H1 d). subst. *)
 
-    inv He.
-    + eapply IHeval1 in H11 as (v' & Hv' & He_v'); eauto.
-      eapply erases_mkApps_inv in Hv' as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-      3: eapply subject_reduction_eval; eauto.
-      * subst.
+  (*   pose proof (length_of_btys e0). *)
 
-        eapply Is_type_app in X0. destruct X0. 2:eauto. 2: econstructor. 2:{ rewrite mkApps_nested. eapply subject_reduction_eval; eauto. }
-        rewrite mkApps_nested in X0.
+  (*   inv He. *)
+  (*   + eapply IHeval1 in H11 as (v' & Hv' & He_v'); eauto. *)
+  (*     eapply erases_mkApps_inv in Hv' as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto. *)
+  (*     3: eapply subject_reduction_eval; eauto. *)
+  (*     * subst. *)
 
-        eapply tConstruct_no_Type in X0.
-        eapply H10 in X0 as []; eauto. 2: exists []; now destruct Σ.
+  (*       eapply Is_type_app in X0. destruct X0. 2:eauto. 2: econstructor. 2:{ rewrite mkApps_nested. eapply subject_reduction_eval; eauto. } *)
+  (*       rewrite mkApps_nested in X0. *)
 
-        destruct (ind_ctors idecl'). cbn in H4. destruct c; inv H2.
-        destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in H2; inv H2.
+  (*       eapply tConstruct_no_Type in X0. *)
+  (*       eapply H10 in X0 as []; eauto. 2: exists []; now destruct Σ. *)
 
-        destruct btys as [ | ? []]; cbn in H3; try lia. clear H3 H4. destruct H7.
-        (* eapply H7 in d1. *) inv a. inv X2. inv H12. inv H8. destruct H4. destruct x4, y; cbn in *; subst.
-        destruct X1. subst. destruct p0; cbn in *.
+  (*       destruct (ind_ctors idecl'). cbn in H4. destruct c; inv H2. *)
+  (*       destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in H2; inv H2. *)
 
-        edestruct (IHeval2) as (? & ? & ?).
-        eapply subject_reduction. eauto. exact Hty.
-        etransitivity.
-        eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
-        econstructor. econstructor. econstructor.
+  (*       destruct btys as [ | ? []]; cbn in H3; try lia. clear H3 H4. destruct H7. *)
+  (*       (* eapply H7 in d1. *) inv a. inv X2. inv H12. inv H8. destruct H4. destruct x4, y; cbn in *; subst. *)
+  (*       destruct X1. subst. destruct p0; cbn in *. *)
 
-        all:unfold iota_red in *. all:cbn in *.
-        eapply erases_mkApps. eauto.
-        instantiate (1 := repeat tBox _).
-        eapply All2_Forall2.
-        eapply All2_impl.
-        eapply All2_All_mix_left. eassumption.
-        2:{ intros. destruct X1. assert (y = tBox). exact y0. subst. econstructor.
-            now eapply isErasable_Proof. }
+  (*       edestruct (IHeval2) as (? & ? & ?). *)
+  (*       eapply subject_reduction. eauto. exact Hty. *)
+  (*       etransitivity. *)
+  (*       eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto. *)
+  (*       econstructor. econstructor. econstructor. *)
 
-        eapply All2_right_triv. 2: now rewrite repeat_length.
+  (*       all:unfold iota_red in *. all:cbn in *. *)
+  (*       eapply erases_mkApps. eauto. *)
+  (*       instantiate (1 := repeat tBox _). *)
+  (*       eapply All2_Forall2. *)
+  (*       eapply All2_impl. *)
+  (*       eapply All2_All_mix_left. eassumption. *)
+  (*       2:{ intros. destruct X1. assert (y = tBox). exact y0. subst. econstructor. *)
+  (*           now eapply isErasable_Proof. } *)
 
-        now eapply All_repeat.
+  (*       eapply All2_right_triv. 2: now rewrite repeat_length. *)
 
-        (* destruct x4; cbn in e2; subst. destruct X2. destruct p0; cbn in e2; subst. cbn in *.  destruct y.  *)
-        exists x4. split; eauto. eapply eval_iota_sing.  2:eauto.
-        pose proof (Ee.eval_to_value _ _ _ He_v').
-        eapply value_app_inv in H4. subst. eassumption. 2:eauto.
+  (*       now eapply All_repeat. *)
 
-        eapply wf_ext_wf in extr_env_wf'0.
-        eapply tCase_length_branch_inv in extr_env_wf'0.
-        2:{ eapply subject_reduction. eauto.
-            exact Hty.
-            eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.  }
-        2: reflexivity.
+  (*       (* destruct x4; cbn in e2; subst. destruct X2. destruct p0; cbn in e2; subst. cbn in *.  destruct y.  *) *)
+  (*       exists x4. split; eauto. eapply eval_iota_sing.  2:eauto. *)
+  (*       pose proof (Ee.eval_to_value _ _ _ He_v'). *)
+  (*       eapply value_app_inv in H4. subst. eassumption. 2:eauto. *)
 
-        enough (#|skipn (ind_npars mdecl') (x1 ++ x2)| = n0) as <- by eauto.
-        rewrite skipn_length. rewrite extr_env_wf'0. lia.
-        rewrite extr_env_wf'0. lia.
-      * subst. unfold iota_red in *.
-        destruct (nth_error brs c) eqn:Hnth.
-        2:{ eapply nth_error_None in Hnth. erewrite All2_length in Hnth. 2:exact a. rewrite H3 in Hnth.
-            eapply nth_error_Some_length in H2. cbn in H2. lia.
-        }
-        rewrite <- nth_default_eq in *. unfold nth_default in *.
-        rewrite Hnth in *.
+  (*       eapply wf_ext_wf in extr_env_wf'0. *)
+  (*       eapply tCase_length_branch_inv in extr_env_wf'0. *)
+  (*       2:{ eapply subject_reduction. eauto. *)
+  (*           exact Hty. *)
+  (*           eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.  } *)
+  (*       2: reflexivity. *)
 
-        destruct (All2_nth_error_Some _ _ H12 Hnth) as (? & ? & ? & ?).
-        destruct (All2_nth_error_Some _ _ a Hnth) as (? & ? & ? & ?).
-        destruct p0, x4. cbn in *. subst.
-        edestruct IHeval2 as (? & ? & ?).
-        eapply subject_reduction. eauto. exact Hty.
-        etransitivity.
-        eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
+  (*       enough (#|skipn (ind_npars mdecl') (x1 ++ x2)| = n0) as <- by eauto. *)
+  (*       rewrite skipn_length. rewrite extr_env_wf'0. lia. *)
+  (*       rewrite extr_env_wf'0. lia. *)
+  (*     * subst. unfold iota_red in *. *)
+  (*       destruct (nth_error brs c) eqn:Hnth. *)
+  (*       2:{ eapply nth_error_None in Hnth. erewrite All2_length in Hnth. 2:exact a. rewrite H3 in Hnth. *)
+  (*           eapply nth_error_Some_length in H2. cbn in H2. lia. *)
+  (*       } *)
+  (*       rewrite <- nth_default_eq in *. unfold nth_default in *. *)
+  (*       rewrite Hnth in *. *)
 
-        etransitivity. eapply trans_red. econstructor.
-        econstructor. unfold iota_red. rewrite <- nth_default_eq. unfold nth_default.
-        rewrite Hnth. econstructor.
+  (*       destruct (All2_nth_error_Some _ _ H12 Hnth) as (? & ? & ? & ?). *)
+  (*       destruct (All2_nth_error_Some _ _ a Hnth) as (? & ? & ? & ?). *)
+  (*       destruct p0, x4. cbn in *. subst. *)
+  (*       edestruct IHeval2 as (? & ? & ?). *)
+  (*       eapply subject_reduction. eauto. exact Hty. *)
+  (*       etransitivity. *)
+  (*       eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto. *)
 
-        eapply erases_mkApps. eauto.
-        eapply Forall2_skipn. eauto.
-        inv H5.
-        -- exists x4. split; eauto.
-           econstructor. eauto. unfold ETyping.iota_red.
-           rewrite <- nth_default_eq. unfold nth_default. rewrite e. cbn. eauto.
-        -- eapply Is_type_app in X0 as[]. 2:eauto. 2:econstructor. 2:{ eapply subject_reduction_eval. 3:eassumption. all: eauto. }
+  (*       etransitivity. eapply trans_red. econstructor. *)
+  (*       econstructor. unfold iota_red. rewrite <- nth_default_eq. unfold nth_default. *)
+  (*       rewrite Hnth. econstructor. *)
 
-           eapply tConstruct_no_Type in X0.
-           eapply H10 in X0 as []; eauto. 2: exists []; now destruct Σ.
+  (*       eapply erases_mkApps. eauto. *)
+  (*       eapply Forall2_skipn. eauto. *)
+  (*       inv H5. *)
+  (*       -- exists x4. split; eauto. *)
+  (*          econstructor. eauto. unfold ETyping.iota_red. *)
+  (*          rewrite <- nth_default_eq. unfold nth_default. rewrite e. cbn. eauto. *)
+  (*       -- eapply Is_type_app in X0 as[]. 2:eauto. 2:econstructor. 2:{ eapply subject_reduction_eval. 3:eassumption. all: eauto. } *)
 
-           destruct (ind_ctors idecl'). cbn in H4. destruct c; inv H2.
-           destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in H2; inv H2.
+  (*          eapply tConstruct_no_Type in X0. *)
+  (*          eapply H10 in X0 as []; eauto. 2: exists []; now destruct Σ. *)
 
-           destruct btys as [ | ? []]; cbn in H3; try lia. clear H3 H4. destruct H8.
-           (* eapply H7 in d1. *) inv a. inv X2. inv H12. inv H9. destruct H4. destruct x1, y; cbn in *; subst.
-           destruct X1. subst. destruct p0; cbn in *. destruct x3. inv e. inv Hnth. cbn in *.
+  (*          destruct (ind_ctors idecl'). cbn in H4. destruct c; inv H2. *)
+  (*          destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in H2; inv H2. *)
 
-           edestruct (IHeval2) as (? & ? & ?).
-           eapply subject_reduction. eauto. exact Hty.
-           etransitivity.
-           eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
-           econstructor. econstructor. econstructor.
+  (*          destruct btys as [ | ? []]; cbn in H3; try lia. clear H3 H4. destruct H8. *)
+  (*          (* eapply H7 in d1. *) inv a. inv X2. inv H12. inv H9. destruct H4. destruct x1, y; cbn in *; subst. *)
+  (*          destruct X1. subst. destruct p0; cbn in *. destruct x3. inv e. inv Hnth. cbn in *. *)
 
-           eapply erases_mkApps. eauto.
-           instantiate (1 := repeat tBox _).
-           eapply All2_Forall2.
-           eapply All2_impl.
-           eapply All2_All_mix_left. eassumption.
-           2:{ intros. destruct X1. assert (y = tBox). exact y0. subst. econstructor.
-               now eapply isErasable_Proof. }
+  (*          edestruct (IHeval2) as (? & ? & ?). *)
+  (*          eapply subject_reduction. eauto. exact Hty. *)
+  (*          etransitivity. *)
+  (*          eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto. *)
+  (*          econstructor. econstructor. econstructor. *)
 
-           eapply All2_right_triv. 2:now rewrite repeat_length.
-           now eapply All_repeat.
+  (*          eapply erases_mkApps. eauto. *)
+  (*          instantiate (1 := repeat tBox _). *)
+  (*          eapply All2_Forall2. *)
+  (*          eapply All2_impl. *)
+  (*          eapply All2_All_mix_left. eassumption. *)
+  (*          2:{ intros. destruct X1. assert (y = tBox). exact y0. subst. econstructor. *)
+  (*              now eapply isErasable_Proof. } *)
 
-           exists x1. split; eauto.
-           eapply eval_iota_sing.
-           pose proof (Ee.eval_to_value _ _ _ He_v').
-           eapply value_app_inv in H4. subst. eassumption.
-           reflexivity. cbn in *.
-           enough (#|skipn (ind_npars mdecl') args| = n2) as <- by eauto.
+  (*          eapply All2_right_triv. 2:now rewrite repeat_length. *)
+  (*          now eapply All_repeat. *)
 
-           eapply wf_ext_wf in extr_env_wf'0.
-           eapply tCase_length_branch_inv in extr_env_wf'0.
-           2:{ eapply subject_reduction. eauto.
-               exact Hty.
-               eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.  }
-           2: reflexivity.
+  (*          exists x1. split; eauto. *)
+  (*          eapply eval_iota_sing. *)
+  (*          pose proof (Ee.eval_to_value _ _ _ He_v'). *)
+  (*          eapply value_app_inv in H4. subst. eassumption. *)
+  (*          reflexivity. cbn in *. *)
+  (*          enough (#|skipn (ind_npars mdecl') args| = n2) as <- by eauto. *)
 
-           enough (#|skipn (ind_npars mdecl') args| = n2) as <- by eauto.
-           rewrite skipn_length. rewrite extr_env_wf'0. lia.
-           rewrite extr_env_wf'0. lia. eauto.
-    + exists tBox. split. econstructor.
-      eapply Is_type_eval; eauto. econstructor; eauto.
-    + auto.
-    + auto.
+  (*          eapply wf_ext_wf in extr_env_wf'0. *)
+  (*          eapply tCase_length_branch_inv in extr_env_wf'0. *)
+  (*          2:{ eapply subject_reduction. eauto. *)
+  (*              exact Hty. *)
+  (*              eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.  } *)
+  (*          2: reflexivity. *)
+
+  (*          enough (#|skipn (ind_npars mdecl') args| = n2) as <- by eauto. *)
+  (*          rewrite skipn_length. rewrite extr_env_wf'0. lia. *)
+  (*          rewrite extr_env_wf'0. lia. eauto. *)
+  (*   + exists tBox. split. econstructor. *)
+  (*     eapply Is_type_eval; eauto. econstructor; eauto. *)
+  (*   + auto. *)
+  (*   + auto. *)
+
+  - exact (todo "sim").
+
   - pose (Hty' := Hty).
     eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?).
     inv He.
@@ -1068,7 +1073,9 @@ Proof.
     + auto.
   - destruct ip.
     assert (Hty' := Hty).
-    eapply inversion_Case in Hty' as (u' & args' & mdecl & idecl & pty & indctx & pctx & ps & btys & ? & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
+  eapply inversion_Case in Hty' as [u' [args' [mdecl [idecl [ps [pty [btys
+                                   [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]];
+    eauto.
     eapply type_mkApps_inv in t0 as (? & ? & [] & ?); eauto.
     eapply inversion_CoFix in t0 as (? & ? & ? &?); eauto.
     inversion i1.

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -82,34 +82,6 @@ Section Alpha.
           -- apply All2_same. intro. apply eq_term_upto_univ_refl ; auto.
   Qed.
 
-  (* Lemma types_of_case_eq_term : *)
-  (*   forall ind mdecl idecl npar args u p p' pty indctx pctx ps btys, *)
-  (*     build_case_predicate_type ind mdecl idecl params u ps = Some pty -> *)
-  (*     eq_term_upto_univ eq eq p p' -> *)
-  (*     ∑ btys', *)
-  (*       types_of_case ind mdecl idecl (firstn npar args) u p' pty = *)
-  (*       Some (indctx, pctx, ps, btys') × *)
-  (*       All2 (on_Trel_eq (eq_term_upto_univ eq eq) snd fst) btys btys'. *)
-  (* Proof. *)
-  (*   intros ind mdecl idecl npar args u p p' pty indctx pctx ps btys htc e. *)
-  (*   unfold types_of_case in *. *)
-  (*   case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) (firstn npar args) (subst_instance_constr u (ind_type idecl))) ; *)
-  (*     try solve [ intro bot ; rewrite bot in htc ; discriminate htc ]. *)
-  (*   intros ity eity. rewrite eity in htc. *)
-  (*   case_eq (destArity [] ity) ; *)
-  (*     try solve [ intro bot ; rewrite bot in htc ; discriminate htc ]. *)
-  (*   intros [args0 ?] ear. rewrite ear in htc. *)
-  (*   case_eq (destArity [] pty) ; *)
-  (*     try solve [ intro bot ; rewrite bot in htc ; discriminate htc ]. *)
-  (*   intros [args' s'] ear'. rewrite ear' in htc. *)
-  (*   case_eq (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p)) ; *)
-  (*     try solve [ intro bot ; rewrite bot in htc ; discriminate htc ]. *)
-  (*   intros brtys ebrtys. rewrite ebrtys in htc. *)
-  (*   eapply build_branches_type_eq_term in ebrtys as [brtys' [ebrtys' he]] ; eauto. *)
-  (*   inversion htc. subst. clear htc. *)
-  (*   rewrite ebrtys'. intuition eauto. *)
-  (* Qed. *)
-
   (* TODO MOVE *)
   Lemma wf_local_nth_error_vass :
     forall Σ Γ i na ty,

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -394,7 +394,7 @@ Proof.
     + solve_all. unfold test_snd. simpl in *.
       toProp; eauto.
     + apply closedn_mkApps; auto.
-      rewrite forallb_app. simpl. rewrite H3.
+      rewrite forallb_app. simpl. rewrite H1.
       rewrite forallb_skipn; auto.
       now apply closedn_mkApps_inv in H7.
 

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -179,27 +179,25 @@ Section Inversion.
   Qed.
 
   Lemma inversion_Case :
-    forall {Γ ind npar p c brs T},
-      Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
-      ∑ u args mdecl idecl pty indctx pctx ps btys,
+    forall {Γ indnpar p c brs T},
+      Σ ;;; Γ |- tCase indnpar p c brs : T ->
+      ∑ u args mdecl idecl ps pty btys,
+        let ind := indnpar.1 in
+        let npar := indnpar.2 in
         declared_inductive Σ mdecl ind idecl ×
         ind_npars mdecl = npar ×
-        let pars := firstn npar args in
+        let params := firstn npar args in
+        build_case_predicate_type ind mdecl idecl params u ps = Some pty ×
         Σ ;;; Γ |- p : pty ×
-        types_of_case ind mdecl idecl pars u p pty =
-        Some (indctx, pctx, ps, btys) ×
-        check_correct_arity (global_ext_constraints Σ)
-        idecl ind u indctx pars pctx ×
         existsb (leb_sort_family (universe_family ps)) (ind_kelim idecl) ×
-        Σ ;;; Γ |- c : mkApps (tInd ind u) args ×
-        All2 (fun x y =>
-          (fst x = fst y) *
-          (Σ ;;; Γ |- snd x : snd y) *
-          (Σ ;;; Γ |- snd y : tSort ps)
-        ) brs btys ×
+        Σ;;; Γ |- c : mkApps (tInd ind u) args ×
+        map_option_out (build_branches_type ind mdecl idecl params u p)
+                     = Some btys ×
+        All2 (fun br bty => (br.1 = bty.1 × Σ ;;; Γ |- br.2 : bty.2)
+                           × Σ ;;; Γ |- bty.2 : tSort ps) brs btys ×
         Σ ;;; Γ |- mkApps p (skipn npar args ++ [c]) <= T.
   Proof.
-    intros Γ ind npar p c brs T h. invtac h.
+    intros Γ indnpar p c brs T h. invtac h.
   Qed.
 
   Lemma inversion_Proj :

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -1074,8 +1074,6 @@ Proof.
     eapply type_Case with  (mdecl0:=nl_mutual_inductive_body mdecl)
                            (idecl0:=nl_one_inductive_body idecl)
                            (btys0:=map (on_snd nl) btys)
-                           (indctx0:=nlctx indctx)
-                           (pctx0:=nlctx pctx)
                            (u0:=u)
     ; tea.
     + destruct isdecl as [HH1 HH2]. split.
@@ -1083,69 +1081,71 @@ Proof.
       * replace (ind_bodies (nl_mutual_inductive_body mdecl)) with
             (map nl_one_inductive_body (ind_bodies mdecl)); [|now destruct mdecl].
         rewrite nth_error_map, HH2. reflexivity.
-    + clear -H0. unfold types_of_case in *.
-      set (params := instantiate_params
-                       (subst_instance_context u (ind_params mdecl))
-                       (firstn npar args)
-                       (subst_instance_constr u (ind_type idecl))) in H0.
-      replace (instantiate_params _ _ _) with (option_map nl params).
-      * destruct params; [|discriminate]. simpl.
-        case_eq (destArity [] t);
-          [|intro HH; rewrite HH in H0; discriminate].
-        intros [Δ s] H. rewrite H in H0.
-        apply nl_destArity in H. cbn in H; rewrite H; clear H.
-        case_eq (destArity [] pty);
-          [|intro HH; rewrite HH in H0; discriminate].
-        intros [Δ' s'] H. rewrite H in H0.
-        apply nl_destArity in H. cbn in H; rewrite H; clear H.
-        case_eq (map_option_out (build_branches_type ind mdecl idecl
-                                                     (firstn npar args) u p));
-          [|intro HH; rewrite HH in H0; discriminate].
-        intros tys H; rewrite H in H0.
-        inversion H0; subst; clear H0.
-        replace (map_option_out (build_branches_type ind (nl_mutual_inductive_body mdecl) (nl_one_inductive_body idecl) (firstn npar (map nl args)) u (nl p)))
-          with (option_map (map (on_snd nl)) (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p))).
-        now rewrite H.
-        rewrite <- map_option_out_map_option_map. f_equal.
-        rewrite firstn_map. generalize (firstn npar args); intro args'. clear.
-        unfold build_branches_type. simpl.
-        rewrite mapi_map, map_mapi. apply mapi_ext.
-        intros n [[id t] k].
-        rewrite <- nl_subst_instance_constr, <- nl_inds, <- nl_subst.
-        rewrite subst_instance_context_nlctx.
-        rewrite <- nl_instantiate_params.
-        destruct (instantiate_params _ _ _); [|reflexivity].
-        cbn. change (@nil context_decl) with (nlctx []) at 2.
-        rewrite nl_decompose_prod_assum.
-        destruct (decompose_prod_assum [] t0); cbn.
-        rewrite nl_decompose_app.
-        destruct (decompose_app t1) as [t11 t12]; cbn.
-        case_eq (chop (ind_npars mdecl) t12).
-        intros paramrels args eq.
-        erewrite chop_map; tea. cbn.
-        unfold on_snd. cbn. f_equal. f_equal.
-        rewrite nl_it_mkProd_or_LetIn, nl_mkApps, nl_lift.
-        unfold nlctx at 3; rewrite map_length. f_equal. f_equal.
-        rewrite map_app. cbn. rewrite nl_mkApps. cbn. repeat f_equal.
-        rewrite map_app. f_equal. apply nl_to_extended_list.
-      * rewrite firstn_map. cbn. subst params.
-        rewrite nl_instantiate_params. f_equal.
-        now rewrite <- subst_instance_context_nlctx.
-        apply nl_subst_instance_constr.
-    + clear -H1. unfold check_correct_arity in *.
-      rewrite global_ext_constraints_nlg.
-      inversion H1; subst. cbn. constructor.
-      * clear -H2. destruct H2 as [H1 H2]; cbn in *.
-        destruct y as [? [?|] ?]; cbn in *; [contradiction|].
-        split; cbn; tas. apply nl_eq_term in H2.
-        refine (eq_rect _ (fun d => eq_term _ d _) H2 _ _).
-        clear. rewrite nl_mkApps, map_app, firstn_map, !map_map.
-        f_equal. rewrite nl_to_extended_list. f_equal.
-        apply map_ext. intro; rewrite nl_lift; cbn.
-        unfold nlctx; now rewrite map_length.
-      * eapply All2_map, All2_impl; tea.
-        apply nl_eq_decl'.
+    + exact (todo "build_case_predicate_type Nameless").
+    (* + clear -H0. unfold types_of_case in *. *)
+    (*   set (params := instantiate_params *)
+    (*                    (subst_instance_context u (ind_params mdecl)) *)
+    (*                    (firstn npar args) *)
+    (*                    (subst_instance_constr u (ind_type idecl))) in H0. *)
+    (*   replace (instantiate_params _ _ _) with (option_map nl params). *)
+    (*   * destruct params; [|discriminate]. simpl. *)
+    (*     case_eq (destArity [] t); *)
+    (*       [|intro HH; rewrite HH in H0; discriminate]. *)
+    (*     intros [Δ s] H. rewrite H in H0. *)
+    (*     apply nl_destArity in H. cbn in H; rewrite H; clear H. *)
+    (*     case_eq (destArity [] pty); *)
+    (*       [|intro HH; rewrite HH in H0; discriminate]. *)
+    (*     intros [Δ' s'] H. rewrite H in H0. *)
+    (*     apply nl_destArity in H. cbn in H; rewrite H; clear H. *)
+    (*     case_eq (map_option_out (build_branches_type ind mdecl idecl *)
+    (*                                                  (firstn npar args) u p)); *)
+    (*       [|intro HH; rewrite HH in H0; discriminate]. *)
+    (*     intros tys H; rewrite H in H0. *)
+    (*     inversion H0; subst; clear H0. *)
+    (*     replace (map_option_out (build_branches_type ind (nl_mutual_inductive_body mdecl) (nl_one_inductive_body idecl) (firstn npar (map nl args)) u (nl p))) *)
+    (*       with (option_map (map (on_snd nl)) (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p))). *)
+    (*     now rewrite H. *)
+    (*     rewrite <- map_option_out_map_option_map. f_equal. *)
+    (*     rewrite firstn_map. generalize (firstn npar args); intro args'. clear. *)
+    (*     unfold build_branches_type. simpl. *)
+    (*     rewrite mapi_map, map_mapi. apply mapi_ext. *)
+    (*     intros n [[id t] k]. *)
+    (*     rewrite <- nl_subst_instance_constr, <- nl_inds, <- nl_subst. *)
+    (*     rewrite subst_instance_context_nlctx. *)
+    (*     rewrite <- nl_instantiate_params. *)
+    (*     destruct (instantiate_params _ _ _); [|reflexivity]. *)
+    (*     cbn. change (@nil context_decl) with (nlctx []) at 2. *)
+    (*     rewrite nl_decompose_prod_assum. *)
+    (*     destruct (decompose_prod_assum [] t0); cbn. *)
+    (*     rewrite nl_decompose_app. *)
+    (*     destruct (decompose_app t1) as [t11 t12]; cbn. *)
+    (*     case_eq (chop (ind_npars mdecl) t12). *)
+    (*     intros paramrels args eq. *)
+    (*     erewrite chop_map; tea. cbn. *)
+    (*     unfold on_snd. cbn. f_equal. f_equal. *)
+    (*     rewrite nl_it_mkProd_or_LetIn, nl_mkApps, nl_lift. *)
+    (*     unfold nlctx at 3; rewrite map_length. f_equal. f_equal. *)
+    (*     rewrite map_app. cbn. rewrite nl_mkApps. cbn. repeat f_equal. *)
+    (*     rewrite map_app. f_equal. apply nl_to_extended_list. *)
+    (*   * rewrite firstn_map. cbn. subst params. *)
+    (*     rewrite nl_instantiate_params. f_equal. *)
+    (*     now rewrite <- subst_instance_context_nlctx. *)
+    (*     apply nl_subst_instance_constr. *)
+    (* + clear -H1. unfold check_correct_arity in *. *)
+    (*   rewrite global_ext_constraints_nlg. *)
+    (*   inversion H1; subst. cbn. constructor. *)
+    (*   * clear -H2. destruct H2 as [H1 H2]; cbn in *. *)
+    (*     destruct y as [? [?|] ?]; cbn in *; [contradiction|]. *)
+    (*     split; cbn; tas. apply nl_eq_term in H2. *)
+    (*     refine (eq_rect _ (fun d => eq_term _ d _) H2 _ _). *)
+    (*     clear. rewrite nl_mkApps, map_app, firstn_map, !map_map. *)
+    (*     f_equal. rewrite nl_to_extended_list. f_equal. *)
+    (*     apply map_ext. intro; rewrite nl_lift; cbn. *)
+    (*     unfold nlctx; now rewrite map_length. *)
+    (*   * eapply All2_map, All2_impl; tea. *)
+    (*     apply nl_eq_decl'. *)
     + rewrite nl_mkApps in *; eassumption.
+    + exact (todo "build_branches_type Nameless").
     + clear -X5. eapply All2_map, All2_impl; tea. cbn.
       clear. intros x y [[[? ?] ?] ?]. intuition eauto.
   - destruct pdecl as [pdecl1 pdecl2]; simpl.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -788,9 +788,9 @@ Section Principality.
       specialize (IHu1 _ _ _ t t1). clear t t1.
       specialize (IHu2 _ _ _ t0 t2). clear t0 t2.
       repeat outsum. repeat outtimes.
-      eapply invert_cumul_ind_r in c3 as [u' [x0' [redr [redu ?]]]].
-      eapply invert_cumul_ind_r in c4 as [u'' [x9' [redr' [redu' ?]]]].
-      assert (All2 (fun a a' => Σ ;;; Γ |- a == a') x0 x9).
+      eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]].
+      eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]].
+      assert (All2 (fun a a' => Σ ;;; Γ |- a == a') x0 x7).
       { destruct (red_confluence wfΣ redr redr').
         destruct p.
         eapply red_mkApps_tInd in r as [args' [? ?]]; auto.
@@ -808,21 +808,22 @@ Section Principality.
         intros ? ? ?. eapply conv_alt_sym. assumption. auto.
       }
       clear redr redr' a1 a2.
-      exists (mkApps u1 (skipn (ind_npars x10) x9 ++ [u2])); repeat split; auto.
+      exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto.
 
-      2:{ revert e2.
-          rewrite /types_of_case.
-          destruct instantiate_params eqn:Heq => //.
-          destruct (destArity [] t1) as [[args s']|] eqn:eqar => //.
-          destruct (destArity [] x12) as [[args' s'']|] eqn:eqx12 => //.
-          destruct (destArity [] x2) as [[ctxx2 sx2]|] eqn:eqx2 => //.
-          destruct map_option_out eqn:eqbrs => //.
-          intros [=]. subst.
-          eapply (type_Case _ _ _ x8). eauto. repeat split; eauto. auto.
-          eapply t0. rewrite /types_of_case.
-          rewrite Heq eqar eqx2 eqbrs. reflexivity.
-          admit. admit. eapply type_Cumul. eauto.
-          all:admit. }
+      (* 2:{ revert e2. *)
+      (*     rewrite /types_of_case. *)
+      (*     destruct instantiate_params eqn:Heq => //. *)
+      (*     destruct (destArity [] t1) as [[args s']|] eqn:eqar => //. *)
+      (*     destruct (destArity [] x12) as [[args' s'']|] eqn:eqx12 => //. *)
+      (*     destruct (destArity [] x2) as [[ctxx2 sx2]|] eqn:eqx2 => //. *)
+      (*     destruct map_option_out eqn:eqbrs => //. *)
+      (*     intros [=]. subst. *)
+      (*     eapply (type_Case _ _ _ x8). eauto. repeat split; eauto. auto. *)
+      (*     eapply t0. rewrite /types_of_case. *)
+      (*     rewrite Heq eqar eqx2 eqbrs. reflexivity. *)
+      (*     admit. admit. eapply type_Cumul. eauto. *)
+      (*     all:admit. } *)
+      admit.
 
       admit.
 

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -1290,127 +1290,127 @@ Proof.
 Qed.
 
 
-Lemma types_of_case_rename :
-  forall Σ ind mdecl idecl npar args u p pty indctx pctx ps btys f,
-    wf Σ ->
-    declared_inductive Σ mdecl ind idecl ->
-    types_of_case ind mdecl idecl (firstn npar args) u p pty =
-    Some (indctx, pctx, ps, btys) ->
-    types_of_case
-      ind mdecl idecl
-      (firstn npar (map (rename f) args)) u (rename f p) (rename f pty)
-    =
-    Some (
-        rename_context f indctx,
-        rename_context f pctx,
-        ps,
-        map (on_snd (rename f)) btys
-    ).
-Proof.
-  intros Σ ind mdecl idecl npar args u p pty indctx pctx ps btys f hΣ hdecl h.
-  unfold types_of_case in *.
-  case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) (firstn npar args) (subst_instance_constr u (ind_type idecl))) ;
-    try solve [ intro bot ; rewrite bot in h ; discriminate h ].
-  intros ity eity. rewrite eity in h.
-  pose proof (on_declared_inductive hΣ hdecl) as [onmind onind].
-  apply onParams in onmind as Hparams.
-  assert (closedparams : closed_ctx (subst_instance_context u (ind_params mdecl))).
-  { rewrite closedn_subst_instance_context.
-    eapply PCUICWeakening.closed_wf_local. all: eauto. eauto. }
-  epose proof (inst_declared_inductive _ ind mdecl idecl (ren f) hΣ) as hi.
-  forward hi by assumption. rewrite <- hi.
-  eapply instantiate_params_rename with (f := f) in eity ; auto.
-  rewrite -> ind_type_map.
-  rewrite firstn_map.
-  lazymatch type of eity with
-  | ?t = _ =>
-    lazymatch goal with
-    | |- match ?t' with _ => _ end = _ =>
-      replace t' with t ; revgoals
-    end
-  end.
-  { autorewrite with sigma.
-    rewrite <- !rename_inst.
-    now rewrite rename_subst_instance_constr. }
-  rewrite eity.
-  case_eq (destArity [] ity) ;
-    try solve [ intro bot ; rewrite bot in h ; discriminate h ].
-  intros [args0 ?] ear. rewrite ear in h.
-  eapply inst_destArity with (σ := ren f) in ear as ear'.
-  simpl in ear'.
-  lazymatch type of ear' with
-  | ?t = _ =>
-    lazymatch goal with
-    | |- match ?t' with _ => _ end = _ =>
-      replace t' with t ; revgoals
-    end
-  end.
-  { autorewrite with sigma. reflexivity. }
-  rewrite ear'.
-  case_eq (destArity [] pty) ;
-    try solve [ intro bot ; rewrite bot in h ; discriminate h ].
-  intros [args' s'] epty. rewrite epty in h.
-  eapply inst_destArity with (σ := ren f) in epty as epty'.
-  simpl in epty'.
-  lazymatch type of epty' with
-  | ?t = _ =>
-    lazymatch goal with
-    | |- match ?t' with _ => _ end = _ =>
-      replace t' with t ; revgoals
-    end
-  end.
-  { autorewrite with sigma. reflexivity. }
-  rewrite epty'.
-  case_eq (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p)) ;
-    try solve [ intro bot ; rewrite bot in h ; discriminate h ].
-  intros brtys ebrtys. rewrite ebrtys in h.
-  inversion h. subst. clear h.
-  eapply build_branches_type_rename with (f := f) in ebrtys as ebrtys'.
-  2: assumption.
-  lazymatch type of ebrtys' with
-  | ?t = _ =>
-    lazymatch goal with
-    | |- match ?t' with _ => _ end = _ =>
-      replace t' with t ; revgoals
-    end
-  end.
-  { f_equal. f_equal. unfold map_one_inductive_body. destruct idecl.
-    simpl. f_equal.
-    - autorewrite with sigma.
-      eapply inst_ext. intro j.
-      unfold ren, shiftn. simpl.
-      f_equal. f_equal. lia.
-    - clear. induction ind_ctors. 1: reflexivity.
-      simpl. unfold on_pi2. destruct a. simpl.
-      destruct p. simpl. f_equal. 2: easy.
-      f_equal. f_equal.
-      autorewrite with sigma.
-      eapply inst_ext. intro j.
-      unfold ren, Upn, shiftn, subst_consn.
-      rewrite arities_context_length.
-      destruct (Nat.ltb_spec j #|ind_bodies mdecl|).
-      + rewrite nth_error_idsn_Some. all: easy.
-      + rewrite nth_error_idsn_None. 1: auto.
-        unfold subst_compose, shiftk. simpl.
-        rewrite idsn_length. reflexivity.
-    - clear. induction ind_projs. 1: auto.
-      simpl. destruct a. unfold on_snd. simpl.
-      f_equal. 2: easy.
-      f_equal. autorewrite with sigma.
-      eapply inst_ext. intro j.
-      unfold Upn, Up, ren, shiftn, subst_cons, subst_consn, subst_compose,
-      shift, shiftk.
-      destruct j.
-      + simpl. reflexivity.
-      + simpl.
-        destruct (Nat.ltb_spec (S j) (S (context_assumptions (ind_params mdecl)))).
-        * rewrite nth_error_idsn_Some. 1: lia.
-          simpl. reflexivity.
-        * rewrite nth_error_idsn_None. 1: lia.
-          simpl. rewrite idsn_length. reflexivity.
-  }
-  rewrite ebrtys'. autorewrite with sigma. reflexivity.
-Qed.
+(* Lemma types_of_case_rename : *)
+(*   forall Σ ind mdecl idecl npar args u p pty indctx pctx ps btys f, *)
+(*     wf Σ -> *)
+(*     declared_inductive Σ mdecl ind idecl -> *)
+(*     types_of_case ind mdecl idecl (firstn npar args) u p pty = *)
+(*     Some (indctx, pctx, ps, btys) -> *)
+(*     types_of_case *)
+(*       ind mdecl idecl *)
+(*       (firstn npar (map (rename f) args)) u (rename f p) (rename f pty) *)
+(*     = *)
+(*     Some ( *)
+(*         rename_context f indctx, *)
+(*         rename_context f pctx, *)
+(*         ps, *)
+(*         map (on_snd (rename f)) btys *)
+(*     ). *)
+(* Proof. *)
+(*   intros Σ ind mdecl idecl npar args u p pty indctx pctx ps btys f hΣ hdecl h. *)
+(*   unfold types_of_case in *. *)
+(*   case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) (firstn npar args) (subst_instance_constr u (ind_type idecl))) ; *)
+(*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
+(*   intros ity eity. rewrite eity in h. *)
+(*   pose proof (on_declared_inductive hΣ hdecl) as [onmind onind]. *)
+(*   apply onParams in onmind as Hparams. *)
+(*   assert (closedparams : closed_ctx (subst_instance_context u (ind_params mdecl))). *)
+(*   { rewrite closedn_subst_instance_context. *)
+(*     eapply PCUICWeakening.closed_wf_local. all: eauto. eauto. } *)
+(*   epose proof (inst_declared_inductive _ ind mdecl idecl (ren f) hΣ) as hi. *)
+(*   forward hi by assumption. rewrite <- hi. *)
+(*   eapply instantiate_params_rename with (f := f) in eity ; auto. *)
+(*   rewrite -> ind_type_map. *)
+(*   rewrite firstn_map. *)
+(*   lazymatch type of eity with *)
+(*   | ?t = _ => *)
+(*     lazymatch goal with *)
+(*     | |- match ?t' with _ => _ end = _ => *)
+(*       replace t' with t ; revgoals *)
+(*     end *)
+(*   end. *)
+(*   { autorewrite with sigma. *)
+(*     rewrite <- !rename_inst. *)
+(*     now rewrite rename_subst_instance_constr. } *)
+(*   rewrite eity. *)
+(*   case_eq (destArity [] ity) ; *)
+(*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
+(*   intros [args0 ?] ear. rewrite ear in h. *)
+(*   eapply inst_destArity with (σ := ren f) in ear as ear'. *)
+(*   simpl in ear'. *)
+(*   lazymatch type of ear' with *)
+(*   | ?t = _ => *)
+(*     lazymatch goal with *)
+(*     | |- match ?t' with _ => _ end = _ => *)
+(*       replace t' with t ; revgoals *)
+(*     end *)
+(*   end. *)
+(*   { autorewrite with sigma. reflexivity. } *)
+(*   rewrite ear'. *)
+(*   case_eq (destArity [] pty) ; *)
+(*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
+(*   intros [args' s'] epty. rewrite epty in h. *)
+(*   eapply inst_destArity with (σ := ren f) in epty as epty'. *)
+(*   simpl in epty'. *)
+(*   lazymatch type of epty' with *)
+(*   | ?t = _ => *)
+(*     lazymatch goal with *)
+(*     | |- match ?t' with _ => _ end = _ => *)
+(*       replace t' with t ; revgoals *)
+(*     end *)
+(*   end. *)
+(*   { autorewrite with sigma. reflexivity. } *)
+(*   rewrite epty'. *)
+(*   case_eq (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p)) ; *)
+(*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
+(*   intros brtys ebrtys. rewrite ebrtys in h. *)
+(*   inversion h. subst. clear h. *)
+(*   eapply build_branches_type_rename with (f := f) in ebrtys as ebrtys'. *)
+(*   2: assumption. *)
+(*   lazymatch type of ebrtys' with *)
+(*   | ?t = _ => *)
+(*     lazymatch goal with *)
+(*     | |- match ?t' with _ => _ end = _ => *)
+(*       replace t' with t ; revgoals *)
+(*     end *)
+(*   end. *)
+(*   { f_equal. f_equal. unfold map_one_inductive_body. destruct idecl. *)
+(*     simpl. f_equal. *)
+(*     - autorewrite with sigma. *)
+(*       eapply inst_ext. intro j. *)
+(*       unfold ren, shiftn. simpl. *)
+(*       f_equal. f_equal. lia. *)
+(*     - clear. induction ind_ctors. 1: reflexivity. *)
+(*       simpl. unfold on_pi2. destruct a. simpl. *)
+(*       destruct p. simpl. f_equal. 2: easy. *)
+(*       f_equal. f_equal. *)
+(*       autorewrite with sigma. *)
+(*       eapply inst_ext. intro j. *)
+(*       unfold ren, Upn, shiftn, subst_consn. *)
+(*       rewrite arities_context_length. *)
+(*       destruct (Nat.ltb_spec j #|ind_bodies mdecl|). *)
+(*       + rewrite nth_error_idsn_Some. all: easy. *)
+(*       + rewrite nth_error_idsn_None. 1: auto. *)
+(*         unfold subst_compose, shiftk. simpl. *)
+(*         rewrite idsn_length. reflexivity. *)
+(*     - clear. induction ind_projs. 1: auto. *)
+(*       simpl. destruct a. unfold on_snd. simpl. *)
+(*       f_equal. 2: easy. *)
+(*       f_equal. autorewrite with sigma. *)
+(*       eapply inst_ext. intro j. *)
+(*       unfold Upn, Up, ren, shiftn, subst_cons, subst_consn, subst_compose, *)
+(*       shift, shiftk. *)
+(*       destruct j. *)
+(*       + simpl. reflexivity. *)
+(*       + simpl. *)
+(*         destruct (Nat.ltb_spec (S j) (S (context_assumptions (ind_params mdecl)))). *)
+(*         * rewrite nth_error_idsn_Some. 1: lia. *)
+(*           simpl. reflexivity. *)
+(*         * rewrite nth_error_idsn_None. 1: lia. *)
+(*           simpl. rewrite idsn_length. reflexivity. *)
+(*   } *)
+(*   rewrite ebrtys'. autorewrite with sigma. reflexivity. *)
+(* Qed. *)
 
 (* TODO MOVE *)
 Lemma declared_constant_closed_type :
@@ -1656,8 +1656,8 @@ Proof.
     + econstructor. all: eauto. destruct hf. assumption.
     + rewrite rename_closed. 2: reflexivity.
       eapply declared_constructor_closed_type. all: eauto.
-  - intros Σ wfΣ Γ wfΓ ind u npar p c brs args mdecl idecl isdecl X X0 e pars
-           pty hp indctx pctx ps btys htoc hca hel ihp hc ihc hbrs Δ f hf.
+  - intros Σ wfΣ Γ wfΓ ind u npar p c brs args mdecl idecl isdecl X X0 e
+           pars ps pty H1 X1 X2 H0 X3 X4 btys H2 X5 Δ f X6.
     simpl.
     rewrite rename_mkApps.
     rewrite map_app. simpl.
@@ -2089,53 +2089,53 @@ Proof.
     (*     -- apply All2_same. intro. apply eq_term_upto_univ_refl ; auto. *)
 Admitted.
 
-Lemma types_of_case_inst :
-  forall Σ ind mdecl idecl npar args u p pty indctx pctx ps btys σ,
-    wf Σ ->
-    declared_inductive Σ mdecl ind idecl ->
-    types_of_case ind mdecl idecl (firstn npar args) u p pty =
-    Some (indctx, pctx, ps, btys) ->
-    types_of_case ind mdecl idecl (firstn npar (map (inst σ) args)) u p.[σ] pty.[σ] =
-    Some (inst_context σ indctx, inst_context σ pctx, ps, map (on_snd (inst σ)) btys).
-Proof.
-  intros Σ ind mdecl idecl npar args u p pty indctx pctx ps btys σ hΣ hdecl h.
-  unfold types_of_case in *.
-  case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) (firstn npar args) (subst_instance_constr u (ind_type idecl))) ;
-    try solve [ intro bot ; rewrite bot in h ; discriminate h ].
-  intros ity eity. rewrite eity in h.
-  pose proof (on_declared_inductive hΣ hdecl) as [onmind onind].
-  apply onParams in onmind as Hparams.
-  assert (closedparams : closed_ctx (subst_instance_context u (ind_params mdecl))).
-  { rewrite closedn_subst_instance_context.
-    eapply PCUICWeakening.closed_wf_local. all: eauto. eauto. }
-  epose proof (inst_declared_inductive _ ind mdecl idecl σ hΣ) as hi.
-  forward hi by assumption. rewrite <- hi.
-  eapply instantiate_params_inst with (σ := σ) in eity ; auto.
-  rewrite -> ind_type_map.
-  rewrite firstn_map.
-  autorewrite with sigma.
-(*   rewrite eity. *)
-(*   case_eq (destArity [] ity) ; *)
+(* Lemma types_of_case_inst : *)
+(*   forall Σ ind mdecl idecl npar args u p pty indctx pctx ps btys σ, *)
+(*     wf Σ -> *)
+(*     declared_inductive Σ mdecl ind idecl -> *)
+(*     types_of_case ind mdecl idecl (firstn npar args) u p pty = *)
+(*     Some (indctx, pctx, ps, btys) -> *)
+(*     types_of_case ind mdecl idecl (firstn npar (map (inst σ) args)) u p.[σ] pty.[σ] = *)
+(*     Some (inst_context σ indctx, inst_context σ pctx, ps, map (on_snd (inst σ)) btys). *)
+(* Proof. *)
+(*   intros Σ ind mdecl idecl npar args u p pty indctx pctx ps btys σ hΣ hdecl h. *)
+(*   unfold types_of_case in *. *)
+(*   case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) (firstn npar args) (subst_instance_constr u (ind_type idecl))) ; *)
 (*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
-(*   intros [args0 ?] ear. rewrite ear in h. *)
-(*   eapply inst_destArity with (σ := σ) in ear as ear'. *)
-(*   simpl in ear'. autorewrite with sigma in ear'. *)
-(*   rewrite ear'. *)
-(*   case_eq (destArity [] pty) ; *)
-(*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
-(*   intros [args' s'] epty. rewrite epty in h. *)
-(*   eapply inst_destArity with (σ := σ) in epty as epty'. *)
-(*   simpl in epty'. autorewrite with sigma in epty'. *)
-(*   rewrite epty'. *)
-(*   case_eq (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p)) ; *)
-(*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *)
-(*   intros brtys ebrtys. rewrite ebrtys in h. *)
-(*   inversion h. subst. clear h. *)
-(*   eapply build_branches_type_inst with (σ := σ) in ebrtys as ebrtys'. *)
-(*   2: assumption. *)
-(*   rewrite ebrtys'. reflexivity. *)
-(* Qed. *)
-Admitted.
+(*   intros ity eity. rewrite eity in h. *)
+(*   pose proof (on_declared_inductive hΣ hdecl) as [onmind onind]. *)
+(*   apply onParams in onmind as Hparams. *)
+(*   assert (closedparams : closed_ctx (subst_instance_context u (ind_params mdecl))). *)
+(*   { rewrite closedn_subst_instance_context. *)
+(*     eapply PCUICWeakening.closed_wf_local. all: eauto. eauto. } *)
+(*   epose proof (inst_declared_inductive _ ind mdecl idecl σ hΣ) as hi. *)
+(*   forward hi by assumption. rewrite <- hi. *)
+(*   eapply instantiate_params_inst with (σ := σ) in eity ; auto. *)
+(*   rewrite -> ind_type_map. *)
+(*   rewrite firstn_map. *)
+(*   autorewrite with sigma. *)
+(* (*   rewrite eity. *) *)
+(* (*   case_eq (destArity [] ity) ; *) *)
+(* (*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *) *)
+(* (*   intros [args0 ?] ear. rewrite ear in h. *) *)
+(* (*   eapply inst_destArity with (σ := σ) in ear as ear'. *) *)
+(* (*   simpl in ear'. autorewrite with sigma in ear'. *) *)
+(* (*   rewrite ear'. *) *)
+(* (*   case_eq (destArity [] pty) ; *) *)
+(* (*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *) *)
+(* (*   intros [args' s'] epty. rewrite epty in h. *) *)
+(* (*   eapply inst_destArity with (σ := σ) in epty as epty'. *) *)
+(* (*   simpl in epty'. autorewrite with sigma in epty'. *) *)
+(* (*   rewrite epty'. *) *)
+(* (*   case_eq (map_option_out (build_branches_type ind mdecl idecl (firstn npar args) u p)) ; *) *)
+(* (*     try solve [ intro bot ; rewrite bot in h ; discriminate h ]. *) *)
+(* (*   intros brtys ebrtys. rewrite ebrtys in h. *) *)
+(* (*   inversion h. subst. clear h. *) *)
+(* (*   eapply build_branches_type_inst with (σ := σ) in ebrtys as ebrtys'. *) *)
+(* (*   2: assumption. *) *)
+(* (*   rewrite ebrtys'. reflexivity. *) *)
+(* (* Qed. *) *)
+(* Admitted. *)
 
 Lemma type_inst :
   forall Σ Γ Δ σ t A,
@@ -2203,21 +2203,21 @@ Proof.
     (* autorewrite with sigma. *) simpl.
     (* NEED Commutation *)
     admit.
-  - intros Σ wfΣ Γ wfΓ ind u npar p c brs args mdecl idecl isdecl X X0 e pars
-           pty hp indctx pctx ps btys htoc hca hel ihp hc ihc hbrs Δ σ hΔ hσ.
+  - intros Σ wfΣ Γ wfΓ ind u npar p c brs args mdecl idecl isdecl X X0 a pars
+           ps pty htoc X1 ihp H2 X3 ihc btys H3 ihbtys Δ σ hΔ hσ. 
     autorewrite with sigma. simpl.
     rewrite map_app. simpl.
     rewrite map_skipn.
-    eapply types_of_case_inst with (σ := σ) in htoc. all: try eassumption.
+    (* eapply types_of_case_inst with (σ := σ) in htoc. all: try eassumption. *)
     eapply type_Case.
     + eassumption.
     + assumption.
-    + eapply ihp. all: auto.
-    + eassumption.
     + admit.
-    + assumption.
+    + simpl. eapply ihp. all: auto.
+    + eassumption.
     + specialize (ihc _ _ hΔ hσ). autorewrite with sigma in ihc.
       eapply ihc.
+    + admit.
     + admit.
   - intros Σ wfΣ Γ wfΓ p c u mdecl idecl pdecl isdecl args X X0 hc ihc e ty
            Δ σ hΔ hσ.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia.
-From MetaCoq.Template Require Import config utils Universes BasicAst AstUtils
+From MetaCoq.Template Require Import config utils monad_utils Universes BasicAst AstUtils
 UnivSubst EnvironmentTyping.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
 PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils.
@@ -17,6 +17,7 @@ Set Asymmetric Patterns.
 
 From Equations Require Import Equations.
 Require Import Equations.Prop.DepElim.
+Import MonadNotation.
 
 (** * Typing derivations
 
@@ -489,119 +490,6 @@ Proof.
 Qed.
 
 
-(** Compute the type of a case from the predicate [p], actual parameters [pars] and
-    an inductive declaration. *)
-
-Fixpoint instantiate_params_subst params pars s ty :=
-  match params with
-  | [] => match pars with
-          | [] => Some (s, ty)
-          | _ :: _ => None (* Too many arguments to substitute *)
-          end
-  | d :: params =>
-    match d.(decl_body), ty with
-    | None, tProd _ _ B =>
-      match pars with
-      | hd :: tl => instantiate_params_subst params tl (hd :: s) B
-      | [] => None (* Not enough arguments to substitute *)
-      end
-    | Some b, tLetIn _ _ _ b' => instantiate_params_subst params pars (subst0 s b :: s) b'
-    | _, _ => None (* Not enough products in the type *)
-    end
-  end.
-
-(* If [ty] is [Π params . B] *)
-(* and [⊢ pars : params] *)
-(* then [instantiate_params] is [B{pars}] *)
-
-Definition instantiate_params params pars ty :=
-  match instantiate_params_subst (List.rev params) pars [] ty with
-  | Some (s, ty) => Some (subst0 s ty)
-  | None => None
-  end.
-
-Lemma instantiate_params_ params pars ty :
-  instantiate_params params pars ty
-  = option_map (fun '(s, ty) => subst0 s ty)
-               (instantiate_params_subst (List.rev params) pars [] ty).
-Proof.
-  unfold instantiate_params.
-  repeat (destruct ?; cbnr).
-Qed.
-
-(* [params], [p] and output are already instanciated by [u] *)
-Definition build_branches_type ind mdecl idecl params u p :=
-  let inds := inds (inductive_mind ind) u mdecl.(ind_bodies) in
-  let branch_type i '(id, t, ar) :=
-    let ty := subst0 inds (subst_instance_constr u t) in
-    match instantiate_params (subst_instance_context u mdecl.(ind_params)) params ty with
-    | Some ty =>
-      let '(sign, ccl) := decompose_prod_assum [] ty in
-      let nargs := List.length sign in
-      let allargs := snd (decompose_app ccl) in
-      let '(paramrels, args) := chop mdecl.(ind_npars) allargs in
-      let cstr := tConstruct ind i u in
-      let args := (args ++ [mkApps cstr (paramrels ++ to_extended_list sign)])%list in
-      Some (ar, it_mkProd_or_LetIn sign (mkApps (lift0 nargs p) args))
-    | None => None
-    end
-  in mapi branch_type idecl.(ind_ctors).
-
-Lemma build_branches_type_ ind mdecl idecl params u p :
-  build_branches_type ind mdecl idecl params u p
-  = let inds := inds (inductive_mind ind) u mdecl.(ind_bodies) in
-    let branch_type i '(id, t, ar) :=
-        let ty := subst0 inds (subst_instance_constr u t) in
-        option_map (fun ty =>
-         let '(sign, ccl) := decompose_prod_assum [] ty in
-         let nargs := List.length sign in
-         let allargs := snd (decompose_app ccl) in
-         let '(paramrels, args) := chop mdecl.(ind_npars) allargs in
-         let cstr := tConstruct ind i u in
-         let args := (args ++ [mkApps cstr (paramrels ++ to_extended_list sign)])%list in
-         (ar, it_mkProd_or_LetIn sign (mkApps (lift0 nargs p) args)))
-                  (instantiate_params (subst_instance_context u mdecl.(ind_params))
-                                      params ty)
-    in mapi branch_type idecl.(ind_ctors).
-Proof.
-  apply mapi_ext. intros ? [[? ?] ?]; cbnr.
-  repeat (destruct ?; cbnr).
-Qed.
-
-(* [params], [p], [pty] and output already instanciated by [u] *)
-Definition types_of_case ind mdecl idecl params u p pty :=
-  let brtys := build_branches_type ind mdecl idecl params u p in
-  match instantiate_params (subst_instance_context u mdecl.(ind_params)) params (subst_instance_constr u idecl.(ind_type)) with
-  | Some ity =>
-    match
-      destArity [] ity,
-      destArity [] pty,
-      map_option_out brtys
-    with
-    | Some (args, s), Some (args', s'), Some brtys =>
-      Some (args, args', s', brtys)
-    | _, _, _ => None
-    end
-  | None => None
-  end.
-
-Lemma types_of_case_spec ind mdecl idecl pars u p pty indctx pctx ps btys :
-  types_of_case ind mdecl idecl pars u p pty
-  = Some (indctx, pctx, ps, btys)
-  <~> ∑ s', option_map (destArity [])
-                     (instantiate_params (subst_instance_context u (ind_params mdecl)) pars (subst_instance_constr u (ind_type idecl)))
-          = Some (Some (indctx, s'))
-          /\ destArity [] pty = Some (pctx, ps)
-          /\ map_option_out (build_branches_type ind mdecl idecl pars u p)
-            = Some btys.
-Proof.
-  unfold types_of_case.
-  repeat (destruct ?; cbn).
-  all: split; [try discriminate; inversion 1; subst; eexists; repeat split|].
-  all: intros [s' [HH1 [HH2 HH3]]]; inversion HH1; inversion HH2; now inversion HH3.
-Qed.
-
-
 Reserved Notation " Σ ;;; Γ |- t : T " (at level 50, Γ, t, T at next level).
 Reserved Notation " Σ ;;; Γ |- t <= u " (at level 50, Γ, t, u at next level).
 
@@ -624,12 +512,6 @@ Definition conv `{checker_flags} Σ Γ T U : Type :=
 
 Notation " Σ ;;; Γ |- t = u " := (conv Σ Γ t u) (at level 50, Γ, t, u at next level) : type_scope.
 
-Definition check_correct_arity `{checker_flags} φ decl ind u ctx pars pctx :=
-  let inddecl :=
-      {| decl_name := nNamed decl.(ind_name);
-         decl_body := None;
-         decl_type := mkApps (tInd ind u) (map (lift0 #|ctx|) pars ++ to_extended_list ctx) |}
-  in eq_context φ (inddecl :: ctx) pctx.
 
 (** ** Typing relation *)
 
@@ -690,6 +572,97 @@ Axiom fix_guard_subst :
 (* AXIOM INDUCTIVE GUARD CONDITION *)
 Axiom ind_guard : mutual_inductive_body -> bool.
 
+
+(** Compute the type of a case from the predicate [p], actual parameters [pars] and
+    an inductive declaration. *)
+
+Fixpoint instantiate_params_subst params pars s ty :=
+  match params with
+  | [] => match pars with
+          | [] => Some (s, ty)
+          | _ :: _ => None (* Too many arguments to substitute *)
+          end
+  | d :: params =>
+    match d.(decl_body), ty with
+    | None, tProd _ _ B =>
+      match pars with
+      | hd :: tl => instantiate_params_subst params tl (hd :: s) B
+      | [] => None (* Not enough arguments to substitute *)
+      end
+    | Some b, tLetIn _ _ _ b' => instantiate_params_subst params pars (subst0 s b :: s) b'
+    | _, _ => None (* Not enough products in the type *)
+    end
+  end.
+
+(* If [ty] is [Π params . B] *)
+(* and [⊢ pars : params] *)
+(* then [instantiate_params] is [B{pars}] *)
+
+Definition instantiate_params (params : context) (pars : list term) (ty : term) : option term :=
+  match instantiate_params_subst (List.rev params) pars [] ty with
+  | Some (s, ty) => Some (subst0 s ty)
+  | None => None
+  end.
+
+Lemma instantiate_params_ params pars ty :
+  instantiate_params params pars ty
+  = option_map (fun '(s, ty) => subst0 s ty)
+               (instantiate_params_subst (List.rev params) pars [] ty).
+Proof.
+  unfold instantiate_params.
+  repeat (destruct ?; cbnr).
+Qed.
+
+(* [params], [p] and output are already instanciated by [u] *)
+Definition build_branches_type ind mdecl idecl params u p : list (option (nat × term)) :=
+  let inds := inds ind.(inductive_mind) u mdecl.(ind_bodies) in
+  let branch_type i '(id, t, ar) :=
+    let ty := subst0 inds (subst_instance_constr u t) in
+    match instantiate_params (subst_instance_context u mdecl.(ind_params)) params ty with
+    | Some ty =>
+      let '(sign, ccl) := decompose_prod_assum [] ty in
+      let nargs := List.length sign in
+      let allargs := snd (decompose_app ccl) in
+      let '(paramrels, args) := chop mdecl.(ind_npars) allargs in
+      let cstr := tConstruct ind i u in
+      let args := (args ++ [mkApps cstr (paramrels ++ to_extended_list sign)])%list in
+      Some (ar, it_mkProd_or_LetIn sign (mkApps (lift0 nargs p) args))
+    | None => None
+    end
+  in mapi branch_type idecl.(ind_ctors).
+
+Lemma build_branches_type_ ind mdecl idecl params u p :
+  build_branches_type ind mdecl idecl params u p
+  = let inds := inds ind.(inductive_mind) u mdecl.(ind_bodies) in
+    let branch_type i '(id, t, ar) :=
+        let ty := subst0 inds (subst_instance_constr u t) in
+        option_map (fun ty =>
+         let '(sign, ccl) := decompose_prod_assum [] ty in
+         let nargs := List.length sign in
+         let allargs := snd (decompose_app ccl) in
+         let '(paramrels, args) := chop mdecl.(ind_npars) allargs in
+         let cstr := tConstruct ind i u in
+         let args := (args ++ [mkApps cstr (paramrels ++ to_extended_list sign)])%list in
+         (ar, it_mkProd_or_LetIn sign (mkApps (lift0 nargs p) args)))
+                  (instantiate_params (subst_instance_context u mdecl.(ind_params))
+                                      params ty)
+    in mapi branch_type idecl.(ind_ctors).
+Proof.
+  apply mapi_ext. intros ? [[? ?] ?]; cbnr.
+  repeat (destruct ?; cbnr).
+Qed.
+
+(* [params] and output already instanciated by [u] *)
+Definition build_case_predicate_type ind mdecl idecl params u ps : option term :=
+  X <- instantiate_params (subst_instance_context u (ind_params mdecl)) params
+                         (subst_instance_constr u (ind_type idecl)) ;;
+  X <- destArity [] X ;;
+  let inddecl :=
+      {| decl_name := nNamed idecl.(ind_name);
+         decl_body := None;
+         decl_type := mkApps (tInd ind u) (map (lift0 #|X.1|) params ++ to_extended_list X.1) |} in
+  ret (it_mkProd_or_LetIn (X.1 ,, inddecl) (tSort ps)).
+
 Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
 | type_Rel n decl :
     All_local_env (lift_typing typing Σ) Γ ->
@@ -740,17 +713,19 @@ Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term ->
     consistent_instance_ext Σ mdecl.(ind_universes) u ->
     Σ ;;; Γ |- (tConstruct ind i u) : type_of_constructor mdecl cdecl (ind, i) u
 
-| type_Case ind u npar p c brs args :
+| type_Case indnpar u p c brs args :
+    let ind := indnpar.1 in
+    let npar := indnpar.2 in
     forall mdecl idecl (isdecl : declared_inductive Σ.1 mdecl ind idecl),
     mdecl.(ind_npars) = npar ->
-    let pars := List.firstn npar args in
-    forall pty, Σ ;;; Γ |- p : pty ->
-    forall indctx pctx ps btys, types_of_case ind mdecl idecl pars u p pty = Some (indctx, pctx, ps, btys) ->
-    check_correct_arity (global_ext_constraints Σ) idecl ind u indctx pars pctx ->
+    let params := List.firstn npar args in
+    forall ps pty, build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+    Σ ;;; Γ |- p : pty ->
     existsb (leb_sort_family (universe_family ps)) idecl.(ind_kelim) ->
     Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
-    All2 (fun x y => (fst x = fst y) * (Σ ;;; Γ |- snd x : snd y) * (Σ ;;; Γ |- snd y : tSort ps)) brs btys ->
-    Σ ;;; Γ |- tCase (ind, npar) p c brs : mkApps p (List.skipn npar args ++ [c])
+    forall btys, map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+    All2 (fun br bty => (br.1 = bty.1) * (Σ ;;; Γ |- br.2 : bty.2) * (Σ ;;; Γ |- bty.2 : tSort ps)) brs btys ->
+    Σ ;;; Γ |- tCase indnpar p c brs : mkApps p (skipn npar args ++ [c])
 
 | type_Proj p c u :
     forall mdecl idecl pdecl (isdecl : declared_projection Σ.1 mdecl idecl p pdecl) args,
@@ -947,11 +922,12 @@ Lemma typing_wf_local_size `{checker_flags} {Σ} {Γ t T}
   wf_local_size Σ (@typing_size _) _ (typing_wf_local d) < typing_size d.
 Proof.
   induction d; simpl; try lia.
-  pose proof (size_wf_local_app _ _ a).
-  eapply Nat.le_lt_trans. eauto. subst types. lia.
-  pose proof (size_wf_local_app _ _ a).
-  eapply Nat.le_lt_trans. eauto. subst types. lia.
-  destruct s as [s | [u Hu]]; try lia.
+  - destruct indnpar as [ind' npar']; cbn in *; subst ind npar. lia.
+  - pose proof (size_wf_local_app _ _ a).
+    eapply Nat.le_lt_trans. eauto. subst types. lia.
+  - pose proof (size_wf_local_app _ _ a).
+    eapply Nat.le_lt_trans. eauto. subst types. lia.
+  - destruct s as [s | [u Hu]]; try lia.
 Qed.
 
 Lemma wf_local_inv `{checker_flags} {Σ Γ'} (w : wf_local Σ Γ') :
@@ -1071,22 +1047,18 @@ Lemma typing_ind_env `{cf : checker_flags} :
             (isdecl : declared_inductive (fst Σ) mdecl ind idecl),
         Forall_decls_typing P Σ.1 -> All_local_env_over typing Pdecl Σ Γ wfΓ ->
         ind_npars mdecl = npar ->
-        let pars := firstn npar args in
-        forall (pty : term), Σ ;;; Γ |- p : pty ->
-        forall indctx pctx ps btys,
-        types_of_case ind mdecl idecl pars u p pty = Some (indctx, pctx, ps, btys) ->
-        check_correct_arity (global_ext_constraints Σ) idecl ind u indctx pars pctx ->
-        existsb (leb_sort_family (universe_family ps)) (ind_kelim idecl) ->
+        let params := firstn npar args in
+        forall ps pty, build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+        Σ ;;; Γ |- p : pty ->
         P Σ Γ p pty ->
-        Σ;;; Γ |- c : mkApps (tInd ind u) args ->
+        existsb (leb_sort_family (universe_family ps)) idecl.(ind_kelim) ->
+        Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
         P Σ Γ c (mkApps (tInd ind u) args) ->
-        All2 (fun x y : nat * term =>
-                (fst x = fst y) *
-                (Σ;;; Γ |- snd x : snd y) *
-                P Σ Γ (snd x) (snd y) *
-                (Σ ;;; Γ |- snd y : tSort ps) *
-                P Σ Γ (snd y) (tSort ps)
-        )%type brs btys ->
+        forall btys, map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+        All2 (fun br bty => (br.1 = bty.1) *
+                         (Σ ;;; Γ |- br.2 : bty.2) * P Σ Γ br.2 bty.2 *
+                         (Σ ;;; Γ |- bty.2 : tSort ps) * P Σ Γ bty.2 (tSort ps))
+             brs btys ->
         P Σ Γ (tCase (ind, npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : projection) (c : term) u
@@ -1305,11 +1277,13 @@ Proof.
        specialize (X14 [] localenv_nil _ _ (type_Prop _)).
        simpl in X14. forward X14; auto. lia. apply X14.
 
-    -- eapply X8; eauto.
+    -- destruct indnpar as [ind' npar'];
+         cbn in ind; cbn in npar; subst ind; subst npar.
+       eapply X8; eauto.
        ++ eapply (X14 _ wfΓ _ _ H); eauto. simpl; auto with arith.
        ++ eapply (X14 _ wfΓ _ _ H); eauto. simpl; auto with arith.
        ++ simpl in *.
-          eapply (X14 _ wfΓ _ _ H0); eauto. lia.
+          eapply (X14 _ wfΓ _ _ H0); eauto. clear. lia.
        ++ clear X13. revert a wfΓ X14. simpl. clear. intros.
           induction a; simpl in *.
           ** constructor.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -1098,42 +1098,31 @@ Proof.
       cbn. now rewrite IHn.
     + symmetry; apply subst_instance_constr_two.
 
-  - intros ind u npar p c brs args mdecl idecl isdecl X X0 H pty X1 indctx pctx ps
-           btys H0 X2 H1 X3 X4 X5 X6 u0 univs wfΣ' HSub H2.
+  - intros ind u npar p c brs args mdecl idecl isdecl X X0 H ps pty H0 X1
+           X2 H1 X3 X4 btys H2 X5 u0 univs X6 HSub H4. 
     rewrite subst_instance_constr_mkApps in *.
     rewrite map_app. cbn. rewrite map_skipn.
     eapply type_Case with (u1:=subst_instance_instance u0 u)
-                          (indctx0:=subst_instance_context u0 indctx)
                           (ps0 :=subst_instance_univ u0 ps)
-                          (pctx0:=subst_instance_context u0 pctx)
                           (btys0:=map (on_snd (subst_instance_constr u0)) btys);
       eauto.
-    + clear -H0 H2. rewrite firstn_map.
-      apply* types_of_case_spec in H0. destruct H0 as [s' [E1 [E2 E3]]].
-      eexists. repeat split.
-      2: now rewrite (subst_instance_destArity []), E2.
-      * rewrite <- subst_instance_constr_two, <- subst_instance_context_two.
-        set (param' := subst_instance_context u (ind_params mdecl)) in *.
-        set (type' := subst_instance_constr u (ind_type idecl)) in *.
-        rewrite <- subst_instance_instantiate_params.
-        destruct (instantiate_params param' (firstn npar args) type');
-          [|discriminate].
-        cbn in *. apply some_inj in E1.
-        rewrite (subst_instance_destArity []), E1; reflexivity.
-      * rewrite <- subst_instance_build_branches_type.
-        now rewrite map_option_out_map_option_map, E3.
-    + clear -X2 X HSub wfΣ' H2. destruct HSub as [_ HSub]; cbn in *.
-      eapply consistent_instance_valid_constraints in H2 as H2'; aa; simpl in *.
-      eapply eq_context_subst_instance in X2; aa.
-      refine (transport (fun c => eq_context _ c _) _ X2). clear.
-      cbn. f_equal. unfold map_decl; cbn. f_equal.
-      rewrite subst_instance_constr_mkApps. f_equal.
-      rewrite !map_app. f_equal.
-      * rewrite firstn_map, !map_map. eapply map_ext.
-        rewrite subst_instance_context_length.
-        intro; symmetry; apply lift_subst_instance_constr.
-      * apply subst_instance_to_extended_list.
-    + clear -H1 H2.
+    + clear -H0. rewrite firstn_map. unfold build_case_predicate_type. simpl.
+      rewrite <- subst_instance_constr_two, <- subst_instance_context_two.
+      set (param' := subst_instance_context u (ind_params mdecl)) in *.
+      set (type' := subst_instance_constr u (ind_type idecl)) in *.
+      rewrite <- subst_instance_instantiate_params.
+      destruct (instantiate_params param' (firstn npar args) type');
+        [|discriminate].
+      simpl. rewrite (subst_instance_destArity []).
+      destruct (destArity [] t) as [[ctx s'] ?|]; [|discriminate]. 
+      apply some_inj in H0; subst; simpl in *. f_equal.
+      rewrite subst_instance_constr_it_mkProd_or_LetIn. f_equal; cbn.
+      f_equal. rewrite subst_instance_constr_mkApps; cbn.
+      f_equal. rewrite map_app. f_equal.
+      * rewrite !map_map, subst_instance_context_length; apply map_ext. clear.
+        intro. now apply lift_subst_instance_constr.
+      * symmetry; apply subst_instance_to_extended_list.
+    + clear -H1 H4.
       induction (ind_kelim idecl) as [|a l]; try discriminate; cbn in *.
       apply* orb_true_iff in H1.
       destruct H1 as [H1|H1]; [left|right; now eapply IHl].
@@ -1145,8 +1134,10 @@ Proof.
          now rewrite HH.
       ++ destruct a; inv H1.
          destruct ?; constructor.
-    + apply X5 in H2; tea.
-      rewrite subst_instance_constr_mkApps in H2; eassumption.
+    + eapply X4 in H4; tea.
+      rewrite subst_instance_constr_mkApps in H4; eassumption.
+    + cbn. rewrite firstn_map. rewrite <- subst_instance_build_branches_type.
+      now rewrite map_option_out_map_option_map, H2.
     + eapply All2_map with (f := (on_snd (subst_instance_constr u0)))
                            (g:= (on_snd (subst_instance_constr u0))).
       eapply All2_impl. eassumption. intros.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -253,41 +253,43 @@ Section Validity.
 
     - (* Case *)
       right. red.
-      destruct X2.
-      + destruct i as [ctx [s [Heq Hs]]].
-        exists s.
-        unfold check_correct_arity in *.
-        assert (ctx = pctx). admit. (* WF of cases *)
-        subst ctx.
-        pose proof (PCUICClosed.destArity_spec [] pty). rewrite Heq in H.
-        simpl in H. subst pty.
-        assert (#|args| = #|pctx|). admit. (* WF of case *)
-        eapply type_mkApps. eauto.
-        destruct X4. destruct i as [ctx' [s' [Heq' Hs']]].
-        elimtype False.
-        { clear -Heq'.
-          revert Heq'.
-          assert (destArity [] (tInd ind u) = None) by reflexivity.
-          revert H.
-          generalize (tInd ind u). clear. induction args.
-          intros. simpl in Heq'. congruence.
-          intros. unshelve eapply (IHargs _ _ Heq').
-          reflexivity. }
-        destruct i as [si Hi].
-        eapply (invert_type_mkApps _ _ (tInd ind u)) in Hi; pcuic.
-        2:{ econstructor; eauto. admit. (* universes *) }
-        2:{ destruct Σ as [Σ φ]. eapply (isWfArity_or_Type_subst_instance (_, _)); pcuic.
-            admit.
-            eapply on_declared_inductive in isdecl as [dm di].
-            destruct di.
-            right. red in onArity.
-            red in onArity.
-            destruct onArity as [s' Hs'].
-            now exists s'. simpl; auto. }
-        admit.
+      (* destruct X2. *)
+      (* + destruct i as [ctx [s [Heq Hs]]]. *)
+      (*   exists s. *)
+      (*   unfold check_correct_arity in *. *)
+      (*   assert (ctx = pctx). admit. (* WF of cases *) *)
+      (*   subst ctx. *)
+      (*   pose proof (PCUICClosed.destArity_spec [] pty). rewrite Heq in H. *)
+      (*   simpl in H. subst pty. *)
+      (*   assert (#|args| = #|pctx|). admit. (* WF of case *) *)
+      (*   eapply type_mkApps. eauto. *)
+      (*   destruct X4. destruct i as [ctx' [s' [Heq' Hs']]]. *)
+      (*   elimtype False. *)
+      (*   { clear -Heq'. *)
+      (*     revert Heq'. *)
+      (*     assert (destArity [] (tInd ind u) = None) by reflexivity. *)
+      (*     revert H. *)
+      (*     generalize (tInd ind u). clear. induction args. *)
+      (*     intros. simpl in Heq'. congruence. *)
+      (*     intros. unshelve eapply (IHargs _ _ Heq'). *)
+      (*     reflexivity. } *)
+      (*   destruct i as [si Hi]. *)
+      (*   eapply (invert_type_mkApps _ _ (tInd ind u)) in Hi; pcuic. *)
+      (*   2:{ econstructor; eauto. admit. (* universes *) } *)
+      (*   2:{ destruct Σ as [Σ φ]. eapply (isWfArity_or_Type_subst_instance (_, _)); pcuic. *)
+      (*       admit. *)
+      (*       eapply on_declared_inductive in isdecl as [dm di]. *)
+      (*       destruct di. *)
+      (*       right. red in onArity. *)
+      (*       red in onArity. *)
+      (*       destruct onArity as [s' Hs']. *)
+      (*       now exists s'. simpl; auto. } *)
+      (*   admit. *)
 
-      + destruct i as [ui Hi]. exists ui.
-        admit. (* Same idea *)
+      (* + destruct i as [ui Hi]. exists ui. *)
+      (*   admit. (* Same idea *) *)
+
+      admit.
 
     - (* Proj *)
       right.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -833,11 +833,11 @@ Proof.
     7:{ cbn. rewrite -> firstn_map.
         erewrite lift_build_branches_type; tea.
         rewrite map_option_out_map_option_map.
-        erewrite heq_map_option_out. reflexivity. }
+        subst params. erewrite heq_map_option_out. reflexivity. }
     all: eauto.
     -- erewrite -> lift_declared_inductive; eauto.
     -- simpl. erewrite firstn_map, lift_build_case_predicate_type; tea.
-       erewrite heq_build_case_predicate_type; reflexivity.
+       subst params. erewrite heq_build_case_predicate_type; reflexivity.
     -- destruct idecl; simpl in *; auto.
     -- now rewrite -> !lift_mkApps in IHc.
     -- solve_all.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -560,73 +560,6 @@ Proof.
   destruct (leb_spec_Set (#|c| + k) x'). f_equal. lia. reflexivity.
 Qed.
 
-Lemma lift_types_of_case ind mdecl idecl args u p pty indctx pctx ps btys n k :
-  let f k' := lift n (k' + k) in
-  let f_ctx := lift_context n k in
-  closed_ctx (subst_instance_context u (ind_params mdecl)) ->
-  types_of_case ind mdecl idecl args u p pty = Some (indctx, pctx, ps, btys) ->
-  types_of_case ind mdecl (map_one_inductive_body (context_assumptions mdecl.(ind_params))
-                                                  (length (arities_context mdecl.(ind_bodies)))
-                                                  f (inductive_ind ind) idecl)
-                (map (f 0) args) u (f 0 p) (f 0 pty) =
-  Some (f_ctx indctx, f_ctx pctx, ps, map (on_snd (f 0)) btys).
-Proof.
-  simpl. intros closedpars.
-  unfold types_of_case.
-  rewrite -> ind_type_map. simpl.
-  epose proof (lift_instantiate_params n k _ args (subst_instance_constr u (ind_type idecl))) as H.
-  rewrite <- lift_subst_instance_constr.
-  erewrite <- H; trivial. clear H.
-  case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) args (subst_instance_constr u (ind_type idecl))) ; try discriminate.
-  intros ity eq. simpl.
-  pose proof (lift_destArity [] ity n k); trivial. simpl in H.
-  unfold lift_context, fold_context in H. simpl in H. simpl. rewrite -> H. clear H.
-  destruct destArity as [[ctx s] | ]; try congruence.
-  pose proof (lift_destArity [] pty n k); trivial. simpl in H.
-  unfold lift_context, fold_context in H. simpl in H. rewrite -> H. clear H.
-  destruct destArity as [[ctx' s'] | ]; try congruence.
-  assert(forall brs,
-         build_branches_type ind mdecl idecl args u p = brs ->
-         (build_branches_type ind mdecl
-         (map_one_inductive_body (context_assumptions mdecl.(ind_params))
-            (length (arities_context (ind_bodies mdecl))) (fun k' => lift n (k' + k))
-            (inductive_ind ind) idecl) (map (lift n k) args) u (lift n k p)) =
-         map (option_map (on_snd (lift n k))) brs).
-  { unfold build_branches_type. simpl. intros brs. intros <-.
-    rewrite -> ind_ctors_map.
-    rewrite -> mapi_map, map_mapi. eapply mapi_ext. intros i x.
-    destruct x as [[id t] arity]. simpl.
-    rewrite <- lift_subst_instance_constr.
-    rewrite subst0_inds_lift.
-    rewrite <- lift_instantiate_params ; trivial.
-    match goal with
-    | |- context [ option_map _ (instantiate_params ?x ?y ?z) ] =>
-      destruct (instantiate_params x y z) eqn:Heqip
-    end.
-    - simpl.
-      epose proof (lift_decompose_prod_assum t0 n k).
-      destruct (decompose_prod_assum [] t0).
-      rewrite <- H.
-      destruct (decompose_app t1) as [fn arg] eqn:?.
-      rewrite (decompose_app_lift _ _ _ fn arg); auto. simpl.
-      destruct (chop _ arg) eqn:Heqchop.
-      eapply chop_map in Heqchop.
-      rewrite -> Heqchop. clear Heqchop.
-      unfold on_snd. simpl. f_equal.
-      rewrite -> lift_it_mkProd_or_LetIn, !lift_mkApps, map_app; simpl.
-      rewrite -> !lift_mkApps, !map_app, lift_context_length.
-      rewrite -> permute_lift by lia. arith_congr.
-      now rewrite -> to_extended_list_lift, <- to_extended_list_map_lift.
-    - simpl. reflexivity.
-  }
-  specialize (H _ eq_refl). rewrite -> H. clear H.
-  rewrite -> map_option_out_map_option_map.
-  destruct (map_option_out (build_branches_type _ _ _ _ _ _)).
-  intros [= -> -> -> <-].
-  - reflexivity.
-  - congruence.
-Qed.
-
 Lemma weakening_red1 `{CF:checker_flags} Σ Γ Γ' Γ'' M N :
   wf Σ ->
   red1 Σ (Γ ,,, Γ') M N ->
@@ -740,35 +673,6 @@ Proof.
     econstructor 3; eauto.
 Qed.
 
-Lemma lift_check_correct_arity:
-  forall (cf : checker_flags) φ (Γ' : context) (ind : inductive) (u : universe_instance)
-         (npar : nat) (args : list term) (idecl : one_inductive_body)
-         (Γ'' : context) (indctx pctx : list context_decl),
-    check_correct_arity φ idecl ind u indctx (firstn npar args) pctx ->
-    check_correct_arity
-      φ idecl ind u (lift_context #|Γ''| #|Γ'| indctx) (firstn npar (map (lift #|Γ''| #|Γ'|) args))
-      (lift_context #|Γ''| #|Γ'| pctx).
-Proof.
-  intros cf φ Γ' ind u npar args idecl Γ'' indctx pctx.
-  unfold check_correct_arity. intro H.
-  inversion H; subst. simpl. rewrite lift_context_snoc0.
-  constructor.
-  - apply All2_length in H4. destruct H4.
-    clear -H2. apply (lift_eq_decl _ #|Γ''| (#|indctx| + #|Γ'|)) in H2.
-    unfold lift_decl, map_decl in H2; cbn in H2.
-    assert (XX : lift #|Γ''| (#|indctx| + #|Γ'|) (mkApps (tInd ind u) (map (lift0 #|indctx|) (firstn npar args) ++ to_extended_list indctx)) = mkApps (tInd ind u) (map (lift0 #|lift_context #|Γ''| #|Γ'| indctx|) (firstn npar (map (lift #|Γ''| #|Γ'|) args)) ++ to_extended_list (lift_context #|Γ''| #|Γ'| indctx)));
-      [|now rewrite XX in H2].
-
-    rewrite -> lift_mkApps, map_app.
-    rewrite -> firstn_map. rewrite -> to_extended_list_lift.
-    erewrite <- (to_extended_list_map_lift #|Γ''|).
-    rewrite -> lift_context_length.
-    rewrite -> !map_map_compose. f_equal. f_equal. apply map_ext.
-    intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). lia.
-    f_equal. lia.
-  - now apply lift_eq_context.
-Qed.
-
 Lemma destArity_it_mkProd_or_LetIn ctx ctx' t :
   destArity ctx (it_mkProd_or_LetIn ctx' t) =
   destArity (ctx ,,, ctx') t.
@@ -776,6 +680,69 @@ Proof.
   induction ctx' in ctx, t |- *; simpl; auto.
   rewrite IHctx'. destruct a as [na [b|] ty]; reflexivity.
 Qed.
+
+Lemma lift_build_case_predicate_type ind mdecl idecl u params ps n k :
+  closed_ctx (subst_instance_context u (ind_params mdecl)) ->
+  build_case_predicate_type ind mdecl
+    (map_one_inductive_body (context_assumptions mdecl.(ind_params))
+            (length (arities_context (ind_bodies mdecl))) (fun k' => lift n (k' + k))
+            (inductive_ind ind) idecl)
+    (map (lift n k) params) u ps
+  = option_map (lift n k) (build_case_predicate_type ind mdecl idecl params u ps).
+Proof.
+  intros closedpars. unfold build_case_predicate_type.
+  rewrite -> ind_type_map. simpl.
+  epose proof (lift_instantiate_params n k _ params (subst_instance_constr u (ind_type idecl))) as H.
+  rewrite <- lift_subst_instance_constr.
+  erewrite <- H; trivial. clear H.
+  case_eq (instantiate_params (subst_instance_context u (ind_params mdecl)) params (subst_instance_constr u (ind_type idecl))) ; cbnr.
+  intros ity eq.
+  pose proof (lift_destArity [] ity n k) as H; cbn in H. rewrite H; clear H.
+  destruct destArity as [[ctx s] | ]; [|reflexivity]. simpl. f_equal.
+  rewrite lift_it_mkProd_or_LetIn; cbn. f_equal. f_equal. 
+  - destruct idecl; reflexivity.
+  - rewrite lift_mkApps; cbn; f_equal. rewrite map_app. f_equal.
+    + rewrite !map_map lift_context_length; apply map_ext. clear.
+      intro. now rewrite -> permute_lift by lia.
+    + now rewrite -> to_extended_list_lift, <- to_extended_list_map_lift.
+Qed.
+
+Lemma lift_build_branches_type ind mdecl idecl u p params n k :
+  closed_ctx (subst_instance_context u (ind_params mdecl)) ->
+  build_branches_type ind mdecl
+         (map_one_inductive_body (context_assumptions mdecl.(ind_params))
+            #|arities_context (ind_bodies mdecl)| (fun k' => lift n (k' + k))
+            (inductive_ind ind) idecl)
+         (map (lift n k) params) u (lift n k p)
+  = map (option_map (on_snd (lift n k)))
+        (build_branches_type ind mdecl idecl params u p).
+Proof.
+  intros closedpars. unfold build_branches_type.
+  rewrite -> ind_ctors_map.
+  rewrite -> mapi_map, map_mapi. eapply mapi_ext. intros i x.
+  destruct x as [[id t] arity]. simpl.
+  rewrite <- lift_subst_instance_constr.
+  rewrite subst0_inds_lift.
+  rewrite <- lift_instantiate_params ; trivial.
+  match goal with
+  | |- context [ option_map _ (instantiate_params ?x ?y ?z) ] =>
+    destruct (instantiate_params x y z) eqn:Heqip; cbnr
+  end.
+  epose proof (lift_decompose_prod_assum t0 n k).
+  destruct (decompose_prod_assum [] t0).
+  rewrite <- H.
+  destruct (decompose_app t1) as [fn arg] eqn:?.
+  rewrite (decompose_app_lift _ _ _ fn arg); auto. simpl.
+  destruct (chop _ arg) eqn:Heqchop.
+  eapply chop_map in Heqchop.
+  rewrite -> Heqchop. clear Heqchop.
+  unfold on_snd. simpl. f_equal.
+  rewrite -> lift_it_mkProd_or_LetIn, !lift_mkApps, map_app; simpl.
+  rewrite -> !lift_mkApps, !map_app, lift_context_length.
+  rewrite -> permute_lift by lia. arith_congr.
+  now rewrite -> to_extended_list_lift, <- to_extended_list_map_lift.
+Qed.
+
 
 Lemma weakening_typing `{cf : checker_flags} Σ Γ Γ' Γ'' (t : term) :
   wf Σ.1 ->
@@ -856,22 +823,21 @@ Proof.
   - rewrite -> lift_mkApps, map_app, map_skipn.
     specialize (IHc _ _ _ wf eq_refl).
     specialize (IHp _ _ _ wf eq_refl).
+    assert (Hclos: closed_ctx (subst_instance_context u (ind_params mdecl))). {
+      destruct isdecl as [Hmdecl Hidecl].
+      eapply on_declared_minductive in Hmdecl; eauto.
+      eapply onParams in Hmdecl.
+      rewrite closedn_subst_instance_context.
+      eapply closed_wf_local in Hmdecl; eauto. }
     simpl. econstructor.
-    4:{ eapply lift_types_of_case in heq_types_of_case.
-        simpl in heq_types_of_case. subst pars. rewrite -> firstn_map.
-        eapply heq_types_of_case.
-        -- destruct isdecl as [Hmdecl Hidecl].
-           eapply on_declared_minductive in Hmdecl; eauto.
-           eapply onParams in Hmdecl.
-           rewrite closedn_subst_instance_context.
-           eapply closed_wf_local in Hmdecl; eauto. }
+    7:{ cbn. rewrite -> firstn_map.
+        erewrite lift_build_branches_type; tea.
+        rewrite map_option_out_map_option_map.
+        erewrite heq_map_option_out. reflexivity. }
+    all: eauto.
     -- erewrite -> lift_declared_inductive; eauto.
-    -- auto.
-    -- auto.
-    -- revert H1.
-       subst pars.
-       erewrite lift_declared_inductive; eauto.
-       apply lift_check_correct_arity.
+    -- simpl. erewrite firstn_map, lift_build_case_predicate_type; tea.
+       erewrite heq_build_case_predicate_type; reflexivity.
     -- destruct idecl; simpl in *; auto.
     -- now rewrite -> !lift_mkApps in IHc.
     -- solve_all.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -121,13 +121,6 @@ Proof.
   eapply eq_decl_subset; eassumption. assumption.
 Qed.
 
-Lemma check_correct_arity_subset {cf:checker_flags} φ φ' decl ind u ctx pars pctx
-  : ConstraintSet.Subset φ φ' -> check_correct_arity φ decl ind u ctx pars pctx
-    -> check_correct_arity φ' decl ind u ctx pars pctx.
-Proof.
-  apply eq_context_subset.
-Qed.
-
 Ltac my_rename_hyp h th :=
   match th with
   | (extends ?t _) => fresh "ext" t
@@ -306,9 +299,7 @@ Proof.
     rename_all_hyps; try solve [econstructor; eauto 2 with extends].
 
   - econstructor; eauto 2 with extends.
-    + eapply check_correct_arity_subset; tea.
-      apply weakening_env_global_ext_constraints; tas.
-    + close_Forall. intros; intuition eauto with extends.
+    close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
     + eapply All_local_env_impl.
       * eapply X.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -2016,8 +2016,8 @@ Section Conversion.
     zip fold in h1. apply wellformed_context in h1 ; auto. simpl in h1.
     destruct h1 as [[T h1] | [[ctx [s [h1 _]]]]] ; [| discriminate ].
     apply inversion_Case in h1 as hh ; auto.
-    destruct hh
-      as [uni [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
+    destruct hh as [uni [args [mdecl [idecl [ps [pty [btys
+                                 [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]].
     left. eexists. eassumption.
   Qed.
   Next Obligation.
@@ -2026,8 +2026,8 @@ Section Conversion.
     zip fold in h2. apply wellformed_context in h2 ; auto. simpl in h2.
     destruct h2 as [[T h2] | [[ctx [s [h2 _]]]]] ; [| discriminate ].
     apply inversion_Case in h2 as hh ; auto.
-    destruct hh
-      as [uni [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]]].
+    destruct hh as [uni [args [mdecl [idecl [ps [pty [btys
+                                 [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]].
     left. eexists. eassumption.
   Qed.
   Next Obligation.
@@ -2783,8 +2783,8 @@ Section Conversion.
     destruct hΣ as [wΣ].
     cbn. destruct h as [[T h] | [[ctx [s [h1 _]]]]]; [| discriminate ].
     apply inversion_Case in h ; auto.
-    destruct h as
-        [u [args [mdecl [idecl [pty [indctx [pctx [ps [btys [? [? [? [? [? [? [? [? ?]]]]]]]]]]]]]]]]].
+    destruct h as [uni [args [mdecl [idecl [ps [pty [btys
+                                 [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]].
     left; eexists. eassumption.
   Qed.
 

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -763,3 +763,10 @@ Coercion fst_ctx : global_env_ext >-> global_env.
 
 Definition empty_ext (Σ : global_env) : global_env_ext
   := (Σ, Monomorphic_ctx ContextSet.empty).
+
+
+Definition isConstruct_app t :=
+  match fst (decompose_app t) with
+  | tConstruct _ _ _ => true
+  | _ => false
+  end.


### PR DESCRIPTION
We had a revelation with Theo.
The typing rule of match should not be:
Γ ⊢ p : forall pctx, ps + conv_ctx pctx (indctx ,, I)
But instead directly:
Γ ⊢ p : forall (indctx ,, I), ps
Once again, we confused the checker and the spec. That's cool, isn't it?
I hope it will simplify weakening/subst/... proofs because we can remove conv_ctx ...