### PR TITLE
η-conversion

### DIFF
--- a/checker/theories/Substitution.v
+++ b/checker/theories/Substitution.v
@@ -1465,10 +1465,10 @@ Proof.
       + inversion b0. auto.
 Qed.
 
-Lemma eq_term_upto_univ_refl Re Rle :
+Lemma eq_term_upto_refl Re Rle :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
-  forall t, eq_term_upto_univ Re Rle t t.
+  forall t, eq_term_upto Re Rle t t.
 Proof.
   intros hRe hRle.
   induction t in Rle, hRle |- * using term_forall_list_rect; simpl;
@@ -1489,7 +1489,7 @@ Qed.
 
 Lemma eq_term_refl `{checker_flags} φ t : eq_term φ t t.
 Proof.
-  apply eq_term_upto_univ_refl.
+  apply eq_term_upto_refl.
   - intro; apply eq_universe_refl.
   - intro; apply eq_universe_refl.
 Qed.
@@ -1497,7 +1497,7 @@ Qed.
 
 Lemma leq_term_refl `{checker_flags} φ t : leq_term φ t t.
 Proof.
-  apply eq_term_upto_univ_refl.
+  apply eq_term_upto_refl.
   - intro; apply eq_universe_refl.
   - intro; apply leq_universe_refl.
 Qed.
@@ -1512,8 +1512,8 @@ Proof.
   all: try (apply Forall_True, eq_universe_leq_universe).
 Qed.
 
-Lemma eq_term_upto_univ_App `{checker_flags} Re Rle f f' :
-  eq_term_upto_univ Re Rle f f' ->
+Lemma eq_term_upto_App `{checker_flags} Re Rle f f' :
+  eq_term_upto Re Rle f f' ->
   isApp f = isApp f'.
 Proof.
   inversion 1; reflexivity.
@@ -1526,14 +1526,14 @@ Proof.
   inversion 1; reflexivity.
 Qed.
 
-Lemma eq_term_upto_univ_mkApps `{checker_flags} Re Rle f l f' l' :
-  eq_term_upto_univ Re Rle f f' ->
-  All2 (eq_term_upto_univ Re Re) l l' ->
-  eq_term_upto_univ Re Rle (mkApps f l) (mkApps f' l').
+Lemma eq_term_upto_mkApps `{checker_flags} Re Rle f l f' l' :
+  eq_term_upto Re Rle f f' ->
+  All2 (eq_term_upto Re Re) l l' ->
+  eq_term_upto Re Rle (mkApps f l) (mkApps f' l').
 Proof.
   induction l in f, f' |- *; intro e; inversion_clear 1.
   - assumption.
-  - pose proof (eq_term_upto_univ_App _ _ _ _ e).
+  - pose proof (eq_term_upto_App _ _ _ _ e).
     case_eq (isApp f).
     + intro X; rewrite X in H0.
       destruct f; try discriminate.
@@ -1554,7 +1554,7 @@ Lemma leq_term_mkApps `{checker_flags} φ f l f' l' :
   All2 (eq_term φ) l l' ->
   leq_term φ (mkApps f l) (mkApps f' l').
 Proof.
-  eapply eq_term_upto_univ_mkApps.
+  eapply eq_term_upto_mkApps.
 Qed.
 
 Lemma leq_term_App `{checker_flags} φ f f' :
@@ -1564,22 +1564,22 @@ Proof.
   inversion 1; reflexivity.
 Qed.
 
-Lemma subst_eq_term_upto_univ `{checker_flags} Re Rle n k T U :
+Lemma subst_eq_term_upto `{checker_flags} Re Rle n k T U :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
-  eq_term_upto_univ Re Rle T U ->
-  eq_term_upto_univ Re Rle (subst n k T) (subst n k U).
+  eq_term_upto Re Rle T U ->
+  eq_term_upto Re Rle (subst n k T) (subst n k U).
 Proof.
   intros hRe hRle h.
   induction T in n, k, U, h, Rle, hRle |- * using term_forall_list_rect.
   all: simpl ; inversion h ; simpl.
-  all: try (eapply eq_term_upto_univ_refl ; easy).
+  all: try (eapply eq_term_upto_refl ; easy).
   all: try (constructor ; easy).
   - constructor.
     eapply All2_map. eapply All2_impl' ; try eassumption.
     eapply All_impl ; try eassumption.
     cbn. intros x HH y HH'. now eapply HH.
-  - subst. eapply eq_term_upto_univ_mkApps. all: try easy.
+  - subst. eapply eq_term_upto_mkApps. all: try easy.
     eapply All2_map. eapply All2_impl' ; try eassumption.
     eapply All_impl ; try eassumption.
     cbn. intros x HH y HH'. now eapply HH.
@@ -1607,7 +1607,7 @@ Lemma subst_eq_term `{checker_flags} ϕ n k T U :
   eq_term ϕ (subst n k T) (subst n k U).
 Proof.
   intros Hleq.
-  eapply subst_eq_term_upto_univ.
+  eapply subst_eq_term_upto.
   - intro. eapply eq_universe_refl.
   - intro. eapply eq_universe_refl.
   - assumption.
@@ -1618,7 +1618,7 @@ Lemma subst_leq_term `{checker_flags} ϕ n k T U :
   leq_term ϕ (subst n k T) (subst n k U).
 Proof.
   intros Hleq.
-  eapply subst_eq_term_upto_univ.
+  eapply subst_eq_term_upto.
   - intro. eapply eq_universe_refl.
   - intro. eapply leq_universe_refl.
   - assumption.

--- a/checker/theories/Typing.v
+++ b/checker/theories/Typing.v
@@ -446,97 +446,97 @@ Inductive red Σ Γ M : term -> Type :=
 Definition R_universe_instance R :=
   fun u u' => Forall2 R (List.map Universe.make u) (List.map Universe.make u').
 
-Inductive eq_term_upto_univ (Re Rle : universe -> universe -> Prop) : term -> term -> Type :=
+Inductive eq_term_upto (Re Rle : universe -> universe -> Prop) : term -> term -> Type :=
 | eq_Rel n  :
-    eq_term_upto_univ Re Rle (tRel n) (tRel n)
+    eq_term_upto Re Rle (tRel n) (tRel n)
 
 | eq_Evar e args args' :
