### PR TITLE
Added opaque fresh_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Options
 the unquoting of a universe level fails if this level does not exists.
 Otherwise the level is added to the current context. It is on by default.
 
-There is also an "opaque" universe `fresh_universe` which is unquoted to
-a fresh level when `Strict Unquote Universe Mode` is off.
+There is also an "opaque" universe `fresh_universe` and an opaque level `fresh_level` which are unquoted to
+a fresh universe and a fresh level when `Strict Unquote Universe Mode` is off.
 
 Papers
 ======

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -172,7 +172,14 @@ struct
 
   let unquote_level evm trm (* of type level *) : Evd.evar_map * Univ.Level.t =
     let (h,args) = app_full trm [] in
-    if constr_equall h lProp then
+    if constr_equall h lfresh_level then
+      if !strict_unquote_universe_mode then
+        CErrors.user_err ~hdr:"unquote_level" (str "It is not possible to unquote a fresh level in Strict Unquote Universe Mode.")
+      else
+        let evm, l = Evd.new_univ_level_variable (Evd.UnivFlexible false) evm in
+        Feedback.msg_info (str"Fresh level " ++ Level.pr l ++ str" was added to the context.");
+        evm, l
+    else if constr_equall h lProp then
       match args with
       | [] -> evm, Univ.Level.prop
       | _ -> bad_term_verb trm "unquote_level"

--- a/template-coq/src/constr_quoted.ml
+++ b/template-coq/src/constr_quoted.ml
@@ -119,6 +119,7 @@ struct
   let lSet = resolve_symbol pkg_level "lSet"
   let tsort_family = resolve_symbol pkg_univ "sort_family"
   let lfresh_universe = resolve_symbol pkg_univ "fresh_universe"
+  let lfresh_level = resolve_symbol pkg_univ "fresh_level"
   let sfProp = resolve_symbol pkg_univ "InProp"
   let sfSet = resolve_symbol pkg_univ "InSet"
   let sfType = resolve_symbol pkg_univ "InType"

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -689,6 +689,8 @@ Defined.
 
 (* This universe is a hack used in plugings to generate fresh universes *)
 Definition fresh_universe : universe. exact Universe.type0. Qed.
+(* This level is a hack used in plugings to generate fresh levels *)
+Definition fresh_level : Level.t. exact Level.set. Qed.
 
 End Univ.
 

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -215,3 +215,5 @@ Check (eq_refl : infer' (empty_ext (fst ff)) [] (snd ff) =
                               (NEL.sing (Level.Level _, true))))).
 Open Scope string_scope.
 Check (eq_refl : infer [] init_graph [] ((tProd (nNamed "A") (tSort (Universe.make' (Level.Level "Toto.85", false))) (tProd (nNamed "B") (tSort (Universe.make' (Level.Level "Toto.86", false))) (tProd nAnon (tRel 1) (tProd nAnon (tRel 1) (tRel 3)))))) = Checked (tSort _)).
+
+Make Definition t4 := (tSort (Universe.make (fresh_level))).


### PR DESCRIPTION
This small PR adds an opaque level `fresh_level` which behaves similarly to `fresh_universe`. It is useful when you want a fresh level inside of a term, which you cannot get from `fresh_universe` since the latter is opaque.