### PR TITLE
Replace omega with lia

### DIFF
--- a/checker/theories/Closed.v
+++ b/checker/theories/Closed.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith Lia.
 From MetaCoq.Template Require Import config utils Ast AstUtils Induction utils
   LiftSubst UnivSubst.
 From MetaCoq.Checker Require Import Typing TypingWf WeakeningEnv.

--- a/checker/theories/Generation.v
+++ b/checker/theories/Generation.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Lia.
 From MetaCoq.Template Require Import config utils Ast AstUtils Induction utils LiftSubst UnivSubst.
 From MetaCoq.Checker Require Import Typing Reflect.
 Require Import ssreflect ssrbool.

--- a/checker/theories/MetaTheory.v
+++ b/checker/theories/MetaTheory.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils Ast Induction LiftSubst UnivSubst.
 From MetaCoq.Template Require AstUtils.
 From MetaCoq.Checker Require Import Typing.

--- a/checker/theories/Retyping.v
+++ b/checker/theories/Retyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config monad_utils utils Ast Induction LiftSubst UnivSubst.
 From MetaCoq.Template Require AstUtils.
 From MetaCoq.Checker Require Import Typing Checker.

--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith Lia.
 From MetaCoq.Template Require Import config utils Ast AstUtils Induction utils
   LiftSubst UnivSubst.
 From MetaCoq.Checker Require Import LibHypsNaming Typing TypingWf WeakeningEnv
@@ -981,8 +981,8 @@ Proof.
     erewrite <- (to_extended_list_map_lift #|Γ''|).
     rewrite -> lift_context_length.
     rewrite -> !map_map_compose. f_equal. f_equal. apply map_ext.
-    intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). omega.
-    f_equal. omega.
+    intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). lia.
+    f_equal. lia.
   - now apply lift_eq_context.
 Qed.
 
@@ -1028,7 +1028,7 @@ Proof.
     intros Σ wfΣ Γ0; !!intros; subst Γ0; simpl in *; try solve [econstructor; eauto].
 
   - elim (leb_spec_Set); intros Hn.