-    All2 (eq_term_upto_univ Re Re) args args' ->
-    eq_term_upto_univ Re Rle (tEvar e args) (tEvar e args')
+    All2 (eq_term_upto Re Re) args args' ->
+    eq_term_upto Re Rle (tEvar e args) (tEvar e args')
 
 | eq_Var id :
-    eq_term_upto_univ Re Rle (tVar id) (tVar id)
+    eq_term_upto Re Rle (tVar id) (tVar id)
 
 | eq_Sort s s' :
     Rle s s' ->
-    eq_term_upto_univ Re Rle (tSort s) (tSort s')
+    eq_term_upto Re Rle (tSort s) (tSort s')
 
 | eq_Cast f f' k T T' :
-    eq_term_upto_univ Re Re f f' ->
-    eq_term_upto_univ Re Re T T' ->
-    eq_term_upto_univ Re Rle (tCast f k T) (tCast f' k T')
+    eq_term_upto Re Re f f' ->
+    eq_term_upto Re Re T T' ->
+    eq_term_upto Re Rle (tCast f k T) (tCast f' k T')
 
 | eq_App t t' args args' :
-    eq_term_upto_univ Re Rle t t' ->
-    All2 (eq_term_upto_univ Re Re) args args' ->
-    eq_term_upto_univ Re Rle (tApp t args) (tApp t' args')
+    eq_term_upto Re Rle t t' ->
+    All2 (eq_term_upto Re Re) args args' ->
+    eq_term_upto Re Rle (tApp t args) (tApp t' args')
 
 | eq_Const c u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto_univ Re Rle (tConst c u) (tConst c u')
+    eq_term_upto Re Rle (tConst c u) (tConst c u')
 
 | eq_Ind i u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto_univ Re Rle (tInd i u) (tInd i u')
+    eq_term_upto Re Rle (tInd i u) (tInd i u')
 
 | eq_Construct i k u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto_univ Re Rle (tConstruct i k u) (tConstruct i k u')
+    eq_term_upto Re Rle (tConstruct i k u) (tConstruct i k u')
 
 | eq_Lambda na na' ty ty' t t' :
-    eq_term_upto_univ Re Re ty ty' ->
-    eq_term_upto_univ Re Rle t t' ->
-    eq_term_upto_univ Re Rle (tLambda na ty t) (tLambda na' ty' t')
+    eq_term_upto Re Re ty ty' ->
+    eq_term_upto Re Rle t t' ->
+    eq_term_upto Re Rle (tLambda na ty t) (tLambda na' ty' t')
 
 | eq_Prod na na' a a' b b' :
-    eq_term_upto_univ Re Re a a' ->
-    eq_term_upto_univ Re Rle b b' ->
-    eq_term_upto_univ Re Rle (tProd na a b) (tProd na' a' b')
+    eq_term_upto Re Re a a' ->
+    eq_term_upto Re Rle b b' ->
+    eq_term_upto Re Rle (tProd na a b) (tProd na' a' b')
 
 | eq_LetIn na na' ty ty' t t' u u' :
-    eq_term_upto_univ Re Re ty ty' ->
-    eq_term_upto_univ Re Re t t' ->
-    eq_term_upto_univ Re Rle u u' ->
-    eq_term_upto_univ Re Rle (tLetIn na ty t u) (tLetIn na' ty' t' u')
+    eq_term_upto Re Re ty ty' ->
+    eq_term_upto Re Re t t' ->
+    eq_term_upto Re Rle u u' ->
+    eq_term_upto Re Rle (tLetIn na ty t u) (tLetIn na' ty' t' u')
 
 | eq_Case ind par p p' c c' brs brs' :
-    eq_term_upto_univ Re Re p p' ->
-    eq_term_upto_univ Re Re c c' ->
+    eq_term_upto Re Re p p' ->
+    eq_term_upto Re Re c c' ->
     All2 (fun x y =>
       fst x = fst y ×
-      eq_term_upto_univ Re Re (snd x) (snd y)
+      eq_term_upto Re Re (snd x) (snd y)
     ) brs brs' ->
-    eq_term_upto_univ Re Rle (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
+    eq_term_upto Re Rle (tCase (ind, par) p c brs) (tCase (ind, par) p' c' brs')
 
 | eq_Proj p c c' :
-    eq_term_upto_univ Re Re c c' ->
-    eq_term_upto_univ Re Rle (tProj p c) (tProj p c')
+    eq_term_upto Re Re c c' ->
+    eq_term_upto Re Rle (tProj p c) (tProj p c')
 
 | eq_Fix mfix mfix' idx :
     All2 (fun x y =>
-      eq_term_upto_univ Re Re x.(dtype) y.(dtype) ×
-      eq_term_upto_univ Re Re x.(dbody) y.(dbody) ×
+      eq_term_upto Re Re x.(dtype) y.(dtype) ×
+      eq_term_upto Re Re x.(dbody) y.(dbody) ×
       x.(rarg) = y.(rarg)
     ) mfix mfix' ->
-    eq_term_upto_univ Re Rle (tFix mfix idx) (tFix mfix' idx)
+    eq_term_upto Re Rle (tFix mfix idx) (tFix mfix' idx)
 
 | eq_CoFix mfix mfix' idx :
     All2 (fun x y =>
-      eq_term_upto_univ Re Re x.(dtype) y.(dtype) ×
-      eq_term_upto_univ Re Re x.(dbody) y.(dbody) ×
+      eq_term_upto Re Re x.(dtype) y.(dtype) ×
+      eq_term_upto Re Re x.(dbody) y.(dbody) ×
       x.(rarg) = y.(rarg)
     ) mfix mfix' ->
-    eq_term_upto_univ Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
+    eq_term_upto Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
 
 Definition eq_term `{checker_flags} φ :=
-  eq_term_upto_univ (eq_universe φ) (eq_universe φ).
+  eq_term_upto (eq_universe φ) (eq_universe φ).
 
 (* ** Syntactic cumulativity up-to universes
 
   We shouldn't look at printing annotations *)
 
 Definition leq_term `{checker_flags} φ :=
-  eq_term_upto_univ (eq_universe φ) (leq_universe φ).
+  eq_term_upto (eq_universe φ) (leq_universe φ).
 
 Fixpoint strip_casts t :=
   match t with

--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -769,9 +769,9 @@ Proof.
     + inversion b. eauto.
 Qed.
 
-Lemma lift_eq_term_upto_univ Re Rl n k T U :
-  eq_term_upto_univ Re Rl T U ->
-  eq_term_upto_univ Re Rl (lift n k T) (lift n k U).
+Lemma lift_eq_term_upto Re Rl n k T U :
+  eq_term_upto Re Rl T U ->
+  eq_term_upto Re Rl (lift n k T) (lift n k U).
 Proof.
   induction T in n, k, U, Rl |- * using term_forall_list_rect;
     inversion 1; simpl; try (now constructor).
@@ -794,8 +794,8 @@ Proof.
       easy.
   - constructor; try easy. clear - X H3.
     assert (XX:forall k k', All2
-                         (fun x y  => eq_term_upto_univ Re Re (dtype x) (dtype y) ×
-                        eq_term_upto_univ Re Re (dbody x) (dbody y) ×
+                         (fun x y  => eq_term_upto Re Re (dtype x) (dtype y) ×
+                        eq_term_upto Re Re (dbody x) (dbody y) ×
                                    rarg x = rarg y)
                          (map (map_def (lift n k) (lift n (#|m| + k'))) m)
                          (map (map_def (lift n k) (lift n (#|mfix'| + k'))) mfix'));
@@ -810,8 +810,8 @@ Proof.
       rewrite !plus_n_Sm. now apply IHm.
   - constructor; try easy. clear - X H3.
     assert (XX:forall k k', All2
-                         (fun x y  => eq_term_upto_univ Re Re (dtype x) (dtype y) ×
-                            eq_term_upto_univ Re Re (dbody x) (dbody y) ×
+                         (fun x y  => eq_term_upto Re Re (dtype x) (dtype y) ×
+                            eq_term_upto Re Re (dbody x) (dbody y) ×
                                    rarg x = rarg y)
                          (map (map_def (lift n k) (lift n (#|m| + k'))) m)
                          (map (map_def (lift n k) (lift n (#|mfix'| + k'))) mfix'));
@@ -830,13 +830,13 @@ Qed.
 Lemma lift_eq_term `{checker_flags} ϕ n k T U :
   eq_term ϕ T U -> eq_term ϕ (lift n k T) (lift n k U).
 Proof.
-  apply lift_eq_term_upto_univ.
+  apply lift_eq_term_upto.
 Qed.
 
 Lemma lift_leq_term `{checker_flags} ϕ n k T U :
   leq_term ϕ T U -> leq_term ϕ (lift n k T) (lift n k U).
 Proof.
-  apply lift_eq_term_upto_univ.
+  apply lift_eq_term_upto.
 Qed.
 
 Lemma weakening_cumul `{CF:checker_flags} Σ Γ Γ' Γ'' M N :

--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -129,9 +129,9 @@ Proof.
 Qed.
 
 
-Lemma eq_term_upto_univ_morphism0 (Re Re' : _ -> _ -> Prop)
+Lemma eq_term_upto_morphism0 (Re Re' : _ -> _ -> Prop)
       (Hre : forall t u, Re t u -> Re' t u)
-  : forall t u, eq_term_upto_univ Re Re t u -> eq_term_upto_univ Re' Re' t u.
+  : forall t u, eq_term_upto Re Re t u -> eq_term_upto Re' Re' t u.
 Proof.
   fix aux 3.
   destruct 1; constructor; eauto.
@@ -143,31 +143,31 @@ Proof.
   all: intuition eauto.
 Qed.
 
-Lemma eq_term_upto_univ_morphism (Re Re' Rle Rle' : _ -> _ -> Prop)
+Lemma eq_term_upto_morphism (Re Re' Rle Rle' : _ -> _ -> Prop)
       (Hre : forall t u, Re t u -> Re' t u)
       (Hrle : forall t u, Rle t u -> Rle' t u)
-  : forall t u, eq_term_upto_univ Re Rle t u -> eq_term_upto_univ Re' Rle' t u.
+  : forall t u, eq_term_upto Re Rle t u -> eq_term_upto Re' Rle' t u.
 Proof.
   fix aux 3.
-  destruct 1; constructor; eauto using eq_term_upto_univ_morphism0.
+  destruct 1; constructor; eauto using eq_term_upto_morphism0.
   all: unfold R_universe_instance in *.
   all: match goal with
        | H : Forall2 _ _ _ |- _ => induction H; constructor;
-                                   eauto using eq_term_upto_univ_morphism0
+                                   eauto using eq_term_upto_morphism0
        | H : All2 _ _ _ |- _ => induction H; constructor;
-                                eauto using eq_term_upto_univ_morphism0
+                                eauto using eq_term_upto_morphism0
        end.
-  - destruct r. split; eauto using eq_term_upto_univ_morphism0.
+  - destruct r. split; eauto using eq_term_upto_morphism0.
   - destruct r as [? [? ?]].
-    repeat split; eauto using eq_term_upto_univ_morphism0.
+    repeat split; eauto using eq_term_upto_morphism0.
   - destruct r as [? [? ?]].
-    repeat split; eauto using eq_term_upto_univ_morphism0.
+    repeat split; eauto using eq_term_upto_morphism0.
 Qed.
 
 Lemma leq_term_subset {cf:checker_flags} ctrs ctrs' t u
   : ConstraintSet.Subset ctrs ctrs' -> leq_term ctrs t u -> leq_term ctrs' t u.
 Proof.
-  intro H. apply eq_term_upto_univ_morphism.
+  intro H. apply eq_term_upto_morphism.
   intros t' u'; eapply eq_universe_subset; assumption.
   intros t' u'; eapply leq_universe_subset; assumption.
 Qed.
@@ -257,7 +257,7 @@ Lemma eq_term_subset {cf:checker_flags} φ φ' t t'
   : ConstraintSet.Subset φ φ'
     -> eq_term φ t t' ->  eq_term φ' t t'.
 Proof.
-  intro H. apply eq_term_upto_univ_morphism.
+  intro H. apply eq_term_upto_morphism.
   all: intros u u'; eapply eq_universe_subset; assumption.
 Qed.
 

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -24,7 +24,7 @@ Section Alpha.
 
   Lemma build_branches_type_eq_term :
     forall p p' ind mdecl idecl pars u brtys,
-      eq_term_upto_univ eq eq p p' ->
+      eq_term_upto eq eq p p' ->
       map_option_out
         (build_branches_type ind mdecl idecl pars u p) =
       Some brtys ->
@@ -32,7 +32,7 @@ Section Alpha.
         map_option_out
           (build_branches_type ind mdecl idecl pars u p') =
         Some brtys' ×
-        All2 (on_Trel_eq (eq_term_upto_univ eq eq) snd fst) brtys brtys'.
+        All2 (on_Trel_eq (eq_term_upto eq eq) snd fst) brtys brtys'.
   Proof.
     intros p p' ind mdecl idecl pars u brtys e hb.
     unfold build_branches_type in *.
@@ -76,10 +76,10 @@ Section Alpha.
         * reflexivity.
         * constructor ; auto.
           simpl. split ; auto.
-          eapply eq_term_upto_univ_it_mkProd_or_LetIn ; auto.
-          eapply eq_term_upto_univ_mkApps.
-          -- eapply eq_term_upto_univ_lift. assumption.
-          -- apply All2_same. intro. apply eq_term_upto_univ_refl ; auto.
+          eapply eq_term_upto_it_mkProd_or_LetIn ; auto.
+          eapply eq_term_upto_mkApps.
+          -- eapply eq_term_upto_lift. assumption.
+          -- apply All2_same. intro. apply eq_term_upto_refl ; auto.
   Qed.
 
   (* TODO MOVE *)
@@ -168,13 +168,13 @@ Qed.
     forall Σ Γ u v A,
       wf Σ.1 ->
       Σ ;;; Γ |- u : A ->
-      eq_term_upto_univ eq eq u v ->
+      eq_term_upto eq eq u v ->
       Σ ;;; Γ |- v : A.
   Proof.
     assert (tm :
       env_prop (fun Σ Γ u A =>
                   forall v,
-                    eq_term_upto_univ eq eq u v ->
+                    eq_term_upto eq eq u v ->
                     Σ ;;; Γ |- v : A)
     ).
     eapply typing_ind_env.
@@ -239,7 +239,7 @@ Qed.
                 ** eapply ihb. assumption.
                 ** right. eexists. eapply ihB. assumption.
                 ** eapply cumul_refl.
-                   eapply eq_term_upto_univ_impl. 3: eassumption.
+                   eapply eq_term_upto_impl. 3: eassumption.
                    all: intros x ? [].
                    --- eapply eq_universe_refl.
                    --- eapply leq_universe_refl.
@@ -270,7 +270,7 @@ Qed.
         eapply eq_term_leq_term.
         apply eq_term_sym.
         eapply upto_names_impl_eq_term.
-        eapply eq_term_upto_univ_subst ; now auto.
+        eapply eq_term_upto_subst ; now auto.
     - intros cst u decl ? ? hdecl hcons v e.
       dependent destruction e.
       apply Forall2_eq in r. apply map_inj in r ; revgoals.
@@ -307,7 +307,7 @@ Qed.
                       × Σ;;; Γ |- bty.2 : tSort ps)
                      × (forall v : term, upto_names' bty.2 v -> Σ;;; Γ |- v : tSort ps)).
         * clear. intros x y z X; rdestruct; cbn in *.
-          congruence. 2: eauto. econstructor; tea. 
+          congruence. 2: eauto. econstructor; tea.
           right. exists ps. eauto. constructor.
           now eapply upto_names_impl_leq_term.
         * eapply All2_trans'; [..|eassumption].
@@ -342,10 +342,10 @@ Qed.
         eapply eq_term_leq_term.
         apply eq_term_sym.
         eapply upto_names_impl_eq_term.
-        eapply eq_term_upto_univ_substs ; auto; try reflexivity.
+        eapply eq_term_upto_substs ; auto; try reflexivity.
         * constructor ; auto.
           eapply All2_same.
-          intro. eapply eq_term_upto_univ_refl ; auto.
+          intro. eapply eq_term_upto_refl ; auto.
     - intros mfix n decl types hnth hguard hwf ihmfix v e.
       dependent destruction e.
       eapply All2_nth_error_Some in hnth as hnth' ; eauto.
@@ -360,7 +360,7 @@ Qed.
           induction a in n |- *.
           - constructor.
           - simpl. constructor.
-            + eapply eq_term_upto_univ_lift. apply r.
+            + eapply eq_term_upto_lift. apply r.
             + eapply IHa.
         }
         clearbody Δ Ξ.
@@ -403,7 +403,7 @@ Qed.
               -- eapply ih2. assumption.
               -- right. eexists. eapply ih1. assumption.
               -- eapply cumul_refl.
-                 eapply eq_term_upto_univ_impl. 3: eassumption.
+                 eapply eq_term_upto_impl. 3: eassumption.
                  all: intros ? ? [].
                  ++ eapply eq_universe_refl.
                  ++ eapply leq_universe_refl.
@@ -447,7 +447,7 @@ Qed.
             induction a in n |- *.
             - constructor.
             - simpl. constructor.
-              + eapply eq_term_upto_univ_lift. apply r.
+              + eapply eq_term_upto_lift. apply r.
               + eapply IHa.
           }
           clearbody Δ Ξ.
@@ -481,8 +481,8 @@ Qed.
                                          eapply eq_context_upto_refl. auto.
                                     ++++ intros ? ? []. eapply eq_universe_refl.
                        +++ eapply cumul_refl. rewrite <- el.
-                           eapply eq_term_upto_univ_lift.
-                           eapply eq_term_upto_univ_impl.
+                           eapply eq_term_upto_lift.
+                           eapply eq_term_upto_impl.
                            3: intuition eauto.
                            all: intros ? ? [].
                            *** eapply eq_universe_refl.
@@ -521,7 +521,7 @@ Qed.
           induction a in n |- *.
           - constructor.
           - simpl. constructor.
-            + eapply eq_term_upto_univ_lift. apply r.
+            + eapply eq_term_upto_lift. apply r.
             + eapply IHa.
         }
         clearbody Δ Ξ.
@@ -564,7 +564,7 @@ Qed.
               -- eapply ih2. assumption.
               -- right. eexists. eapply ih1. assumption.
               -- eapply cumul_refl.
-                 eapply eq_term_upto_univ_impl. 3: eassumption.
+                 eapply eq_term_upto_impl. 3: eassumption.
                  all: intros ? ? [].
                  ++ eapply eq_universe_refl.
                  ++ eapply leq_universe_refl.
@@ -608,7 +608,7 @@ Qed.
             induction a in n |- *.
             - constructor.
             - simpl. constructor.
-              + eapply eq_term_upto_univ_lift. apply r.
+              + eapply eq_term_upto_lift. apply r.
               + eapply IHa.
           }
           clearbody Δ Ξ.
@@ -641,8 +641,8 @@ Qed.
                                     eapply eq_context_upto_refl. auto.
                                ---- intros ? ? []. eapply eq_universe_refl.
                    --- eapply cumul_refl. rewrite <- el.
-                       eapply eq_term_upto_univ_lift.
-                       eapply eq_term_upto_univ_impl.
+                       eapply eq_term_upto_lift.
+                       eapply eq_term_upto_impl.
                        3: intuition eauto.
                        all: intros ? ? [].
                        +++ eapply eq_universe_refl.
@@ -685,15 +685,15 @@ Qed.
   Proof.
     intros Σ Γ u A hΣ h.
     eapply typing_alpha ; eauto.
-    eapply eq_term_upto_univ_tm_nl. all: auto.
+    eapply eq_term_upto_tm_nl. all: auto.
   Qed.
 
   Local Ltac inv H := inversion H; subst; clear H.
 
-  Lemma upto_names_eq_term_upto_univ Re Rle t u
-    : eq_term_upto_univ Re Rle t u ->
+  Lemma upto_names_eq_term_upto Re Rle t u
+    : eq_term_upto Re Rle t u ->
       forall t' u', t ≡ t' -> u ≡ u' ->
-               eq_term_upto_univ Re Rle t' u'.
+               eq_term_upto Re Rle t' u'.
   Proof.
     revert t u Rle. fix aux 4.
     destruct 1; cbn; intros t'' u'' H' H0';
@@ -736,13 +736,13 @@ Qed.
   Lemma upto_names_leq_term φ t u t' u'
     : t ≡ t' -> u ≡ u' -> leq_term φ t u -> leq_term φ t' u'.
   Proof.
-    intros; eapply upto_names_eq_term_upto_univ; eassumption.
+    intros; eapply upto_names_eq_term_upto; eassumption.
   Qed.
 
   Lemma upto_names_eq_term φ t u t' u'
     : t ≡ t' -> u ≡ u' -> eq_term φ t u -> eq_term φ t' u'.
   Proof.
-    intros; eapply upto_names_eq_term_upto_univ; eassumption.
+    intros; eapply upto_names_eq_term_upto; eassumption.
   Qed.
 
   Definition upto_names_decl := eq_decl_upto eq.
@@ -828,7 +828,7 @@ Qed.
   Lemma upto_names_nl t
     : t ≡ nl t.
   Proof.
-    eapply eq_term_upto_univ_tm_nl; exact _.
+    eapply eq_term_upto_tm_nl; exact _.
   Qed.
 
   Lemma upto_names_nlctx Γ

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -24,7 +24,7 @@ Section Alpha.
 
   Lemma build_branches_type_eq_term :
     forall p p' ind mdecl idecl pars u brtys,
-      eq_term_upto eq eq p p' ->
+      eq_term_upto eq eq no_η p p' ->
       map_option_out
         (build_branches_type ind mdecl idecl pars u p) =
       Some brtys ->
@@ -32,7 +32,7 @@ Section Alpha.
         map_option_out
           (build_branches_type ind mdecl idecl pars u p') =
         Some brtys' ×
-        All2 (on_Trel_eq (eq_term_upto eq eq) snd fst) brtys brtys'.
+        All2 (on_Trel_eq (eq_term_upto eq eq no_η) snd fst) brtys brtys'.
   Proof.
     intros p p' ind mdecl idecl pars u brtys e hb.
     unfold build_branches_type in *.
@@ -168,13 +168,13 @@ Qed.
     forall Σ Γ u v A,
       wf Σ.1 ->
       Σ ;;; Γ |- u : A ->
-      eq_term_upto eq eq u v ->
+      eq_term_upto eq eq no_η u v ->
       Σ ;;; Γ |- v : A.
   Proof.
     assert (tm :
       env_prop (fun Σ Γ u A =>
                   forall v,
-                    eq_term_upto eq eq u v ->
+                    eq_term_upto eq eq no_η u v ->
                     Σ ;;; Γ |- v : A)
     ).
     eapply typing_ind_env.
@@ -239,7 +239,8 @@ Qed.
                 ** eapply ihb. assumption.
                 ** right. eexists. eapply ihB. assumption.
                 ** eapply cumul_refl.
-                   eapply eq_term_upto_impl. 3: eassumption.
+                   eapply eq_term_upto_impl. 4: eassumption.
+                   3:{ intros. constructor. }
                    all: intros x ? [].
                    --- eapply eq_universe_refl.
                    --- eapply leq_universe_refl.
@@ -353,7 +354,7 @@ Qed.
       destruct hh as [[ety ebo] era].
       assert (hwf' : wf_local Σ (Γ ,,, fix_context mfix')).
       { rename types into Δ. set (Ξ := fix_context mfix').
-        assert (e : eq_context_upto eq Δ Ξ).
+        assert (e : eq_context_upto eq no_η Δ Ξ).
         { eapply eq_context_upto_rev'.
           clear - a.
           unfold mapi. generalize 0 at 2 4. intro n.
@@ -380,6 +381,7 @@ Qed.
               eapply eq_context_impl ; revgoals.
               -- eapply eq_context_upto_cat. 2: eassumption.
                  eapply eq_context_upto_refl. auto.
+              -- intros. constructor.
               -- intros ? ? []. eapply eq_universe_refl.
         - simpl in *. inversion hwf. subst.
           constructor.
@@ -394,6 +396,7 @@ Qed.
               eapply eq_context_impl ; revgoals.
               -- eapply eq_context_upto_cat. 2: eassumption.
                  eapply eq_context_upto_refl. auto.
+              -- intros. constructor.
               -- intros ? ? []. eapply eq_universe_refl.
           + simpl in *. destruct X0 as [? [? ih1]]. destruct X1 as [? ih2].
             eapply context_conversion'.
@@ -403,7 +406,8 @@ Qed.
               -- eapply ih2. assumption.
               -- right. eexists. eapply ih1. assumption.
               -- eapply cumul_refl.
-                 eapply eq_term_upto_impl. 3: eassumption.
+                 eapply eq_term_upto_impl. 4: eassumption.
+                 3:{ intros. constructor. }
                  all: intros ? ? [].
                  ++ eapply eq_universe_refl.
                  ++ eapply leq_universe_refl.
@@ -411,6 +415,7 @@ Qed.
               eapply eq_context_impl ; revgoals.
               -- eapply eq_context_upto_cat. 2: eassumption.
                  eapply eq_context_upto_refl. auto.
+              -- intros. constructor.
               -- intros ? ? []. eapply eq_universe_refl.
       }
       eapply type_Cumul.
@@ -440,7 +445,7 @@ Qed.
             rewrite fix_context_length. assumption.
           }
           rename types into Δ. set (Ξ := fix_context mfix') in *.
-          assert (e : eq_context_upto eq Δ Ξ).
+          assert (e : eq_context_upto eq no_η Δ Ξ).
           { eapply eq_context_upto_rev'.
             clear - a.
             unfold mapi. generalize 0 at 2 4. intro n.
@@ -479,11 +484,13 @@ Qed.
                                     ++++ eapply eq_context_upto_cat.
                                          2: eassumption.
                                          eapply eq_context_upto_refl. auto.
+                                    ++++ intros. constructor.
                                     ++++ intros ? ? []. eapply eq_universe_refl.
                        +++ eapply cumul_refl. rewrite <- el.
                            eapply eq_term_upto_lift.
                            eapply eq_term_upto_impl.
-                           3: intuition eauto.
+                           4: intuition eauto.
+                           3:{ intros. constructor. }
                            all: intros ? ? [].
                            *** eapply eq_universe_refl.
                            *** eapply leq_universe_refl.
@@ -491,6 +498,7 @@ Qed.
                        eapply eq_context_impl ; revgoals.
                        +++ eapply eq_context_upto_cat. 2: eassumption.
                            eapply eq_context_upto_refl. auto.
+                       +++ intros. constructor.
                        +++ intros ? ? []. eapply eq_universe_refl.
                 ** eapply isLambda_eq_term_l.
                    --- eassumption.
@@ -514,7 +522,7 @@ Qed.
       assert (hwf' : wf_local Σ (Γ ,,, fix_context mfix')).
       { set (Δ := fix_context mfix) in *.
         set (Ξ := fix_context mfix').
-        assert (e : eq_context_upto eq Δ Ξ).
+        assert (e : eq_context_upto eq no_η Δ Ξ).
         { eapply eq_context_upto_rev'.
           clear - a.
           unfold mapi. generalize 0 at 2 4. intro n.
@@ -541,6 +549,7 @@ Qed.
               eapply eq_context_impl ; revgoals.
               -- eapply eq_context_upto_cat. 2: eassumption.
                  eapply eq_context_upto_refl. auto.
+              -- intros. constructor.
               -- intros ? ? []. eapply eq_universe_refl.
         - simpl in *. inversion hwf. subst.
           constructor.
@@ -555,6 +564,7 @@ Qed.
               eapply eq_context_impl ; revgoals.
               -- eapply eq_context_upto_cat. 2: eassumption.
                  eapply eq_context_upto_refl. auto.
+              -- intros. constructor.
               -- intros ? ? []. eapply eq_universe_refl.
           + simpl in *. destruct X0 as [? [? ih1]]. destruct X1 as [? ih2].
             eapply context_conversion'.
@@ -564,7 +574,8 @@ Qed.
               -- eapply ih2. assumption.
               -- right. eexists. eapply ih1. assumption.
               -- eapply cumul_refl.
-                 eapply eq_term_upto_impl. 3: eassumption.
+                 eapply eq_term_upto_impl. 4: eassumption.
+                 3:{ intros. constructor. }
                  all: intros ? ? [].
                  ++ eapply eq_universe_refl.
                  ++ eapply leq_universe_refl.
@@ -572,6 +583,7 @@ Qed.
               eapply eq_context_impl ; revgoals.
               -- eapply eq_context_upto_cat. 2: eassumption.
                  eapply eq_context_upto_refl. auto.
+              -- intros. constructor.
               -- intros ? ? []. eapply eq_universe_refl.
       }
       eapply type_Cumul.
@@ -601,7 +613,7 @@ Qed.
           }
           set (Δ := fix_context mfix) in *.
           set (Ξ := fix_context mfix') in *.
-          assert (e : eq_context_upto eq Δ Ξ).
+          assert (e : eq_context_upto eq no_η Δ Ξ).
           { eapply eq_context_upto_rev'.
             clear - a.
             unfold mapi. generalize 0 at 2 4. intro n.
@@ -639,11 +651,13 @@ Qed.
                                ---- eapply eq_context_upto_cat.
                                     2: eassumption.
                                     eapply eq_context_upto_refl. auto.
+                               ---- intros. constructor.
                                ---- intros ? ? []. eapply eq_universe_refl.
                    --- eapply cumul_refl. rewrite <- el.
                        eapply eq_term_upto_lift.
                        eapply eq_term_upto_impl.
-                       3: intuition eauto.
+                       4: intuition eauto.
+                       3:{ intros. constructor. }
                        all: intros ? ? [].
                        +++ eapply eq_universe_refl.
                        +++ eapply leq_universe_refl.
@@ -651,6 +665,7 @@ Qed.
                    eapply eq_context_impl ; revgoals.
                    --- eapply eq_context_upto_cat. 2: eassumption.
                        eapply eq_context_upto_refl. auto.
+                   --- intros. constructor.
                    --- intros ? ? []. eapply eq_universe_refl.
              ++ eapply IHa.
                 ** assumption.
@@ -690,10 +705,10 @@ Qed.
 
   Local Ltac inv H := inversion H; subst; clear H.
 
-  Lemma upto_names_eq_term_upto Re Rle t u
-    : eq_term_upto Re Rle t u ->
+  Lemma upto_names_eq_term_upto Re Rle ηpred t u
+    : eq_term_upto Re Rle ηpred t u ->
       forall t' u', t ≡ t' -> u ≡ u' ->
-               eq_term_upto Re Rle t' u'.
+               eq_term_upto Re Rle ηpred t' u'.
   Proof.
     revert t u Rle. fix aux 4.
     destruct 1; cbn; intros t'' u'' H' H0';
@@ -745,9 +760,9 @@ Qed.
     intros; eapply upto_names_eq_term_upto; eassumption.
   Qed.
 
-  Definition upto_names_decl := eq_decl_upto eq.
+  Definition upto_names_decl := eq_decl_upto eq no_η.
 
-  Definition upto_names_ctx := eq_context_upto eq.
+  Definition upto_names_ctx := eq_context_upto eq no_η.
 
   Infix "≡Γ" := upto_names_ctx (at level 60).
 

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -27,14 +27,14 @@ Lemma red1_eq_context_upto_l Σ Re Γ Δ u v :
   red1 Σ Γ u v ->
   eq_context_upto Re Γ Δ ->
   ∑ v', red1 Σ Δ u v' *
-        eq_term_upto_univ Re Re v v'.
+        eq_term_upto Re Re v v'.
 Proof.
   intros he he' h e.
   induction h in Δ, e |- * using red1_ind_all.
   all: try solve [
     eexists ; split ; [
       solve [ econstructor ; eauto ]
-    | eapply eq_term_upto_univ_refl ; eauto
+    | eapply eq_term_upto_refl ; eauto
     ]
   ].
   all: try solve [
@@ -42,7 +42,7 @@ Proof.
     eexists ; split ; [
       solve [ econstructor ; eauto ]
     | constructor; eauto ;
-      eapply eq_term_upto_univ_refl ; eauto
+      eapply eq_term_upto_refl ; eauto
     ]
   ].
   all: try solve [
@@ -50,7 +50,7 @@ Proof.
     | r : red1 _ (?Γ ,, ?d) _ _ |- _ =>
       assert (e' : eq_context_upto Re (Γ,, d) (Δ,, d)) ; [
         constructor ; eauto ;
-        eapply eq_term_upto_univ_refl ; eauto
+        eapply eq_term_upto_refl ; eauto
       |
       ]
     end ;
@@ -58,12 +58,12 @@ Proof.
     eexists ; split ; [
       solve [ econstructor ; eauto ]
     | constructor ; eauto ;
-      eapply eq_term_upto_univ_refl ; eauto
+      eapply eq_term_upto_refl ; eauto
     ]
   ].
   - assert (h : ∑ b',
                 (option_map decl_body (nth_error Δ i) = Some (Some b')) *
-                eq_term_upto_univ Re Re body b').
+                eq_term_upto Re Re body b').
     { induction i in Γ, Δ, H, e |- *.
       - destruct e.
         + cbn in *. discriminate.
@@ -78,31 +78,31 @@ Proof.
     destruct h as [b' [e1 e2]].
     eexists. split.
     + constructor. eassumption.
-    + eapply eq_term_upto_univ_lift ; eauto.
+    + eapply eq_term_upto_lift ; eauto.
   - destruct (IHh _ e) as [? [? ?]].
     eexists. split.
     + solve [ econstructor ; eauto ].
     + destruct ind.
       econstructor ; eauto.
-      * eapply eq_term_upto_univ_refl ; eauto.
+      * eapply eq_term_upto_refl ; eauto.
       * eapply All2_same.
         intros. split ; eauto.
-        eapply eq_term_upto_univ_refl ; eauto.
+        eapply eq_term_upto_refl ; eauto.
   - destruct (IHh _ e) as [? [? ?]].
     eexists. split.
     + solve [ econstructor ; eauto ].
     + destruct ind.
       econstructor ; eauto.
-      * eapply eq_term_upto_univ_refl ; eauto.
+      * eapply eq_term_upto_refl ; eauto.
       * eapply All2_same.
         intros. split ; eauto.
-        eapply eq_term_upto_univ_refl ; eauto.
+        eapply eq_term_upto_refl ; eauto.
   - destruct ind.
     assert (h : ∑ brs0,
       OnOne2 (on_Trel_eq (red1 Σ Δ) snd fst) brs brs0 *
       All2 (fun x y =>
                 (fst x = fst y) *
-                eq_term_upto_univ Re Re (snd x) (snd y))%type
+                eq_term_upto Re Re (snd x) (snd y))%type
        brs' brs0
     ).
     { induction X.
@@ -117,22 +117,22 @@ Proof.
           * split ; eauto.
           * eapply All2_same.
             intros. split ; eauto.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
       - destruct IHX as [brs0 [? ?]].
         eexists. split.
         + eapply OnOne2_tl. eassumption.
         + constructor.
           * split ; eauto.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
           * eassumption.
     }
     destruct h as [? [? ?]].
     eexists. split.
     + eapply case_red_brs. eassumption.
-    + econstructor. all: try eapply eq_term_upto_univ_refl ; eauto.
+    + econstructor. all: try eapply eq_term_upto_refl ; eauto.
   - assert (h : ∑ ll,
       OnOne2 (red1 Σ Δ) l ll *
-      All2 (eq_term_upto_univ Re Re) l' ll
+      All2 (eq_term_upto Re Re) l' ll
     ).
     { induction X.
       - destruct p as [p1 p2].
@@ -143,12 +143,12 @@ Proof.
           * assumption.
           * eapply All2_same.
             intros.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
       - destruct IHX as [ll [? ?]].
         eexists. split.
         + eapply OnOne2_tl. eassumption.
         + constructor ; eauto.
-          eapply eq_term_upto_univ_refl ; eauto.
+          eapply eq_term_upto_refl ; eauto.
     }
     destruct h as [? [? ?]].
     eexists. split.
@@ -162,8 +162,8 @@ Proof.
         ) mfix0 mfix'
       *
       All2 (fun x y =>
-        eq_term_upto_univ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Re Re (dbody x) (dbody y) *
+        eq_term_upto Re Re (dtype x) (dtype y) *
+        eq_term_upto Re Re (dbody x) (dbody y) *
         (rarg x = rarg y))%type mfix1 mfix').
     { induction X.
       - destruct p as [[p1 p2] p3].
@@ -174,16 +174,16 @@ Proof.
           split ; eauto.
         + constructor.
           * simpl. repeat split ; eauto.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
           * eapply All2_same.
             intros. repeat split ; eauto.
-            all: eapply eq_term_upto_univ_refl ; eauto.
+            all: eapply eq_term_upto_refl ; eauto.
       - destruct IHX as [? [? ?]].
         eexists. split.
         + eapply OnOne2_tl. eassumption.
         + constructor ; eauto.
           repeat split ; eauto.
-          all: eapply eq_term_upto_univ_refl ; eauto.
+          all: eapply eq_term_upto_refl ; eauto.
     }
     destruct h as [? [? ?]].
     eexists. split.
@@ -196,8 +196,8 @@ Proof.
           (d'.(dname), d'.(dtype), d'.(rarg))
         ) mfix0 mfix' *
       All2 (fun x y =>
-        eq_term_upto_univ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Re Re (dbody x) (dbody y) *
+        eq_term_upto Re Re (dtype x) (dtype y) *
+        eq_term_upto Re Re (dbody x) (dbody y) *
         (rarg x = rarg y))%type mfix1 mfix').
     { (* Maybe we should use a lemma using firstn or skipn to keep
          fix_context intact. Anything general?
@@ -213,7 +213,7 @@ Proof.
         × (forall Δ : context,
            eq_context_upto Re (Γ ,,, fix_context L) Δ ->
            ∑ v' : term,
-             red1 Σ Δ (dbody x) v' × eq_term_upto_univ Re Re (dbody y) v'))
+             red1 Σ Δ (dbody x) v' × eq_term_upto Re Re (dbody y) v'))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix0) mfix0 mfix1
       ) in X.
       Fail induction X using OnOne2_ind_l.
@@ -223,7 +223,7 @@ Proof.
      × (forall Δ0 : context,
         eq_context_upto Re (Γ ,,, fix_context L) Δ0 ->
         ∑ v' : term,
-          red1 Σ Δ0 (dbody x) v' × eq_term_upto_univ Re Re (dbody y) v'))
+          red1 Σ Δ0 (dbody x) v' × eq_term_upto Re Re (dbody y) v'))
     × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)))
   (fun L mfix0 mfix1 o => ∑ mfix' : list (def term),
   OnOne2
@@ -232,8 +232,8 @@ Proof.
        × (dname d, dtype d, rarg d) = (dname d', dtype d', rarg d')) mfix0 mfix'
     × All2
         (fun x y : def term =>
-         (eq_term_upto_univ Re Re (dtype x) (dtype y)
-          × eq_term_upto_univ Re Re (dbody x) (dbody y)) ×
+         (eq_term_upto Re Re (dtype x) (dtype y)
+          × eq_term_upto Re Re (dbody x) (dbody y)) ×
          rarg x = rarg y) mfix1 mfix') _ _).
       - intros L x y l [[p1 p2] p3].
         assert (
@@ -249,16 +249,16 @@ Proof.
           split ; eauto.
         + constructor.
           * simpl. repeat split ; eauto.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
           * eapply All2_same. intros.
             repeat split ; eauto.
-            all: eapply eq_term_upto_univ_refl ; eauto.
+            all: eapply eq_term_upto_refl ; eauto.
       - intros L x l l' h [? [? ?]].
         eexists. constructor.
         + eapply OnOne2_tl. eassumption.
         + constructor ; eauto.
           repeat split ; eauto.
-          all: eapply eq_term_upto_univ_refl ; eauto.
+          all: eapply eq_term_upto_refl ; eauto.
     }
     destruct h as [? [? ?]].
     eexists. split.
@@ -271,8 +271,8 @@ Proof.
           (d'.(dname), d'.(dbody), d'.(rarg))
         ) mfix0 mfix' *
       All2 (fun x y =>
-        eq_term_upto_univ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Re Re (dbody x) (dbody y) *
+        eq_term_upto Re Re (dtype x) (dtype y) *
+        eq_term_upto Re Re (dbody x) (dbody y) *
         (rarg x = rarg y))%type mfix1 mfix'
     ).
     { induction X.
@@ -284,16 +284,16 @@ Proof.
           split ; eauto.
         + constructor.
           * simpl. repeat split ; eauto.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
           * eapply All2_same.
             intros. repeat split ; eauto.
-            all: eapply eq_term_upto_univ_refl ; eauto.
+            all: eapply eq_term_upto_refl ; eauto.
       - destruct IHX as [? [? ?]].
         eexists. split.
         + eapply OnOne2_tl. eassumption.
         + constructor ; eauto.
           repeat split ; eauto.
-          all: eapply eq_term_upto_univ_refl ; eauto.
+          all: eapply eq_term_upto_refl ; eauto.
     }
     destruct h as [? [? ?]].
     eexists. split.
@@ -306,8 +306,8 @@ Proof.
           (d'.(dname), d'.(dtype), d'.(rarg))
         ) mfix0 mfix' *
       All2 (fun x y =>
-        eq_term_upto_univ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Re Re (dbody x) (dbody y) *
+        eq_term_upto Re Re (dtype x) (dtype y) *
+        eq_term_upto Re Re (dbody x) (dbody y) *
         (rarg x = rarg y))%type mfix1 mfix').
     { (* Maybe we should use a lemma using firstn or skipn to keep
          fix_context intact. Anything general?
@@ -323,7 +323,7 @@ Proof.
         × (forall Δ : context,
            eq_context_upto Re (Γ ,,, fix_context L) Δ ->
            ∑ v' : term,
-             red1 Σ Δ (dbody x) v' × eq_term_upto_univ Re Re (dbody y) v' ))
+             red1 Σ Δ (dbody x) v' × eq_term_upto Re Re (dbody y) v' ))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix0) mfix0 mfix1
       ) in X.
       Fail induction X using OnOne2_ind_l.
@@ -333,7 +333,7 @@ Proof.
      × (forall Δ0 : context,
         eq_context_upto Re (Γ ,,, fix_context L) Δ0 ->
         ∑ v' : term,
-           red1 Σ Δ0 (dbody x) v' × eq_term_upto_univ Re Re (dbody y) v' ))
+           red1 Σ Δ0 (dbody x) v' × eq_term_upto Re Re (dbody y) v' ))
     × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) (fun L mfix0 mfix1 o => ∑ mfix' : list (def term),
   (OnOne2
       (fun d d' : def term =>
@@ -341,8 +341,8 @@ Proof.
        × (dname d, dtype d, rarg d) = (dname d', dtype d', rarg d')) mfix0 mfix'
     × All2
         (fun x y : def term =>
-         (eq_term_upto_univ Re Re (dtype x) (dtype y)
-          × eq_term_upto_univ Re Re (dbody x) (dbody y)) ×
+         (eq_term_upto Re Re (dtype x) (dtype y)
+          × eq_term_upto Re Re (dbody x) (dbody y)) ×
          rarg x = rarg y) mfix1 mfix')) _ _).
       - intros L x y l [[p1 p2] p3].
         assert (
@@ -358,16 +358,16 @@ Proof.
           split ; eauto.
         + constructor.
           * simpl. repeat split ; eauto.
-            eapply eq_term_upto_univ_refl ; eauto.
+            eapply eq_term_upto_refl ; eauto.
           * eapply All2_same. intros.
             repeat split ; eauto.
-            all: eapply eq_term_upto_univ_refl ; eauto.
+            all: eapply eq_term_upto_refl ; eauto.
       - intros L x l l' h [? [? ?]].
         eexists. constructor.
         + eapply OnOne2_tl. eassumption.
         + constructor ; eauto.
           repeat split ; eauto.
-          all: eapply eq_term_upto_univ_refl ; eauto.
+          all: eapply eq_term_upto_refl ; eauto.
     }
     destruct h as [? [? ?]].
     eexists. split.
@@ -376,17 +376,17 @@ Proof.
 Qed.
 
 
-Lemma red1_eq_term_upto_univ_l Σ Re Rle Γ u v u' :
+Lemma red1_eq_term_upto_l Σ Re Rle Γ u v u' :
   RelationClasses.Reflexive Re ->
   SubstUnivPreserving Re ->
   RelationClasses.Reflexive Rle ->
   RelationClasses.Transitive Re ->
   RelationClasses.Transitive Rle ->
   RelationClasses.subrelation Re Rle ->
-  eq_term_upto_univ Re Rle u u' ->
+  eq_term_upto Re Rle u u' ->
   red1 Σ Γ u v ->
   ∑ v', red1 Σ Γ u' v' *
-        eq_term_upto_univ Re Rle v v'.
+        eq_term_upto Re Rle v v'.
 Proof.
   unfold RelationClasses.subrelation.
   intros he he' hle tRe tRle hR e h.
@@ -406,7 +406,7 @@ Proof.
     clear h ;
     lazymatch goal with
     | r : red1 _ (?Γ,, vass ?na ?A) ?u ?v,
-      e : eq_term_upto_univ _ _ ?A ?B
+      e : eq_term_upto _ _ ?A ?B
       |- _ =>
       let hh := fresh "hh" in
       eapply red1_eq_context_upto_l in r as hh ; revgoals ; [
@@ -422,35 +422,35 @@ Proof.
     eexists ; split ; [
       solve [ econstructor ; eauto ]
     | constructor ; eauto ;
-      eapply eq_term_upto_univ_trans ; eauto ;
-      eapply eq_term_upto_univ_leq ; eauto
+      eapply eq_term_upto_trans ; eauto ;
+      eapply eq_term_upto_leq ; eauto
     ]
   ].
   - dependent destruction e. dependent destruction e1.
     eexists. split.
     + constructor.
-    + eapply eq_term_upto_univ_subst ; eauto.
+    + eapply eq_term_upto_subst ; eauto.
   - dependent destruction e.
     eexists. split.
     + constructor.
-    + eapply eq_term_upto_univ_subst ; assumption.
+    + eapply eq_term_upto_subst ; assumption.
   - dependent destruction e.
     eexists. split.
     + constructor. eassumption.
-    + eapply eq_term_upto_univ_refl ; assumption.
+    + eapply eq_term_upto_refl ; assumption.
   - dependent destruction e.
-    apply eq_term_upto_univ_mkApps_l_inv in e2 as [? [? [[h1 h2] h3]]]. subst.
+    apply eq_term_upto_mkApps_l_inv in e2 as [? [? [[h1 h2] h3]]]. subst.
     dependent destruction h1.
     eexists. split.
     + constructor.
-    + eapply eq_term_upto_univ_mkApps.
+    + eapply eq_term_upto_mkApps.
       * eapply All2_nth
-          with (P := fun x y => eq_term_upto_univ Re Rle (snd x) (snd y)).
+          with (P := fun x y => eq_term_upto Re Rle (snd x) (snd y)).
         -- solve_all.
-           eapply eq_term_upto_univ_leq ; eauto.
-        -- cbn. eapply eq_term_upto_univ_refl ; eauto.
+           eapply eq_term_upto_leq ; eauto.
+        -- cbn. eapply eq_term_upto_refl ; eauto.
       * eapply All2_skipn. assumption.
-  - apply eq_term_upto_univ_mkApps_l_inv in e as [? [? [[h1 h2] h3]]]. subst.
+  - apply eq_term_upto_mkApps_l_inv in e as [? [? [[h1 h2] h3]]]. subst.
     dependent destruction h1.
     unfold unfold_fix in H.
     case_eq (nth_error mfix idx) ;
@@ -472,9 +472,9 @@ Proof.
         erewrite isLambda_eq_term_l; eauto.
       * unfold is_constructor. rewrite <- erarg. rewrite ea'.
         eapply isConstruct_app_eq_term_l ; eassumption.
-    + eapply eq_term_upto_univ_mkApps.
-      * eapply eq_term_upto_univ_substs ; eauto.
-        -- eapply eq_term_upto_univ_leq ; eauto.
+    + eapply eq_term_upto_mkApps.
+      * eapply eq_term_upto_substs ; eauto.
+        -- eapply eq_term_upto_leq ; eauto.
         -- unfold fix_subst.
            apply All2_length in a as el. rewrite <- el.
            generalize #|mfix|. intro n.
@@ -484,7 +484,7 @@ Proof.
               constructor. assumption.
       * assumption.
   - dependent destruction e.
-    apply eq_term_upto_univ_mkApps_l_inv in e2 as [? [? [[h1 h2] h3]]]. subst.
+    apply eq_term_upto_mkApps_l_inv in e2 as [? [? [[h1 h2] h3]]]. subst.
     dependent destruction h1.
     unfold unfold_cofix in H.
     case_eq (nth_error mfix idx) ;
@@ -496,8 +496,8 @@ Proof.
     + eapply red_cofix_case.
       unfold unfold_cofix. rewrite e'. reflexivity.
     + constructor. all: eauto.
-      eapply eq_term_upto_univ_mkApps. all: eauto.
-      eapply eq_term_upto_univ_substs ; eauto; try exact _.
+      eapply eq_term_upto_mkApps. all: eauto.
+      eapply eq_term_upto_substs ; eauto; try exact _.
       unfold cofix_subst.
       apply All2_length in a0 as el. rewrite <- el.
       generalize #|mfix|. intro n.
@@ -506,7 +506,7 @@ Proof.
       * constructor ; eauto.
         constructor. assumption.
   - dependent destruction e.
-    apply eq_term_upto_univ_mkApps_l_inv in e as [? [? [[h1 h2] h3]]]. subst.
+    apply eq_term_upto_mkApps_l_inv in e as [? [? [[h1 h2] h3]]]. subst.
     dependent destruction h1.
     unfold unfold_cofix in H.
     case_eq (nth_error mfix idx) ;
@@ -518,8 +518,8 @@ Proof.
     + eapply red_cofix_proj.
       unfold unfold_cofix. rewrite e'. reflexivity.
     + constructor.
-      eapply eq_term_upto_univ_mkApps. all: eauto.
-      eapply eq_term_upto_univ_substs ; eauto; try exact _.
+      eapply eq_term_upto_mkApps. all: eauto.
+      eapply eq_term_upto_substs ; eauto; try exact _.
       unfold cofix_subst.
       apply All2_length in a as el. rewrite <- el.
       generalize #|mfix|. intro n.
@@ -530,23 +530,23 @@ Proof.
   - dependent destruction e.
     eexists. split.
     + econstructor. all: eauto.
-    + eapply eq_term_upto_univ_leq; tas.
-      now apply eq_term_upto_univ_subst_instance_constr.
+    + eapply eq_term_upto_leq; tas.
+      now apply eq_term_upto_subst_instance_constr.
   - dependent destruction e.
-    apply eq_term_upto_univ_mkApps_l_inv in e as [? [? [[h1 h2] h3]]]. subst.
+    apply eq_term_upto_mkApps_l_inv in e as [? [? [[h1 h2] h3]]]. subst.
     dependent destruction h1.
     eapply All2_nth_error_Some in h2 as hh ; try eassumption.
     destruct hh as [arg' [e' ?]].
     eexists. split.
     + constructor. eassumption.
-    + eapply eq_term_upto_univ_leq ; eauto.
+    + eapply eq_term_upto_leq ; eauto.
   - dependent destruction e.
     edestruct IHh as [? [? ?]] ; [ .. | eassumption | ] ; eauto.
     clear h.
     lazymatch goal with
     | r : red1 _ (?Γ,, vdef ?na ?a ?A) ?u ?v,
-      e1 : eq_term_upto_univ _ _ ?A ?B,
-      e2 : eq_term_upto_univ _ _ ?a ?b
+      e1 : eq_term_upto _ _ ?A ?B,
+      e2 : eq_term_upto _ _ ?a ?b
       |- _ =>
       let hh := fresh "hh" in
       eapply red1_eq_context_upto_l in r as hh ; revgoals ; [
@@ -563,14 +563,14 @@ Proof.
     eexists. split.
     + eapply letin_red_body ; eauto.
     + constructor ; eauto.
-      eapply eq_term_upto_univ_trans ; eauto.
-      eapply eq_term_upto_univ_leq ; eauto.
+      eapply eq_term_upto_trans ; eauto.
+      eapply eq_term_upto_leq ; eauto.
   - dependent destruction e.
     assert (h : ∑ brs0,
                OnOne2 (on_Trel_eq (red1 Σ Γ) snd fst) brs'0 brs0 *
                All2 (fun x y =>
                        (fst x = fst y) *
-                       (eq_term_upto_univ Re Re (snd x) (snd y))
+                       (eq_term_upto Re Re (snd x) (snd y))
                        )%type brs' brs0
            ).
     { induction X in a, brs'0 |- *.
@@ -596,7 +596,7 @@ Proof.
   - dependent destruction e.
     assert (h : ∑ args,
                OnOne2 (red1 Σ Γ) args' args *
-               All2 (eq_term_upto_univ Re Re) l' args
+               All2 (eq_term_upto Re Re) l' args
            ).
     { induction X in a, args' |- *.
       - destruct p as [p1 p2].
@@ -624,8 +624,8 @@ Proof.
                    (d1.(dname), d1.(dbody), d1.(rarg))
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg)))%type mfix1 mfix
            ).
     { induction X in a, mfix' |- *.
@@ -658,8 +658,8 @@ Proof.
                    (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg))
                ) mfix1 mfix
            ).
@@ -669,14 +669,14 @@ Proof.
            RelationClasses.Reflexive Rle ->
            RelationClasses.Transitive Rle ->
            (forall u u'0 : universe, Re u u'0 -> Rle u u'0) ->
-           eq_term_upto_univ Re Rle (dbody x) u' ->
+           eq_term_upto Re Rle (dbody x) u' ->
            ∑ v' : term,
              red1 Σ (Γ ,,, fix_context L) u' v'
-                  × eq_term_upto_univ Re Rle (dbody y) v' ))
+                  × eq_term_upto Re Rle (dbody y) v' ))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) (fun L mfix0 mfix1 o => forall mfix', All2
       (fun x y : def term =>
-       (eq_term_upto_univ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Re Re (dbody x) (dbody y)) ×
+       (eq_term_upto Re Re (dtype x) (dtype y)
+        × eq_term_upto Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) mfix0 mfix' -> ∑ mfix : list (def term),
   ( OnOne2
       (fun x y : def term =>
@@ -684,8 +684,8 @@ Proof.
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix' mfix ) *
   ( All2
       (fun x y : def term =>
-       (eq_term_upto_univ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Re Re (dbody x) (dbody y)) ×
+       (eq_term_upto Re Re (dtype x) (dtype y)
+        × eq_term_upto Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) mfix1 mfix )) _ _ _ _ X).
       - clear X. intros L x y l [[p1 p2] p3] mfix' h.
         dependent destruction h. destruct p as [[h1 h2] h3].
@@ -713,8 +713,8 @@ Proof.
                   (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                ) mfix' mfix ×
         All2 (fun x y =>
-                eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-                eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+                eq_term_upto Re Re x.(dtype) y.(dtype) *
+                eq_term_upto Re Re x.(dbody) y.(dbody) *
                 (x.(rarg) = y.(rarg))
              ) mfix1 mfix %type
     ).
@@ -735,11 +735,11 @@ Proof.
             constructor.
             * intros i. split.
               -- cbn. constructor.
-              -- cbn. eapply eq_term_upto_univ_lift. eauto.
+              -- cbn. eapply eq_term_upto_lift. eauto.
             * eapply All2_impl ; eauto.
               intros ? ? [[? ?] ?] i. split.
               -- cbn. constructor.
-              -- cbn. eapply eq_term_upto_univ_lift. eauto.
+              -- cbn. eapply eq_term_upto_lift. eauto.
       }
       clear a.
       eapply OnOne2_impl_exist_and_All ; try eassumption.
@@ -753,7 +753,7 @@ Proof.
       intuition eauto.
       intuition eauto.
       - rewrite H1. eauto.
-      - eapply eq_term_upto_univ_trans ; eassumption.
+      - eapply eq_term_upto_trans ; eassumption.
       - etransitivity ; eauto.
     }
     destruct h as [? [? ?]].
@@ -768,8 +768,8 @@ Proof.
                    (d1.(dname), d1.(dbody), d1.(rarg))
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg)))%type mfix1 mfix
            ).
     { induction X in a, mfix' |- *.
@@ -802,8 +802,8 @@ Proof.
                    (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg))
                ) mfix1 mfix
            ).
@@ -813,14 +813,14 @@ Proof.
            RelationClasses.Reflexive Rle ->
            RelationClasses.Transitive Rle ->
            (forall u u'0 : universe, Re u u'0 -> Rle u u'0) ->
-           eq_term_upto_univ Re Rle (dbody x) u' ->
+           eq_term_upto Re Rle (dbody x) u' ->
            ∑ v' : term,
              red1 Σ (Γ ,,, fix_context L) u' v'
-               × eq_term_upto_univ Re Rle (dbody y) v'))
+               × eq_term_upto Re Rle (dbody y) v'))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) (fun L mfix0 mfix1 o => forall mfix', All2
       (fun x y : def term =>
-       (eq_term_upto_univ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Re Re (dbody x) (dbody y)) ×
+       (eq_term_upto Re Re (dtype x) (dtype y)
+        × eq_term_upto Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) mfix0 mfix' -> ∑ mfix : list (def term),
   ( OnOne2
       (fun x y : def term =>
@@ -828,8 +828,8 @@ Proof.
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix' mfix ) *
   ( All2
       (fun x y : def term =>
-       (eq_term_upto_univ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Re Re (dbody x) (dbody y)) ×
+       (eq_term_upto Re Re (dtype x) (dtype y)
+        × eq_term_upto Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) mfix1 mfix )) _ _ _ _ X).
       - clear X. intros L x y l [[p1 p2] p3] mfix' h.
         dependent destruction h. destruct p as [[h1 h2] h3].
@@ -856,8 +856,8 @@ Proof.
                   (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                ) mfix' mfix ×
         All2 (fun x y =>
-                eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-                eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+                eq_term_upto Re Re x.(dtype) y.(dtype) *
+                eq_term_upto Re Re x.(dbody) y.(dbody) *
                 (x.(rarg) = y.(rarg))
              ) mfix1 mfix
     ).
@@ -878,11 +878,11 @@ Proof.
             constructor.
             * intros i. split.
               -- cbn. constructor.
-              -- cbn. eapply eq_term_upto_univ_lift. eauto.
+              -- cbn. eapply eq_term_upto_lift. eauto.
             * eapply All2_impl ; eauto.
               intros ? ? [[? ?] ?] i. split.
               -- cbn. constructor.
-              -- cbn. eapply eq_term_upto_univ_lift. eauto.
+              -- cbn. eapply eq_term_upto_lift. eauto.
       }
       clear a.
       eapply OnOne2_impl_exist_and_All ; try eassumption.
@@ -895,7 +895,7 @@ Proof.
       instantiate (1 := mkdef _ _ _ _ _). simpl.
       intuition eauto.
       - rewrite H1. eauto.
-      - eapply eq_term_upto_univ_trans ; eassumption.
+      - eapply eq_term_upto_trans ; eassumption.
       - etransitivity ; eauto.
     }
     destruct h as [? [? ?]].
@@ -911,16 +911,16 @@ Lemma red1_eq_context_upto_r Σ Re Γ Δ u v :
   red1 Σ Γ u v ->
   eq_context_upto Re Δ Γ ->
   ∑ v', red1 Σ Δ u v' *
-        eq_term_upto_univ Re Re v' v.
+        eq_term_upto Re Re v' v.
 Proof.
   intros.
   destruct (red1_eq_context_upto_l Σ Re Γ Δ u v); auto.
   now apply eq_context_upto_sym.
   exists x. intuition auto.
-  now eapply eq_term_upto_univ_sym.
+  now eapply eq_term_upto_sym.
 Qed.
 
-Lemma red1_eq_term_upto_univ_r Σ Re Rle Γ u v u' :
+Lemma red1_eq_term_upto_r Σ Re Rle Γ u v u' :
   RelationClasses.Reflexive Re ->
   SubstUnivPreserving Re ->
   RelationClasses.Reflexive Rle ->
@@ -928,18 +928,18 @@ Lemma red1_eq_term_upto_univ_r Σ Re Rle Γ u v u' :
   RelationClasses.Transitive Re ->
   RelationClasses.Transitive Rle ->
   RelationClasses.subrelation Re Rle ->
-  eq_term_upto_univ Re Rle u' u ->
+  eq_term_upto Re Rle u' u ->
   red1 Σ Γ u v ->
   ∑ v', red1 Σ Γ u' v' ×
-        eq_term_upto_univ Re Rle v' v.
+        eq_term_upto Re Rle v' v.
 Proof.
   intros he he' hle tRe tRle hR e h uv.
-  destruct (red1_eq_term_upto_univ_l Σ Re (flip Rle) Γ u v u'); auto.
+  destruct (red1_eq_term_upto_l Σ Re (flip Rle) Γ u v u'); auto.
   - now eapply flip_Transitive.
   - intros x y X. symmetry in X. apply e. auto.
-  - eapply eq_term_upto_univ_flip; eauto.
+  - eapply eq_term_upto_flip; eauto.
   - exists x. intuition auto.
-    eapply (eq_term_upto_univ_flip Re (flip Rle) Rle); eauto.
+    eapply (eq_term_upto_flip Re (flip Rle) Rle); eauto.
     + now eapply flip_Transitive.
     + unfold flip. intros ? ? H. symmetry in H. eauto.
 Qed.
@@ -955,14 +955,14 @@ Section RedEq.
           {trle : RelationClasses.Transitive Rle}.
   Context (inclre : RelationClasses.subrelation Re Rle).
 
-  Lemma red_eq_term_upto_univ_r {Γ T V U} :
-    eq_term_upto_univ Re Rle T U -> red Σ Γ U V ->
-    ∑ T', red Σ Γ T T' * eq_term_upto_univ Re Rle T' V.
+  Lemma red_eq_term_upto_r {Γ T V U} :
+    eq_term_upto Re Rle T U -> red Σ Γ U V ->
+    ∑ T', red Σ Γ T T' * eq_term_upto Re Rle T' V.
   Proof.
     intros eq r.
     apply red_alt in r.
     induction r in T, eq |- *.
-    - eapply red1_eq_term_upto_univ_r in eq as [v' [r' eq']]; eauto.
+    - eapply red1_eq_term_upto_r in eq as [v' [r' eq']]; eauto.
     - exists T; split; eauto.
     - case: (IHr1 _ eq) => T' [r' eq'].
       case: (IHr2 _ eq') => T'' [r'' eq''].
@@ -970,17 +970,17 @@ Section RedEq.
       now transitivity T'.
   Qed.
 
-  Lemma red_eq_term_upto_univ_l {Γ u v u'} :
-    eq_term_upto_univ Re Rle u u' ->
+  Lemma red_eq_term_upto_l {Γ u v u'} :
+    eq_term_upto Re Rle u u' ->
     red Σ Γ u v ->
     ∑ v',
     red Σ Γ u' v' *
-    eq_term_upto_univ Re Rle v v'.
+    eq_term_upto Re Rle v v'.
   Proof.
     intros eq r.
     eapply red_alt in r.
     induction r in u', eq |- *.
-    - eapply red1_eq_term_upto_univ_l in eq as [v' [r' eq']]; eauto.
+    - eapply red1_eq_term_upto_l in eq as [v' [r' eq']]; eauto.
     - exists u'. split; auto.
     - case: (IHr1 _ eq) => T' [r' eq'].
       case: (IHr2 _ eq') => T'' [r'' eq''].
@@ -2735,8 +2735,8 @@ Proof.
   eapply conv_alt_red in X1 as [u'' [v' [[uu'' vv'] eq']]].
   eapply conv_alt_red.
   destruct (red_confluence wfΣ uu' uu'') as [u'nf [ul ur]].
-  eapply red_eq_term_upto_univ_r in ul as [tnf [redtnf ?]]; tea; tc.
-  eapply red_eq_term_upto_univ_l in ur as [unf [redunf ?]]; tea; tc.
+  eapply red_eq_term_upto_r in ul as [tnf [redtnf ?]]; tea; tc.
+  eapply red_eq_term_upto_l in ur as [unf [redunf ?]]; tea; tc.
   exists tnf, unf.
   intuition auto.
   now transitivity t'.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -349,10 +349,10 @@ Section ContextConversion.
   Proof.
     intros tu tt' uu'.
     pose proof tu as tu2.
-    eapply red_eq_term_upto_univ_l in tu; try exact tt'; tc.
+    eapply red_eq_term_upto_l in tu; try exact tt'; tc.
     destruct tu as [u'' [uu'' t'u'']].
     destruct (red_confluence wfΣ uu' uu'') as [unf [ul ur]].
-    eapply red_eq_term_upto_univ_r in t'u''; try exact ur; tc.
+    eapply red_eq_term_upto_r in t'u''; try exact ur; tc.
     destruct t'u'' as [t'' [t't'' t''unf]].
     exists t'', unf. intuition auto.
   Qed.
@@ -363,10 +363,10 @@ Section ContextConversion.
   Proof.
     intros tu tt' uu'.
     pose proof tu as tu2.
-    eapply red_eq_term_upto_univ_l in tu; try exact tt'; tc.
+    eapply red_eq_term_upto_l in tu; try exact tt'; tc.
     destruct tu as [u'' [uu'' t'u'']].
     destruct (red_confluence wfΣ uu' uu'') as [unf [ul ur]].
-    eapply red_eq_term_upto_univ_r in t'u''; try exact ur; tc.
+    eapply red_eq_term_upto_r in t'u''; try exact ur; tc.
     destruct t'u'' as [t'' [t't'' t''unf]].
     exists t'', unf. intuition auto.
   Qed.
@@ -380,11 +380,11 @@ Section ContextConversion.
     apply cumul_alt in H as [v [v' [[redl redr] leq]]].
     destruct (red_red_ctx Σ wfΣ redl Hctx) as [lnf [redl0 redr0]].
     apply cumul_alt.
-    eapply red_eq_term_upto_univ_l in leq; tea; tc.
+    eapply red_eq_term_upto_l in leq; tea; tc.
     destruct leq as [? [? ?]].
     destruct (red_red_ctx _ wfΣ redr Hctx) as [rnf [redl1 redr1]].
     destruct (red_confluence wfΣ r redr1). destruct p.
-    edestruct (red_eq_term_upto_univ_r Σ (eq_universe_leq_universe _) e r0) as [lnf' [? ?]].
+    edestruct (red_eq_term_upto_r Σ (eq_universe_leq_universe _) e r0) as [lnf' [? ?]].
     exists lnf', x0. intuition auto. now transitivity lnf.
     now transitivity rnf.
   Qed.
@@ -429,7 +429,7 @@ Section ContextConversion.
     eq_context_upto Re Γ Δ ->
     ∑ v',
     red Σ Δ u v' *
-    eq_term_upto_univ Re Re v v'.
+    eq_term_upto Re Re v v'.
   Proof.
     intros r HΓ.
     eapply red_alt in r.
@@ -439,11 +439,11 @@ Section ContextConversion.
     - exists x. split; auto. reflexivity.
     - destruct IHr1 as [v' [? ?]].
       destruct IHr2 as [v'' [? ?]].
-      unshelve eapply (red_eq_term_upto_univ_l Σ _ (u:=y) (v:=v'') (u':=v')) in e; tc. all:pcuic.
+      unshelve eapply (red_eq_term_upto_l Σ _ (u:=y) (v:=v'') (u':=v')) in e; tc. all:pcuic.
       destruct e as [? [? ?]].
       exists x0; split; eauto.
       now transitivity v'.
-      eapply eq_term_upto_univ_trans with v''; auto.
+      eapply eq_term_upto_trans with v''; auto.
   Qed.
 
   Definition eq_universe_leq_universe' φ u u'
@@ -463,9 +463,9 @@ Section ContextConversion.
     eapply cumul_alt in X as [t0 [u0 [[redl redr] eq]]].
     eapply cumul_alt in X0 as [u1 [v0 [[redl' redr'] eq']]].
     destruct (red_confluence wfΣ redr redl') as [unf [nfl nfr]].
-    eapply red_eq_term_upto_univ_r in eq; tc;eauto with pcuic.
+    eapply red_eq_term_upto_r in eq; tc;eauto with pcuic.
     destruct eq as [t1 [red'0 eq2]].
-    eapply red_eq_term_upto_univ_l in eq'; tc;eauto with pcuic.
+    eapply red_eq_term_upto_l in eq'; tc;eauto with pcuic.
     destruct eq' as [v1 [red'1 eq1]].
     exists t1, unf, v1.
     repeat split.
@@ -560,7 +560,7 @@ Section ContextConversion.
       split; [split|]; constructor; auto.
       + red.
         eapply PCUICConfluence.red_red_ctx; eauto.
-      + eapply eq_term_upto_univ_trans with U'; eauto; tc.
+      + eapply eq_term_upto_trans with U'; eauto; tc.
     - destruct IHHctx as [Δ [Δ' [[? ?] ?]]].
       depelim p.
       + pose proof (conv_alt_red_ctx c r).
@@ -573,7 +573,7 @@ Section ContextConversion.
         exists (Δ ,, vdef na' t T'), (Δ' ,, vdef na' t x0).
         split; [split|]; constructor; auto. red. split; auto. red. split; auto.
         eapply PCUICConfluence.red_red_ctx; eauto. reflexivity.
-        eapply eq_term_upto_univ_trans with U'; eauto; tc.
+        eapply eq_term_upto_trans with U'; eauto; tc.
       + pose proof (conv_alt_red_ctx c r).
         eapply conv_alt_red in X.
         destruct X as [t' [u' [[? ?] ?]]].
@@ -594,8 +594,8 @@ Section ContextConversion.
         * red. split.
           -- eapply PCUICConfluence.red_red_ctx; eauto.
           -- eapply PCUICConfluence.red_red_ctx; eauto.
-        * eapply eq_term_upto_univ_trans with u'; eauto; tc.
-        * eapply eq_term_upto_univ_trans with U'; eauto; tc.
+        * eapply eq_term_upto_trans with u'; eauto; tc.
+        * eapply eq_term_upto_trans with U'; eauto; tc.
   Qed.
 
   Lemma conv_alt_conv_ctx Γ Γ' T U :
@@ -629,7 +629,7 @@ Section ContextConversion.
     conv_context Γ' Γ ->
     Σ ;;; Γ' |- T <= U.
   Proof.
-    intros H Hctx. 
+    intros H Hctx.
     apply conv_context_red_context in Hctx => //.
     destruct Hctx as [Δ [Δ' [[l r] elr]]].
     eapply cumul_red_ctx_inv in l; eauto.
@@ -695,13 +695,13 @@ Proof.
   depelim X2; depelim X3; try constructor; auto.
   * eapply conv_alt_trans; eauto.
     eapply conv_alt_conv_ctx => //. apply c0.
-    apply conv_context_sym => //. 
+    apply conv_context_sym => //.
   * eapply conv_alt_trans; eauto.
     eapply conv_alt_conv_ctx => //. apply c0.
-    apply conv_context_sym => //. 
+    apply conv_context_sym => //.
   * eapply conv_alt_trans; eauto.
     eapply conv_alt_conv_ctx => //. apply c0.
-    apply conv_context_sym => //. 
+    apply conv_context_sym => //.
   * eapply conv_alt_trans; eauto.
     eapply conv_alt_conv_ctx => //; eauto.
     apply conv_context_sym => //.
@@ -755,12 +755,12 @@ Proof.
   - constructor.
   - constructor; tas.
     constructor. eapply conv_alt_refl.
-    eapply eq_term_upto_univ_impl; tea.
+    eapply eq_term_upto_impl; tea.
   - constructor; tas.
     constructor. eapply conv_alt_refl.
-    eapply eq_term_upto_univ_impl; tea.
+    eapply eq_term_upto_impl; tea.
     eapply conv_alt_refl.
-    eapply eq_term_upto_univ_impl; tea.
+    eapply eq_term_upto_impl; tea.
 Qed.
 
 Lemma eq_context_upto_univ_conv_context {cf:checker_flags} Σ Γ Δ :
@@ -944,7 +944,7 @@ Proof.
   eapply typing_wf_local. eassumption.
 Qed.
 
-(* 
+(*
 Lemma conv_isWfArity_or_Type {cf:checker_flags} Σ Γ Γ' T U :
 wf Σ.1  ->
 conv_context Σ Γ' Γ ->

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -29,9 +29,9 @@ Proof.
   eapply cumul_alt in X0 as [w [w' [[redl' redr'] eq']]].
   destruct (red_confluence wfΣ redr redl') as [nf [nfl nfr]].
   eapply cumul_alt.
-  eapply red_eq_term_upto_univ_r in eq; tc;eauto with pcuic.
+  eapply red_eq_term_upto_r in eq; tc;eauto with pcuic.
   destruct eq as [v'0 [red'0 eq2]].
-  eapply red_eq_term_upto_univ_l in eq'; tc;eauto with pcuic.
+  eapply red_eq_term_upto_l in eq'; tc;eauto with pcuic.
   destruct eq' as [v'1 [red'1 eq1]].
   exists v'0, v'1.
   split. split; auto.
@@ -135,7 +135,7 @@ Proof.
   intros wfΣ H; depind H; auto.
   - inv l. eexists (u' {0 := t'}); intuition eauto. eapply red1_red. constructor.
     transitivity (codom {0 := t'}).
-    { constructor. eapply eq_term_upto_univ_subst; trivial. auto with pcuic. reflexivity. }
+    { constructor. eapply eq_term_upto_subst; trivial. auto with pcuic. reflexivity. }
     constructor. now eapply subst_leq_term.
   - depelim r.
     * exists u; intuition auto.
@@ -171,8 +171,8 @@ Proof.
   intros wfΣ H; depind H; auto.
   - inv l. eexists (u {0 := t0}); intuition eauto. eapply red1_red. constructor.
     transitivity (codom {0 := t0}).
-    { constructor. eapply eq_term_upto_univ_subst; trivial. auto with pcuic. reflexivity. }
-    constructor. eapply eq_term_upto_univ_subst; auto with pcuic. reflexivity.
+    { constructor. eapply eq_term_upto_subst; trivial. auto with pcuic. reflexivity. }
+    constructor. eapply eq_term_upto_subst; auto with pcuic. reflexivity.
   - specialize (IHcumul wfΣ).
     destruct IHcumul as [codom' [reddom' leq]] => //.
     exists codom'; intuition auto.
@@ -839,7 +839,7 @@ Section Inversions.
           rewrite 2!mapi_app. cbn.
           eapply eq_context_upto_cat.
           + constructor.
-            * eapply eq_term_upto_univ_refl. all: auto.
+            * eapply eq_term_upto_refl. all: auto.
             * eapply eq_context_upto_refl. auto.
           + eapply eq_context_upto_refl. auto.
       }
@@ -860,7 +860,7 @@ Section Inversions.
         * apply All2_same. intros. intuition reflexivity.
         * constructor.
           -- simpl. intuition eauto.
-             ++ eapply eq_term_upto_univ_refl.
+             ++ eapply eq_term_upto_refl.
                 all: apply eq_universe_refl.
              ++ eapply upto_names_impl. 3: assumption.
                 all: apply eq_universe_refl.
@@ -914,7 +914,7 @@ Section Inversions.
                rewrite 2!mapi_app. cbn.
                eapply eq_context_upto_cat.
                ++ constructor.
-                  ** eapply eq_term_upto_univ_refl. all: auto.
+                  ** eapply eq_term_upto_refl. all: auto.
                   ** eapply eq_context_upto_refl. auto.
                ++ eapply eq_context_upto_refl. auto.
     }

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -862,7 +862,7 @@ Section Inversions.
           -- simpl. intuition eauto.
              ++ eapply eq_term_upto_refl.
                 all: apply eq_universe_refl.
-             ++ eapply upto_names_impl. 3: assumption.
+             ++ eapply upto_names_impl. 3: eassumption.
                 all: apply eq_universe_refl.
           -- apply All2_same. intros. intuition reflexivity.
   Qed.
@@ -880,7 +880,7 @@ Section Inversions.
     intros Γ mfix mfix' idx wΣ h.
     assert (thm :
       Σ ;;; Γ |- tFix mfix idx == tFix mfix' idx ×
-      eq_context_upto eq (Γ ,,, fix_context mfix) (Γ ,,, fix_context mfix')
+      eq_context_upto eq no_η (Γ ,,, fix_context mfix) (Γ ,,, fix_context mfix')
     ).
     { apply All2_many_OnOne2 in h.
       induction h.
@@ -897,7 +897,8 @@ Section Inversions.
             intros [na ty bo ra] [na' ty' bo' ra'] [? [hh ?]].
             simpl in *. intuition eauto.
             eapply conv_alt_eq_context_upto. 2: eassumption.
-            eapply eq_context_impl. 2: eassumption.
+            eapply eq_context_impl. 3: eassumption.
+            2:{ intros. constructor. }
             intros ? ? []. eapply eq_universe_refl.
         + eapply eq_ctx_trans.
           * intros ? ? ? [] []. reflexivity.

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -55,93 +55,93 @@ Qed.
 (** ** Syntactic equality up-to universes
   We don't look at printing annotations *)
 
-Inductive eq_term_upto_univ (Re Rle : universe -> universe -> Prop) : term -> term -> Type :=
+Inductive eq_term_upto (Re Rle : universe -> universe -> Prop) : term -> term -> Type :=
 | eq_Rel n  :
-    eq_term_upto_univ Re Rle (tRel n) (tRel n)
+    eq_term_upto Re Rle (tRel n) (tRel n)
 
 | eq_Evar e args args' :
-    All2 (eq_term_upto_univ Re Re) args args' ->
-    eq_term_upto_univ Re Rle (tEvar e args) (tEvar e args')
+    All2 (eq_term_upto Re Re) args args' ->
+    eq_term_upto Re Rle (tEvar e args) (tEvar e args')
 
 | eq_Var id :
-    eq_term_upto_univ Re Rle (tVar id) (tVar id)
+    eq_term_upto Re Rle (tVar id) (tVar id)
 
 | eq_Sort s s' :
     Rle s s' ->
-    eq_term_upto_univ Re Rle (tSort s) (tSort s')
+    eq_term_upto Re Rle (tSort s) (tSort s')
 
 | eq_App t t' u u' :
-    eq_term_upto_univ Re Rle t t' ->
-    eq_term_upto_univ Re Re u u' ->
-    eq_term_upto_univ Re Rle (tApp t u) (tApp t' u')
+    eq_term_upto Re Rle t t' ->
+    eq_term_upto Re Re u u' ->
+    eq_term_upto Re Rle (tApp t u) (tApp t' u')
 
 | eq_Const c u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto_univ Re Rle (tConst c u) (tConst c u')
+    eq_term_upto Re Rle (tConst c u) (tConst c u')
 
 | eq_Ind i u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto_univ Re Rle (tInd i u) (tInd i u')
+    eq_term_upto Re Rle (tInd i u) (tInd i u')
 
 | eq_Construct i k u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto_univ Re Rle (tConstruct i k u) (tConstruct i k u')
+    eq_term_upto Re Rle (tConstruct i k u) (tConstruct i k u')
 
 | eq_Lambda na na' ty ty' t t' :
-    eq_term_upto_univ Re Re ty ty' ->
-    eq_term_upto_univ Re Rle t t' ->
-    eq_term_upto_univ Re Rle (tLambda na ty t) (tLambda na' ty' t')
+    eq_term_upto Re Re ty ty' ->
+    eq_term_upto Re Rle t t' ->
+    eq_term_upto Re Rle (tLambda na ty t) (tLambda na' ty' t')
 
 | eq_Prod na na' a a' b b' :
-    eq_term_upto_univ Re Re a a' ->
-    eq_term_upto_univ Re Rle b b' ->
-    eq_term_upto_univ Re Rle (tProd na a b) (tProd na' a' b')
+    eq_term_upto Re Re a a' ->
+    eq_term_upto Re Rle b b' ->
+    eq_term_upto Re Rle (tProd na a b) (tProd na' a' b')
 
 | eq_LetIn na na' t t' ty ty' u u' :
-    eq_term_upto_univ Re Re t t' ->
-    eq_term_upto_univ Re Re ty ty' ->
-    eq_term_upto_univ Re Rle u u' ->
-    eq_term_upto_univ Re Rle (tLetIn na t ty u) (tLetIn na' t' ty' u')
+    eq_term_upto Re Re t t' ->
+    eq_term_upto Re Re ty ty' ->
+    eq_term_upto Re Rle u u' ->
+    eq_term_upto Re Rle (tLetIn na t ty u) (tLetIn na' t' ty' u')
 
 | eq_Case indn p p' c c' brs brs' :
-    eq_term_upto_univ Re Re p p' ->
-    eq_term_upto_univ Re Re c c' ->
+    eq_term_upto Re Re p p' ->
+    eq_term_upto Re Re c c' ->
     All2 (fun x y =>
       (fst x = fst y) *
-      eq_term_upto_univ Re Re (snd x) (snd y)
+      eq_term_upto Re Re (snd x) (snd y)
     ) brs brs' ->
-    eq_term_upto_univ Re Rle (tCase indn p c brs) (tCase indn p' c' brs')
+    eq_term_upto Re Rle (tCase indn p c brs) (tCase indn p' c' brs')
 
 | eq_Proj p c c' :
-    eq_term_upto_univ Re Re c c' ->
-    eq_term_upto_univ Re Rle (tProj p c) (tProj p c')
+    eq_term_upto Re Re c c' ->
+    eq_term_upto Re Rle (tProj p c) (tProj p c')
 
 | eq_Fix mfix mfix' idx :
     All2 (fun x y =>
-      eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-      eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+      eq_term_upto Re Re x.(dtype) y.(dtype) *
+      eq_term_upto Re Re x.(dbody) y.(dbody) *
       (x.(rarg) = y.(rarg))
     ) mfix mfix' ->
-    eq_term_upto_univ Re Rle (tFix mfix idx) (tFix mfix' idx)
+    eq_term_upto Re Rle (tFix mfix idx) (tFix mfix' idx)
 
 | eq_CoFix mfix mfix' idx :
     All2 (fun x y =>
-      eq_term_upto_univ Re Re x.(dtype) y.(dtype) *
-      eq_term_upto_univ Re Re x.(dbody) y.(dbody) *
+      eq_term_upto Re Re x.(dtype) y.(dtype) *
+      eq_term_upto Re Re x.(dbody) y.(dbody) *
       (x.(rarg) = y.(rarg))
     ) mfix mfix' ->
-    eq_term_upto_univ Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
+    eq_term_upto Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
 
 
 (* ** Syntactic conversion up-to universes *)
 
 Definition eq_term `{checker_flags} φ :=
-  eq_term_upto_univ (eq_universe φ) (eq_universe φ).
+  eq_term_upto (eq_universe φ) (eq_universe φ).
 
 (* ** Syntactic cumulativity up-to universes *)
 
 Definition leq_term `{checker_flags} φ :=
-  eq_term_upto_univ (eq_universe φ) (leq_universe φ).
+  eq_term_upto (eq_universe φ) (leq_universe φ).
 
 (* TODO MOVE *)
 Lemma Forall2_same :
@@ -157,10 +157,10 @@ Proof.
     + assumption.
 Qed.
 
-Instance eq_term_upto_univ_refl Re Rle :
+Instance eq_term_upto_refl Re Rle :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
-  Reflexive (eq_term_upto_univ Re Rle).
+  Reflexive (eq_term_upto Re Rle).
 Proof.
   intros hRe hRle t.
   induction t in Rle, hRle |- * using term_forall_list_ind.
@@ -174,12 +174,12 @@ Qed.
 
 Instance eq_term_refl `{checker_flags} φ : Reflexive (eq_term φ).
 Proof.
-  apply eq_term_upto_univ_refl. all: exact _.
+  apply eq_term_upto_refl. all: exact _.
 Qed.
 
 Instance leq_term_refl `{checker_flags} φ : Reflexive (leq_term φ).
 Proof.
-  apply eq_term_upto_univ_refl; exact _.
+  apply eq_term_upto_refl; exact _.
 Qed.
 
 (* TODO MOVE *)
@@ -195,12 +195,12 @@ Proof.
   induction hl. all: auto.
 Qed.
 
-Derive Signature for eq_term_upto_univ.
+Derive Signature for eq_term_upto.
 
-Instance eq_term_upto_univ_sym Re Rle :
+Instance eq_term_upto_sym Re Rle :
   RelationClasses.Symmetric Re ->
   RelationClasses.Symmetric Rle ->
-  Symmetric (eq_term_upto_univ Re Rle).
+  Symmetric (eq_term_upto Re Rle).
 Proof.
   intros he hle u v e.
   induction u in Rle, hle, v, e |- * using term_forall_list_ind.
@@ -238,14 +238,14 @@ Qed.
 
 Instance eq_term_sym `{checker_flags} φ : Symmetric (eq_term φ).
 Proof.
-  eapply eq_term_upto_univ_sym. all: exact _.
+  eapply eq_term_upto_sym. all: exact _.
 Qed.
 
 
-Instance eq_term_upto_univ_trans Re Rle :
+Instance eq_term_upto_trans Re Rle :
   RelationClasses.Transitive Re ->
   RelationClasses.Transitive Rle ->
-  Transitive (eq_term_upto_univ Re Rle).
+  Transitive (eq_term_upto Re Rle).
 Proof.
   intros he hle u v w e1 e2.
   induction u in Rle, hle, v, w, e1, e2 |- * using term_forall_list_ind.
@@ -295,17 +295,17 @@ Qed.
 
 Instance eq_term_trans {cf:checker_flags} φ : Transitive (eq_term φ).
 Proof.
-  eapply eq_term_upto_univ_trans. all: exact _.
+  eapply eq_term_upto_trans. all: exact _.
 Qed.
 
 Instance leq_term_trans {cf:checker_flags} φ : Transitive (leq_term φ).
 Proof.
-  eapply eq_term_upto_univ_trans ; exact _.
+  eapply eq_term_upto_trans ; exact _.
 Qed.
 
 
-Instance eq_term_upto_univ_equiv Re (hRe : RelationClasses.Equivalence Re)
-  : Equivalence (eq_term_upto_univ Re Re).
+Instance eq_term_upto_equiv Re (hRe : RelationClasses.Equivalence Re)
+  : Equivalence (eq_term_upto Re Re).
 Proof.
   constructor. all: exact _.
 Defined.
@@ -350,9 +350,9 @@ Proof.
   cbn; intros ? ? [? ?]. eapply H; assumption.
 Qed.
 
-Lemma eq_term_upto_univ_antisym Re Rle (hRe : RelationClasses.Equivalence Re) :
+Lemma eq_term_upto_antisym Re Rle (hRe : RelationClasses.Equivalence Re) :
   RelationClasses.Antisymmetric _ Re Rle ->
-  Antisymmetric (eq_term_upto_univ Re Re) (eq_term_upto_univ Re Rle).
+  Antisymmetric (eq_term_upto Re Re) (eq_term_upto Re Rle).
 Proof.
   intros hR u v h h'.
   induction u in v, h, h' |- * using term_forall_list_ind.
@@ -363,14 +363,14 @@ Qed.
 Instance leq_term_antisym {cf:checker_flags} φ
   : Antisymmetric (eq_term φ) (leq_term φ).
 Proof.
-  eapply eq_term_upto_univ_antisym; exact _.
+  eapply eq_term_upto_antisym; exact _.
 Qed.
 
 
-Instance eq_term_upto_univ_impl Re Re' Rle Rle' :
+Instance eq_term_upto_impl Re Re' Rle Rle' :
   RelationClasses.subrelation Re Re' ->
   RelationClasses.subrelation Rle Rle' ->
-  subrelation (eq_term_upto_univ Re Rle) (eq_term_upto_univ Re' Rle').
+  subrelation (eq_term_upto Re Rle) (eq_term_upto Re' Rle').
 Proof.
   intros he hle t t'.
   induction t in t', Rle, Rle', hle |- * using term_forall_list_ind;
@@ -394,17 +394,17 @@ Proof.
 Qed.
 
 
-Instance eq_term_upto_univ_leq Re Rle :
+Instance eq_term_upto_leq Re Rle :
   RelationClasses.subrelation Re Rle ->
-  subrelation (eq_term_upto_univ Re Re) (eq_term_upto_univ Re Rle).
+  subrelation (eq_term_upto Re Re) (eq_term_upto Re Rle).
 Proof.
-  intros H. eapply eq_term_upto_univ_impl; exact _.
+  intros H. eapply eq_term_upto_impl; exact _.
 Qed.
 
 Instance eq_term_leq_term {cf:checker_flags} φ
   : subrelation (eq_term φ) (leq_term φ).
 Proof.
-  eapply eq_term_upto_univ_leq; exact _.
+  eapply eq_term_upto_leq; exact _.
 Qed.
 
 Instance leq_term_partial_order {cf:checker_flags} φ
@@ -418,13 +418,13 @@ Qed.
 
 Local Ltac lih :=
   lazymatch goal with
-  | ih : forall Rle v n k, eq_term_upto_univ _ _ ?u _ -> _
-    |- eq_term_upto_univ _ _ (lift _ _ ?u) _ =>
+  | ih : forall Rle v n k, eq_term_upto _ _ ?u _ -> _
+    |- eq_term_upto _ _ (lift _ _ ?u) _ =>
     eapply ih
   end.
 
-Lemma eq_term_upto_univ_lift Re Rle n k :
-  Proper (eq_term_upto_univ Re Rle ==> eq_term_upto_univ Re Rle) (lift n k).
+Lemma eq_term_upto_lift Re Rle n k :
+  Proper (eq_term_upto Re Rle ==> eq_term_upto Re Rle) (lift n k).
 Proof.
   intros u v e.
   induction u in v, n, k, e, Rle |- * using term_forall_list_ind.
@@ -446,28 +446,28 @@ Qed.
 Lemma lift_eq_term {cf:checker_flags} φ n k T U :
   eq_term φ T U -> eq_term φ (lift n k T) (lift n k U).
 Proof.
-  apply eq_term_upto_univ_lift.
+  apply eq_term_upto_lift.
 Qed.
 
 Lemma lift_leq_term {cf:checker_flags} φ n k T U :
   leq_term φ T U -> leq_term φ (lift n k T) (lift n k U).
 Proof.
-  apply eq_term_upto_univ_lift.
+  apply eq_term_upto_lift.
 Qed.
 
 
 Local Ltac sih :=
   lazymatch goal with
-  | ih : forall Rle v n x y, _ -> eq_term_upto_univ _ _ ?u _ -> _ -> _
-    |- eq_term_upto_univ _ _ (subst _ _ ?u) _ => eapply ih
+  | ih : forall Rle v n x y, _ -> eq_term_upto _ _ ?u _ -> _ -> _
+    |- eq_term_upto _ _ (subst _ _ ?u) _ => eapply ih
   end.
 
-Lemma eq_term_upto_univ_substs Re Rle :
+Lemma eq_term_upto_substs Re Rle :
   RelationClasses.subrelation Re Rle ->
   forall u v n l l',
-    eq_term_upto_univ Re Rle u v ->
-    All2 (eq_term_upto_univ Re Re) l l' ->
-    eq_term_upto_univ Re Rle (subst l n u) (subst l' n v).
+    eq_term_upto Re Rle u v ->
+    All2 (eq_term_upto Re Re) l l' ->
+    eq_term_upto Re Rle (subst l n u) (subst l' n v).
 Proof.
   unfold RelationClasses.subrelation; intros hR u v n l l' hu hl.
   induction u in v, n, l, l', hu, hl, Rle, hR |- * using term_forall_list_ind.
@@ -478,8 +478,8 @@ Proof.
       * intros t e. eapply All2_nth_error_Some in e as h ; eauto.
         destruct h as [t' [e' h]].
         rewrite e'.
-        eapply eq_term_upto_univ_lift.
-        eapply eq_term_upto_univ_leq ; eauto.
+        eapply eq_term_upto_lift.
+        eapply eq_term_upto_leq ; eauto.
       * intros h. eapply All2_nth_error_None in h as hh ; eauto.
         rewrite hh.
         apply All2_length in hl as e. rewrite <- e.
@@ -495,15 +495,15 @@ Proof.
     solve_all. now rewrite H.
 Qed.
 
-Lemma eq_term_upto_univ_subst Re Rle :
+Lemma eq_term_upto_subst Re Rle :
   RelationClasses.subrelation Re Rle ->
   forall u v n x y,
-    eq_term_upto_univ Re Rle u v ->
-    eq_term_upto_univ Re Re x y ->
-    eq_term_upto_univ Re Rle (u{n := x}) (v{n := y}).
+    eq_term_upto Re Rle u v ->
+    eq_term_upto Re Re x y ->
+    eq_term_upto Re Rle (u{n := x}) (v{n := y}).
 Proof.
   intros hR u v n x y e1 e2.
-  eapply eq_term_upto_univ_substs; eauto.
+  eapply eq_term_upto_substs; eauto.
 Qed.
 
 Lemma subst_eq_term {cf:checker_flags} φ l k T U :
@@ -511,7 +511,7 @@ Lemma subst_eq_term {cf:checker_flags} φ l k T U :
   eq_term φ (subst l k T) (subst l k U).
 Proof.
   intros Hleq.
-  eapply eq_term_upto_univ_substs; try easy.
+  eapply eq_term_upto_substs; try easy.
   now eapply All2_same.
 Qed.
 
@@ -520,7 +520,7 @@ Lemma subst_leq_term {cf:checker_flags} φ l k T U :
   leq_term φ (subst l k T) (subst l k U).
 Proof.
   intros Hleq.
-  eapply eq_term_upto_univ_substs; try easy.
+  eapply eq_term_upto_substs; try easy.
   intro; apply eq_universe_leq_universe.
   now eapply All2_same.
 Qed.
@@ -623,7 +623,7 @@ Local Ltac equspec equ h :=
 
 Local Ltac ih :=
   repeat lazymatch goal with
-  | ih : forall lequ Rle hle t', reflectT (eq_term_upto_univ _ _ ?t _) _,
+  | ih : forall lequ Rle hle t', reflectT (eq_term_upto _ _ ?t _) _,
     hle : forall u u', reflectT (?Rle u u') (?lequ u u')
     |- context [ eqb_term_upto_univ _ ?lequ ?t ?t' ] =>
     destruct (ih lequ Rle hle t') ; nodec ; subst
@@ -647,7 +647,7 @@ Qed.
 Lemma eqb_term_upto_univ_impl (equ lequ : _ -> _ -> bool) Re Rle :
   RelationClasses.subrelation equ Re ->
   RelationClasses.subrelation lequ Rle ->
-  subrelation (eqb_term_upto_univ equ lequ) (eq_term_upto_univ Re Rle).
+  subrelation (eqb_term_upto_univ equ lequ) (eq_term_upto Re Rle).
 Proof.
   intros he hle t t'.
   induction t in t', lequ, Rle, hle |- * using term_forall_list_ind.
@@ -701,10 +701,10 @@ Proof.
 Qed.
 
 
-Lemma reflect_eq_term_upto_univ equ lequ (Re Rle : universe -> universe -> Prop) :
+Lemma reflect_eq_term_upto equ lequ (Re Rle : universe -> universe -> Prop) :
   (forall u u', reflectT (Re u u') (equ u u')) ->
   (forall u u', reflectT (Rle u u') (lequ u u')) ->
-  forall t t', reflectT (eq_term_upto_univ Re Rle t t')
+  forall t t', reflectT (eq_term_upto Re Rle t t')
                    (eqb_term_upto_univ equ lequ t t').
 Proof.
   intros he hle t t'.
@@ -940,10 +940,10 @@ Qed.
 
 (** ** Behavior on mkApps and it_mkLambda_or_LetIn **  *)
 
-Lemma eq_term_upto_univ_mkApps Re Rle u1 l1 u2 l2 :
-    eq_term_upto_univ Re Rle u1 u2 ->
-    All2 (eq_term_upto_univ Re Re) l1 l2 ->
-    eq_term_upto_univ Re Rle (mkApps u1 l1) (mkApps u2 l2).
+Lemma eq_term_upto_mkApps Re Rle u1 l1 u2 l2 :
+    eq_term_upto Re Rle u1 u2 ->
+    All2 (eq_term_upto Re Re) l1 l2 ->
+    eq_term_upto Re Rle (mkApps u1 l1) (mkApps u2 l2).
 Proof.
   intros hu hl. induction l1 in u1, u2, l2, hu, hl |- *.
   - inversion hl. subst. assumption.
@@ -953,11 +953,11 @@ Proof.
     + assumption.
 Qed.
 
-Lemma eq_term_upto_univ_mkApps_l_inv Re Rle u l t :
-    eq_term_upto_univ Re Rle (mkApps u l) t ->
+Lemma eq_term_upto_mkApps_l_inv Re Rle u l t :
+    eq_term_upto Re Rle (mkApps u l) t ->
     ∑ u' l',
-      eq_term_upto_univ Re Rle u u' *
-      All2 (eq_term_upto_univ Re Re) l l' *
+      eq_term_upto Re Rle u u' *
+      All2 (eq_term_upto Re Re) l l' *
       (t = mkApps u' l').
 Proof.
   intros h. induction l in u, t, h, Rle |- *.
@@ -972,11 +972,11 @@ Proof.
     + cbn. reflexivity.
 Qed.
 
-Lemma eq_term_upto_univ_mkApps_r_inv Re Rle u l t :
-    eq_term_upto_univ Re Rle t (mkApps u l) ->
+Lemma eq_term_upto_mkApps_r_inv Re Rle u l t :
+    eq_term_upto Re Rle t (mkApps u l) ->
     ∑ u' l',
-      eq_term_upto_univ Re Rle u' u *
-      All2 (eq_term_upto_univ Re Re) l' l *
+      eq_term_upto Re Rle u' u *
+      All2 (eq_term_upto Re Re) l' l *
       (t = mkApps u' l').
 Proof.
   intros h. induction l in u, t, h, Rle |- *.
@@ -991,17 +991,17 @@ Proof.
     + cbn. reflexivity.
 Qed.
 
-Lemma eq_term_upto_univ_it_mkLambda_or_LetIn Re Rle Γ :
+Lemma eq_term_upto_it_mkLambda_or_LetIn Re Rle Γ :
   RelationClasses.Reflexive Re ->
-  respectful (eq_term_upto_univ Re Rle) (eq_term_upto_univ Re Rle)
+  respectful (eq_term_upto Re Rle) (eq_term_upto Re Rle)
              (it_mkLambda_or_LetIn Γ) (it_mkLambda_or_LetIn Γ).
 Proof.
   intros he u v h.
   induction Γ as [| [na [b|] A] Γ ih ] in u, v, h |- *.
   - assumption.
-  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_univ_refl.
+  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_refl.
     all: auto.
-  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_univ_refl.
+  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_refl.
     all: auto.
 Qed.
 
@@ -1009,20 +1009,20 @@ Lemma eq_term_it_mkLambda_or_LetIn {cf:checker_flags} φ Γ :
   respectful (eq_term φ) (eq_term φ)
              (it_mkLambda_or_LetIn Γ) (it_mkLambda_or_LetIn Γ).
 Proof.
-  apply eq_term_upto_univ_it_mkLambda_or_LetIn; exact _.
+  apply eq_term_upto_it_mkLambda_or_LetIn; exact _.
 Qed.
 
-Lemma eq_term_upto_univ_it_mkProd_or_LetIn Re Rle Γ :
+Lemma eq_term_upto_it_mkProd_or_LetIn Re Rle Γ :
   RelationClasses.Reflexive Re ->
-  respectful (eq_term_upto_univ Re Rle) (eq_term_upto_univ Re Rle)
+  respectful (eq_term_upto Re Rle) (eq_term_upto Re Rle)
              (it_mkProd_or_LetIn Γ) (it_mkProd_or_LetIn Γ).
 Proof.
   intros he u v h.
   induction Γ as [| [na [b|] A] Γ ih ] in u, v, h |- *.
   - assumption.
-  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_univ_refl.
+  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_refl.
     all: auto.
-  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_univ_refl.
+  - simpl. cbn. apply ih. constructor ; try apply eq_term_upto_refl.
     all: auto.
 Qed.
 
@@ -1030,7 +1030,7 @@ Lemma eq_term_it_mkProd_or_LetIn {cf:checker_flags} φ Γ:
   respectful (eq_term φ) (eq_term φ)
              (it_mkProd_or_LetIn Γ) (it_mkProd_or_LetIn Γ).
 Proof.
-  eapply eq_term_upto_univ_it_mkProd_or_LetIn ; exact _.
+  eapply eq_term_upto_it_mkProd_or_LetIn ; exact _.
 Qed.
 
 Lemma eq_term_it_mkLambda_or_LetIn_inv {cf:checker_flags} φ Γ u v :
@@ -1048,26 +1048,26 @@ Qed.
 
 (** ** Syntactic equality up to printing anotations ** *)
 
-Definition upto_names := eq_term_upto_univ eq eq.
+Definition upto_names := eq_term_upto eq eq.
 
 Infix "≡" := upto_names (at level 60).
 
-Infix "≡'" := (eq_term_upto_univ eq eq) (at level 60).
-Notation upto_names' := (eq_term_upto_univ eq eq).
+Infix "≡'" := (eq_term_upto eq eq) (at level 60).
+Notation upto_names' := (eq_term_upto eq eq).
 
 Instance upto_names_ref : Reflexive upto_names.
 Proof.
-  eapply eq_term_upto_univ_refl; exact _.
+  eapply eq_term_upto_refl; exact _.
 Qed.
 
 Instance upto_names_sym : Symmetric upto_names.
 Proof.
-  eapply eq_term_upto_univ_sym; exact _.
+  eapply eq_term_upto_sym; exact _.
 Qed.
 
 Instance upto_names_trans : Transitive upto_names.
 Proof.
-  eapply eq_term_upto_univ_trans; exact _.
+  eapply eq_term_upto_trans; exact _.
 Qed.
 
 (* todo: rename *)
@@ -1077,16 +1077,16 @@ Definition nleq_term t t' :=
 Corollary reflect_upto_names :
   forall t t', reflectT (upto_names t t') (nleq_term t t').
 Proof.
-  intros t t'. eapply reflect_eq_term_upto_univ.
+  intros t t'. eapply reflect_eq_term_upto.
   all: intros u u'; eapply reflect_reflectT, eqb_spec.
 Qed.
 
 Lemma upto_names_impl Re Rle :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
-  subrelation upto_names (eq_term_upto_univ Re Rle).
+  subrelation upto_names (eq_term_upto Re Rle).
 Proof.
-  intros he hle. eapply eq_term_upto_univ_impl.
+  intros he hle. eapply eq_term_upto_impl.
   all: intros ? ? []; eauto.
 Qed.
 
@@ -1104,8 +1104,8 @@ Qed.
 
 
 
-Lemma eq_term_upto_univ_isApp Re Rle u v :
-  eq_term_upto_univ Re Rle u v ->
+Lemma eq_term_upto_isApp Re Rle u v :
+  eq_term_upto Re Rle u v ->
   isApp u = isApp v.
 Proof.
   induction 1.
@@ -1118,18 +1118,18 @@ Qed.
 Inductive eq_context_upto (Re : universe -> universe -> Prop) : context -> context -> Type :=
 | eq_context_nil : eq_context_upto Re [] []
 | eq_context_vass na A Γ nb B Δ :
-    eq_term_upto_univ Re Re A B ->
+    eq_term_upto Re Re A B ->
     eq_context_upto Re Γ Δ ->
     eq_context_upto Re (Γ ,, vass na A) (Δ ,, vass nb B)
 | eq_context_vdef na u A Γ nb v B Δ :
-    eq_term_upto_univ Re Re u v ->
-    eq_term_upto_univ Re Re A B ->
+    eq_term_upto Re Re u v ->
+    eq_term_upto Re Re A B ->
     eq_context_upto Re Γ Δ ->
     eq_context_upto Re (Γ ,, vdef na u A) (Δ ,, vdef nb v B).
 
 Definition eq_def_upto Re d d' : Type :=
-  (eq_term_upto_univ Re Re d.(dtype) d'.(dtype)) *
-  (eq_term_upto_univ Re Re d.(dbody) d'.(dbody)) *
+  (eq_term_upto Re Re d.(dtype) d'.(dtype)) *
+  (eq_term_upto Re Re d.(dbody) d'.(dbody)) *
   (d.(rarg) = d'.(rarg)).
 
 Inductive rel_option {A B} (R : A -> B -> Type) : option A -> option B -> Type :=
@@ -1137,8 +1137,8 @@ Inductive rel_option {A B} (R : A -> B -> Type) : option A -> option B -> Type :
 | rel_none : rel_option R None None.
 
 Definition eq_decl_upto Re d d' : Type :=
-  rel_option (eq_term_upto_univ Re Re) d.(decl_body) d'.(decl_body) *
-  eq_term_upto_univ Re Re d.(decl_type) d'.(decl_type).
+  rel_option (eq_term_upto Re Re) d.(decl_body) d'.(decl_body) *
+  eq_term_upto Re Re d.(decl_type) d'.(decl_type).
 
 (* TODO perhaps should be def *)
 Lemma All2_eq_context_upto Re :
@@ -1163,9 +1163,9 @@ Proof.
   induction Γ as [| [na [bo |] ty] Γ ih].
   - constructor.
   - constructor ; eauto.
-    all: eapply eq_term_upto_univ_refl ; eauto.
+    all: eapply eq_term_upto_refl ; eauto.
   - constructor ; eauto.
-    all: eapply eq_term_upto_univ_refl ; eauto.
+    all: eapply eq_term_upto_refl ; eauto.
 Qed.
 
 Lemma eq_context_upto_sym Re :
@@ -1173,8 +1173,8 @@ Lemma eq_context_upto_sym Re :
   Symmetric (eq_context_upto Re).
 Proof.
   intros hRe Γ Δ.
-  induction 1; constructor; eauto using eq_term_upto_univ_sym.
-  all:eapply eq_term_upto_univ_sym; auto.
+  induction 1; constructor; eauto using eq_term_upto_sym.
+  all:eapply eq_term_upto_sym; auto.
 Qed.
 
 Lemma eq_context_upto_cat Re Γ Δ Γ' Δ' :
@@ -1225,9 +1225,9 @@ Proof.
   induction h.
   - constructor.
   - constructor. 2: assumption.
-    eapply eq_term_upto_univ_impl. all: eassumption.
+    eapply eq_term_upto_impl. all: eassumption.
   - constructor. 3: assumption.
-    all: eapply eq_term_upto_univ_impl. all: eassumption.
+    all: eapply eq_term_upto_impl. all: eassumption.
 Qed.
 
 Lemma eq_context_upto_length :
@@ -1392,12 +1392,12 @@ Proof.
   - exact (IHu u1 u2 H).
 Qed.
 
-Lemma eq_term_upto_univ_subst_instance_constr Re :
+Lemma eq_term_upto_subst_instance_constr Re :
   RelationClasses.Reflexive Re ->
   SubstUnivPreserving Re ->
   forall t u1 u2,
     R_universe_instance Re u1 u2 ->
-    eq_term_upto_univ Re Re (subst_instance_constr u1 t)
+    eq_term_upto Re Re (subst_instance_constr u1 t)
                             (subst_instance_constr u2 t).
 Proof.
   intros ref hRe t.
@@ -1439,23 +1439,23 @@ Qed.
 
 
 
-Lemma eq_term_upto_univ_mkApps_inv Re u l u' l' :
+Lemma eq_term_upto_mkApps_inv Re u l u' l' :
   isApp u = false ->
   isApp u' = false ->
-  eq_term_upto_univ Re Re (mkApps u l) (mkApps u' l') ->
-  eq_term_upto_univ Re Re u u' * All2 (eq_term_upto_univ Re Re) l l'.
+  eq_term_upto Re Re (mkApps u l) (mkApps u' l') ->
+  eq_term_upto Re Re u u' * All2 (eq_term_upto Re Re) l l'.
 Proof.
   intros hu hu' h.
-  apply eq_term_upto_univ_mkApps_l_inv in h as hh.
+  apply eq_term_upto_mkApps_l_inv in h as hh.
   destruct hh as [v [args [[h1 h2] h3]]].
-  apply eq_term_upto_univ_isApp in h1 as hh1. rewrite hu in hh1.
+  apply eq_term_upto_isApp in h1 as hh1. rewrite hu in hh1.
   apply mkApps_notApp_inj in h3 ; auto.
   destruct h3 as [? ?]. subst. split ; auto.
 Qed.
 
 Lemma isLambda_eq_term_l Re u v :
     isLambda u ->
-    eq_term_upto_univ Re Re u v ->
+    eq_term_upto Re Re u v ->
     isLambda v.
 Proof.
   intros h e.
@@ -1465,7 +1465,7 @@ Qed.
 
 Lemma isLambda_eq_term_r Re u v :
     isLambda v ->
-    eq_term_upto_univ Re Re u v ->
+    eq_term_upto Re Re u v ->
     isLambda u.
 Proof.
   intros h e.
@@ -1475,7 +1475,7 @@ Qed.
 
 Lemma isConstruct_app_eq_term_l Re u v :
     isConstruct_app u ->
-    eq_term_upto_univ Re Re u v ->
+    eq_term_upto Re Re u v ->
     isConstruct_app v.
 Proof.
   intros h e.
@@ -1487,7 +1487,7 @@ Proof.
   destruct t1 ; try discriminate.
   apply decompose_app_inv in e1 as ?. subst.
   apply decompose_app_inv in e2 as ?. subst.
-  apply eq_term_upto_univ_mkApps_inv in e as hh.
+  apply eq_term_upto_mkApps_inv in e as hh.
   - destruct hh as [h1 h2].
     dependent destruction h1. reflexivity.
   - reflexivity.
@@ -1497,7 +1497,7 @@ Qed.
 Lemma isConstruct_app_eq_term_r :
   forall Re u v,
     isConstruct_app v ->
-    eq_term_upto_univ Re Re u v ->
+    eq_term_upto Re Re u v ->
     isConstruct_app u.
 Proof.
   intros Re u v h e.
@@ -1509,7 +1509,7 @@ Proof.
   destruct t2 ; try discriminate.
   apply decompose_app_inv in e1 as ?. subst.
   apply decompose_app_inv in e2 as ?. subst.
-  apply eq_term_upto_univ_mkApps_inv in e as hh.
+  apply eq_term_upto_mkApps_inv in e as hh.
   - destruct hh as [h1 h2].
     dependent destruction h1. reflexivity.
   - eapply decompose_app_notApp. eassumption.
@@ -1524,7 +1524,7 @@ Proof.
   intros A R x y h. assumption.
 Qed.
 
-Lemma eq_term_upto_univ_flip (Re Rle Rle' : universe -> universe -> Prop) u v :
+Lemma eq_term_upto_flip (Re Rle Rle' : universe -> universe -> Prop) u v :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
   RelationClasses.Symmetric Re ->
@@ -1532,8 +1532,8 @@ Lemma eq_term_upto_univ_flip (Re Rle Rle' : universe -> universe -> Prop) u v :
   RelationClasses.Transitive Rle ->
   RelationClasses.subrelation Re Rle ->
   (forall x y, Rle x y -> Rle' y x) ->
-  eq_term_upto_univ Re Rle u v ->
-  eq_term_upto_univ Re Rle' v u.
+  eq_term_upto Re Rle u v ->
+  eq_term_upto Re Rle' v u.
 Proof.
   intros Rerefl Rlerefl Resym Retrans Rletrans incl incl' H.
   assert (Resub : RelationClasses.subrelation Re Re).
@@ -1541,7 +1541,7 @@ Proof.
   revert Rerefl Rlerefl Resym Retrans Rletrans incl incl' Resub.
   revert Re Rle u v H Rle'.
   induction 1; intros; constructor; intuition auto.
-  - eapply All2_symP; auto. eapply eq_term_upto_univ_sym; auto.
+  - eapply All2_symP; auto. eapply eq_term_upto_sym; auto.
   - eapply Forall2_sym. eapply Forall2_map_inv in r.
     eapply Forall2_map. solve_all.
   - eapply Forall2_sym. eapply Forall2_map_inv in r.
@@ -1549,13 +1549,13 @@ Proof.
   - eapply Forall2_sym. eapply Forall2_map_inv in r.
     eapply Forall2_map. solve_all.
   - eapply All2_sym. solve_all.
-    simpl in *. subst. now eapply eq_term_upto_univ_sym.
+    simpl in *. subst. now eapply eq_term_upto_sym.
   - eapply All2_sym. solve_all.
-    now eapply eq_term_upto_univ_sym.
-    now eapply eq_term_upto_univ_sym.
+    now eapply eq_term_upto_sym.
+    now eapply eq_term_upto_sym.
   - eapply All2_sym. solve_all.
-    now eapply eq_term_upto_univ_sym.
-    now eapply eq_term_upto_univ_sym.
+    now eapply eq_term_upto_sym.
+    now eapply eq_term_upto_sym.
 Qed.
 
 Lemma eq_univ_make :

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -55,93 +55,95 @@ Qed.
 (** ** Syntactic equality up-to universes
   We don't look at printing annotations *)
 
-Inductive eq_term_upto (Re Rle : universe -> universe -> Prop) : term -> term -> Type :=
+Inductive eq_term_upto (Re Rle : universe -> universe -> Prop) (ηpred : term -> Prop) : term -> term -> Type :=
 | eq_Rel n  :
-    eq_term_upto Re Rle (tRel n) (tRel n)
+    eq_term_upto Re Rle ηpred (tRel n) (tRel n)
 
 | eq_Evar e args args' :
-    All2 (eq_term_upto Re Re) args args' ->
-    eq_term_upto Re Rle (tEvar e args) (tEvar e args')
+    All2 (eq_term_upto Re Re ηpred) args args' ->
+    eq_term_upto Re Rle ηpred (tEvar e args) (tEvar e args')
 
 | eq_Var id :
-    eq_term_upto Re Rle (tVar id) (tVar id)
+    eq_term_upto Re Rle ηpred (tVar id) (tVar id)
 
 | eq_Sort s s' :
     Rle s s' ->
-    eq_term_upto Re Rle (tSort s) (tSort s')
+    eq_term_upto Re Rle ηpred (tSort s) (tSort s')
 
 | eq_App t t' u u' :
-    eq_term_upto Re Rle t t' ->
-    eq_term_upto Re Re u u' ->
-    eq_term_upto Re Rle (tApp t u) (tApp t' u')
+    eq_term_upto Re Rle ηpred t t' ->
+    eq_term_upto Re Re ηpred u u' ->
+    eq_term_upto Re Rle ηpred (tApp t u) (tApp t' u')
 
 | eq_Const c u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto Re Rle (tConst c u) (tConst c u')
+    eq_term_upto Re Rle ηpred (tConst c u) (tConst c u')
 
 | eq_Ind i u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto Re Rle (tInd i u) (tInd i u')
+    eq_term_upto Re Rle ηpred (tInd i u) (tInd i u')
 
 | eq_Construct i k u u' :
     R_universe_instance Re u u' ->
-    eq_term_upto Re Rle (tConstruct i k u) (tConstruct i k u')
+    eq_term_upto Re Rle ηpred (tConstruct i k u) (tConstruct i k u')
 
 | eq_Lambda na na' ty ty' t t' :
-    eq_term_upto Re Re ty ty' ->
-    eq_term_upto Re Rle t t' ->
-    eq_term_upto Re Rle (tLambda na ty t) (tLambda na' ty' t')
+    eq_term_upto Re Re ηpred ty ty' ->
+    eq_term_upto Re Rle ηpred t t' ->
+    eq_term_upto Re Rle ηpred (tLambda na ty t) (tLambda na' ty' t')
 
 | eq_Prod na na' a a' b b' :
-    eq_term_upto Re Re a a' ->
-    eq_term_upto Re Rle b b' ->
-    eq_term_upto Re Rle (tProd na a b) (tProd na' a' b')
+    eq_term_upto Re Re ηpred a a' ->
+    eq_term_upto Re Rle ηpred b b' ->
+    eq_term_upto Re Rle ηpred (tProd na a b) (tProd na' a' b')
 
 | eq_LetIn na na' t t' ty ty' u u' :
-    eq_term_upto Re Re t t' ->
-    eq_term_upto Re Re ty ty' ->
-    eq_term_upto Re Rle u u' ->
-    eq_term_upto Re Rle (tLetIn na t ty u) (tLetIn na' t' ty' u')
+    eq_term_upto Re Re ηpred t t' ->
+    eq_term_upto Re Re ηpred ty ty' ->
+    eq_term_upto Re Rle ηpred u u' ->
+    eq_term_upto Re Rle ηpred (tLetIn na t ty u) (tLetIn na' t' ty' u')
 
 | eq_Case indn p p' c c' brs brs' :
-    eq_term_upto Re Re p p' ->
-    eq_term_upto Re Re c c' ->
+    eq_term_upto Re Re ηpred p p' ->
+    eq_term_upto Re Re ηpred c c' ->
     All2 (fun x y =>
       (fst x = fst y) *
-      eq_term_upto Re Re (snd x) (snd y)
+      eq_term_upto Re Re ηpred (snd x) (snd y)
     ) brs brs' ->
-    eq_term_upto Re Rle (tCase indn p c brs) (tCase indn p' c' brs')
+    eq_term_upto Re Rle ηpred (tCase indn p c brs) (tCase indn p' c' brs')
 
 | eq_Proj p c c' :
-    eq_term_upto Re Re c c' ->
-    eq_term_upto Re Rle (tProj p c) (tProj p c')
+    eq_term_upto Re Re ηpred c c' ->
+    eq_term_upto Re Rle ηpred (tProj p c) (tProj p c')
 
 | eq_Fix mfix mfix' idx :
     All2 (fun x y =>
-      eq_term_upto Re Re x.(dtype) y.(dtype) *
-      eq_term_upto Re Re x.(dbody) y.(dbody) *
+      eq_term_upto Re Re ηpred x.(dtype) y.(dtype) *
+      eq_term_upto Re Re ηpred x.(dbody) y.(dbody) *
       (x.(rarg) = y.(rarg))
     ) mfix mfix' ->
-    eq_term_upto Re Rle (tFix mfix idx) (tFix mfix' idx)
+    eq_term_upto Re Rle ηpred (tFix mfix idx) (tFix mfix' idx)
 
 | eq_CoFix mfix mfix' idx :
     All2 (fun x y =>
-      eq_term_upto Re Re x.(dtype) y.(dtype) *
-      eq_term_upto Re Re x.(dbody) y.(dbody) *
+      eq_term_upto Re Re ηpred x.(dtype) y.(dtype) *
+      eq_term_upto Re Re ηpred x.(dbody) y.(dbody) *
       (x.(rarg) = y.(rarg))
     ) mfix mfix' ->
-    eq_term_upto Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
+    eq_term_upto Re Rle ηpred (tCoFix mfix idx) (tCoFix mfix' idx).
 
+Definition unrestricted_η (t : term) := True.
+Definition no_η (t : term) := False.
 
 (* ** Syntactic conversion up-to universes *)
 
 Definition eq_term `{checker_flags} φ :=
-  eq_term_upto (eq_universe φ) (eq_universe φ).
+  eq_term_upto (eq_universe φ) (eq_universe φ) unrestricted_η.
 
 (* ** Syntactic cumulativity up-to universes *)
 
 Definition leq_term `{checker_flags} φ :=
-  eq_term_upto (eq_universe φ) (leq_universe φ).
+  eq_term_upto (eq_universe φ) (leq_universe φ) unrestricted_η.
 
 (* TODO MOVE *)
 Lemma Forall2_same :
@@ -157,10 +159,10 @@ Proof.
     + assumption.
 Qed.
 
-Instance eq_term_upto_refl Re Rle :
+Instance eq_term_upto_refl Re Rle ηpred :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
-  Reflexive (eq_term_upto Re Rle).
+  Reflexive (eq_term_upto Re Rle ηpred).
 Proof.
   intros hRe hRle t.
   induction t in Rle, hRle |- * using term_forall_list_ind.
@@ -197,10 +199,10 @@ Qed.
 
 Derive Signature for eq_term_upto.
 
-Instance eq_term_upto_sym Re Rle :
+Instance eq_term_upto_sym Re Rle ηpred :
   RelationClasses.Symmetric Re ->
   RelationClasses.Symmetric Rle ->
-  Symmetric (eq_term_upto Re Rle).
+  Symmetric (eq_term_upto Re Rle ηpred).
 Proof.
   intros he hle u v e.
   induction u in Rle, hle, v, e |- * using term_forall_list_ind.
@@ -242,10 +244,10 @@ Proof.
 Qed.
 
 
-Instance eq_term_upto_trans Re Rle :
+Instance eq_term_upto_trans Re Rle ηpred :
   RelationClasses.Transitive Re ->
   RelationClasses.Transitive Rle ->
-  Transitive (eq_term_upto Re Rle).
+  Transitive (eq_term_upto Re Rle ηpred).
 Proof.
   intros he hle u v w e1 e2.
   induction u in Rle, hle, v, w, e1, e2 |- * using term_forall_list_ind.
@@ -304,8 +306,8 @@ Proof.
 Qed.
 
 
-Instance eq_term_upto_equiv Re (hRe : RelationClasses.Equivalence Re)
-  : Equivalence (eq_term_upto Re Re).
+Instance eq_term_upto_equiv Re (hRe : RelationClasses.Equivalence Re) ηpred
+  : Equivalence (eq_term_upto Re Re ηpred).
 Proof.
   constructor. all: exact _.
 Defined.
@@ -350,9 +352,9 @@ Proof.
   cbn; intros ? ? [? ?]. eapply H; assumption.
 Qed.
 
-Lemma eq_term_upto_antisym Re Rle (hRe : RelationClasses.Equivalence Re) :
+Lemma eq_term_upto_antisym Re Rle (hRe : RelationClasses.Equivalence Re) ηpred :
   RelationClasses.Antisymmetric _ Re Rle ->
-  Antisymmetric (eq_term_upto Re Re) (eq_term_upto Re Rle).
+  Antisymmetric (eq_term_upto Re Re ηpred) (eq_term_upto Re Rle ηpred).
 Proof.
   intros hR u v h h'.
   induction u in v, h, h' |- * using term_forall_list_ind.
@@ -363,16 +365,17 @@ Qed.
 Instance leq_term_antisym {cf:checker_flags} φ
   : Antisymmetric (eq_term φ) (leq_term φ).
 Proof.
-  eapply eq_term_upto_antisym; exact _.
+  eapply eq_term_upto_antisym. exact _.
 Qed.
 
 
-Instance eq_term_upto_impl Re Re' Rle Rle' :
+Instance eq_term_upto_impl Re Re' Rle Rle' (ηpred ηpred' : term -> Prop) :
   RelationClasses.subrelation Re Re' ->
   RelationClasses.subrelation Rle Rle' ->
-  subrelation (eq_term_upto Re Rle) (eq_term_upto Re' Rle').
+  (forall t, ηpred t -> ηpred' t) ->
+  subrelation (eq_term_upto Re Rle ηpred) (eq_term_upto Re' Rle' ηpred').
 Proof.
-  intros he hle t t'.
+  intros he hle hη t t'.
   induction t in t', Rle, Rle', hle |- * using term_forall_list_ind;
     try (inversion 1; subst; constructor;
          eauto using R_universe_instance_impl'; fail).
@@ -394,11 +397,12 @@ Proof.
 Qed.
 
 
-Instance eq_term_upto_leq Re Rle :
+Instance eq_term_upto_leq Re Rle ηpred :
   RelationClasses.subrelation Re Rle ->
-  subrelation (eq_term_upto Re Re) (eq_term_upto Re Rle).
+  subrelation (eq_term_upto Re Re ηpred) (eq_term_upto Re Rle ηpred).
 Proof.
-  intros H. eapply eq_term_upto_impl; exact _.
+  intros H. eapply eq_term_upto_impl. all: try exact _.
+  intro. auto.
 Qed.
 
 Instance eq_term_leq_term {cf:checker_flags} φ
@@ -418,13 +422,13 @@ Qed.
 
 Local Ltac lih :=
   lazymatch goal with
-  | ih : forall Rle v n k, eq_term_upto _ _ ?u _ -> _
-    |- eq_term_upto _ _ (lift _ _ ?u) _ =>
+  | ih : forall Rle v n k, eq_term_upto _ _ _ ?u _ -> _
+    |- eq_term_upto _ _ _ (lift _ _ ?u) _ =>
     eapply ih
   end.
 
-Lemma eq_term_upto_lift Re Rle n k :
-  Proper (eq_term_upto Re Rle ==> eq_term_upto Re Rle) (lift n k).
+Lemma eq_term_upto_lift Re Rle ηpred n k :
+  Proper (eq_term_upto Re Rle ηpred ==> eq_term_upto Re Rle ηpred) (lift n k).
 Proof.
   intros u v e.
   induction u in v, n, k, e, Rle |- * using term_forall_list_ind.
@@ -458,16 +462,16 @@ Qed.
 
 Local Ltac sih :=
   lazymatch goal with
-  | ih : forall Rle v n x y, _ -> eq_term_upto _ _ ?u _ -> _ -> _
-    |- eq_term_upto _ _ (subst _ _ ?u) _ => eapply ih
+  | ih : forall Rle v n x y, _ -> eq_term_upto _ _ _ ?u _ -> _ -> _
+    |- eq_term_upto _ _ _ (subst _ _ ?u) _ => eapply ih
   end.
 
-Lemma eq_term_upto_substs Re Rle :
+Lemma eq_term_upto_substs Re Rle ηpred :
   RelationClasses.subrelation Re Rle ->
   forall u v n l l',
-    eq_term_upto Re Rle u v ->
-    All2 (eq_term_upto Re Re) l l' ->
-    eq_term_upto Re Rle (subst l n u) (subst l' n v).
+    eq_term_upto Re Rle ηpred u v ->
+    All2 (eq_term_upto Re Re ηpred) l l' ->
+    eq_term_upto Re Rle ηpred (subst l n u) (subst l' n v).
 Proof.
   unfold RelationClasses.subrelation; intros hR u v n l l' hu hl.
   induction u in v, n, l, l', hu, hl, Rle, hR |- * using term_forall_list_ind.
@@ -495,12 +499,12 @@ Proof.
     solve_all. now rewrite H.
 Qed.
 
-Lemma eq_term_upto_subst Re Rle :
+Lemma eq_term_upto_subst Re Rle ηpred :
   RelationClasses.subrelation Re Rle ->
   forall u v n x y,
-    eq_term_upto Re Rle u v ->
-    eq_term_upto Re Re x y ->
-    eq_term_upto Re Rle (u{n := x}) (v{n := y}).
+    eq_term_upto Re Rle ηpred u v ->
+    eq_term_upto Re Re ηpred x y ->
+    eq_term_upto Re Rle ηpred (u{n := x}) (v{n := y}).
 Proof.
   intros hR u v n x y e1 e2.
   eapply eq_term_upto_substs; eauto.
@@ -529,14 +533,14 @@ Qed.
 
 (** ** Boolean version **  *)
 
-Fixpoint eqb_term_upto_univ (equ lequ : universe -> universe -> bool) (u v : term) : bool :=
+Fixpoint eqb_term_upto (equ lequ : universe -> universe -> bool) (ηb : term -> bool) (u v : term) : bool :=
   match u, v with
   | tRel n, tRel m =>
     eqb n m
 
   | tEvar e args, tEvar e' args' =>
     eqb e e' &&
-    forallb2 (eqb_term_upto_univ equ equ) args args'
+    forallb2 (eqb_term_upto equ equ ηb) args args'
 
   | tVar id, tVar id' =>
     eqb id id'
@@ -545,8 +549,8 @@ Fixpoint eqb_term_upto_univ (equ lequ : universe -> universe -> bool) (u v : ter
     lequ u u'
 
   | tApp u v, tApp u' v' =>
-    eqb_term_upto_univ equ lequ u u' &&
-    eqb_term_upto_univ equ equ v v'
+    eqb_term_upto equ lequ ηb u u' &&
+    eqb_term_upto equ equ ηb v v'
 
   | tConst c u, tConst c' u' =>
     eqb c c' &&
@@ -562,44 +566,44 @@ Fixpoint eqb_term_upto_univ (equ lequ : universe -> universe -> bool) (u v : ter
     forallb2 equ (map Universe.make u) (map Universe.make u')
 
   | tLambda na A t, tLambda na' A' t' =>
-    eqb_term_upto_univ equ equ A A' &&
-    eqb_term_upto_univ equ lequ t t'
+    eqb_term_upto equ equ ηb A A' &&
+    eqb_term_upto equ lequ ηb t t'
 
   | tProd na A B, tProd na' A' B' =>
-    eqb_term_upto_univ equ equ A A' &&
-    eqb_term_upto_univ equ lequ B B'
+    eqb_term_upto equ equ ηb A A' &&
+    eqb_term_upto equ lequ ηb B B'
 
   | tLetIn na B b u, tLetIn na' B' b' u' =>
-    eqb_term_upto_univ equ equ B B' &&
-    eqb_term_upto_univ equ equ b b' &&
-    eqb_term_upto_univ equ lequ u u'
+    eqb_term_upto equ equ ηb B B' &&
+    eqb_term_upto equ equ ηb b b' &&
+    eqb_term_upto equ lequ ηb u u'
 
   | tCase indp p c brs, tCase indp' p' c' brs' =>
     eqb indp indp' &&
-    eqb_term_upto_univ equ equ p p' &&
-    eqb_term_upto_univ equ equ c c' &&
+    eqb_term_upto equ equ ηb p p' &&
+    eqb_term_upto equ equ ηb c c' &&
     forallb2 (fun x y =>
       eqb (fst x) (fst y) &&
-      eqb_term_upto_univ equ equ (snd x) (snd y)
+      eqb_term_upto equ equ ηb (snd x) (snd y)
     ) brs brs'
 
   | tProj p c, tProj p' c' =>
     eqb p p' &&
-    eqb_term_upto_univ equ equ c c'
+    eqb_term_upto equ equ ηb c c'
 
   | tFix mfix idx, tFix mfix' idx' =>
     eqb idx idx' &&
     forallb2 (fun x y =>
-      eqb_term_upto_univ equ equ x.(dtype) y.(dtype) &&
-      eqb_term_upto_univ equ equ x.(dbody) y.(dbody) &&
+      eqb_term_upto equ equ ηb x.(dtype) y.(dtype) &&
+      eqb_term_upto equ equ ηb x.(dbody) y.(dbody) &&
       eqb x.(rarg) y.(rarg)
     ) mfix mfix'
 
   | tCoFix mfix idx, tCoFix mfix' idx' =>
     eqb idx idx' &&
     forallb2 (fun x y =>
-      eqb_term_upto_univ equ equ x.(dtype) y.(dtype) &&
-      eqb_term_upto_univ equ equ x.(dbody) y.(dbody) &&
+      eqb_term_upto equ equ ηb x.(dtype) y.(dtype) &&
+      eqb_term_upto equ equ ηb x.(dbody) y.(dbody) &&
       eqb x.(rarg) y.(rarg)
     ) mfix mfix'
 
@@ -623,9 +627,9 @@ Local Ltac equspec equ h :=
 
 Local Ltac ih :=
   repeat lazymatch goal with
-  | ih : forall lequ Rle hle t', reflectT (eq_term_upto _ _ ?t _) _,
+  | ih : forall lequ Rle hle t', reflectT (eq_term_upto _ _ _ ?t _) _,
     hle : forall u u', reflectT (?Rle u u') (?lequ u u')
-    |- context [ eqb_term_upto_univ _ ?lequ ?t ?t' ] =>
+    |- context [ eqb_term_upto _ ?lequ _ ?t ?t' ] =>
     destruct (ih lequ Rle hle t') ; nodec ; subst
   end.
 
@@ -644,12 +648,13 @@ Proof.
     constructor. all: auto.
 Qed.
 
-Lemma eqb_term_upto_univ_impl (equ lequ : _ -> _ -> bool) Re Rle :
+Lemma eqb_term_upto_impl (equ lequ : _ -> _ -> bool) (ηb : _ -> bool) Re Rle (ηpred : _ -> Prop) :
   RelationClasses.subrelation equ Re ->
   RelationClasses.subrelation lequ Rle ->
-  subrelation (eqb_term_upto_univ equ lequ) (eq_term_upto Re Rle).
+  (forall t, ηb t -> ηpred t) ->
+  subrelation (eqb_term_upto equ lequ ηb) (eq_term_upto Re Rle ηpred).
 Proof.
-  intros he hle t t'.
+  intros he hle hη t t'.
   induction t in t', lequ, Rle, hle |- * using term_forall_list_ind.
   all: destruct t'; try discriminate 1. all: cbn -[eqb].
   - eqspec; [intros _|discriminate]. constructor.
@@ -701,13 +706,15 @@ Proof.
 Qed.
 
 
-Lemma reflect_eq_term_upto equ lequ (Re Rle : universe -> universe -> Prop) :
+Lemma reflect_eq_term_upto equ lequ ηb (Re Rle : universe -> universe -> Prop) (ηpred : _ -> Prop) :
   (forall u u', reflectT (Re u u') (equ u u')) ->
   (forall u u', reflectT (Rle u u') (lequ u u')) ->
-  forall t t', reflectT (eq_term_upto Re Rle t t')
-                   (eqb_term_upto_univ equ lequ t t').
+  (forall t, reflectT (ηpred t) (ηb t)) ->
+  forall t t',
+    reflectT
+      (eq_term_upto Re Rle ηpred t t') (eqb_term_upto equ lequ ηb t t').
 Proof.
-  intros he hle t t'.
+  intros he hle hη t t'.
   induction t in t', lequ, Rle, hle |- * using term_forall_list_ind.
   all: destruct t' ; nodec.
   (* all: try solve [ *)
@@ -893,13 +900,13 @@ Proof.
            inversion bot. subst. inversion H0. subst. apply H3.
 Qed.
 
-Lemma eqb_term_upto_univ_refl :
-  forall (eqb leqb : universe -> universe -> bool) t,
+Lemma eqb_term_upto_refl :
+  forall (eqb leqb : universe -> universe -> bool) ηb t,
     (forall u, eqb u u) ->
     (forall u, leqb u u) ->
-    eqb_term_upto_univ eqb leqb t t.
+    eqb_term_upto eqb leqb ηb t t.
 Proof.
-  intros eqb leqb t eqb_refl leqb_refl.
+  intros eqb leqb ηb t eqb_refl leqb_refl.
   induction t using term_forall_list_ind in leqb, leqb_refl |- *.
   all: simpl.
   all: rewrite -> ?Nat.eqb_refl, ?eq_string_refl, ?eq_inductive_refl.
@@ -940,10 +947,10 @@ Qed.
 
 (** ** Behavior on mkApps and it_mkLambda_or_LetIn **  *)
 
-Lemma eq_term_upto_mkApps Re Rle u1 l1 u2 l2 :
-    eq_term_upto Re Rle u1 u2 ->
-    All2 (eq_term_upto Re Re) l1 l2 ->
-    eq_term_upto Re Rle (mkApps u1 l1) (mkApps u2 l2).
+Lemma eq_term_upto_mkApps Re Rle ηpred u1 l1 u2 l2 :
+    eq_term_upto Re Rle ηpred u1 u2 ->
+    All2 (eq_term_upto Re Re ηpred) l1 l2 ->
+    eq_term_upto Re Rle ηpred (mkApps u1 l1) (mkApps u2 l2).
 Proof.
   intros hu hl. induction l1 in u1, u2, l2, hu, hl |- *.
   - inversion hl. subst. assumption.
@@ -953,11 +960,11 @@ Proof.
     + assumption.
 Qed.
 
-Lemma eq_term_upto_mkApps_l_inv Re Rle u l t :
-    eq_term_upto Re Rle (mkApps u l) t ->
+Lemma eq_term_upto_mkApps_l_inv Re Rle ηpred u l t :
+    eq_term_upto Re Rle ηpred (mkApps u l) t ->
     ∑ u' l',
-      eq_term_upto Re Rle u u' *
-      All2 (eq_term_upto Re Re) l l' *
+      eq_term_upto Re Rle ηpred u u' *
+      All2 (eq_term_upto Re Re ηpred) l l' *
       (t = mkApps u' l').
 Proof.
   intros h. induction l in u, t, h, Rle |- *.
@@ -972,11 +979,11 @@ Proof.
     + cbn. reflexivity.
 Qed.
 
-Lemma eq_term_upto_mkApps_r_inv Re Rle u l t :
-    eq_term_upto Re Rle t (mkApps u l) ->
+Lemma eq_term_upto_mkApps_r_inv Re Rle ηpred u l t :
+    eq_term_upto Re Rle ηpred t (mkApps u l) ->
     ∑ u' l',
-      eq_term_upto Re Rle u' u *
-      All2 (eq_term_upto Re Re) l' l *
+      eq_term_upto Re Rle ηpred u' u *
+      All2 (eq_term_upto Re Re ηpred) l' l *
       (t = mkApps u' l').
 Proof.
   intros h. induction l in u, t, h, Rle |- *.
@@ -991,9 +998,9 @@ Proof.
     + cbn. reflexivity.
 Qed.
 
-Lemma eq_term_upto_it_mkLambda_or_LetIn Re Rle Γ :
+Lemma eq_term_upto_it_mkLambda_or_LetIn Re Rle ηpred Γ :
   RelationClasses.Reflexive Re ->
-  respectful (eq_term_upto Re Rle) (eq_term_upto Re Rle)
+  respectful (eq_term_upto Re Rle ηpred) (eq_term_upto Re Rle ηpred)
              (it_mkLambda_or_LetIn Γ) (it_mkLambda_or_LetIn Γ).
 Proof.
   intros he u v h.
@@ -1012,9 +1019,9 @@ Proof.
   apply eq_term_upto_it_mkLambda_or_LetIn; exact _.
 Qed.
 
-Lemma eq_term_upto_it_mkProd_or_LetIn Re Rle Γ :
+Lemma eq_term_upto_it_mkProd_or_LetIn Re Rle ηpred Γ :
   RelationClasses.Reflexive Re ->
-  respectful (eq_term_upto Re Rle) (eq_term_upto Re Rle)
+  respectful (eq_term_upto Re Rle ηpred) (eq_term_upto Re Rle ηpred)
              (it_mkProd_or_LetIn Γ) (it_mkProd_or_LetIn Γ).
 Proof.
   intros he u v h.
@@ -1048,12 +1055,12 @@ Qed.
 
 (** ** Syntactic equality up to printing anotations ** *)
 
-Definition upto_names := eq_term_upto eq eq.
+Definition upto_names := eq_term_upto eq eq no_η.
 
 Infix "≡" := upto_names (at level 60).
 
-Infix "≡'" := (eq_term_upto eq eq) (at level 60).
-Notation upto_names' := (eq_term_upto eq eq).
+Infix "≡'" := (eq_term_upto eq eq no_η) (at level 60).
+Notation upto_names' := (eq_term_upto eq eq no_η).
 
 Instance upto_names_ref : Reflexive upto_names.
 Proof.
@@ -1072,21 +1079,23 @@ Qed.
 
 (* todo: rename *)
 Definition nleq_term t t' :=
-  eqb_term_upto_univ eqb eqb t t'.
+  eqb_term_upto eqb eqb (fun t => false) t t'.
 
 Corollary reflect_upto_names :
   forall t t', reflectT (upto_names t t') (nleq_term t t').
 Proof.
   intros t t'. eapply reflect_eq_term_upto.
+  3:{ constructor. auto. }
   all: intros u u'; eapply reflect_reflectT, eqb_spec.
 Qed.
 
-Lemma upto_names_impl Re Rle :
+Lemma upto_names_impl Re Rle ηpred :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
-  subrelation upto_names (eq_term_upto Re Rle).
+  subrelation upto_names (eq_term_upto Re Rle ηpred).
 Proof.
   intros he hle. eapply eq_term_upto_impl.
+  3:{ intros ? []. }
   all: intros ? ? []; eauto.
 Qed.
 
@@ -1104,8 +1113,8 @@ Qed.
 
 
 
-Lemma eq_term_upto_isApp Re Rle u v :
-  eq_term_upto Re Rle u v ->
+Lemma eq_term_upto_isApp Re Rle ηpred u v :
+  eq_term_upto Re Rle ηpred u v ->
   isApp u = isApp v.
 Proof.
   induction 1.
@@ -1115,34 +1124,34 @@ Qed.
 
 (** ** Equality on contexts ** *)
 
-Inductive eq_context_upto (Re : universe -> universe -> Prop) : context -> context -> Type :=
-| eq_context_nil : eq_context_upto Re [] []
+Inductive eq_context_upto (Re : universe -> universe -> Prop) (ηpred : term -> Prop) : context -> context -> Type :=
+| eq_context_nil : eq_context_upto Re ηpred [] []
 | eq_context_vass na A Γ nb B Δ :
-    eq_term_upto Re Re A B ->
-    eq_context_upto Re Γ Δ ->
-    eq_context_upto Re (Γ ,, vass na A) (Δ ,, vass nb B)
+    eq_term_upto Re Re ηpred A B ->
+    eq_context_upto Re ηpred Γ Δ ->
+    eq_context_upto Re ηpred (Γ ,, vass na A) (Δ ,, vass nb B)
 | eq_context_vdef na u A Γ nb v B Δ :
-    eq_term_upto Re Re u v ->
-    eq_term_upto Re Re A B ->
-    eq_context_upto Re Γ Δ ->
-    eq_context_upto Re (Γ ,, vdef na u A) (Δ ,, vdef nb v B).
+    eq_term_upto Re Re ηpred u v ->
+    eq_term_upto Re Re ηpred A B ->
+    eq_context_upto Re ηpred Γ Δ ->
+    eq_context_upto Re ηpred (Γ ,, vdef na u A) (Δ ,, vdef nb v B).
 
-Definition eq_def_upto Re d d' : Type :=
-  (eq_term_upto Re Re d.(dtype) d'.(dtype)) *
-  (eq_term_upto Re Re d.(dbody) d'.(dbody)) *
+Definition eq_def_upto Re ηpred d d' : Type :=
+  (eq_term_upto Re Re ηpred d.(dtype) d'.(dtype)) *
+  (eq_term_upto Re Re ηpred d.(dbody) d'.(dbody)) *
   (d.(rarg) = d'.(rarg)).
 
 Inductive rel_option {A B} (R : A -> B -> Type) : option A -> option B -> Type :=
 | rel_some : forall a b, R a b -> rel_option R (Some a) (Some b)
 | rel_none : rel_option R None None.
 
-Definition eq_decl_upto Re d d' : Type :=
-  rel_option (eq_term_upto Re Re) d.(decl_body) d'.(decl_body) *
-  eq_term_upto Re Re d.(decl_type) d'.(decl_type).
+Definition eq_decl_upto Re ηpred d d' : Type :=
+  rel_option (eq_term_upto Re Re ηpred) d.(decl_body) d'.(decl_body) *
+  eq_term_upto Re Re ηpred d.(decl_type) d'.(decl_type).
 
 (* TODO perhaps should be def *)
-Lemma All2_eq_context_upto Re :
-  subrelation (All2 (eq_decl_upto Re)) (eq_context_upto Re).
+Lemma All2_eq_context_upto Re ηpred :
+  subrelation (All2 (eq_decl_upto Re ηpred)) (eq_context_upto Re ηpred).
 Proof.
   intros Γ Δ h.
   induction h.
@@ -1155,9 +1164,9 @@ Proof.
     + constructor ; eauto.
 Qed.
 
-Lemma eq_context_upto_refl Re :
+Lemma eq_context_upto_refl Re ηpred :
   RelationClasses.Reflexive Re ->
-  Reflexive (eq_context_upto Re).
+  Reflexive (eq_context_upto Re ηpred).
 Proof.
   intros hRe Γ.
   induction Γ as [| [na [bo |] ty] Γ ih].
@@ -1168,19 +1177,19 @@ Proof.
     all: eapply eq_term_upto_refl ; eauto.
 Qed.
 
-Lemma eq_context_upto_sym Re :
+Lemma eq_context_upto_sym Re ηpred :
   RelationClasses.Symmetric Re ->
-  Symmetric (eq_context_upto Re).
+  Symmetric (eq_context_upto Re ηpred).
 Proof.
   intros hRe Γ Δ.
   induction 1; constructor; eauto using eq_term_upto_sym.
   all:eapply eq_term_upto_sym; auto.
 Qed.
 
-Lemma eq_context_upto_cat Re Γ Δ Γ' Δ' :
-  eq_context_upto Re Γ Γ' ->
-  eq_context_upto Re Δ Δ' ->
-  eq_context_upto Re (Γ ,,, Δ) (Γ' ,,, Δ').
+Lemma eq_context_upto_cat Re ηpred Γ Δ Γ' Δ' :
+  eq_context_upto Re ηpred Γ Γ' ->
+  eq_context_upto Re ηpred Δ Δ' ->
+  eq_context_upto Re ηpred (Γ ,,, Δ) (Γ' ,,, Δ').
 Proof.
   intros h1 h2. induction h2 in Γ, Γ', h1 |- *.
   - assumption.
@@ -1188,9 +1197,9 @@ Proof.
   - simpl. constructor ; eauto.
 Qed.
 
-Lemma eq_context_upto_rev Re Γ Δ :
-  eq_context_upto Re Γ Δ ->
-  eq_context_upto Re (rev Γ) (rev Δ).
+Lemma eq_context_upto_rev Re ηpred Γ Δ :
+  eq_context_upto Re ηpred Γ Δ ->
+  eq_context_upto Re ηpred (rev Γ) (rev Δ).
 Proof.
   induction 1.
   - constructor.
@@ -1201,11 +1210,11 @@ Proof.
 Qed.
 
 Lemma eq_context_upto_rev' :
-  forall Γ Δ Re,
-    eq_context_upto Re Γ Δ ->
-    eq_context_upto Re (List.rev Γ) (List.rev Δ).
+  forall Γ Δ Re ηpred,
+    eq_context_upto Re ηpred Γ Δ ->
+    eq_context_upto Re ηpred (List.rev Γ) (List.rev Δ).
 Proof.
-  intros Γ Δ Re h.
+  intros Γ Δ Re ηpred h.
   induction h.
   - constructor.
   - simpl. eapply eq_context_upto_cat.
@@ -1217,11 +1226,12 @@ Proof.
 Qed.
 
 Lemma eq_context_impl :
-  forall Re Re',
+  forall Re Re' (ηpred ηpred' : term -> Prop),
     RelationClasses.subrelation Re Re' ->
-    subrelation (eq_context_upto Re) (eq_context_upto Re').
+    (forall t, ηpred t -> ηpred' t) ->
+    subrelation (eq_context_upto Re ηpred) (eq_context_upto Re' ηpred').
 Proof.
-  intros Re Re' hR Γ Δ h.
+  intros Re Re' ηpred ηpred' hR hη Γ Δ h.
   induction h.
   - constructor.
   - constructor. 2: assumption.
@@ -1231,11 +1241,11 @@ Proof.
 Qed.
 
 Lemma eq_context_upto_length :
-  forall Re Γ Δ,
-    eq_context_upto Re Γ Δ ->
+  forall Re ηpred Γ Δ,
+    eq_context_upto Re ηpred Γ Δ ->
     #|Γ| = #|Δ|.
 Proof.
-  intros Re Γ Δ h.
+  intros Re ηpred Γ Δ h.
   induction h. all: simpl ; auto.
 Qed.
 
@@ -1245,8 +1255,9 @@ Section ContextUpTo.
   Context (ReR : RelationClasses.Reflexive Re).
   Context (ReS : RelationClasses.Symmetric Re).
   Context (ReT : RelationClasses.Transitive Re).
+  Context (ηpred : term -> Prop).
 
-  Notation eq_ctx := (eq_context_upto Re).
+  Notation eq_ctx := (eq_context_upto Re ηpred).
 
   Global Instance eq_ctx_refl : Reflexive eq_ctx.
   Proof. now intros ?; apply eq_context_upto_refl. Qed.
@@ -1392,13 +1403,14 @@ Proof.
   - exact (IHu u1 u2 H).
 Qed.
 
-Lemma eq_term_upto_subst_instance_constr Re :
+Lemma eq_term_upto_subst_instance_constr Re ηpred :
   RelationClasses.Reflexive Re ->
   SubstUnivPreserving Re ->
   forall t u1 u2,
     R_universe_instance Re u1 u2 ->
-    eq_term_upto Re Re (subst_instance_constr u1 t)
-                            (subst_instance_constr u2 t).
+    eq_term_upto Re Re ηpred
+      (subst_instance_constr u1 t)
+      (subst_instance_constr u2 t).
 Proof.
   intros ref hRe t.
   induction t using term_forall_list_ind; intros u1 u2 hu.
@@ -1439,11 +1451,11 @@ Qed.
 
 
 
-Lemma eq_term_upto_mkApps_inv Re u l u' l' :
+Lemma eq_term_upto_mkApps_inv Re ηpred u l u' l' :
   isApp u = false ->
   isApp u' = false ->
-  eq_term_upto Re Re (mkApps u l) (mkApps u' l') ->
-  eq_term_upto Re Re u u' * All2 (eq_term_upto Re Re) l l'.
+  eq_term_upto Re Re ηpred (mkApps u l) (mkApps u' l') ->
+  eq_term_upto Re Re ηpred u u' * All2 (eq_term_upto Re Re ηpred) l l'.
 Proof.
   intros hu hu' h.
   apply eq_term_upto_mkApps_l_inv in h as hh.
@@ -1453,9 +1465,9 @@ Proof.
   destruct h3 as [? ?]. subst. split ; auto.
 Qed.
 
-Lemma isLambda_eq_term_l Re u v :
+Lemma isLambda_eq_term_l Re ηpred u v :
     isLambda u ->
-    eq_term_upto Re Re u v ->
+    eq_term_upto Re Re ηpred u v ->
     isLambda v.
 Proof.
   intros h e.
@@ -1463,9 +1475,9 @@ Proof.
   depelim e. auto.
 Qed.
 
-Lemma isLambda_eq_term_r Re u v :
+Lemma isLambda_eq_term_r Re ηpred u v :
     isLambda v ->
-    eq_term_upto Re Re u v ->
+    eq_term_upto Re Re ηpred u v ->
     isLambda u.
 Proof.
   intros h e.
@@ -1473,9 +1485,9 @@ Proof.
   depelim e. auto.
 Qed.
 
-Lemma isConstruct_app_eq_term_l Re u v :
+Lemma isConstruct_app_eq_term_l Re ηpred u v :
     isConstruct_app u ->
-    eq_term_upto Re Re u v ->
+    eq_term_upto Re Re ηpred u v ->
     isConstruct_app v.
 Proof.
   intros h e.
@@ -1495,12 +1507,12 @@ Proof.
 Qed.
 
 Lemma isConstruct_app_eq_term_r :
-  forall Re u v,
+  forall Re ηpred u v,
     isConstruct_app v ->
-    eq_term_upto Re Re u v ->
+    eq_term_upto Re Re ηpred u v ->
     isConstruct_app u.
 Proof.
-  intros Re u v h e.
+  intros Re ηpred u v h e.
   case_eq (decompose_app u). intros t1 l1 e1.
   case_eq (decompose_app v). intros t2 l2 e2.
   unfold isConstruct_app in *.
@@ -1524,7 +1536,7 @@ Proof.
   intros A R x y h. assumption.
 Qed.
 
-Lemma eq_term_upto_flip (Re Rle Rle' : universe -> universe -> Prop) u v :
+Lemma eq_term_upto_flip (Re Rle Rle' : universe -> universe -> Prop) ηpred u v :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
   RelationClasses.Symmetric Re ->
@@ -1532,8 +1544,8 @@ Lemma eq_term_upto_flip (Re Rle Rle' : universe -> universe -> Prop) u v :
   RelationClasses.Transitive Rle ->
   RelationClasses.subrelation Re Rle ->
   (forall x y, Rle x y -> Rle' y x) ->
-  eq_term_upto Re Rle u v ->
-  eq_term_upto Re Rle' v u.
+  eq_term_upto Re Rle ηpred u v ->
+  eq_term_upto Re Rle' ηpred v u.
 Proof.
   intros Rerefl Rlerefl Resym Retrans Rletrans incl incl' H.
   assert (Resub : RelationClasses.subrelation Re Re).

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -84,7 +84,7 @@ Local Ltac anonify :=
 
 Local Ltac ih :=
   lazymatch goal with
-  | ih : forall v : term, _ -> _ -> eq_term_upto_univ _ _ _ _ -> ?u = _
+  | ih : forall v : term, _ -> _ -> eq_term_upto _ _ _ _ -> ?u = _
     |- ?u = ?v =>
     eapply ih ; assumption
   end.
@@ -93,7 +93,7 @@ Lemma nameless_eq_term_spec :
   forall u v,
     nameless u ->
     nameless v ->
-    eq_term_upto_univ eq eq u v ->
+    eq_term_upto eq eq u v ->
     u = v.
 Proof.
   intros u v hu hv e.
@@ -202,10 +202,10 @@ Proof.
         eapply IHm. assumption.
 Qed.
 
-Lemma nl_eq_term_upto_univ :
+Lemma nl_eq_term_upto :
   forall Re Rle t t',
-    eq_term_upto_univ Re Rle t t' ->
-    eq_term_upto_univ Re Rle (nl t) (nl t').
+    eq_term_upto Re Rle t t' ->
+    eq_term_upto Re Rle (nl t) (nl t').
 Proof.
   intros Re Rle t t' h.
   revert t t' Rle h. fix aux 4.
@@ -243,7 +243,7 @@ Lemma nl_leq_term {cf:checker_flags} :
     leq_term φ t t' ->
     leq_term φ (nl t) (nl t').
 Proof.
-  intros. apply nl_eq_term_upto_univ. assumption.
+  intros. apply nl_eq_term_upto. assumption.
 Qed.
 
 Lemma nl_eq_term {cf:checker_flags} :
@@ -251,32 +251,32 @@ Lemma nl_eq_term {cf:checker_flags} :
     eq_term φ t t' ->
     eq_term φ (nl t) (nl t').
 Proof.
-  intros. apply nl_eq_term_upto_univ. assumption.
+  intros. apply nl_eq_term_upto. assumption.
 Qed.
 
 Corollary eq_term_nl_eq :
   forall u v,
-    eq_term_upto_univ eq eq u v ->
+    eq_term_upto eq eq u v ->
     nl u = nl v.
 Proof.
   intros u v h.
   eapply nameless_eq_term_spec.
   - eapply nl_spec.
   - eapply nl_spec.
-  - now eapply nl_eq_term_upto_univ.
+  - now eapply nl_eq_term_upto.
 Qed.
 
 Local Ltac ih3 :=
   lazymatch goal with
-  | ih : forall Rle v, eq_term_upto_univ _ _ (nl ?u) _ -> _
-    |- eq_term_upto_univ _ _ ?u _ =>
+  | ih : forall Rle v, eq_term_upto _ _ (nl ?u) _ -> _
+    |- eq_term_upto _ _ ?u _ =>
     eapply ih ; assumption
   end.
 
-Lemma eq_term_upto_univ_nl_inv :
+Lemma eq_term_upto_nl_inv :
   forall Re Rle u v,
-    eq_term_upto_univ Re Rle (nl u) (nl v) ->
-    eq_term_upto_univ Re Rle u v.
+    eq_term_upto Re Rle (nl u) (nl v) ->
+    eq_term_upto Re Rle u v.
 Proof.
   intros Re Rle u v h.
   induction u in v, h, Rle |- * using term_forall_list_ind.
@@ -333,16 +333,16 @@ Proof.
   - simpl. rewrite nl_spec, ih. reflexivity.
 Qed.
 
-Lemma eq_term_upto_univ_tm_nl :
+Lemma eq_term_upto_tm_nl :
   forall Re Rle u,
     Reflexive Re ->
     Reflexive Rle ->
-    eq_term_upto_univ Re Rle u (nl u).
+    eq_term_upto Re Rle u (nl u).
 Proof.
   intros Re Rle u hRe hRle.
   induction u in Rle, hRle |- * using term_forall_list_ind.
   all: try solve [
-    simpl ; try apply eq_term_upto_univ_refl ; auto ; constructor ; eauto
+    simpl ; try apply eq_term_upto_refl ; auto ; constructor ; eauto
   ].
   - simpl. constructor.
     induction l.
@@ -370,7 +370,7 @@ Corollary eq_term_tm_nl :
   forall `{checker_flags} G u, eq_term G u (nl u).
 Proof.
   intros flags G u.
-  eapply eq_term_upto_univ_tm_nl.
+  eapply eq_term_upto_tm_nl.
   - intro. eapply eq_universe_refl.
   - intro. eapply eq_universe_refl.
 Qed.
@@ -1196,7 +1196,7 @@ Proof.
     + eapply fix_guard_eq_term with (idx:=n). eassumption.
       constructor. clear. induction mfix. constructor.
       simpl. constructor; tas. cbn.
-      repeat split; now apply eq_term_upto_univ_tm_nl.
+      repeat split; now apply eq_term_upto_tm_nl.
     + now rewrite nth_error_map, H.
     + rewrite XX. revert X. clear.
       induction 1; simpl; econstructor; tas; cbn in *.
@@ -1244,9 +1244,9 @@ Proof.
   destruct (reflect_upto_names t t').
   - constructor. eapply eq_term_nl_eq. assumption.
   - constructor. intro bot. apply f.
-    apply eq_term_upto_univ_nl_inv.
+    apply eq_term_upto_nl_inv.
     rewrite bot.
-    apply eq_term_upto_univ_refl.
+    apply eq_term_upto_refl.
     all: auto.
 Qed.
 

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -84,7 +84,7 @@ Local Ltac anonify :=
 
 Local Ltac ih :=
   lazymatch goal with
-  | ih : forall v : term, _ -> _ -> eq_term_upto _ _ _ _ -> ?u = _
+  | ih : forall v : term, _ -> _ -> eq_term_upto _ _ _ _ _ -> ?u = _
     |- ?u = ?v =>
     eapply ih ; assumption
   end.
@@ -93,7 +93,7 @@ Lemma nameless_eq_term_spec :
   forall u v,
     nameless u ->
     nameless v ->
-    eq_term_upto eq eq u v ->
+    eq_term_upto eq eq no_η u v ->
     u = v.
 Proof.
   intros u v hu hv e.
@@ -203,11 +203,11 @@ Proof.
 Qed.
 
 Lemma nl_eq_term_upto :
-  forall Re Rle t t',
-    eq_term_upto Re Rle t t' ->
-    eq_term_upto Re Rle (nl t) (nl t').
+  forall Re Rle ηpred t t',
+    eq_term_upto Re Rle ηpred t t' ->
+    eq_term_upto Re Rle ηpred (nl t) (nl t').
 Proof.
-  intros Re Rle t t' h.
+  intros Re Rle ηpred t t' h.
   revert t t' Rle h. fix aux 4.
   intros t t' Rle h.
   destruct h.
@@ -256,7 +256,7 @@ Qed.
 
 Corollary eq_term_nl_eq :
   forall u v,
-    eq_term_upto eq eq u v ->
+    eq_term_upto eq eq no_η u v ->
     nl u = nl v.
 Proof.
   intros u v h.
@@ -268,17 +268,17 @@ Qed.
 
 Local Ltac ih3 :=
   lazymatch goal with
-  | ih : forall Rle v, eq_term_upto _ _ (nl ?u) _ -> _
-    |- eq_term_upto _ _ ?u _ =>
+  | ih : forall Rle v, eq_term_upto _ _ _ (nl ?u) _ -> _
+    |- eq_term_upto _ _ _ ?u _ =>
     eapply ih ; assumption
   end.
 
 Lemma eq_term_upto_nl_inv :
-  forall Re Rle u v,
-    eq_term_upto Re Rle (nl u) (nl v) ->
-    eq_term_upto Re Rle u v.
+  forall Re Rle ηpred u v,
+    eq_term_upto Re Rle ηpred (nl u) (nl v) ->
+    eq_term_upto Re Rle ηpred u v.
 Proof.
-  intros Re Rle u v h.
+  intros Re Rle ηpred u v h.
   induction u in v, h, Rle |- * using term_forall_list_ind.
   all: dependent destruction h.
   all: destruct v ; try discriminate.
@@ -334,12 +334,12 @@ Proof.
 Qed.
 
 Lemma eq_term_upto_tm_nl :
-  forall Re Rle u,
+  forall Re Rle ηpred u,
     Reflexive Re ->
     Reflexive Rle ->
-    eq_term_upto Re Rle u (nl u).
+    eq_term_upto Re Rle ηpred u (nl u).
 Proof.
-  intros Re Rle u hRe hRle.
+  intros Re Rle ηpred u hRe hRle.
   induction u in Rle, hRle |- * using term_forall_list_ind.
   all: try solve [
     simpl ; try apply eq_term_upto_refl ; auto ; constructor ; eauto

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -122,12 +122,12 @@ Definition dlet_in na A b t (p : pos t) : pos (tLetIn na A b t) :=
   exist (let_in :: ` p) (proj2_sig p).
 
 Lemma eq_term_upto_valid_pos :
-  forall {u v p Re Rle},
+  forall {u v p Re Rle ηpred},
     validpos u p ->
-    eq_term_upto Re Rle u v ->
+    eq_term_upto Re Rle ηpred u v ->
     validpos v p.
 Proof.
-  intros u v p Re Rle vp e.
+  intros u v p Re Rle ηpred vp e.
   induction p as [| c p ih ] in u, v, Re, Rle, vp, e |- *.
   - reflexivity.
   - destruct c, u. all: try discriminate.

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -124,7 +124,7 @@ Definition dlet_in na A b t (p : pos t) : pos (tLetIn na A b t) :=
 Lemma eq_term_upto_valid_pos :
   forall {u v p Re Rle},
     validpos u p ->
-    eq_term_upto_univ Re Rle u v ->
+    eq_term_upto Re Rle u v ->
     validpos v p.
 Proof.
   intros u v p Re Rle vp e.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -160,10 +160,10 @@ Section Principality.
     now eapply red_cumul_inv.
   Qed.
 
-  Lemma eq_term_upto_univ_conv_arity_l :
+  Lemma eq_term_upto_conv_arity_l :
     forall Re Rle Γ u v,
       isArity u ->
-      eq_term_upto_univ Re Rle u v ->
+      eq_term_upto Re Rle u v ->
       Is_conv_to_Arity Σ Γ v.
   Proof.
     intros Re Rle Γ u v a e.
@@ -188,10 +188,10 @@ Section Principality.
       + simpl. assumption.
   Qed.
 
-  Lemma eq_term_upto_univ_conv_arity_r :
+  Lemma eq_term_upto_conv_arity_r :
     forall Re Rle Γ u v,
       isArity u ->
-      eq_term_upto_univ Re Rle v u ->
+      eq_term_upto Re Rle v u ->
       Is_conv_to_Arity Σ Γ v.
   Proof.
     intros Re Rle Γ u v a e.
@@ -267,7 +267,7 @@ Section Principality.
   Proof.
     intros Γ C T a h.
     induction h.
-    - eapply eq_term_upto_univ_conv_arity_r. all: eassumption.
+    - eapply eq_term_upto_conv_arity_r. all: eassumption.
     - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
       exists v'. split.
       + constructor. eapply red_trans.
@@ -287,7 +287,7 @@ Section Principality.
   Proof.
     intros Γ C T a h.
     induction h.
-    - eapply eq_term_upto_univ_conv_arity_l. all: eassumption.
+    - eapply eq_term_upto_conv_arity_l. all: eassumption.
     - eapply IHh. eapply isArity_red1. all: eassumption.
     - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
       exists v'. split.
@@ -428,7 +428,7 @@ Section Principality.
     intros Γ ind ui l T h.
     eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
     eapply invert_red_ind in redv as [l' [? ha]]. subst.
-    eapply eq_term_upto_univ_mkApps_l_inv in leqvv'
+    eapply eq_term_upto_mkApps_l_inv in leqvv'
       as [u [l'' [[e ?] ?]]].
     subst.
     dependent destruction e.
@@ -452,7 +452,7 @@ Section Principality.
     intros Γ ind ui l T h.
     eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
     eapply invert_red_ind in redv' as [l' [? ?]]. subst.
-    eapply eq_term_upto_univ_mkApps_r_inv in leqvv'
+    eapply eq_term_upto_mkApps_r_inv in leqvv'
       as [u [l'' [[e ?] ?]]].
     subst.
     dependent destruction e.
@@ -535,12 +535,12 @@ Section Principality.
   Qed.
 
   (* Duplicate *)
-  (* Lemma eq_term_upto_univ_mkApps_r_inv : *)
+  (* Lemma eq_term_upto_mkApps_r_inv : *)
   (*   forall Re Rle u l t, *)
-  (*     eq_term_upto_univ Re Rle t (mkApps u l) -> *)
+  (*     eq_term_upto Re Rle t (mkApps u l) -> *)
   (*     ∑ u' l', *)
-  (*   eq_term_upto_univ Re Rle u' u * *)
-  (*   All2 (eq_term_upto_univ Re Re) l' l * *)
+  (*   eq_term_upto Re Rle u' u * *)
+  (*   All2 (eq_term_upto Re Re) l' l * *)
   (*   (t = mkApps u' l'). *)
   (* Proof. *)
   (*   intros Re Rle u l t h. *)
@@ -566,7 +566,7 @@ Section Principality.
   (*   intros H. eapply cumul_alt in H. *)
   (*   destruct H as [v [v' [[redv redv'] leq]]]. *)
   (*   eapply red_mkApps_tInd in redv' as [args' [-> ?]]; eauto. *)
-  (*   apply eq_term_upto_univ_mkApps_r_inv in leq as [u' [l' [[eqhd eqargs] Heq]]]. *)
+  (*   apply eq_term_upto_mkApps_r_inv in leq as [u' [l' [[eqhd eqargs] Heq]]]. *)
   (*   subst v. depelim eqhd. *)
   (*   exists u0, l'. split; auto. *)
   (*   clear -eqargs a0. *)

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -161,12 +161,12 @@ Section Principality.
   Qed.
 
   Lemma eq_term_upto_conv_arity_l :
-    forall Re Rle Γ u v,
+    forall Re Rle ηpred Γ u v,
       isArity u ->
-      eq_term_upto Re Rle u v ->
+      eq_term_upto Re Rle ηpred u v ->
       Is_conv_to_Arity Σ Γ v.
   Proof.
-    intros Re Rle Γ u v a e.
+    intros Re Rle ηpred Γ u v a e.
     induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
     all: dependent destruction e.
     - eexists. split.
@@ -189,12 +189,12 @@ Section Principality.
   Qed.
 
   Lemma eq_term_upto_conv_arity_r :
-    forall Re Rle Γ u v,
+    forall Re Rle ηpred Γ u v,
       isArity u ->
-      eq_term_upto Re Rle v u ->
+      eq_term_upto Re Rle ηpred v u ->
       Is_conv_to_Arity Σ Γ v.
   Proof.
-    intros Re Rle Γ u v a e.
+    intros Re Rle ηpred Γ u v a e.
     induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
     all: dependent destruction e.
     - eexists. split.

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -232,7 +232,7 @@ Section Alpha.
   Qed.
 
   Lemma cored_eq_term_upto :
-    forall Re Rle Γ u v u',
+    forall Re Rle ηpred Γ u v u',
       RelationClasses.Reflexive Re ->
       SubstUnivPreserving Re ->
       RelationClasses.Reflexive Rle ->
@@ -240,11 +240,11 @@ Section Alpha.
       RelationClasses.Transitive Re ->
       RelationClasses.Transitive Rle ->
       RelationClasses.subrelation Re Rle ->
-      eq_term_upto Re Rle u u' ->
+      eq_term_upto Re Rle ηpred u u' ->
       cored Σ Γ v u ->
-      exists v', cored Σ Γ v' u' /\ ∥ eq_term_upto Re Rle v v' ∥.
+      exists v', cored Σ Γ v' u' /\ ∥ eq_term_upto Re Rle ηpred v v' ∥.
   Proof.
-    intros Re Rle Γ u v u' X X0 X1 X2 X3 X4 X5 e h.
+    intros Re Rle ηpred Γ u v u' X X0 X1 X2 X3 X4 X5 e h.
     apply cored_alt in h as [h].
     induction h in u', e |- *.
     - eapply red1_eq_term_upto_l in r. 8: eauto. all: auto.
@@ -260,16 +260,16 @@ Section Alpha.
   Qed.
 
   Lemma cored_eq_context_upto :
-    forall Re Γ Δ u v,
+    forall Re ηpred Γ Δ u v,
       RelationClasses.Reflexive Re ->
       RelationClasses.Symmetric Re ->
       RelationClasses.Transitive Re ->
       SubstUnivPreserving Re ->
-      eq_context_upto Re Γ Δ ->
+      eq_context_upto Re ηpred Γ Δ ->
       cored Σ Γ u v ->
-      exists u', cored Σ Δ u' v /\ ∥ eq_term_upto Re Re u u' ∥.
+      exists u', cored Σ Δ u' v /\ ∥ eq_term_upto Re Re ηpred u u' ∥.
   Proof.
-    intros Re Γ Δ u v hRe1 hRe2 hRe3 hRe4 e h.
+    intros Re ηpred Γ Δ u v hRe1 hRe2 hRe3 hRe4 e h.
     apply cored_alt in h as [h].
     induction h.
     - eapply red1_eq_context_upto_l in r. all: eauto.
@@ -289,7 +289,7 @@ Section Alpha.
 
   Lemma eq_context_upto_nlctx :
     forall Γ,
-      eq_context_upto eq Γ (nlctx Γ).
+      eq_context_upto eq no_η Γ (nlctx Γ).
   Proof.
     intros Γ.
     induction Γ as [| [na [b|] A] Γ ih ].

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -140,7 +140,7 @@ Section Alpha.
     apply cored_alt in r.
     destruct r as [r].
     induction r in u, v, hu, hv.
-    - eapply red1_eq_term_upto_univ_r in r. 9: eassumption.
+    - eapply red1_eq_term_upto_r in r. 9: eassumption.
       (* all: auto. *)
       (* They should be automatic... *)
       all: try eapply eq_universe_refl.
@@ -240,14 +240,14 @@ Section Alpha.
       RelationClasses.Transitive Re ->
       RelationClasses.Transitive Rle ->
       RelationClasses.subrelation Re Rle ->
-      eq_term_upto_univ Re Rle u u' ->
+      eq_term_upto Re Rle u u' ->
       cored Σ Γ v u ->
-      exists v', cored Σ Γ v' u' /\ ∥ eq_term_upto_univ Re Rle v v' ∥.
+      exists v', cored Σ Γ v' u' /\ ∥ eq_term_upto Re Rle v v' ∥.
   Proof.
     intros Re Rle Γ u v u' X X0 X1 X2 X3 X4 X5 e h.
     apply cored_alt in h as [h].
     induction h in u', e |- *.
-    - eapply red1_eq_term_upto_univ_l in r. 8: eauto. all: auto.
+    - eapply red1_eq_term_upto_l in r. 8: eauto. all: auto.
       destruct r as [? [? ?]].
       eexists. split.
       + constructor. eassumption.
@@ -267,7 +267,7 @@ Section Alpha.
       SubstUnivPreserving Re ->
       eq_context_upto Re Γ Δ ->
       cored Σ Γ u v ->
-      exists u', cored Σ Δ u' v /\ ∥ eq_term_upto_univ Re Re u u' ∥.
+      exists u', cored Σ Δ u' v /\ ∥ eq_term_upto Re Re u u' ∥.
   Proof.
     intros Re Γ Δ u v hRe1 hRe2 hRe3 hRe4 e h.
     apply cored_alt in h as [h].
@@ -283,7 +283,7 @@ Section Alpha.
       + destruct r2 as [y'' [r2' [e2']]].
         exists y''. split.
         * eapply cored_trans'. all: eassumption.
-        * constructor. eapply eq_term_upto_univ_trans. all: eauto.
+        * constructor. eapply eq_term_upto_trans. all: eauto.
       + intros ? ? ?. assumption.
   Qed.
 
@@ -295,13 +295,13 @@ Section Alpha.
     induction Γ as [| [na [b|] A] Γ ih ].
     - constructor.
     - simpl. constructor.
-      + eapply eq_term_upto_univ_tm_nl.
+      + eapply eq_term_upto_tm_nl.
         all: auto.
-      + simpl. eapply eq_term_upto_univ_tm_nl.
+      + simpl. eapply eq_term_upto_tm_nl.
         all: auto.
       + assumption.
     - simpl. constructor.
-      + simpl. eapply eq_term_upto_univ_tm_nl.
+      + simpl. eapply eq_term_upto_tm_nl.
         all: auto.
       + assumption.
   Qed.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -128,62 +128,62 @@ Section Lemmata.
     eassumption.
   Qed.
 
-  Lemma eq_term_upto_univ_zipc :
+  Lemma eq_term_upto_zipc :
     forall Re u v π,
       RelationClasses.Reflexive Re ->
-      eq_term_upto_univ Re Re u v ->
-      eq_term_upto_univ Re Re (zipc u π) (zipc v π).
+      eq_term_upto Re Re u v ->
+      eq_term_upto Re Re (zipc u π) (zipc v π).
   Proof.
     intros Re u v π he h.
     induction π in u, v, h |- *.
     all: try solve [
                simpl ; try apply IHπ ;
-               cbn ; constructor ; try apply eq_term_upto_univ_refl ; assumption
+               cbn ; constructor ; try apply eq_term_upto_refl ; assumption
              ].
     - assumption.
     - simpl. apply IHπ. constructor.
       apply All2_app.
       + apply All2_same.
-        intros. split ; auto. split. all: apply eq_term_upto_univ_refl.
+        intros. split ; auto. split. all: apply eq_term_upto_refl.
         all: assumption.
       + constructor.
         * simpl. intuition eauto. reflexivity.
         * apply All2_same.
-          intros. split ; auto. split. all: apply eq_term_upto_univ_refl.
+          intros. split ; auto. split. all: apply eq_term_upto_refl.
           all: assumption.
     - simpl. apply IHπ. constructor.
       apply All2_app.
       + apply All2_same.
-        intros. split ; auto. split. all: apply eq_term_upto_univ_refl.
+        intros. split ; auto. split. all: apply eq_term_upto_refl.
         all: assumption.
       + constructor.
         * simpl. intuition eauto. reflexivity.
         * apply All2_same.
-          intros. split ; auto. split. all: apply eq_term_upto_univ_refl.
+          intros. split ; auto. split. all: apply eq_term_upto_refl.
           all: assumption.
     - simpl. apply IHπ. destruct indn as [i n].
       constructor.
       + assumption.
-      + apply eq_term_upto_univ_refl. all: assumption.
+      + apply eq_term_upto_refl. all: assumption.
       + eapply All2_same.
-        intros. split ; auto. apply eq_term_upto_univ_refl. all: assumption.
+        intros. split ; auto. apply eq_term_upto_refl. all: assumption.
     - simpl. apply IHπ. destruct indn as [i n].
       constructor.
-      + apply eq_term_upto_univ_refl. all: assumption.
+      + apply eq_term_upto_refl. all: assumption.
       + assumption.
       + eapply All2_same.
-        intros. split ; auto. apply eq_term_upto_univ_refl. all: assumption.
+        intros. split ; auto. apply eq_term_upto_refl. all: assumption.
     - simpl. apply IHπ. destruct indn as [i n].
       constructor.
-      + apply eq_term_upto_univ_refl. all: assumption.
-      + apply eq_term_upto_univ_refl. all: assumption.
+      + apply eq_term_upto_refl. all: assumption.
+      + apply eq_term_upto_refl. all: assumption.
       + apply All2_app.
         * eapply All2_same.
-          intros. split ; auto. apply eq_term_upto_univ_refl. all: assumption.
+          intros. split ; auto. apply eq_term_upto_refl. all: assumption.
         * constructor.
           -- simpl. intuition eauto.
           -- eapply All2_same.
-             intros. split ; auto. apply eq_term_upto_univ_refl.
+             intros. split ; auto. apply eq_term_upto_refl.
              all: assumption.
   Qed.
 
@@ -193,21 +193,21 @@ Section Lemmata.
       eq_term (global_ext_constraints Σ) (zipc u π) (zipc v π).
   Proof.
     intros Σ u v π h.
-    eapply eq_term_upto_univ_zipc.
+    eapply eq_term_upto_zipc.
     - intro. eapply eq_universe_refl.
     - assumption.
   Qed.
 
-  Lemma eq_term_upto_univ_zipp :
+  Lemma eq_term_upto_zipp :
     forall Re u v π,
       RelationClasses.Reflexive Re ->
-      eq_term_upto_univ Re Re u v ->
-      eq_term_upto_univ Re Re (zipp u π) (zipp v π).
+      eq_term_upto Re Re u v ->
+      eq_term_upto Re Re (zipp u π) (zipp v π).
   Proof.
     intros Re u v π he h.
     unfold zipp.
     case_eq (decompose_stack π). intros l ρ e.
-    eapply eq_term_upto_univ_mkApps.
+    eapply eq_term_upto_mkApps.
     - assumption.
     - apply All2_same. intro. reflexivity.
   Qed.
@@ -218,20 +218,20 @@ Section Lemmata.
       eq_term (global_ext_constraints Σ) (zipp u π) (zipp v π).
   Proof.
     intros Σ u v π h.
-    eapply eq_term_upto_univ_zipp.
+    eapply eq_term_upto_zipp.
     - intro. eapply eq_universe_refl.
     - assumption.
   Qed.
 
-  Lemma eq_term_upto_univ_zipx :
+  Lemma eq_term_upto_zipx :
     forall Re Γ u v π,
       RelationClasses.Reflexive Re ->
-      eq_term_upto_univ Re Re u v ->
-      eq_term_upto_univ Re Re (zipx Γ u π) (zipx Γ v π).
+      eq_term_upto Re Re u v ->
+      eq_term_upto Re Re (zipx Γ u π) (zipx Γ v π).
   Proof.
     intros Re Γ u v π he h.
-    eapply eq_term_upto_univ_it_mkLambda_or_LetIn ; auto.
-    eapply eq_term_upto_univ_zipc ; auto.
+    eapply eq_term_upto_it_mkLambda_or_LetIn ; auto.
+    eapply eq_term_upto_zipc ; auto.
   Qed.
 
   Lemma eq_term_zipx :
@@ -240,7 +240,7 @@ Section Lemmata.
       eq_term φ (zipx Γ u π) (zipx Γ v π).
   Proof.
     intros Σ Γ u v π h.
-    eapply eq_term_upto_univ_zipx ; auto.
+    eapply eq_term_upto_zipx ; auto.
     intro. eapply eq_universe_refl.
   Qed.
 
@@ -255,7 +255,7 @@ Section Lemmata.
 
   Derive Signature for cored.
 
-  Hint Resolve eq_term_upto_univ_refl : core.
+  Hint Resolve eq_term_upto_refl : core.
 
   Lemma fresh_global_nl :
     forall Σ k,
@@ -311,7 +311,7 @@ Section Lemmata.
 
   Lemma welltyped_alpha Γ u v :
       welltyped Σ Γ u ->
-      eq_term_upto_univ eq eq u v ->
+      eq_term_upto eq eq u v ->
       welltyped Σ Γ v.
   Proof.
     intros [A h] e.
@@ -321,7 +321,7 @@ Section Lemmata.
 
   Lemma wellformed_alpha Γ u v :
       wellformed Σ Γ u ->
-      eq_term_upto_univ eq eq u v ->
+      eq_term_upto eq eq u v ->
       wellformed Σ Γ v.
   Proof.
     destruct hΣ as [hΣ'].
@@ -1738,7 +1738,7 @@ Lemma type_Case' {cf:checker_flags} Σ Γ indnpar u p c brs args :
     All2 (fun br bty => (br.1 = bty.1) × (Σ ;;; Γ |- br.2 : bty.2)) brs btys ->
     Σ ;;; Γ |- tCase indnpar p c brs : mkApps p (skipn npar args ++ [c]).
 Proof.
-  intros ind npar mdecl idecl isdecl H params ps pty H0 X H1 X0 btys H2 X1. 
+  intros ind npar mdecl idecl isdecl H params ps pty H0 X H1 X0 btys H2 X1.
   econstructor; tea.
   eapply type_Case_valid_btys in X; tea.
   eapply All2_All_mix_right; tea.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -129,12 +129,12 @@ Section Lemmata.
   Qed.
 
   Lemma eq_term_upto_zipc :
-    forall Re u v π,
+    forall Re ηpred u v π,
       RelationClasses.Reflexive Re ->
-      eq_term_upto Re Re u v ->
-      eq_term_upto Re Re (zipc u π) (zipc v π).
+      eq_term_upto Re Re ηpred u v ->
+      eq_term_upto Re Re ηpred (zipc u π) (zipc v π).
   Proof.
-    intros Re u v π he h.
+    intros Re ηpred u v π he h.
     induction π in u, v, h |- *.
     all: try solve [
                simpl ; try apply IHπ ;
@@ -199,12 +199,12 @@ Section Lemmata.
   Qed.
 
   Lemma eq_term_upto_zipp :
-    forall Re u v π,
+    forall Re ηpred u v π,
       RelationClasses.Reflexive Re ->
-      eq_term_upto Re Re u v ->
-      eq_term_upto Re Re (zipp u π) (zipp v π).
+      eq_term_upto Re Re ηpred u v ->
+      eq_term_upto Re Re ηpred (zipp u π) (zipp v π).
   Proof.
-    intros Re u v π he h.
+    intros Re ηpred u v π he h.
     unfold zipp.
     case_eq (decompose_stack π). intros l ρ e.
     eapply eq_term_upto_mkApps.
@@ -224,12 +224,12 @@ Section Lemmata.
   Qed.
 
   Lemma eq_term_upto_zipx :
-    forall Re Γ u v π,
+    forall Re ηpred Γ u v π,
       RelationClasses.Reflexive Re ->
-      eq_term_upto Re Re u v ->
-      eq_term_upto Re Re (zipx Γ u π) (zipx Γ v π).
+      eq_term_upto Re Re ηpred u v ->
+      eq_term_upto Re Re ηpred (zipx Γ u π) (zipx Γ v π).
   Proof.
-    intros Re Γ u v π he h.
+    intros Re ηpred Γ u v π he h.
     eapply eq_term_upto_it_mkLambda_or_LetIn ; auto.
     eapply eq_term_upto_zipc ; auto.
   Qed.
@@ -311,7 +311,7 @@ Section Lemmata.
 
   Lemma welltyped_alpha Γ u v :
       welltyped Σ Γ u ->
-      eq_term_upto eq eq u v ->
+      eq_term_upto eq eq no_η u v ->
       welltyped Σ Γ v.
   Proof.
     intros [A h] e.
@@ -321,7 +321,7 @@ Section Lemmata.
 
   Lemma wellformed_alpha Γ u v :
       wellformed Σ Γ u ->
-      eq_term_upto eq eq u v ->
+      eq_term_upto eq eq no_η u v ->
       wellformed Σ Γ v.
   Proof.
     destruct hΣ as [hΣ'].

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -288,11 +288,11 @@ Section Renaming.
 Context `{checker_flags}.
 
 Lemma eq_term_upto_rename :
-  forall Re Rle u v f,
-    eq_term_upto Re Rle u v ->
-    eq_term_upto Re Rle (rename f u) (rename f v).
+  forall Re Rle ηpred u v f,
+    eq_term_upto Re Rle ηpred u v ->
+    eq_term_upto Re Rle ηpred (rename f u) (rename f v).
 Proof.
-  intros Re Rle u v f h.
+  intros Re Rle ηpred u v f h.
   induction u in v, Rle, f, h |- * using term_forall_list_ind.
   all: dependent destruction h.
   all: try solve [

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -287,10 +287,10 @@ Section Renaming.
 
 Context `{checker_flags}.
 
-Lemma eq_term_upto_univ_rename :
+Lemma eq_term_upto_rename :
   forall Re Rle u v f,
-    eq_term_upto_univ Re Rle u v ->
-    eq_term_upto_univ Re Rle (rename f u) (rename f v).
+    eq_term_upto Re Rle u v ->
+    eq_term_upto Re Rle (rename f u) (rename f v).
 Proof.
   intros Re Rle u v f h.
   induction u in v, Rle, f, h |- * using term_forall_list_ind.
@@ -1155,10 +1155,10 @@ Proof.
     (*   * reflexivity. *)
     (*   * constructor ; auto. *)
     (*     simpl. split ; auto. *)
-    (*     eapply eq_term_upto_univ_it_mkProd_or_LetIn ; auto. *)
-    (*     eapply eq_term_upto_univ_mkApps. *)
-    (*     -- eapply eq_term_upto_univ_lift. assumption. *)
-    (*     -- apply All2_same. intro. apply eq_term_upto_univ_refl ; auto. *)
+    (*     eapply eq_term_upto_it_mkProd_or_LetIn ; auto. *)
+    (*     eapply eq_term_upto_mkApps. *)
+    (*     -- eapply eq_term_upto_lift. assumption. *)
+    (*     -- apply All2_same. intro. apply eq_term_upto_refl ; auto. *)
 Admitted.
 
 Lemma typed_inst :
@@ -1567,7 +1567,7 @@ Lemma cumul_rename :
 Proof.
   intros Σ Γ Δ f A B hΣ hf h.
   induction h.
-  - eapply cumul_refl. eapply eq_term_upto_univ_rename. assumption.
+  - eapply cumul_refl. eapply eq_term_upto_rename. assumption.
   - eapply cumul_red_l.
     + eapply red1_rename. all: try eassumption.
       apply hf.
@@ -2083,10 +2083,10 @@ Proof.
     (*   * reflexivity. *)
     (*   * constructor ; auto. *)
     (*     simpl. split ; auto. *)
-    (*     eapply eq_term_upto_univ_it_mkProd_or_LetIn ; auto. *)
-    (*     eapply eq_term_upto_univ_mkApps. *)
-    (*     -- eapply eq_term_upto_univ_lift. assumption. *)
-    (*     -- apply All2_same. intro. apply eq_term_upto_univ_refl ; auto. *)
+    (*     eapply eq_term_upto_it_mkProd_or_LetIn ; auto. *)
+    (*     eapply eq_term_upto_mkApps. *)
+    (*     -- eapply eq_term_upto_lift. assumption. *)
+    (*     -- apply All2_same. intro. apply eq_term_upto_refl ; auto. *)
 Admitted.
 
 (* Lemma types_of_case_inst : *)
@@ -2204,7 +2204,7 @@ Proof.
     (* NEED Commutation *)
     admit.
   - intros Σ wfΣ Γ wfΓ ind u npar p c brs args mdecl idecl isdecl X X0 a pars
-           ps pty htoc X1 ihp H2 X3 ihc btys H3 ihbtys Δ σ hΔ hσ. 
+           ps pty htoc X1 ihp H2 X3 ihc btys H3 ihbtys Δ σ hΔ hσ.
     autorewrite with sigma. simpl.
     rewrite map_app. simpl.
     rewrite map_skipn.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -598,10 +598,10 @@ Definition precompose_subst_instance_instance__2 Rle u i i'
   := equiv_inv _ _ (precompose_subst_instance_instance Rle u i i').
 
 
-Global Instance eq_term_upto_univ_subst_instance
+Global Instance eq_term_upto_subst_instance
          (Re Rle : constraints -> universe -> universe -> Prop)
       {he: SubstUnivPreserved Re} {hle: SubstUnivPreserved Rle}
-  : SubstUnivPreserved (fun φ => eq_term_upto_univ (Re φ) (Rle φ)).
+  : SubstUnivPreserved (fun φ => eq_term_upto (Re φ) (Rle φ)).
 Proof.
   intros φ φ' u Hu HH t t'.
   specialize (he _ _ _ Hu HH).
@@ -1098,7 +1098,7 @@ Proof.
     + symmetry; apply subst_instance_constr_two.
 
   - intros ind u npar p c brs args mdecl idecl isdecl X X0 H ps pty H0 X1
-           X2 H1 X3 X4 btys H2 X5 u0 univs X6 HSub H4. 
+           X2 H1 X3 X4 btys H2 X5 u0 univs X6 HSub H4.
     rewrite subst_instance_constr_mkApps in *.
     rewrite map_app. cbn. rewrite map_skipn.
     eapply type_Case with (u1:=subst_instance_instance u0 u)
@@ -1113,7 +1113,7 @@ Proof.
       destruct (instantiate_params param' (firstn npar args) type');
         [|discriminate].
       simpl. rewrite (subst_instance_destArity []).
-      destruct (destArity [] t) as [[ctx s'] ?|]; [|discriminate]. 
+      destruct (destArity [] t) as [[ctx s'] ?|]; [|discriminate].
       apply some_inj in H0; subst; simpl in *. f_equal.
       rewrite subst_instance_constr_it_mkProd_or_LetIn. f_equal; cbn.
       f_equal. rewrite subst_instance_constr_mkApps; cbn.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -599,9 +599,9 @@ Definition precompose_subst_instance_instance__2 Rle u i i'
 
 
 Global Instance eq_term_upto_subst_instance
-         (Re Rle : constraints -> universe -> universe -> Prop)
+         (Re Rle : constraints -> universe -> universe -> Prop) ηpred
       {he: SubstUnivPreserved Re} {hle: SubstUnivPreserved Rle}
-  : SubstUnivPreserved (fun φ => eq_term_upto (Re φ) (Rle φ)).
+  : SubstUnivPreserved (fun φ => eq_term_upto (Re φ) (Rle φ) ηpred).
 Proof.
   intros φ φ' u Hu HH t t'.
   specialize (he _ _ _ Hu HH).

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -50,7 +50,7 @@ Qed.
 Lemma leq_term_subset {cf:checker_flags} ctrs ctrs' t u
   : ConstraintSet.Subset ctrs ctrs' -> leq_term ctrs t u -> leq_term ctrs' t u.
 Proof.
-  intro H. apply eq_term_upto_univ_impl.
+  intro H. apply eq_term_upto_impl.
   intros t' u'; eapply eq_universe_subset; assumption.
   intros t' u'; eapply leq_universe_subset; assumption.
 Qed.
@@ -100,7 +100,7 @@ Lemma eq_term_subset {cf:checker_flags} φ φ' t t'
   : ConstraintSet.Subset φ φ'
     -> eq_term φ t t' ->  eq_term φ' t t'.
 Proof.
-  intro H. apply eq_term_upto_univ_impl.
+  intro H. apply eq_term_upto_impl.
   all: intros u u'; eapply eq_universe_subset; assumption.
 Qed.
 

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -51,8 +51,9 @@ Lemma leq_term_subset {cf:checker_flags} ctrs ctrs' t u
   : ConstraintSet.Subset ctrs ctrs' -> leq_term ctrs t u -> leq_term ctrs' t u.
 Proof.
   intro H. apply eq_term_upto_impl.
-  intros t' u'; eapply eq_universe_subset; assumption.
-  intros t' u'; eapply leq_universe_subset; assumption.
+  - intros t' u'. eapply eq_universe_subset. assumption.
+  - intros t' u'. eapply leq_universe_subset. assumption.
+  - intro. auto.
 Qed.
 
 (** * Weakening lemmas w.r.t. the global environment *)
@@ -101,6 +102,7 @@ Lemma eq_term_subset {cf:checker_flags} φ φ' t t'
     -> eq_term φ t t' ->  eq_term φ' t t'.
 Proof.
   intro H. apply eq_term_upto_impl.
+  3:{ intro. auto. }
   all: intros u u'; eapply eq_universe_subset; assumption.
 Qed.
 

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -718,21 +718,21 @@ Proof.
   simpl in *. apply IHu. assumption. constructor; assumption.
 Qed.
 
-Lemma eq_term_upto_App `{checker_flags} Re Rle f f' :
-  eq_term_upto Re Rle f f' ->
+Lemma eq_term_upto_App `{checker_flags} Re Rle ηpred f f' :
+  eq_term_upto Re Rle ηpred f f' ->
   isApp f = isApp f'.
 Proof.
   inversion 1; reflexivity.
 Qed.
 
-Lemma eq_term_upto_mkApps `{checker_flags} Re Rle f l f' l' :
-  eq_term_upto Re Rle f f' ->
-  All2 (eq_term_upto Re Re) l l' ->
-  eq_term_upto Re Rle (mkApps f l) (mkApps f' l').
+Lemma eq_term_upto_mkApps `{checker_flags} Re Rle ηpred f l f' l' :
+  eq_term_upto Re Rle ηpred f f' ->
+  All2 (eq_term_upto Re Re ηpred) l l' ->
+  eq_term_upto Re Rle ηpred (mkApps f l) (mkApps f' l').
 Proof.
   induction l in f, f', l' |- *; intro e; inversion_clear 1.
   - assumption.
-  - pose proof (eq_term_upto_App _ _ _ _ e).
+  - pose proof (eq_term_upto_App _ _ _ _ _ e).
     case_eq (isApp f).
     + intro X; rewrite X in H0.
       destruct f; try discriminate.
@@ -748,13 +748,13 @@ Qed.
 
 (* TODO REMOVE trans_eq_term *)
 Lemma trans_eq_term_upto :
-  forall Re Rle t u,
+  forall Re Rle ηpred t u,
     T.wf t ->
     T.wf u ->
     TTy.eq_term_upto Re Rle t u ->
-    eq_term_upto Re Rle (trans t) (trans u).
+    eq_term_upto Re Rle ηpred (trans t) (trans u).
 Proof.
-  intros Re Rle  t u wt wu e.
+  intros Re Rle ηpred t u wt wu e.
   induction t using Induction.term_forall_list_rect in Rle, wt, u, wu, e |- *.
   all: dependent destruction e.
   all: simpl.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -533,7 +533,7 @@ Proof.
   rewrite mkApps_app. simpl. reflexivity.
 Qed.
 
-Derive Signature for TTy.eq_term_upto_univ.
+Derive Signature for TTy.eq_term_upto.
 
 Lemma trans_eq_term :
   forall φ t u,
@@ -718,21 +718,21 @@ Proof.
   simpl in *. apply IHu. assumption. constructor; assumption.
 Qed.
 
-Lemma eq_term_upto_univ_App `{checker_flags} Re Rle f f' :
-  eq_term_upto_univ Re Rle f f' ->
+Lemma eq_term_upto_App `{checker_flags} Re Rle f f' :
+  eq_term_upto Re Rle f f' ->
   isApp f = isApp f'.
 Proof.
   inversion 1; reflexivity.
 Qed.
 
-Lemma eq_term_upto_univ_mkApps `{checker_flags} Re Rle f l f' l' :
-  eq_term_upto_univ Re Rle f f' ->
-  All2 (eq_term_upto_univ Re Re) l l' ->
-  eq_term_upto_univ Re Rle (mkApps f l) (mkApps f' l').
+Lemma eq_term_upto_mkApps `{checker_flags} Re Rle f l f' l' :
+  eq_term_upto Re Rle f f' ->
+  All2 (eq_term_upto Re Re) l l' ->
+  eq_term_upto Re Rle (mkApps f l) (mkApps f' l').
 Proof.
   induction l in f, f', l' |- *; intro e; inversion_clear 1.
   - assumption.
-  - pose proof (eq_term_upto_univ_App _ _ _ _ e).
+  - pose proof (eq_term_upto_App _ _ _ _ e).
     case_eq (isApp f).
     + intro X; rewrite X in H0.
       destruct f; try discriminate.
@@ -747,12 +747,12 @@ Proof.
 Qed.
 
 (* TODO REMOVE trans_eq_term *)
-Lemma trans_eq_term_upto_univ :
+Lemma trans_eq_term_upto :
   forall Re Rle t u,
     T.wf t ->
     T.wf u ->
-    TTy.eq_term_upto_univ Re Rle t u ->
-    eq_term_upto_univ Re Rle (trans t) (trans u).
+    TTy.eq_term_upto Re Rle t u ->
+    eq_term_upto Re Rle (trans t) (trans u).
 Proof.
   intros Re Rle  t u wt wu e.
   induction t using Induction.term_forall_list_rect in Rle, wt, u, wu, e |- *.
@@ -795,7 +795,7 @@ Proof.
       * inversion wt. assumption.
       * inversion wu. assumption.
       * assumption.
-  - eapply eq_term_upto_univ_mkApps.
+  - eapply eq_term_upto_mkApps.
     + eapply IHt.
       * inversion wt. assumption.
       * inversion wu. assumption.
@@ -897,7 +897,7 @@ Lemma trans_leq_term ϕ T U :
   leq_term ϕ (trans T) (trans U).
 Proof.
   intros HT HU H.
-  eapply trans_eq_term_upto_univ ; eauto.
+  eapply trans_eq_term_upto ; eauto.
 Qed.
 
 (* Lemma wf_mkApps t u : T.wf (T.mkApps t u) -> List.Forall T.wf u. *)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1542,9 +1542,9 @@ Section Conversion.
   Qed.
 
   (* TODO (RE)MOVE *)
-  Lemma destArity_eq_term_upto_univ :
+  Lemma destArity_eq_term_upto :
     forall Re Rle Γ1 Γ2 t1 t2 Δ1 s1,
-      eq_term_upto_univ Re Rle t1 t2 ->
+      eq_term_upto Re Rle t1 t2 ->
       eq_context_upto Re Γ1 Γ2 ->
       destArity Γ1 t1 = Some (Δ1, s1) ->
       exists Δ2 s2,


### PR DESCRIPTION
I will try to add η-conversion to `eq_term` in this branch. It will only regard the spec for now, I will attempt to add η-conversion to safe conversion in a later PR.

This first action I'm taking is to rename `eq_term_upto_univ` to `eq_term_upto` since I will ultimately have `eq_term_upto` not only depend on universe relations but also on a predicate restricting applications of η-conversion.
With this PR, `eq_term_upto` takes another parameter `ηpred : term -> Prop`, stating which terms can be η-expanded.