### PR TITLE
In the ci-opam case, also remove the packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,4 @@ ci-local:
 
 ci-opam:
 	opam install -y .
-	opam remove coq-metacoq coq-metacoq-template
+	opam remove -y coq-metacoq coq-metacoq-template

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,4 @@ ci-local:
 
 ci-opam:
 	opam install -y .
+	opam remove coq-metacoq coq-metacoq-template


### PR DESCRIPTION
This avoids confusing the opam cache, which might think it does  not have to recompile some packages