-    + rewrite -> simpl_lift; try omega. rewrite -> Nat.add_succ_r.
+    + rewrite -> simpl_lift; try lia. rewrite -> Nat.add_succ_r.
       constructor. auto.
       now rewrite <- (weaken_nth_error_ge Hn).
     + assert (forall t, lift0 (S n) (lift #|Γ''| (#|Γ'| - S n) t) = lift #|Γ''| #|Γ'| (lift0 (S n) t)).

--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Lia.
 From MetaCoq.Template Require Import config utils Ast AstUtils Induction LiftSubst.
 From MetaCoq.Checker Require Import LibHypsNaming Typing.
 Require Import Equations.Prop.DepElim.

--- a/checker/theories/kernel/Checker.v
+++ b/checker/theories/kernel/Checker.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith.
 From MetaCoq.Template Require Import config Ast AstUtils monad_utils utils
      Induction LiftSubst UnivSubst.
 From MetaCoq.Checker Require Import Typing uGraph.

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -1,5 +1,5 @@
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith Lia.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICMetaTheory PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR PCUICNormal PCUICSafeLemmata PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination PCUICEquality PCUICContextConversion PCUICConversion.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker.
@@ -226,7 +226,7 @@ Proof.
     }
     eapply inversion_Construct in t as (? & ? & ? & ? & ? & ? & ?) ; auto. (* destruct x5. destruct p. cbn in *. *)
     assert (HL : #|ind_bodies x3| > 0).
-    { destruct d. destruct H. destruct (ind_bodies x3); cbn; try omega.
+    { destruct d. destruct H. destruct (ind_bodies x3); cbn; try lia.
       rewrite nth_error_nil in H1. inv H1.
     }
     eapply invert_cumul_arity_r in c0; eauto.
@@ -248,11 +248,11 @@ Proof.
     cbn in c2.
     rewrite PCUICUnivSubst.subst_instance_context_length in *.
     rewrite app_length in *.
-    destruct (Nat.leb_spec (#|cshape_args| + #|ind_params x3| + 0) (#|ind_bodies x3| - S (inductive_ind ind) + #|ind_params x3| + #|cshape_args|)). 2:omega.
+    destruct (Nat.leb_spec (#|cshape_args| + #|ind_params x3| + 0) (#|ind_bodies x3| - S (inductive_ind ind) + #|ind_params x3| + #|cshape_args|)). 2:lia.
     clear H.
     assert ((#|ind_bodies x3| - S (inductive_ind ind) + #|ind_params x3| +
                                                                          #|cshape_args| - (#|cshape_args| + #|ind_params x3| + 0)) < #|inds (inductive_mind ind) u (ind_bodies x3)|).
-    { rewrite inds_length. omega. }
+    { rewrite inds_length. lia. }
     eapply nth_error_Some in H.
     destruct ?; try congruence.
     (* destruct c2 as (? & [] & ?). *)

--- a/erasure/theories/EInversion.v
+++ b/erasure/theories/EInversion.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Lia.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping
      PCUICWeakening PCUICSubstitution PCUICChecker PCUICRetyping PCUICMetaTheory

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Lia.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICTyping PCUICWeakening PCUICSubstitution PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICSR PCUICValidity PCUICWeakeningEnv PCUICElimination.
 From MetaCoq.Erasure Require Import EAst ELiftSubst ETyping EWcbvEval Extract Prelim.

--- a/erasure/theories/ETyping.v
+++ b/erasure/theories/ETyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils AstUtils.
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst.
 Require Import String.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils Ast.
 From MetaCoq.PCUIC Require Import PCUICAstUtils.
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst ETyping.
@@ -167,11 +167,11 @@ Section Wcbv.
   | eval_atom t : atom t -> eval t t.
 
   Hint Constructors eval.
-  
+
   (* Scheme Minimality for eval Sort Type. *)
   Definition eval_evals_ind :
     forall P : term -> term -> Prop,
-      (forall a t t', eval a tBox -> P a tBox -> eval t t' -> P t t' -> eval (tApp a t) tBox -> P (tApp a t) tBox ) -> 
+      (forall a t t', eval a tBox -> P a tBox -> eval t t' -> P t t' -> eval (tApp a t) tBox -> P (tApp a t) tBox ) ->
       (forall (f : term) (na : name) (b a a' res : term),
           eval f (tLambda na b) ->
           P f (tLambda na b) -> eval a a' -> P a a' -> eval (b {0 := a'}) res -> P (b {0 := a'}) res -> P (tApp f a) res) ->
@@ -182,7 +182,7 @@ Section Wcbv.
           forall (res : term),
             cst_body decl = Some body ->
             eval body res -> P body res -> P (tConst c) res) ->
-      (forall (ind : inductive) (pars : nat) (discr : term) (c : nat) 
+      (forall (ind : inductive) (pars : nat) (discr : term) (c : nat)
               (args : list term) (brs : list (nat × term)) (res : term),
           eval discr (mkApps (tConstruct ind c) args) ->
           P discr (mkApps (tConstruct ind c) args) ->
@@ -237,7 +237,7 @@ Section Wcbv.
                                forall t t0, eval t t0 -> _ => fail 1
                              | _ => eapply H
                              end end; eauto].
-    - eapply Hbox; eauto. 
+    - eapply Hbox; eauto.
     - eapply Hcase; eauto.
     - eapply Hfix; eauto.
       clear -H3 eval_evals_ind.
@@ -286,7 +286,7 @@ Section Wcbv.
     - apply H; auto.
     - eapply H0; auto.
       revert l H3. fix aux 2. destruct 1. constructor; auto.
-      constructor. eauto. eauto. 
+      constructor. eauto. eauto.
     - eapply H1; eauto.
       clear H3. revert args H2. fix aux 2. destruct 1. constructor; auto.
       constructor. now eapply value_values_ind. now apply aux.
@@ -326,7 +326,7 @@ Section Wcbv.
     value_head t = (~~ (isLambda t || isFix t || isBox t)) && atom t.
   Proof.
     destruct t; intuition auto.
-  Qed.    
+  Qed.
 
   Lemma isFixApp_mkApps f args : ~~ isApp f -> isFixApp (mkApps f args) = isFixApp f.
   Proof.
@@ -347,7 +347,7 @@ Section Wcbv.
     induction 1 using eval_evals_ind; simpl; auto using value.
     (* eapply (value_app (tEvar n l') []). constructor. constructor. *)
     - eapply value_stuck_fix => //.
-      now eapply Forall2_right in H1. 
+      now eapply Forall2_right in H1.
     - destruct (mkApps_elim f' [a']).
       eapply value_mkApps_inv in IHeval1 => //.
       destruct IHeval1; intuition subst.
@@ -363,12 +363,12 @@ Section Wcbv.
         rewrite /isFixApp in H0. simpl in H0.
         rewrite orb_true_r orb_true_l in H0. easy.
   Qed.
-  
+
   (* Lemma eval_to_value e e' : eval e e' -> value e'. *)
   (* Proof. *)
   (*   induction 1 using eval_ind; simpl; auto using value. *)
   (*   - eapply value_stuck_fix => //. *)
-      
+
   (*     eapply Forall2_right. *)
   (*     eauto. *)
   (*     admit. *)
@@ -378,7 +378,7 @@ Section Wcbv.
   (*     * rewrite H3. *)
   (*       simpl. rewrite H3 in H. simpl in *. *)
   (*       apply (value_app f0 [a']). destruct f0; simpl in * |- *; try congruence. *)
-        
+
   (*       constructor; auto. constructor. constructor; auto. *)
   (*     * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']). *)
   (*       constructor 2; auto. eapply All_app_inv; auto. *)
@@ -389,7 +389,7 @@ Section Wcbv.
   (*       rewrite orb_true_r orb_true_l in H. easy. *)
   (* Qed. *)
   (* Admitted. *)
-  
+
   (* Lemma value_final e : value e -> eval e e. *)
   (* Proof. *)
   (*   induction 1 using value_values_ind; simpl; auto using value. *)

--- a/erasure/theories/EWndEval.v
+++ b/erasure/theories/EWndEval.v
@@ -1,4 +1,4 @@
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils Ast.
 From MetaCoq.Erasure Require Import EAst EInduction ELiftSubst ETyping.
 From MetaCoq.Template Require AstUtils.
@@ -28,7 +28,7 @@ Inductive Wnd : term -> term -> Prop :=
 
 End Wnd.
 
-(********************************  
+(********************************
 | sConst: forall (s:string) (t:Term),
     LookupDfn s p t -> wndEval (TConst s) t
 | sBeta: forall (nm:name) (bod arg:Term),
@@ -52,7 +52,7 @@ End Wnd.
 | sProj: forall bod r npars nargs args arg x ind,
     canonicalP bod = Some (r, npars, nargs, args) ->
     List.nth_error args (npars + arg) = Some x ->
-    wndEval (TProj (ind, npars, arg) bod) x          
+    wndEval (TProj (ind, npars, arg) bod) x
 (*** congruence steps ***)
 (** no xi rules: sLambdaR, sLetInR,
  *** no congruence on Case branches ***)

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.Erasure Require Import EAst ELiftSubst ETyping EWcbvEval Extract Prelim
      ESubstitution EInversion EArities.
@@ -620,9 +620,9 @@ Proof.
         eapply H10 in X0 as []; eauto. 2: exists []; now destruct Σ.
 
         destruct (ind_ctors idecl'). cbn in H4. destruct c; inv H2.
-        destruct l; cbn in *; try omega. destruct c as [ | []]; cbn in H2; inv H2.
+        destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in H2; inv H2.
 
-        destruct btys as [ | ? []]; cbn in H3; try omega. clear H3 H4. destruct H7.
+        destruct btys as [ | ? []]; cbn in H3; try lia. clear H3 H4. destruct H7.
         (* eapply H7 in d1. *) inv a. inv X2. inv H12. inv H8. destruct H4. destruct x4, y; cbn in *; subst.
         destruct X1. subst. destruct p0; cbn in *.
 
@@ -658,12 +658,12 @@ Proof.
         2: reflexivity.
 
         enough (#|skipn (ind_npars mdecl') (x1 ++ x2)| = n0) as <- by eauto.
-        rewrite skipn_length. rewrite extr_env_wf'0. omega.
-        rewrite extr_env_wf'0. omega.
+        rewrite skipn_length. rewrite extr_env_wf'0. lia.
+        rewrite extr_env_wf'0. lia.
       * subst. unfold iota_red in *.
         destruct (nth_error brs c) eqn:Hnth.
         2:{ eapply nth_error_None in Hnth. erewrite All2_length in Hnth. 2:exact a. rewrite H3 in Hnth.
-            eapply nth_error_Some_length in H2. cbn in H2. omega.
+            eapply nth_error_Some_length in H2. cbn in H2. lia.
         }
         rewrite <- nth_default_eq in *. unfold nth_default in *.
         rewrite Hnth in *.
@@ -692,9 +692,9 @@ Proof.
            eapply H10 in X0 as []; eauto. 2: exists []; now destruct Σ.
 
            destruct (ind_ctors idecl'). cbn in H4. destruct c; inv H2.
-           destruct l; cbn in *; try omega. destruct c as [ | []]; cbn in H2; inv H2.
+           destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in H2; inv H2.
 
-           destruct btys as [ | ? []]; cbn in H3; try omega. clear H3 H4. destruct H8.
+           destruct btys as [ | ? []]; cbn in H3; try lia. clear H3 H4. destruct H8.
            (* eapply H7 in d1. *) inv a. inv X2. inv H12. inv H9. destruct H4. destruct x1, y; cbn in *; subst.
            destruct X1. subst. destruct p0; cbn in *. destruct x3. inv e. inv Hnth. cbn in *.
 
@@ -730,8 +730,8 @@ Proof.
            2: reflexivity.
 
            enough (#|skipn (ind_npars mdecl') args| = n2) as <- by eauto.
-           rewrite skipn_length. rewrite extr_env_wf'0. omega.
-           rewrite extr_env_wf'0. omega. eauto.
+           rewrite skipn_length. rewrite extr_env_wf'0. lia.
+           rewrite extr_env_wf'0. lia. eauto.
     + exists tBox. split. econstructor.
       eapply Is_type_eval; eauto. econstructor; eauto.
     + auto.
@@ -813,7 +813,7 @@ Proof.
           clear a0. subst.
           assert (forall x n, nth_error x3 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
           { intros. eapply typing_spine_inv with (arg := n + #|x2|) in t0 as [].
-            2:{ rewrite nth_error_app2. 2:omega. rewrite Nat.add_sub. eassumption. }
+            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
             eauto.
           }
           clear - X3 a1 H7. revert X3 x4 H7; induction a1; intros.
@@ -958,7 +958,7 @@ Proof.
           clear a0. subst.
           assert (forall x n, nth_error x3 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
           { intros. eapply typing_spine_inv with (arg := n + #|x2|) in t0 as [].
-            2:{ rewrite nth_error_app2. 2:omega. rewrite Nat.add_sub. eassumption. }
+            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
             eauto.
           }
           clear - X3 a1 H4. revert X3 x4 H4; induction a1; intros.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -1,5 +1,5 @@
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.Checker Require Import uGraph.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICTyping PCUICChecker PCUICRetyping PCUICMetaTheory PCUICWcbvEval PCUICElimination.
 From MetaCoq.Erasure Require EAst ELiftSubst ETyping.
@@ -39,7 +39,7 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
   | erases_tLambda : forall (na : name) (b t : term) (t' : E.term),
                      Σ;;; (vass na b :: Γ) |- t ⇝ℇ t' ->
                      Σ;;; Γ |- tLambda na b t ⇝ℇ E.tLambda na t'
-  | erases_tLetIn : forall (na : name) (t1 : term) (t1' : E.term) 
+  | erases_tLetIn : forall (na : name) (t1 : term) (t1' : E.term)
                       (T t2 : term) (t2' : E.term),
                     Σ;;; Γ |- t1 ⇝ℇ t1' ->
                     Σ;;; (vdef na t1 T :: Γ) |- t2 ⇝ℇ t2' ->
@@ -52,7 +52,7 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
   | erases_tConstruct : forall (kn : inductive) (k : nat) (n : universe_instance),
                         Σ;;; Γ |- tConstruct kn k n ⇝ℇ E.tConstruct kn k
   | erases_tCase1 : forall (ind : inductive) (npar : nat) (T c : term)
-                      (brs : list (nat × term)) (c' : E.term) 
+                      (brs : list (nat × term)) (c' : E.term)
                       (brs' : list (nat × E.term)),
                     Informative Σ ind ->
                     Σ;;; Γ |- c ⇝ℇ c' ->
@@ -69,7 +69,7 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
                     (fun (d : def term) (d' : E.def E.term) =>
                      dname d = E.dname d'
                      × rarg d = E.rarg d'
-                       × Σ;;; Γ ,,, PCUICLiftSubst.fix_context mfix |- 
+                       × Σ;;; Γ ,,, PCUICLiftSubst.fix_context mfix |-
                          dbody d ⇝ℇ E.dbody d') mfix mfix' ->
                   Σ;;; Γ |- tFix mfix n ⇝ℇ E.tFix mfix' n
   | erases_tCoFix : forall (mfix : mfixpoint term) (n : nat) (mfix' : list (E.def E.term)),
@@ -77,7 +77,7 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
                       (fun (d : def term) (d' : E.def E.term) =>
                        dname d = E.dname d'
                        × rarg d = E.rarg d'
-                         × Σ;;; Γ ,,, PCUICLiftSubst.fix_context mfix |- 
+                         × Σ;;; Γ ,,, PCUICLiftSubst.fix_context mfix |-
                            dbody d ⇝ℇ E.dbody d') mfix mfix' ->
                     Σ;;; Γ |- tCoFix mfix n ⇝ℇ E.tCoFix mfix' n
   | erases_box : forall t : term, isErasable Σ Γ t -> Σ;;; Γ |- t ⇝ℇ E.tBox where "Σ ;;; Γ |- s ⇝ℇ t" := (erases Σ Γ s t).
@@ -103,7 +103,7 @@ Definition erases_mutual_inductive_body (Σ : global_env_ext) (mib : mutual_indu
   let arities := arities_context bds in
   Forall2 (erases_one_inductive_body Σ mib.(ind_npars) arities) bds (mib'.(E.ind_bodies)) /\
   mib.(ind_npars) = mib'.(E.ind_npars).
-  
+
 Inductive erases_global_decls : global_env -> E.global_declarations -> Prop :=
 | erases_global_nil : erases_global_decls [] []
 | erases_global_cnst Σ cb cb' kn Σ' :

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst Extract EArities.
 From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction
@@ -155,7 +155,8 @@ Qed.
 Lemma All2_right_triv {A B} {l : list A} {l' : list B} P :
   All P l' -> #|l| = #|l'| -> All2 (fun _ b => P b) l l'.
 Proof.
-  induction 1 in l |- *; cbn; intros; destruct l; cbn in *; try omega; econstructor; eauto.
+  induction 1 in l |- *; cbn; intros; destruct l; cbn in * ;
+  try (exfalso ; lia) ; econstructor; eauto.
 Qed.
 
 Lemma All_repeat {A} {n P} x :
@@ -194,9 +195,9 @@ Proof.
   revert L2; induction L1; cbn; intros.
   - destruct L2; inv H. econstructor.
   - destruct L2; inv H. econstructor.
-    eapply (X 0); cbn; eauto. omega.
+    eapply (X 0); cbn; eauto. lia.
     eapply IHL1. eauto.
-    intros. eapply (X (S n)); cbn; eauto. omega.
+    intros. eapply (X (S n)); cbn; eauto. lia.
 Qed.
 
 Lemma All2_nth_error {A B} {P : A -> B -> Type} {l l'} n t t' :
@@ -281,7 +282,7 @@ Proof.
   - destruct n; inv H.
   - destruct n.
     + cbn. now rewrite <- minus_n_O.
-    + cbn. rewrite IHm. omega. reflexivity.
+    + cbn. rewrite IHm. lia. reflexivity.
 Qed.
 
 Lemma efix_subst_nth mfix n :
@@ -293,7 +294,7 @@ Proof.
   - destruct n; inv H.
   - destruct n.
     + cbn. now rewrite <- minus_n_O.
-    + cbn. rewrite IHm. omega. reflexivity.
+    + cbn. rewrite IHm. lia. reflexivity.
 Qed.
 
 Lemma subslet_fix_subst `{cf : checker_flags} Σ mfix1 T n :
@@ -315,7 +316,7 @@ Proof.
       rewrite PCUICLiftSubst.simpl_subst_k. clear. induction l; cbn; try congruence.
       eapply inversion_Fix in X as (? & ? & ? & ? & ?) ; auto.
       econstructor; eauto. destruct H. subst.
-      rewrite <- app_assoc. rewrite nth_error_app_ge. omega.
+      rewrite <- app_assoc. rewrite nth_error_app_ge. lia.
       rewrite minus_diag. cbn. reflexivity. eapply p.
 Qed.
 

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -1,5 +1,5 @@
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.Checker Require Import uGraph.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
-     Classes.CRelationClasses Omega ProofIrrelevance.
+     Classes.CRelationClasses ProofIrrelevance.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction

--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -1,5 +1,4 @@
-From Coq Require Import Ascii String Bool OrderedType Lia List Program Arith
-     Omega.
+From Coq Require Import Ascii String Bool OrderedType Lia List Program Arith.
 From MetaCoq.Template Require Import utils AstUtils.
 From MetaCoq.Template Require Import BasicAst.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICSize.
@@ -719,8 +718,8 @@ Lemma nApp_mkApps :
 Proof.
   intros t l.
   induction l in t |- *.
-  - simpl. omega.
-  - simpl. rewrite IHl. cbn. omega.
+  - simpl. lia.
+  - simpl. rewrite IHl. cbn. lia.
 Qed.
 
 Lemma decompose_app_eq_mkApps :
@@ -732,7 +731,7 @@ Proof.
   apply decompose_app_notApp in e.
   apply isApp_false_nApp in e.
   rewrite nApp_mkApps in e.
-  destruct l' ; cbn in e ; try omega.
+  destruct l' ; cbn in e ; try lia.
   reflexivity.
 Qed.
 
@@ -747,10 +746,10 @@ Proof.
   - cbn in e. subst.
     destruct l' ; auto.
     exfalso.
-    rewrite nApp_mkApps in h. cbn in h. omega.
+    rewrite nApp_mkApps in h. cbn in h. lia.
   - destruct l'.
     + cbn in e. subst. exfalso.
-      rewrite nApp_mkApps in h. cbn in h. omega.
+      rewrite nApp_mkApps in h. cbn in h. lia.
     + cbn in e. apply IHl in e.
       * destruct e as [e1 e2].
         inversion e1. subst. auto.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -3,7 +3,7 @@ Set Warnings "-notation-overridden".
 Require Import ssreflect ssrbool.
 From MetaCoq Require Import LibHypsNaming.
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Utf8 String Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Utf8 String Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICReduction PCUICWeakening

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Lia.
 From MetaCoq.Template Require Import config utils AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils AstUtils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICTyping PCUICWeakeningEnv

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils monad_utils BasicAst AstUtils.
 From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils PCUICInduction
      PCUICWeakening PCUICSubstitution PCUICRetyping PCUICMetaTheory PCUICWcbvEval
@@ -82,7 +82,7 @@ Proof.
   intros ?. intros. inversion o.
   eapply declared_inductive_inj in H as []; eauto; subst.
   clear - onConstructors ind_sorts. try dependent induction onConstructors.
-  (* - cbn. split. omega. econstructor. admit. *)
+  (* - cbn. split. lia. econstructor. admit. *)
   (* -  *)
 Admitted.                       (* elim_restriction_works *)
 

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
-     RelationClasses CRelationClasses CMorphisms Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec Arith ZArith
+   Lia RelationClasses CRelationClasses CMorphisms.
 From MetaCoq.Template Require Import config utils AstUtils Universes UnivSubst.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst PCUICUnivSubst.

--- a/pcuic/theories/PCUICGeneration.v
+++ b/pcuic/theories/PCUICGeneration.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening

--- a/pcuic/theories/PCUICMetaTheory.v
+++ b/pcuic/theories/PCUICMetaTheory.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICUnivSubst PCUICTyping.
 Require Import String.

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -2,7 +2,7 @@
 Require Import ssreflect ssrbool.
 From MetaCoq Require Import LibHypsNaming.
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega String Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec String Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICSize
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICReduction PCUICWeakening PCUICSubstitution.

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -3,7 +3,8 @@ Set Warnings "-notation-overridden".
 Require Import ssreflect ssrbool.
 From MetaCoq Require Import LibHypsNaming.
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Utf8 String Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Utf8 String
+  ZArith Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICSize
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICReduction PCUICWeakening PCUICSubstitution

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -2,7 +2,7 @@
 Set Warnings "-notation-overridden".
 
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -2,7 +2,8 @@
 Require Import ssreflect ssrbool.
 From MetaCoq Require Import LibHypsNaming.
 From Equations Require Import Equations.
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega Utf8 String Lia.
+From Coq Require Import Bool String List Program BinPos Compare_dec Utf8 String
+  ZArith Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping.

--- a/pcuic/theories/PCUICRetyping.v
+++ b/pcuic/theories/PCUICRetyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICChecker PCUICConversion PCUICCumulativity.
 Require Import String.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
-     Classes.CRelationClasses Omega ProofIrrelevance.
+     Classes.CRelationClasses ProofIrrelevance.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
-From Coq Require Import Bool String List BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List BinPos Compare_dec ZArith Lia.
 Require Import Coq.Program.Syntax Coq.Program.Basics.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICUnivSubst
@@ -930,14 +930,14 @@ Proof.
   induction params in pars, s, t, σ, s', t', h |- *.
   - simpl in *. destruct pars. 2: discriminate.
     simpl. inversion h. subst. clear h.
-    f_equal. f_equal. f_equal. f_equal. omega.
+    f_equal. f_equal. f_equal. f_equal. lia.
   - simpl in *. destruct (decl_body a).
     + simpl. destruct t. all: try discriminate.
       simpl. eapply IHparams with (σ := σ) in h.
       simpl in h.
       replace (#|s| + S #|params|)
         with (S (#|s| + #|params|))
-        by omega.
+        by lia.
       rewrite <- h. f_equal.
       * f_equal. autorewrite with sigma.
         eapply inst_ext. intro i.
@@ -956,9 +956,9 @@ Proof.
               autorewrite with sigma.
               rewrite <- subst_ids. eapply inst_ext. intro j.
               cbn. unfold ids. rewrite map_length.
-              replace (#|s| + j - #|s|) with j by omega.
+              replace (#|s| + j - #|s|) with j by lia.
               rewrite nth_error_map.
-              erewrite (iffRL (nth_error_None _ _)) by omega.
+              erewrite (iffRL (nth_error_None _ _)) by lia.
               simpl. reflexivity.
       * autorewrite with sigma. reflexivity.
     + simpl. destruct t. all: try discriminate.
@@ -966,7 +966,7 @@ Proof.
       simpl. eapply IHparams with (σ := σ) in h. simpl in h.
       replace (#|s| + S #|params|)
         with (S (#|s| + #|params|))
-        by omega.
+        by lia.
       rewrite <- h.
       f_equal. autorewrite with sigma. reflexivity.
 Qed.
@@ -1038,9 +1038,9 @@ Proof.
     simpl. autorewrite with sigma. rewrite <- subst_ids.
     eapply inst_ext. intro j.
     cbn. unfold ids.
-    replace (#|s'| + j - #|s'|) with j by omega.
+    replace (#|s'| + j - #|s'|) with j by lia.
     rewrite nth_error_map.
-    erewrite (iffRL (nth_error_None _ _)) by omega.
+    erewrite (iffRL (nth_error_None _ _)) by lia.
     simpl. reflexivity.
 Qed.
 

--- a/pcuic/theories/PCUICSize.v
+++ b/pcuic/theories/PCUICSize.v
@@ -1,5 +1,4 @@
-From Coq Require Import Ascii String Bool OrderedType Lia List Program Arith
-     Omega.
+From Coq Require Import Ascii String Bool OrderedType Lia List Program Arith.
 From MetaCoq.Template Require Import utils AstUtils.
 From MetaCoq.Template Require Import BasicAst.
 From MetaCoq.PCUIC Require Import PCUICAst.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
-From Coq Require Import Bool String List BinPos Compare_dec Omega Lia.
+From Coq Require Import Bool String List BinPos Compare_dec ZArith Lia.
 Require Import Coq.Program.Syntax Coq.Program.Basics.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
@@ -764,8 +764,8 @@ Proof.
     erewrite <- (to_extended_list_map_lift #|Γ''|).
     rewrite -> lift_context_length.
     rewrite -> !map_map_compose. f_equal. f_equal. apply map_ext.
-    intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). omega.
-    f_equal. omega.
+    intros. unfold compose. rewrite (permute_lift _ _ _ _ 0). lia.
+    f_equal. lia.
   - now apply lift_eq_context.
 Qed.
 
@@ -796,7 +796,7 @@ Proof.
     intros Σ wfΣ Γ0; !!intros; subst Γ0; simpl in *; try solve [econstructor; eauto].
 
   - elim (leb_spec_Set); intros Hn.
-    + rewrite -> simpl_lift; try omega. rewrite -> Nat.add_succ_r.
+    + rewrite -> simpl_lift; try lia. rewrite -> Nat.add_succ_r.
       constructor. auto.
       now rewrite <- (weaken_nth_error_ge Hn).
     + assert (forall t, lift0 (S n) (lift #|Γ''| (#|Γ'| - S n) t) = lift #|Γ''| #|Γ'| (lift0 (S n) t)).

--- a/pcuic/theories/TemplateToPCUIC.v
+++ b/pcuic/theories/TemplateToPCUIC.v
@@ -2,7 +2,7 @@
 
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config utils AstUtils BasicAst Ast.
 From MetaCoq.Checker Require Import WfInv Typing Weakening TypingWf.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith.
 From MetaCoq.Template Require Import config utils AstUtils BasicAst Ast.
 (* For two lemmata wf_instantiate_params_subst_term and
    wf_instantiate_params_subst_ctx, maybe they should be moved *)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
-     Classes.RelationClasses Omega.
+     Classes.RelationClasses.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.
 From MetaCoq.Checker Require Import uGraph.
@@ -1157,7 +1157,7 @@ Section Conversion.
         pose proof (eq_sym e0) as eql.
         apply decompose_stack_at_length in eql. subst.
         rewrite nth_error_app_ge by auto.
-        replace (#|l| - #|l|) with 0 by omega. cbn.
+        replace (#|l| - #|l|) with 0 by lia. cbn.
         case_eq (decompose_stack s0). intros l0 s1 ee.
         rewrite ee in hd.
         pose proof (decompose_stack_eq _ _ _ ee). subst.
@@ -1206,7 +1206,7 @@ Section Conversion.
         pose proof (eq_sym e0) as eql.
         apply decompose_stack_at_length in eql. subst.
         rewrite nth_error_app_ge by auto.
-        replace (#|l| - #|l|) with 0 by omega. cbn.
+        replace (#|l| - #|l|) with 0 by lia. cbn.
         case_eq (decompose_stack s0). intros l0 s1 ee.
         rewrite ee in hd.
         pose proof (decompose_stack_eq _ _ _ ee). subst.
@@ -1249,7 +1249,7 @@ Section Conversion.
         pose proof (eq_sym e0) as eql.
         apply decompose_stack_at_length in eql. subst.
         rewrite nth_error_app_ge by auto.
-        replace (#|l| - #|l|) with 0 by omega. cbn.
+        replace (#|l| - #|l|) with 0 by lia. cbn.
         case_eq (decompose_stack s0). intros l0 s1 ee.
         rewrite ee in hd.
         pose proof (decompose_stack_eq _ _ _ ee). subst.
@@ -1292,7 +1292,7 @@ Section Conversion.
         pose proof (eq_sym e0) as eql.
         apply decompose_stack_at_length in eql. subst.
         rewrite nth_error_app_ge by auto.
-        replace (#|l| - #|l|) with 0 by omega. cbn.
+        replace (#|l| - #|l|) with 0 by lia. cbn.
         case_eq (decompose_stack s0). intros l0 s1 ee.
         rewrite ee in hd.
         pose proof (decompose_stack_eq _ _ _ ee). subst.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
 From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
-     Classes.RelationClasses Omega.
+     Classes.RelationClasses.
 From MetaCoq.Template
 Require Import config Universes monad_utils utils BasicAst AstUtils UnivSubst.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.Checker Require Import uGraph.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst

--- a/template-coq/theories/UnivSubst.v
+++ b/template-coq/theories/UnivSubst.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Omega.
+From Coq Require Import Bool String List Program BinPos Compare_dec ZArith.
 From MetaCoq Require Import utils Ast AstUtils Induction LiftSubst.
 Require Import String Lia.
 Local Open Scope string_scope.
@@ -222,7 +222,7 @@ Section UniverseClosedSubst.
 End UniverseClosedSubst.
 
 Section SubstInstanceClosed.
-  (** Substitution of a universe-closed instance of the right size 
+  (** Substitution of a universe-closed instance of the right size
       produces a universe-closed term. *)
 
   Context (u : universe_instance) (Hcl : closedu_instance 0 u).

--- a/template-coq/theories/utils.v
+++ b/template-coq/theories/utils.v
@@ -1,5 +1,5 @@
-From Coq Require Import Bool Program List Ascii String OrderedType Arith Lia Omega
-     ssreflect Utf8.
+From Coq Require Import Bool Program List Ascii String OrderedType Arith Lia
+  ZArith ssreflect Utf8.
 Global Set Asymmetric Patterns.
 
 Import ListNotations.
@@ -1861,7 +1861,7 @@ Proof.
     + cbn in h. inversion h.
   - destruct l.
     + reflexivity.
-    + simpl. apply IHn. cbn in h. omega.
+    + simpl. apply IHn. cbn in h. lia.
 Qed.
 
 Lemma nat_rev_ind (max : nat) :
@@ -1873,20 +1873,20 @@ Proof.
   intros P hmax hS.
   assert (h : forall n, P (max - n)).
   { intros n. induction n.
-    - apply hmax. omega.
+    - apply hmax. lia.
     - destruct (Nat.leb_spec0 max n).
-      + replace (max - S n) with 0 by omega.
-        replace (max - n) with 0 in IHn by omega.
+      + replace (max - S n) with 0 by lia.
+        replace (max - n) with 0 in IHn by lia.
         assumption.
-      + replace (max - n) with (S (max - S n)) in IHn by omega.
+      + replace (max - n) with (S (max - S n)) in IHn by lia.
         apply hS.
-        * omega.
+        * lia.
         * assumption.
   }
   intro n.
   destruct (Nat.leb_spec0 max n).
-  - apply hmax. omega.
-  - replace n with (max - (max - n)) by omega. apply h.
+  - apply hmax. lia.
+  - replace n with (max - (max - n)) by lia. apply h.
 Qed.
 
 Lemma strong_nat_ind :
@@ -1897,10 +1897,10 @@ Proof.
   intros P h n.
   assert (forall m, m < n -> P m).
   { induction n ; intros m hh.
-    - omega.
+    - lia.
     - destruct (Nat.eqb_spec n m).
       + subst. eapply h. assumption.
-      + eapply IHn. omega.
+      + eapply IHn. lia.
   }
   eapply h. assumption.
 Qed.
@@ -2403,7 +2403,13 @@ Qed.
 Lemma All2_right_triv {A B} {l : list A} {l' : list B} P :
   All P l' -> #|l| = #|l'| -> All2 (fun _ b => P b) l l'.
 Proof.
-  induction 1 in l |- *; cbn; intros; destruct l; cbn in *; try omega; econstructor; eauto.
+  induction 1 in l |- *.
+  all: cbn.
+  all: intros.
+  all: destruct l.
+  all: cbn in *.
+  all: try (exfalso ; lia).
+  all: try solve [ econstructor; eauto ].
 Qed.
 
 Lemma All_repeat {A} {n P} x :
@@ -2438,9 +2444,9 @@ Proof.
   revert L2; induction L1; cbn; intros.
   - destruct L2; inv H. econstructor.
   - destruct L2; inversion H. econstructor.
-    eapply (X 0); cbn; eauto. omega.
+    eapply (X 0); cbn; eauto. lia.
     eapply IHL1. eauto.
-    intros. eapply (X (S n)); cbn; eauto. omega.
+    intros. eapply (X (S n)); cbn; eauto. lia.
 Qed.
 
 Lemma All2_nth_error {A B} {P : A -> B -> Type} {l l'} n t t' :
@@ -2515,7 +2521,7 @@ Proof.
   - rewrite firstn_skipn. reflexivity.
   - apply All2_firstn with (n := #|r1|) in h.
     rewrite firstn_app in h. rewrite firstn_all in h.
-    replace (#|r1| - #|r1|) with 0 in h by omega. cbn in h.
+    replace (#|r1| - #|r1|) with 0 in h by lia. cbn in h.
     rewrite app_nil_r in h. assumption.
   - apply All2_skipn with (n := #|r1|) in h.
     rewrite skipn_all_app in h. assumption.


### PR DESCRIPTION
As per #327.
I remove `Omega` everywhere, replacing it with `Lia` and `ZArith` when needed.
Note that `omega` is able to close absurd goals while `lia` needs to be helped with `exfalso`.

I did not remove `Omega` from the `test-suite`.