### PR TITLE
Refactor conversion and cie

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -272,7 +272,7 @@ Proof.
     end.
     clear - wfΣ HWF t0 c0. intros.
     destruct c0 as (? & [] & ?).
-    eapply typing_spine_red in t0. 3:auto. 2:{ eapply PCUICCumulativity.All_All2_refl. clear. induction x1; eauto. }
+    eapply typing_spine_red in t0. 3:auto. 2:{ eapply All_All2_refl. clear. induction x1; eauto. }
     2: eapply PCUICCumulativity.red_cumul. 2: eassumption. 2:eapply PCUICCumulativity.cumul_refl'.
     clear - wfΣ t0 H c2.
     2:{ eapply isWfArity_or_Type_red; eassumption. }
@@ -314,7 +314,6 @@ Proof.
   induction Γ; try econstructor.
   intros wfΣ wfΓ; depelim wfΓ; econstructor; eauto;
   constructor; auto.
-  - constructor; eapply cumul_refl; reflexivity.
 Qed.
 
 Lemma context_conversion_red1 (Σ : global_env_ext) Γ Γ' s t : wf Σ -> (* Σ ;;; Γ' |- t : T -> *)
@@ -342,16 +341,16 @@ Proof.
     eapply PCUICReduction.red_letin; eauto. eapply IHX0; eauto.
     econstructor. eauto. econstructor.
   -     eapply PCUICReduction.red_case; eauto. clear.
-    eapply PCUICCumulativity.All_All2_refl. induction brs; eauto.
+    eapply All_All2_refl. induction brs; eauto.
   -     eapply PCUICReduction.red_case; eauto. clear.
-    eapply PCUICCumulativity.All_All2_refl. induction brs; eauto.
+    eapply All_All2_refl. induction brs; eauto.
   - destruct ind.
     eapply PCUICReduction.red_case; eauto.
     clear - HΣ X HT.
     induction X.
     + econstructor. destruct p. destruct p.
       split; eauto.
-      eapply PCUICCumulativity.All_All2_refl.
+      eapply All_All2_refl.
       induction tl; eauto.
     + econstructor.  repeat econstructor.
       eassumption.
@@ -494,7 +493,7 @@ Proof.
     eapply invert_cumul_arity_l in H0 as (? & ? & ?). 2: eauto.
     2: eapply PCUICConversion.cumul_trans; eauto.
     destruct H.
-    eapply typing_spine_red in t1. 2:{ eapply PCUICCumulativity.All_All2_refl.
+    eapply typing_spine_red in t1. 2:{ eapply All_All2_refl.
                                                   clear. induction L; eauto. }
 
     2:eauto. 2:eauto. 2: eapply PCUICCumulativity.red_cumul_inv. 2:eauto. 2:eauto.
@@ -502,7 +501,7 @@ Proof.
     assert (t11 := t1).
     eapply isArity_typing_spine in t1 as (? & ? & ?). 2:eauto. 2:eauto. 2:eauto.
     sq. exists x5. split. eapply type_mkApps. eapply type_reduction in t0; eauto. 2:eauto.
-    eapply typing_spine_red. eapply PCUICCumulativity.All_All2_refl.
+    eapply typing_spine_red. eapply All_All2_refl.
     clear. induction L; eauto. eauto. eauto. 2:eapply PCUICCumulativity.cumul_refl'.
     eapply PCUICCumulativity.red_cumul. eauto.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -134,13 +134,12 @@ Proof.
   Hint Resolve Is_type_conv_context.
   all: try now (econstructor; eauto).
   - econstructor. eapply h_forall_Γ'0.
-    econstructor. eauto. constructor. eapply conv_alt_refl, eq_term_refl.
+    econstructor. eauto. now constructor.
     constructor; auto.
     exists s1.
     eapply PCUICContextConversion.context_conversion. 3:eauto. all:eauto.
   - econstructor. eauto. eapply h_forall_Γ'1.
-    econstructor. eauto. constructor.
-    eapply PCUICCumulativity.conv_alt_refl; reflexivity.
+    econstructor. eauto. now constructor.
     constructor; auto. exists s1.
     eapply PCUICContextConversion.context_conversion with Γ; eauto.
     eapply PCUICContextConversion.context_conversion with Γ; eauto.
@@ -502,8 +501,8 @@ Proof.
         assert (Σ ;;; [] |- a' : t). {
           eapply subject_reduction_eval; eauto.
           eapply PCUICConversion.cumul_Prod_inv in c0 as [].
-          econstructor. eassumption. eauto. eapply conv_alt_sym in c0; eauto.
-          now eapply conv_alt_cumul. auto. auto. }
+          econstructor. eassumption. eauto. eapply conv_sym in c0; eauto.
+          now eapply conv_cumul. auto. auto. }
       inv Hvf'.
       * assert (Σ;;; [] |- PCUICLiftSubst.subst1 a' 0 b ⇝ℇ subst1 vu' 0 t').
         eapply (erases_subst Σ [] [PCUICAst.vass na t] [] b [a'] t'); eauto.
@@ -533,9 +532,8 @@ Proof.
     + eapply IHeval1 in H6 as (vt1' & Hvt2' & He_vt1'); eauto.
       assert (Hc : PCUICContextConversion.conv_context Σ ([],, vdef na b0 t) [vdef na b0' t]). {
         econstructor. econstructor. econstructor.
-        eapply PCUICCumulativity.red_conv_alt.
-        eapply wcbeval_red; eauto.
-        eapply PCUICCumulativity.conv_alt_refl; reflexivity.
+        eapply PCUICCumulativity.red_conv.
+        eapply wcbeval_red; eauto. reflexivity.
       }
       assert (Σ;;; [vdef na b0' t] |- b1 : x0). {
         cbn in *. eapply PCUICContextConversion.context_conversion. 3:eauto. all:cbn; eauto.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -350,7 +350,7 @@ Next Obligation.
 
      eapply conv_context_refl; eauto. econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
 
   ++ sq. etransitivity. eassumption.
 
@@ -360,7 +360,7 @@ Next Obligation.
 
      econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
 Qed.
 Next Obligation.
   Hint Constructors squash. destruct HΣ.
@@ -438,6 +438,7 @@ Next Obligation.
 
        eapply leq_universe_prop in l0 as []; cbn; eauto.
        eapply leq_universe_prop in l as []; cbn; eauto.
+       reflexivity.
   - sq. econstructor. eauto.
 Qed.
 
@@ -804,4 +805,3 @@ Proof.
            2:{ eauto. } eauto.
   * eapply IHΣ. unfold erase_global. rewrite E3. reflexivity.
 Qed.
-

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -344,8 +344,6 @@ Proof.
   - cbn; eauto.
   - destruct a. destruct decl_body.
     + cbn. econstructor. inv X0. eauto. econstructor.
-      depelim X0.
-      eapply PCUICCumulativity.conv_alt_refl; reflexivity.
-    + cbn. econstructor. inv X0. eauto. econstructor.
-      eapply PCUICCumulativity.conv_alt_refl; reflexivity.
+      depelim X0. reflexivity.
+    + cbn. econstructor. inv X0. eauto. now econstructor.
 Qed.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -182,7 +182,7 @@ Next Obligation.
 
      eapply conv_context_refl; eauto. econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
   ++ sq. etransitivity. eassumption.
 
      eapply context_conversion_red; eauto. econstructor.
@@ -191,7 +191,7 @@ Next Obligation.
 
      econstructor.
 
-     eapply PCUICConversion.conv_sym, red_conv; eauto.
+     eapply conv_sym, red_conv; eauto.
 Qed.
 
 Next Obligation.
@@ -288,7 +288,7 @@ Next Obligation.
 
     eapply leq_universe_prop in l0 as []; cbn; eauto.
     eapply leq_universe_prop in l as []; cbn; eauto.
-    eauto using typing_wf_local.
+    reflexivity. eauto using typing_wf_local.
 Qed.
 
 (* Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (HΓ : ∥wf_local Sigma Gamma∥) (t : PCUICAst.term) : *)

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -40,14 +40,15 @@ Proof.
 Qed. *)
 Admitted.
 
-Lemma cumul_refl' {cf : checker_flags} Σ Γ t : Σ ;;; Γ |- t <= t.
+
+Instance cumul_refl' {cf:checker_flags} Σ Γ : Reflexive (cumul Σ Γ).
 Proof.
-  eapply cumul_alt. exists t, t; intuition eauto. eapply leq_term_refl.
+  intro; constructor. reflexivity.
 Qed.
 
-Lemma conv_refl' {cf : checker_flags} Σ Γ t : Σ ;;; Γ |- t = t.
+Instance conv_refl' {cf:checker_flags} Σ Γ : Reflexive (conv Σ Γ).
 Proof.
-  split; apply cumul_refl'.
+  intro; constructor. reflexivity.
 Qed.
 
 Lemma red_cumul `{cf : checker_flags} {Σ : global_env_ext} {Γ t u} :
@@ -88,20 +89,48 @@ Proof.
   - eauto.
 Qed.
 
-Lemma red_conv {cf:checker_flags} (Σ : global_env_ext) Γ t u : red Σ Γ t u -> Σ ;;; Γ |- t = u.
+
+Lemma conv_cumul2 {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- t = u -> (Σ ;;; Γ |- t <= u) * (Σ ;;; Γ |- u <= t).
 Proof.
-  intros. split; [apply red_cumul|apply red_cumul_inv]; auto.
+  induction 1.
+  - split; constructor; now apply eq_term_leq_term.
+  - destruct IHX as [H1 H2]. split.
+    * econstructor 2; eassumption.
+    * econstructor 3; eassumption.
+  - destruct IHX as [H1 H2]. split.
+    * econstructor 3; eassumption.
+    * econstructor 2; eassumption.
+  - destruct IHX as [H1 H2]. split.
+    * econstructor 4; eassumption.
+    * econstructor 5; eassumption.
+  - destruct IHX as [H1 H2]. split.
+    * econstructor 5; eassumption.
+    * econstructor 4; eassumption.
 Qed.
 
 Lemma conv_cumul {cf:checker_flags} Σ Γ t u :
-  Σ ;;; Γ |- t = u -> (Σ ;;; Γ |- t <= u) * (Σ ;;; Γ |- u <= t).
-Proof. trivial. Qed.
-
-(* todo: move *)
-Lemma All_All2_refl {A : Type} {R} {l : list A} : All (fun x : A => R x x) l -> All2 R l l.
+  Σ ;;; Γ |- t = u -> Σ ;;; Γ |- t <= u.
 Proof.
-  induction 1; constructor; auto.
+  intro H; now apply conv_cumul2 in H.
 Qed.
+
+Lemma conv_cumul_inv {cf:checker_flags} Σ Γ t u :
+  Σ ;;; Γ |- u = t -> Σ ;;; Γ |- t <= u.
+Proof.
+  intro H; now apply conv_cumul2 in H.
+Qed.
+
+Lemma cumul2_conv {cf:checker_flags} Σ Γ t u :
+  (Σ ;;; Γ |- t <= u) * (Σ ;;; Γ |- u <= t) -> Σ ;;; Γ |- t = u.
+Proof.
+Admitted.
+
+Lemma red_conv {cf:checker_flags} (Σ : global_env_ext) Γ t u
+  : red Σ Γ t u -> Σ ;;; Γ |- t = u.
+Proof.
+Admitted.
+Hint Resolve red_conv : core.
 
 Lemma eq_term_App `{checker_flags} φ f f' :
   eq_term φ f f' ->
@@ -141,30 +170,10 @@ Proof.
     + assumption.
 Qed.
 
-Inductive conv_alt `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
-| conv_alt_refl t u : eq_term (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t == u
-| conv_alt_red_l t u v : red1 Σ Γ t v -> Σ ;;; Γ |- v == u -> Σ ;;; Γ |- t == u
-| conv_alt_red_r t u v : Σ ;;; Γ |- t == v -> red1 (fst Σ) Γ u v -> Σ ;;; Γ |- t == u
-| conv_alt_eta_l t u v : eta_expands t v -> Σ ;;; Γ |- v == u -> Σ ;;; Γ |- t == u
-| conv_alt_eta_r t u v : Σ ;;; Γ |- t == v -> eta_expands u v -> Σ ;;; Γ |- t == u
-where " Σ ;;; Γ |- t == u " := (@conv_alt _ Σ Γ t u) : type_scope.
-
-Lemma red_conv_alt `{cf : checker_flags} Σ Γ t u :
-  red (fst Σ) Γ t u ->
-  Σ ;;; Γ |- t == u.
-Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
-  induction X.
-  - constructor. apply eq_term_refl.
-  - apply clos_rt_rt1n_iff in X. apply red_alt in X.
-    econstructor 2; eauto.
-Qed.
-Hint Resolve red_conv_alt.
-
 Hint Resolve leq_term_refl cumul_refl' : core.
 
 Lemma red_conv_conv `{cf : checker_flags} Σ Γ t u v :
-  red (fst Σ) Γ t u -> Σ ;;; Γ |- u == v -> Σ ;;; Γ |- t == v.
+  red (fst Σ) Γ t u -> Σ ;;; Γ |- u = v -> Σ ;;; Γ |- t = v.
 Proof.
   intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
   induction X; auto.
@@ -172,20 +181,17 @@ Proof.
 Qed.
 
 Lemma red_conv_conv_inv `{cf : checker_flags} Σ Γ t u v :
-  red (fst Σ) Γ t u -> Σ ;;; Γ |- v == u -> Σ ;;; Γ |- v == t.
+  red (fst Σ) Γ t u -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- v = t.
 Proof.
   intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
   induction X; auto.
   now econstructor 3; [eapply IHX|]; eauto.
 Qed.
 
-Lemma conv_alt_sym `{cf : checker_flags} (Σ : global_env_ext) Γ t u :
-  wf Σ ->
-  Σ ;;; Γ |- t == u ->
-  Σ ;;; Γ |- u == t.
+Instance conv_sym `{cf : checker_flags} (Σ : global_env_ext) Γ :
+  Symmetric (conv Σ Γ).
 Proof.
-  intros wfΣ X.
-  induction X.
+  intros t u X. induction X.
   - eapply eq_term_sym in e; now constructor.
   - eapply red_conv_conv_inv.
     + eapply red1_red in r. eauto.
@@ -193,15 +199,15 @@ Proof.
   - eapply red_conv_conv.
     + eapply red1_red in r. eauto.
     + eauto.
-  - eapply conv_alt_eta_r. all: eassumption.
-  - eapply conv_alt_eta_l. all: eassumption.
+  - eapply conv_eta_r. all: eassumption.
+  - eapply conv_eta_l. all: eassumption.
 Qed.
 
 (* TODO UPDATE *)
 Lemma conv_alt_red {cf : checker_flags} {Σ : global_env_ext} {Γ : context} {t u : term} :
-  Σ;;; Γ |- t == u <~> (∑ v v' : term, (red Σ Γ t v × red Σ Γ u v') × eq_term (global_ext_constraints Σ) v v').
+  Σ;;; Γ |- t = u <~> (∑ v v' : term, (red Σ Γ t v × red Σ Γ u v') × eq_term (global_ext_constraints Σ) v v').
 Proof.
-  split.
+  (* split. *)
   (* induction 1. exists t, u; intuition auto.
   destruct IHX as [? [? [? ?]]].
   exists x, x0; intuition auto. eapply red_step; eauto.
@@ -214,73 +220,36 @@ Proof.
 Qed. *)
 Admitted.
 
-Lemma conv_alt_cumul `{cf : checker_flags} (Σ : global_env_ext) Γ t u : wf Σ ->
-  Σ ;;; Γ |- t == u -> Σ ;;; Γ |- t <= u.
-Proof.
-  intros wfΣ H.
-  apply conv_alt_red in H as [v [v' [[l r] eq]]].
-  apply cumul_alt.
-  exists v, v'; intuition auto. now eapply eq_term_leq_term.
-Qed.
-
-Lemma conv_alt_conv `{cf : checker_flags} (Σ : global_env_ext) Γ t u : wf Σ ->
-  Σ ;;; Γ |- t == u -> Σ ;;; Γ |- t = u.
-Proof.
-  intros wfΣ H. split.
-  - now apply conv_alt_cumul.
-  - apply conv_alt_sym in H; auto. now apply conv_alt_cumul.
-Qed.
-
-(* TODO Probably not the right place
-   but conv_alt is not defined in PCUICWeakening *)
-Lemma weakening_conv_alt `{cf:checker_flags} :
-  forall Σ Γ Γ' Γ'' M N,
-    wf Σ.1 ->
-    Σ ;;; Γ ,,, Γ' |- M == N ->
-    Σ ;;; Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ' |- lift #|Γ''| #|Γ'| M == lift #|Γ''| #|Γ'| N.
-Proof.
-  intros Σ Γ Γ' Γ'' M N wfΣ. induction 1.
-  - constructor.
-    now apply lift_eq_term.
-  - eapply PCUICWeakening.weakening_red1 in r ; auto.
-    econstructor 2 ; eauto.
-  - eapply PCUICWeakening.weakening_red1 in r ; auto.
-    econstructor 3 ; eauto.
-  - eapply conv_alt_eta_l. 2: eassumption.
-    eapply weakening_eta_expands. assumption.
-  - eapply conv_alt_eta_r. 1: eassumption.
-    eapply weakening_eta_expands. assumption.
-Qed.
 
 Inductive conv_pb :=
 | Conv
 | Cumul.
 
-Definition conv `{cf : checker_flags} leq Σ Γ u v :=
+Definition conv_cum `{cf : checker_flags} leq Σ Γ u v :=
   match leq with
-  | Conv => ∥ Σ ;;; Γ |- u == v ∥
+  | Conv => ∥ Σ ;;; Γ |- u = v ∥
   | Cumul => ∥ Σ ;;; Γ |- u <= v ∥
   end.
 
-Lemma conv_conv_l `{cf : checker_flags} :
+Lemma conv_conv_cum_l `{cf : checker_flags} :
   forall (Σ : global_env_ext) leq Γ u v, wf Σ ->
-      Σ ;;; Γ |- u == v ->
-      conv leq Σ Γ u v.
+      Σ ;;; Γ |- u = v ->
+      conv_cum leq Σ Γ u v.
 Proof.
   intros Σ [] Γ u v h.
   - cbn. constructor. assumption.
-  - cbn. constructor. now apply conv_alt_cumul.
+  - cbn. constructor. now apply conv_cumul.
 Qed.
 
-Lemma conv_conv_r `{cf : checker_flags} :
+Lemma conv_conv_cum_r `{cf : checker_flags} :
   forall (Σ : global_env_ext) leq Γ u v, wf Σ ->
-      Σ ;;; Γ |- u == v ->
-      conv leq Σ Γ v u.
+      Σ ;;; Γ |- u = v ->
+      conv_cum leq Σ Γ v u.
 Proof.
   intros Σ [] Γ u v wfΣ h.
-  - cbn. constructor. apply conv_alt_sym; auto.
-  - cbn. constructor. apply conv_alt_cumul. 1: auto.
-    now apply conv_alt_sym.
+  - cbn. constructor. apply conv_sym; auto.
+  - cbn. constructor. apply conv_cumul.
+    now apply conv_sym.
 Qed.
 
 Lemma cumul_App_l `{cf : checker_flags} :

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -256,7 +256,7 @@ Section Inversion.
   Proof.
     intros Γ Δ t T h.
     induction Δ as [| [na [b|] A] Δ ih ] in Γ, t, h |- *.
-    - eexists. split ; eauto.
+    - eexists. split ; eauto. reflexivity.
     - simpl. apply ih in h. cbn in h.
       destruct h as [B [h c]].
       apply inversion_LetIn in h as hh.

--- a/pcuic/theories/PCUICLiftSubst.v
+++ b/pcuic/theories/PCUICLiftSubst.v
@@ -1649,3 +1649,10 @@ Proof.
     + simpl. repeat f_equal; try lia.
     + simpl. apply IHΓ'; simpl in *; (lia || congruence).
 Qed.
+
+Fixpoint subst_app (t : term) (us : list term) : term :=
+  match t, us with
+  | tLambda _ A t, u :: us => subst_app (t {0 := u}) us
+  | _, [] => t
+  | _, _ => mkApps t us
+  end.

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -156,12 +156,6 @@ Proof. intros. subst k. rewrite simpl_subst_rec; auto. now rewrite Nat.add_0_r. 
 
 (** All2 lemmas *)
 
-(* Duplicate *)
-Lemma All2_app {A} {P : A -> A -> Type} {l l' r r'} :
-  All2 P l l' -> All2 P r r' ->
-  All2 P (l ++ r) (l' ++ r').
-Proof. induction 1; simpl; auto. Qed.
-
 Definition All2_prop_eq Γ Γ' {A B} (f : A -> term) (g : A -> B) (rel : forall (Γ Γ' : context) (t t' : term), Type) :=
   All2 (on_Trel_eq (rel Γ Γ') f g).
 

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -149,7 +149,7 @@ Section Principality.
   Lemma invert_cumul_prod_r Γ C na A B :
     Σ ;;; Γ |- C <= tProd na A B ->
     ∑ na' A' B', red Σ.1 Γ C (tProd na' A' B') *
-                 (Σ ;;; Γ |- A == A') *
+                 (Σ ;;; Γ |- A = A') *
                  (Σ ;;; (Γ ,, vass na A) |- B' <= B).
   Proof.
     intros Hprod.
@@ -157,8 +157,8 @@ Section Principality.
     eapply invert_red_prod in redv' as (A' & B' & ((-> & Ha') & ?)) => //.
     depelim leqvv'.
     do 3 eexists; intuition eauto.
-    - eapply conv_alt_trans with A'; auto.
-      eapply conv_alt_sym; auto.
+    - eapply conv_trans with A'; auto.
+      eapply conv_sym; auto.
       constructor; auto.
     - eapply cumul_trans with B'; auto.
       + constructor. eapply leqvv'2.
@@ -313,7 +313,7 @@ Section Principality.
   Lemma invert_cumul_prod_l Γ C na A B :
     Σ ;;; Γ |- tProd na A B <= C ->
                ∑ na' A' B', red Σ.1 Γ C (tProd na' A' B') *
-                            (Σ ;;; Γ |- A == A') *
+                            (Σ ;;; Γ |- A = A') *
                             (Σ ;;; (Γ ,, vass na A) |- B <= B').
   Proof.
     intros Hprod.
@@ -321,7 +321,7 @@ Section Principality.
     eapply invert_red_prod in redv as (A' & B' & ((-> & Ha') & ?)) => //.
     depelim leqvv'.
     do 3 eexists; intuition eauto.
-    - eapply conv_alt_trans with A'; auto.
+    - eapply conv_trans with A'; auto.
       now constructor.
     - eapply cumul_trans with B'; eauto.
       + now eapply red_cumul.
@@ -364,11 +364,11 @@ Section Principality.
   (*   exists na', ty', t', u'. *)
   (*   split. split. *)
   (*   split. auto. eapply conv_conv_alt. *)
-  (*   now eapply conv_alt_refl. *)
-  (*   now eapply conv_conv_alt, conv_alt_refl. *)
+  (*   now eapply conv_refl. *)
+  (*   now eapply conv_conv_alt, conv_refl. *)
   (*   constructor. auto. *)
   (* - *)
-  (*   eapply conv_conv_alt, conv_alt_refl. *)
+  (*   eapply conv_conv_alt, conv_refl. *)
   (*   eapply *)
 
   (*   eapply red_conv. *)
@@ -447,9 +447,8 @@ Section Principality.
     eapply All2_trans.
     - intros x y z h1 h2. eapply conv_trans ; eauto.
     - eapply All2_impl ; eauto.
-      intros x y h. eapply red_conv. assumption.
     - eapply All2_impl ; eauto.
-      intros x y h. eapply eq_term_conv. assumption.
+      intros x y h. eapply conv_refl. assumption.
   Qed.
 
   Lemma invert_cumul_ind_r :
@@ -458,7 +457,7 @@ Section Principality.
       ∑ ui' l',
         red Σ.1 Γ T (mkApps (tInd ind ui') l') ×
         R_universe_instance (eq_universe Σ) ui' ui ×
-        All2 (fun a a' => Σ ;;; Γ |- a == a') l l'.
+        All2 (fun a a' => Σ ;;; Γ |- a = a') l l'.
   Proof.
     intros Γ ind ui l T h.
     eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
@@ -469,11 +468,11 @@ Section Principality.
     dependent destruction e.
     eexists _,_. split ; eauto. split ; auto.
     eapply All2_trans.
-    - intros x y z h1 h2. eapply conv_alt_trans ; eauto.
+    - intros x y z h1 h2. eapply conv_trans ; eauto.
     - eapply All2_impl ; eauto.
     - eapply All2_swap.
       eapply All2_impl ; eauto.
-      intros x y h. eapply conv_alt_sym; auto. now constructor.
+      intros x y h. eapply conv_sym; auto. now constructor.
   Qed.
 
   Ltac pih :=
@@ -516,7 +515,7 @@ Section Principality.
   Lemma cumul_sort_confluence {Γ A u v} :
     Σ ;;; Γ |- A <= tSort u ->
     Σ ;;; Γ |- A <= tSort v ->
-    ∑ v', (Σ ;;; Γ |- A == tSort v') *
+    ∑ v', (Σ ;;; Γ |- A = tSort v') *
           (leq_universe (global_ext_constraints Σ) v' u /\
            leq_universe (global_ext_constraints Σ) v' v).
   Proof.
@@ -588,9 +587,6 @@ Section Principality.
   (* Qed. *)
 
 
-  Instance conv_alt_transitive Γ : Transitive (fun x y => Σ ;;; Γ |- x == y).
-  Proof. intros x y z; eapply conv_alt_trans. auto. Qed.
-
   Theorem principal_typing {Γ u A B} : Σ ;;; Γ |- u : A -> Σ ;;; Γ |- u : B ->
     ∑ C, Σ ;;; Γ |- C <= A  ×  Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C.
   Proof.
@@ -635,10 +631,10 @@ Section Principality.
       + eapply type_Prod.
         * eapply type_Cumul; eauto.
           -- left; eapply isWfArity_sort. now eapply typing_wf_local in t1.
-          -- eapply conv_alt_cumul; auto.
+          -- eapply conv_cumul; auto.
         * eapply type_Cumul; eauto.
           -- left; eapply isWfArity_sort. now eapply typing_wf_local in t3.
-          -- eapply conv_alt_cumul; auto.
+          -- eapply conv_cumul; auto.
 
     - apply inversion_Lambda in hA => //.
       apply inversion_Lambda in hB => //.
@@ -729,25 +725,25 @@ Section Principality.
       destruct (red_confluence wfΣ redA redA') as [nfprod [redl redr]].
       eapply invert_red_prod in redl as [? [? [[? ?] ?]]] => //. subst.
       eapply invert_red_prod in redr as [? [? [[? ?] ?]]] => //. noconf e.
-      assert(Σ ;;; Γ |- A' == A'').
-      { apply conv_alt_trans with x3 => //.
-        - now eapply red_conv_alt.
-        - apply conv_alt_sym; auto.
+      assert(Σ ;;; Γ |- A' = A'').
+      { apply conv_trans with x3 => //.
+        - now eapply red_conv.
+        - apply conv_sym; auto.
       }
-      assert(Σ ;;; Γ ,, vass x1 A' |- B' == B'').
-      { apply conv_alt_trans with x4 => //.
-        - now eapply red_conv_alt.
-        - apply conv_alt_sym; auto.
-          eapply conv_alt_conv_ctx; eauto.
+      assert(Σ ;;; Γ ,, vass x1 A' |- B' = B'').
+      { apply conv_trans with x4 => //.
+        - now eapply red_conv.
+        - apply conv_sym; auto.
+          eapply conv_conv_ctx; eauto.
           constructor; auto. 1: eapply conv_ctx_refl.
-          constructor. now eapply conv_alt_sym.
+          constructor. now eapply conv_sym.
       }
       exists (B' {0 := u2}).
       repeat split.
       + eapply cumul_trans with (codom {0 := u2}) => //.
         eapply substitution_cumul0 => //. eapply c1.
       + eapply cumul_trans with (B'' {0 := u2}); eauto.
-        * eapply substitution_cumul0 => //. eapply conv_alt_cumul in X0; eauto.
+        * eapply substitution_cumul0 => //. eapply conv_cumul in X0; eauto.
         * eapply cumul_trans with (codom' {0 := u2}) => //.
           eapply substitution_cumul0 => //. eauto.
       + eapply type_App.
@@ -760,7 +756,7 @@ Section Principality.
         * eapply cumul_trans with (tProd x1 A' B')=> //.
           -- eapply red_cumul; eauto.
           -- eapply congr_cumul_prod.
-             ++ eapply conv_alt_sym; eauto.
+             ++ eapply conv_sym; eauto.
              ++ eapply cumul_refl'.
 
     - eapply inversion_Const in hA as [decl ?] => //.
@@ -809,22 +805,23 @@ Section Principality.
       repeat outsum. repeat outtimes.
       eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]].
       eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]].
-      assert (All2 (fun a a' => Σ ;;; Γ |- a == a') x0 x7).
+      assert (All2 (fun a a' => Σ ;;; Γ |- a = a') x0 x7).
       { destruct (red_confluence wfΣ redr redr').
         destruct p.
         eapply red_mkApps_tInd in r as [args' [? ?]]; auto.
         eapply red_mkApps_tInd in r0 as [args'' [? ?]]; auto.
         subst. solve_discr.
         clear -wfΣ a1 a2 a3 a4.
-        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- x == y)) in a3; auto using red_conv.
-        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- y == x)) in a4; auto using conv_alt_sym, red_conv.
-        pose proof (All2_trans _ (conv_alt_transitive _) _ _ _ a1 a3).
+        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- x = y)) in a3; auto using red_conv.
+        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- y = x)) in a4;
+          [|intros; symmetry; now apply red_conv].
+        pose proof (All2_trans _ (conv_trans _ _) _ _ _ a1 a3).
         apply All2_sym in a4.
-        pose proof (All2_trans _ (conv_alt_transitive _) _ _ _ X a4).
-        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- y == x)) in a2; auto using conv_sym, red_conv.
+        pose proof (All2_trans _ (conv_trans _ _) _ _ _ X a4).
+        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- y = x)) in a2;
+          [|intros; now symmetry].
         - apply All2_sym in a2.
-          apply (All2_trans _ (conv_alt_transitive _) _ _ _ X0 a2).
-        - intros ? ? ?. eapply conv_alt_sym. all: assumption.
+          apply (All2_trans _ (conv_trans _ _) _ _ _ X0 a2).
       }
       clear redr redr' a1 a2.
       exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto.

--- a/pcuic/theories/PCUICRetyping.v
+++ b/pcuic/theories/PCUICRetyping.v
@@ -228,7 +228,7 @@ Section TypeOf.
     - go eq. split.
       + econstructor ; try eassumption ; try ih ; try cih.
       + eapply congr_cumul_prod.
-        * eapply conv_alt_refl. reflexivity.
+        * reflexivity.
         * ih.
     - go eq. split.
       + econstructor ; try eassumption ; try ih ; try cih.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -45,8 +45,8 @@ Lemma type_mkApps_inv {cf:checker_flags} (Σ : global_env_ext) Γ f u T : wf Σ 
   { T' & { U & ((Σ ;;; Γ |- f : T') * (typing_spine Σ Γ T' u U) * (Σ ;;; Γ |- U <= T))%type } }.
 Proof.
   intros wfΣ; induction u in f, T |- *. simpl. intros.
-  { exists T, T. intuition auto. constructor. eapply validity; auto.
-    now eapply typing_wf_local. eauto. eapply cumul_refl'. }
+  { exists T, T. intuition auto. constructor. eapply validity; eauto with wf.
+    all: reflexivity. }
   intros Hf. simpl in Hf.
   destruct u. simpl in Hf.
   - eapply inversion_App in Hf as [na' [A' [B' [Hf' [Ha HA''']]]]].
@@ -111,7 +111,7 @@ Proof.
                          rewrite Hi. f_equal. lia.
     + subst types. rewrite simpl_subst_k.
       * now rewrite fix_context_length fix_subst_length.
-      * auto.
+      * reflexivity.
   - destruct (IHtyping wfΣ) as [T' [rarg [f [[unf fty] Hcumul]]]].
     exists T', rarg, f. intuition auto.
     + eapply cumul_trans; eauto.
@@ -122,8 +122,6 @@ Qed.
 
 Definition SR_red1 {cf:checker_flags} (Σ : global_env_ext) Γ t T :=
   forall u (Hu : red1 Σ Γ t u), Σ ;;; Γ |- u : T.
-
-Hint Resolve conv_ctx_refl : pcuic.
 
 Lemma sr_red1 {cf:checker_flags} : env_prop SR_red1.
 Proof.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -257,8 +257,8 @@ Section Lemmata.
   (* Lemma conv_context : *)
   (*   forall Σ Γ u v ρ, *)
   (*     wf Σ.1 -> *)
-  (*     Σ ;;; Γ ,,, stack_context ρ |- u == v -> *)
-  (*     Σ ;;; Γ |- zipc u ρ == zipc v ρ. *)
+  (*     Σ ;;; Γ ,,, stack_context ρ |- u = v -> *)
+  (*     Σ ;;; Γ |- zipc u ρ = zipc v ρ. *)
   (* Proof. *)
   (*   intros Σ Γ u v ρ hΣ h. *)
   (*   induction ρ in u, v, h |- *. *)
@@ -783,8 +783,8 @@ Section Lemmata.
 
   Lemma conv_alt_it_mkLambda_or_LetIn :
     forall Δ Γ u v,
-      Σ ;;; (Δ ,,, Γ) |- u == v ->
-      Σ ;;; Δ |- it_mkLambda_or_LetIn Γ u == it_mkLambda_or_LetIn Γ v.
+      Σ ;;; (Δ ,,, Γ) |- u = v ->
+      Σ ;;; Δ |- it_mkLambda_or_LetIn Γ u = it_mkLambda_or_LetIn Γ v.
   Proof.
     intros Δ Γ u v h. revert Δ u v h.
     induction Γ as [| [na [b|] A] Γ ih ] ; intros Δ u v h.
@@ -797,8 +797,8 @@ Section Lemmata.
 
   Lemma conv_alt_it_mkProd_or_LetIn :
     forall Δ Γ B B',
-      Σ ;;; (Δ ,,, Γ) |- B == B' ->
-      Σ ;;; Δ |- it_mkProd_or_LetIn Γ B == it_mkProd_or_LetIn Γ B'.
+      Σ ;;; (Δ ,,, Γ) |- B = B' ->
+      Σ ;;; Δ |- it_mkProd_or_LetIn Γ B = it_mkProd_or_LetIn Γ B'.
   Proof.
     intros Δ Γ B B' h.
     induction Γ as [| [na [b|] A] Γ ih ] in Δ, B, B', h |- *.
@@ -811,8 +811,8 @@ Section Lemmata.
 
   Lemma conv_zipp :
     forall Γ u v ρ,
-      Σ ;;; Γ |- u == v ->
-      Σ ;;; Γ |- zipp u ρ == zipp v ρ.
+      Σ ;;; Γ |- u = v ->
+      Σ ;;; Γ |- zipp u ρ = zipp v ρ.
   Proof.
     intros Γ u v ρ h.
     unfold zipp.
@@ -835,10 +835,10 @@ Section Lemmata.
     - simpl.  eapply IHl. eapply cumul_App_l. assumption.
   Qed.
 
-  Lemma conv_zipp' :
+  Lemma conv_cum_zipp' :
     forall leq Γ u v π,
-      conv leq Σ Γ u v ->
-      conv leq Σ Γ (zipp u π) (zipp v π).
+      conv_cum leq Σ Γ u v ->
+      conv_cum leq Σ Γ (zipp u π) (zipp v π).
   Proof.
     intros leq Γ u v π h.
     destruct leq.
@@ -848,8 +848,8 @@ Section Lemmata.
 
   Lemma conv_alt_zippx :
     forall Γ u v ρ,
-      Σ ;;; (Γ ,,, stack_context ρ) |- u == v ->
-      Σ ;;; Γ |- zippx u ρ == zippx v ρ.
+      Σ ;;; (Γ ,,, stack_context ρ) |- u = v ->
+      Σ ;;; Γ |- zippx u ρ = zippx v ρ.
   Proof.
     intros Γ u v ρ h.
     revert u v h. induction ρ ; intros u v h.
@@ -879,16 +879,16 @@ Section Lemmata.
 
   Lemma conv_zippx :
     forall Γ u v ρ,
-      Σ ;;; Γ ,,, stack_context ρ |- u == v ->
-      Σ ;;; Γ |- zippx u ρ == zippx v ρ.
+      Σ ;;; Γ ,,, stack_context ρ |- u = v ->
+      Σ ;;; Γ |- zippx u ρ = zippx v ρ.
   Proof.
     intros Γ u v ρ uv. eapply conv_alt_zippx ; assumption.
   Qed.
 
-  Lemma conv_zippx' :
+  Lemma conv_cum_zippx' :
     forall Γ leq u v ρ,
-      conv leq Σ (Γ ,,, stack_context ρ) u v ->
-      conv leq Σ Γ (zippx u ρ) (zippx v ρ).
+      conv_cum leq Σ (Γ ,,, stack_context ρ) u v ->
+      conv_cum leq Σ Γ (zippx u ρ) (zippx v ρ).
   Proof.
     intros Γ leq u v ρ h.
     destruct leq.
@@ -1323,8 +1323,8 @@ Section Lemmata.
     assumption.
   Qed.
 
-  Hint Resolve conv_alt_refl conv_alt_red : core.
-  Hint Resolve conv_ctx_refl: core.
+  Hint Resolve conv_refl conv_alt_red : core.
+  Hint Resolve conv_refl : core.
 
 
   (* Let bindings are not injective, so it_mkLambda_or_LetIn is not either.
@@ -1470,7 +1470,7 @@ Section Lemmata.
     forall Γ u v A B,
       Σ ;;; Γ |- u : A ->
       Σ ;;; Γ |- v : B ->
-      Σ ;;; Γ |- u == v ->
+      Σ ;;; Γ |- u = v ->
       ∑ C,
         Σ ;;; Γ |- u : C ×
         Σ ;;; Γ |- v : C.
@@ -1491,7 +1491,7 @@ Section Lemmata.
     forall Γ u v π,
       welltyped Σ Γ (zipc v π) ->
       welltyped Σ (Γ ,,, stack_context π) u ->
-      Σ ;;; Γ ,,, stack_context π |- u == v ->
+      Σ ;;; Γ ,,, stack_context π |- u = v ->
       welltyped Σ Γ (zipc u π).
   Proof.
     destruct hΣ as [wΣ].
@@ -1516,7 +1516,7 @@ Section Lemmata.
     forall Γ u v π,
       wellformed Σ Γ (zipc v π) ->
       wellformed Σ (Γ ,,, stack_context π) u ->
-      Σ ;;; Γ ,,, stack_context π |- u == v ->
+      Σ ;;; Γ ,,, stack_context π |- u = v ->
       wellformed Σ Γ (zipc u π).
   Admitted.
 
@@ -1624,17 +1624,17 @@ Section Lemmata.
     assumption.
   Qed.
 
-  Lemma conv_context_convp :
+  Lemma conv_cum_context_convp :
     forall Γ Γ' leq u v,
-      conv leq Σ Γ u v ->
+      conv_cum leq Σ Γ u v ->
       conv_context Σ Γ Γ' ->
-      conv leq Σ Γ' u v.
+      conv_cum leq Σ Γ' u v.
   Proof.
     intros Γ Γ' leq u v h hx.
     destruct hΣ.
     destruct leq.
     - simpl. destruct h. constructor.
-      eapply conv_alt_conv_ctx. all: eauto.
+      eapply conv_conv_ctx. all: eauto.
     - simpl in *. destruct h. constructor.
       eapply cumul_conv_ctx. all: eauto.
   Qed.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -115,7 +115,7 @@ Section Validity.
       Σ ;;; Γ |- U <= T.
   Proof.
     induction u in f, fty, T |- *. simpl. intros. exists T, T. intuition auto. constructor.
-    admit. auto.
+    admit. reflexivity. reflexivity.
     intros Hf Hty. simpl in Hty.
     specialize (IHu _ fty _ Hf) as [T' [U' [H' [H'' H''']]]].
     simpl in Hf.
@@ -345,6 +345,7 @@ Proof.
     constructor.
     + eapply validity' ; eauto.
     + apply cumul_refl'.
+    + reflexivity.
   - simpl in h. eapply IHl in h as [C [U [h1 [h2 h3]]]].
     apply inversion_App in h1 as [na [A [B [ht [ha hc]]]]].
     eexists (tProd na A B), _. split ; [| split].

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -1228,3 +1228,23 @@ Lemma weakening_length {cf:checker_flags} Σ Γ Γ' t T n :
   Σ ;;; Γ |- t : T ->
   Σ ;;; Γ ,,, Γ' |- (lift0 n) t : (lift0 n) T.
 Proof. intros wfΣ ->; now apply weakening. Qed.
+
+
+Lemma weakening_conv `{cf:checker_flags} :
+  forall Σ Γ Γ' Γ'' M N,
+    wf Σ.1 ->
+    Σ ;;; Γ ,,, Γ' |- M = N ->
+    Σ ;;; Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ' |- lift #|Γ''| #|Γ'| M = lift #|Γ''| #|Γ'| N.
+Proof.
+  intros Σ Γ Γ' Γ'' M N wfΣ. induction 1.
+  - constructor.
+    now apply lift_eq_term.
+  - eapply weakening_red1 in r ; auto.
+    econstructor 2 ; eauto.
+  - eapply weakening_red1 in r ; auto.
+    econstructor 3 ; eauto.
+  - eapply conv_eta_l. 2: eassumption.
+    eapply weakening_eta_expands. assumption.
+  - eapply conv_eta_r. 1: eassumption.
+    eapply weakening_eta_expands. assumption.
+Qed.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -1344,7 +1344,7 @@ Proof.
     eapply typing_wf in X; eauto. destruct X.
     clear H1 X0 H H0. revert H2.
     induction X1. econstructor; eauto.
-    (* Need updated typing_spine in template-coq *) admit.
+    (* Need updated typing_spine in template-coq *) admit. reflexivity.
     simpl in p.
     destruct (TypingWf.typing_wf _ wfΣ _ _ _ typrod) as [wfAB _].
     intros wfT.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -10,7 +10,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICCumulativity PCUICSR PCUICEquality PCUICNameless PCUICConversion
      PCUICSafeLemmata PCUICNormal PCUICInversion PCUICReduction PCUICPosition
      PCUICContextConversion PCUICConfluence PCUICSN PCUICAlpha PCUICUtils
-     PCUICReduction.
+     PCUICReduction PCUICWeakening.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce.
 From Equations Require Import Equations.
 
@@ -630,7 +630,7 @@ Section Conversion.
   Lemma eqb_termp_spec :
     forall leq u v Γ,
       eqb_termp leq u v ->
-      conv leq Σ Γ u v.
+      conv_cum leq Σ Γ u v.
   Proof.
     intros leq u v Γ e.
     destruct leq.
@@ -659,11 +659,11 @@ Section Conversion.
     (∥ conv_context Σ (Γ ,,, stack_context π1) (Γ ,,, stack_context π2) ∥).
 
   Notation conv_term leq Γ t π t' π' :=
-    (conv leq Σ (Γ ,,, stack_context π) (zipp t π) (zipp t' π'))
+    (conv_cum leq Σ (Γ ,,, stack_context π) (zipp t π) (zipp t' π'))
       (only parsing).
 
   Notation alt_conv_term Γ t π t' π' :=
-    (∥ Σ ;;; Γ ,,, stack_context π |- zipp t π == zipp t' π' ∥)
+    (∥ Σ ;;; Γ ,,, stack_context π |- zipp t π = zipp t' π' ∥)
       (only parsing).
 
   Inductive ConversionError :=
@@ -766,7 +766,7 @@ Section Conversion.
       conv_stack_ctx Γ π π' ->
       (match s with Fallback | Term => isred (t, π) | _ => True end) ->
       (match s with Fallback | Term => isred (t', π') | _ => True end) ->
-      (match s with Args => conv leq Σ (Γ ,,, stack_context π) t t' | _ => True end) ->
+      (match s with Args => conv_cum leq Σ (Γ ,,, stack_context π) t t' | _ => True end) ->
       ConversionResult (conv_term leq Γ t π t' π').
 
   Definition Aux s Γ t1 π1 t2 π2 h2 :=
@@ -1102,16 +1102,13 @@ Section Conversion.
     rewrite stack_context_appstack.
 
     destruct hx as [hx].
-    eapply conv_trans'.
-    - assumption.
-    - eapply red_conv_l ; try assumption.
-      eassumption.
-    - eapply conv_trans'.
-      + assumption.
+    etransitivity.
+    - eapply red_conv_cum_l; eassumption.
+    - etransitivity.
       + eassumption.
-      + eapply conv_context_convp.
+      + eapply conv_cum_context_convp.
         * assumption.
-        * eapply red_conv_r. all: eauto.
+        * eapply red_conv_cum_r. all: eauto.
         * eapply conv_context_sym. all: auto.
   Qed.
 
@@ -1474,8 +1471,8 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_trans' ; try eassumption.
-    eapply red_conv_r ; try assumption.
+    etransitivity ; try eassumption.
+    eapply red_conv_cum_r ; try assumption.
     eapply red_zipp. eapply red_const. eassumption.
   Qed.
   Next Obligation.
@@ -1489,8 +1486,8 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ as [wΣ].
-    eapply conv_trans' ; try eassumption.
-    eapply red_conv_l ; try assumption.
+    etransitivity ; try eassumption.
+    eapply red_conv_cum_l ; try assumption.
     eapply red_zipp. eapply red_const. eassumption.
   Qed.
   Next Obligation.
@@ -1503,8 +1500,8 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ as [wΣ].
-    eapply conv_trans' ; try eassumption.
-    eapply red_conv_l ; try assumption.
+    etransitivity ; try eassumption.
+    eapply red_conv_cum_l ; try assumption.
     eapply red_zipp. eapply red_const. eassumption.
   Qed.
   Next Obligation.
@@ -1517,8 +1514,8 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ as [wΣ].
-    eapply conv_trans' ; try eassumption.
-    eapply red_conv_l ; try assumption.
+    etransitivity ; try eassumption.
+    eapply red_conv_cum_l ; try assumption.
     eapply red_zipp. eapply red_const. eassumption.
   Qed.
 
@@ -1578,9 +1575,9 @@ Section Conversion.
     (p' c' : term) (brs1' brs2' : list (nat × term))
     (π' : stack) (h' : wtp Γ (tCase (ind, par) p' c' (brs1' ++ brs2')) π')
     (hx : conv_stack_ctx Γ π π')
-    (h1 : ∥ All2 (fun u v => u.1 = v.1 × Σ ;;; Γ ,,, stack_context π |- u.2 == v.2) brs1 brs1' ∥)
+    (h1 : ∥ All2 (fun u v => u.1 = v.1 × Σ ;;; Γ ,,, stack_context π |- u.2 = v.2) brs1 brs1' ∥)
     (aux : Aux Term Γ (tCase (ind, par) p c (brs1 ++ brs2)) π (tCase (ind, par) p' c' (brs1' ++ brs2')) π' h')
-    : ConversionResult (∥ All2 (fun u v => u.1 = v.1 × Σ ;;; Γ ,,, stack_context π |- u.2 == v.2) brs2 brs2' ∥)
+    : ConversionResult (∥ All2 (fun u v => u.1 = v.1 × Σ ;;; Γ ,,, stack_context π |- u.2 = v.2) brs2 brs2' ∥)
     by struct brs2 :=
 
     isconv_branches Γ ind par
@@ -1694,7 +1691,7 @@ Section Conversion.
     (hx : conv_stack_ctx Γ π π')
     (ei : ind = ind') (ep : par = par')
     (aux : Aux Term Γ (tCase (ind, par) p c brs) π (tCase (ind', par') p' c' brs') π' h')
-    : ConversionResult (∥ All2 (fun u v => u.1 = v.1 ×  Σ ;;; Γ ,,, stack_context π |- u.2 == v.2) brs brs' ∥) :=
+    : ConversionResult (∥ All2 (fun u v => u.1 = v.1 ×  Σ ;;; Γ ,,, stack_context π |- u.2 = v.2) brs brs' ∥) :=
 
     isconv_branches' Γ ind par p c brs π h ind' par' p' c' brs' π' h' hx ei ep aux :=
       isconv_branches Γ ind par p c [] brs π _ p' c' [] brs' π' _ _ _ _.
@@ -1713,12 +1710,12 @@ Section Conversion.
     (h' : wtp Γ (tFix (mfix1' ++ mfix2') idx) π')
     (hx : conv_stack_ctx Γ π π')
     (h1 : ∥ All2 (fun u v =>
-                   Σ ;;; Γ ,,, stack_context π |- u.(dtype) == v.(dtype) ×
+                   Σ ;;; Γ ,,, stack_context π |- u.(dtype) = v.(dtype) ×
                    u.(rarg) = v.(rarg)
             ) mfix1 mfix1' ∥)
     (aux : Aux Term Γ (tFix (mfix1 ++ mfix2) idx) π (tFix (mfix1' ++ mfix2') idx) π' h')
     : ConversionResult (∥ All2 (fun u v =>
-          Σ ;;; Γ ,,, stack_context π |- u.(dtype) == v.(dtype) ×
+          Σ ;;; Γ ,,, stack_context π |- u.(dtype) = v.(dtype) ×
           u.(rarg) = v.(rarg)
       ) mfix2 mfix2' ∥)
     by struct mfix2 :=
@@ -1848,13 +1845,13 @@ Section Conversion.
     (mfix1' mfix2' : mfixpoint term) (π' : stack)
     (h' : wtp Γ (tFix (mfix1' ++ mfix2') idx) π')
     (hx : conv_stack_ctx Γ π π')
-    (h1 : ∥ All2 (fun u v => Σ ;;; Γ ,,, stack_context π ,,, fix_context_alt (map def_sig mfix1 ++ map def_sig mfix2) |- u.(dbody) == v.(dbody)) mfix1 mfix1' ∥)
+    (h1 : ∥ All2 (fun u v => Σ ;;; Γ ,,, stack_context π ,,, fix_context_alt (map def_sig mfix1 ++ map def_sig mfix2) |- u.(dbody) = v.(dbody)) mfix1 mfix1' ∥)
     (ha : ∥ All2 (fun u v =>
-                    Σ ;;; Γ ,,, stack_context π |- u.(dtype) == v.(dtype) ×
+                    Σ ;;; Γ ,,, stack_context π |- u.(dtype) = v.(dtype) ×
                     u.(rarg) = v.(rarg)
            ) (mfix1 ++ mfix2) (mfix1' ++ mfix2') ∥)
     (aux : Aux Term Γ (tFix (mfix1 ++ mfix2) idx) π (tFix (mfix1' ++ mfix2') idx) π' h')
-    : ConversionResult (∥ All2 (fun u v => Σ ;;; Γ ,,, stack_context π ,,, fix_context_alt (map def_sig mfix1 ++ map def_sig mfix2) |- u.(dbody) == v.(dbody)) mfix2 mfix2' ∥)
+    : ConversionResult (∥ All2 (fun u v => Σ ;;; Γ ,,, stack_context π ,,, fix_context_alt (map def_sig mfix1 ++ map def_sig mfix2) |- u.(dbody) = v.(dbody)) mfix2 mfix2' ∥)
     by struct mfix2 :=
 
   isconv_fix_bodies Γ idx mfix1 (u :: mfix2) π h mfix1' (v :: mfix2') π' h' hx h1 ha aux
@@ -1930,7 +1927,7 @@ Section Conversion.
     clear Γ. intros Γ Γ' hx ha.
     assert (h :
       All2
-        (fun d d' => conv_alt Σ Γ d.2 d'.2)
+        (fun d d' => conv Σ Γ d.2 d'.2)
         (map def_sig Δ) (map def_sig Δ')
     ).
     { apply All2_map. eapply All2_impl. 1: eassumption.
@@ -1959,7 +1956,7 @@ Section Conversion.
       constructor. 2: eapply IHh.
       intros Ξ Θ eΞ. constructor.
       rewrite <- eΞ.
-      eapply @weakening_conv_alt with (Γ' := []). all: assumption.
+      eapply @weakening_conv with (Γ' := []). all: assumption.
     }
     clear h.
     revert hi.
@@ -2064,8 +2061,8 @@ Section Conversion.
     (ei : idx = idx')
     (aux : Aux Term Γ (tFix mfix idx) π (tFix mfix' idx') π' h')
     : ConversionResult (∥ All2 (fun u v =>
-          Σ ;;; Γ ,,, stack_context π |- u.(dtype) == v.(dtype) ×
-          Σ ;;; Γ ,,, stack_context π ,,, fix_context mfix |- u.(dbody) == v.(dbody) ×
+          Σ ;;; Γ ,,, stack_context π |- u.(dtype) = v.(dtype) ×
+          Σ ;;; Γ ,,, stack_context π ,,, fix_context mfix |- u.(dbody) = v.(dbody) ×
           u.(rarg) = v.(rarg)
       ) mfix mfix' ∥) :=
 
@@ -2298,7 +2295,7 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_conv. 1: assumption.
+    eapply conv_conv_cum.
     constructor. constructor.
     constructor. eapply eqb_universe_instance_spec. auto.
   Qed.
@@ -2322,13 +2319,12 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_trans'.
-    - assumption.
-    - eapply red_conv_l ; try assumption.
+    etransitivity.
+    - eapply red_conv_cum_l ; try assumption.
       eapply red_zipp.
       eapply red_const. eassumption.
-    - eapply conv_trans' ; try eassumption.
-      eapply red_conv_r ; try assumption.
+    - etransitivity ; try eassumption.
+      eapply red_conv_cum_r ; try assumption.
       eapply red_zipp.
       eapply red_const. eassumption.
   Qed.
@@ -2374,7 +2370,7 @@ Section Conversion.
     destruct l2 ; try discriminate hl2. clear hl2.
     simpl in *.
     destruct hΣ.
-    now eapply conv_Lambda.
+    now eapply conv_cum_Lambda.
   Qed.
 
   (* tProd *)
@@ -2423,7 +2419,7 @@ Section Conversion.
     apply mkApps_Prod_nil' in h2 ; auto. subst.
 
     simpl.
-    eapply conv_Prod. all: auto.
+    eapply conv_cum_Prod. all: auto.
   Qed.
 
   (* tCase *)
@@ -2434,7 +2430,7 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_conv. 1: assumption.
+    eapply conv_conv_cum.
     constructor. constructor.
     eapply eqb_term_spec. auto.
   Qed.
@@ -2489,7 +2485,7 @@ Section Conversion.
     destruct h1 as [h1], h2 as [h2], h3 as [h3].
     unfold zipp in h1, h2. simpl in h1, h2.
     destruct hΣ as [wΣ].
-    eapply conv_conv. 1: assumption.
+    eapply conv_conv_cum.
     constructor.
     change (eq_inductive ind ind') with (eqb ind ind') in eq4.
     destruct (eqb_spec ind ind'). 2: discriminate.
@@ -2605,9 +2601,8 @@ Section Conversion.
       pose proof (reduce_term_sound f Σ hΣ Γ c' h) as hr'
     end.
     destruct hr as [hr], hr' as [hr'].
-    eapply conv_trans'.
-    - assumption.
-    - eapply red_conv_l ; try assumption.
+    etransitivity.
+    - eapply red_conv_cum_l ; try assumption.
       eapply red_zipp.
       eapply red_case.
       + constructor.
@@ -2615,10 +2610,10 @@ Section Conversion.
       + instantiate (1 := brs).
         clear.
         induction brs ; eauto.
-    - eapply conv_trans' ; try eassumption.
-      eapply conv_context_convp.
+    - etransitivity ; try eassumption.
+      eapply conv_cum_context_convp.
       + assumption.
-      + eapply red_conv_r. 1: assumption.
+      + eapply red_conv_cum_r. 1: assumption.
         eapply red_zipp.
         eapply red_case. 2: eassumption.
         * constructor.
@@ -2643,7 +2638,7 @@ Section Conversion.
     destruct h1 as [h].
     change (true = eqb p p') in eq1.
     destruct (eqb_spec p p'). 2: discriminate. subst.
-    eapply conv_conv. 1: assumption.
+    eapply conv_conv_cum.
     constructor.
     eapply conv_Proj_c. assumption.
   Qed.
@@ -2656,7 +2651,7 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_conv. 1: assumption.
+    eapply conv_conv_cum.
     constructor. constructor.
     eapply eqb_term_spec. auto.
   Qed.
@@ -2800,9 +2795,8 @@ Section Conversion.
       pose proof (decompose_stack_eq _ _ _ e1). subst.
       rewrite stack_context_appstack. reflexivity.
     }
-    eapply conv_trans'.
-    - assumption.
-    - eapply red_conv_l. all: eassumption.
+    etransitivity.
+    - eapply red_conv_cum_l. all: eassumption.
     - rewrite e. assumption.
   Qed.
   Next Obligation.
@@ -2950,14 +2944,13 @@ Section Conversion.
     destruct r2' as [r2'].
     destruct hx as [hx].
     pose proof (red_trans _ _ _ _ _ r1 r2') as r.
-    eapply conv_trans' ; revgoals.
-    - eapply conv_context_convp.
+    etransitivity ; revgoals.
+    - eapply conv_cum_context_convp.
       + assumption.
-      + eapply red_conv_r. 1: assumption.
+      + eapply red_conv_cum_r. 1: assumption.
         eassumption.
       + eapply conv_context_sym. 1: auto.
         assumption.
-    - assumption.
     - assumption.
   Qed.
   Next Obligation.
@@ -2974,7 +2967,7 @@ Section Conversion.
   Next Obligation.
     destruct h1 as [h1].
     destruct hΣ.
-    eapply conv_conv_l. 1: assumption.
+    eapply conv_conv_cum_l. 1: assumption.
     change (true = eqb idx idx') in eq4.
     destruct (eqb_spec idx idx'). 2: discriminate.
     subst.
@@ -2989,7 +2982,7 @@ Section Conversion.
   Qed.
   Next Obligation.
     destruct hΣ.
-    eapply conv_conv. 1: assumption.
+    eapply conv_conv_cum.
     constructor. constructor.
     eapply eqb_term_spec. auto.
   Qed.
@@ -3004,9 +2997,9 @@ Section Conversion.
   (* TODO MOVE *)
   Lemma App_conv' :
     forall leq Γ t1 t2 u1 u2,
-      conv leq Σ Γ t1 t2 ->
-      Σ ;;; Γ |- u1 == u2 ->
-      conv leq Σ Γ (tApp t1 u1) (tApp t2 u2).
+      conv_cum leq Σ Γ t1 t2 ->
+      Σ ;;; Γ |- u1 = u2 ->
+      conv_cum leq Σ Γ (tApp t1 u1) (tApp t2 u2).
   Proof.
     intros leq Γ t1 t2 u1 u2 ht hu.
     destruct hΣ.
@@ -3043,7 +3036,7 @@ Section Conversion.
             (h2 : wtp Γ t2 (appstack l2 π2))
             (hπ2 : isStackApp π2 = false)
             (hx : conv_stack_ctx Γ π1 π2)
-            (h : conv leq Σ (Γ ,,, stack_context π1) (mkApps t1 args1) t2)
+            (h : conv_cum leq Σ (Γ ,,, stack_context π1) (mkApps t1 args1) t2)
             (aux : Aux' Γ t1 args1 l1 π1 t2 (appstack l2 π2) h2)
     : ConversionResult (conv_term leq Γ (mkApps t1 args1) (appstack l1 π1) t2 (appstack l2 π2)) by struct l1 :=
     _isconv_args' leq Γ t1 args1 (u1 :: l1) π1 h1 hπ1 t2 (u2 :: l2) π2 h2 hπ2 hx h aux
@@ -3157,7 +3150,7 @@ Section Conversion.
            (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)
            (t2 : term) (π2 : stack) (h2 : wtp Γ t2 π2)
            (hx : conv_stack_ctx Γ π1 π2)
-           (he : conv leq Σ (Γ ,,, stack_context π1) t1 t2)
+           (he : conv_cum leq Σ (Γ ,,, stack_context π1) t1 t2)
            (aux : Aux Args Γ t1 π1 t2 π2 h2)
     : ConversionResult (conv_term leq Γ t1 π1 t2 π2) :=
     _isconv_args leq Γ t1 π1 h1 t2 π2 h2 hx he aux with inspect (decompose_stack π1) := {
@@ -3671,13 +3664,13 @@ Section Conversion.
     rewrite stack_context_appstack.
     rewrite stack_cat_appstack in h.
     rewrite stack_context_appstack in h.
-    eapply conv_trans' ; try eassumption.
+    etransitivity ; try eassumption.
     unfold zipp. rewrite e'.
     unfold zipp in r1. rewrite e' in r1. rewrite <- eq2 in r1.
     rewrite decompose_stack_appstack.
     erewrite decompose_stack_twice ; eauto. simpl.
     rewrite app_nil_r.
-    eapply red_conv_l ; try assumption.
+    eapply red_conv_cum_l ; try assumption.
     rewrite stack_context_appstack in r1.
     eapply red_trans ; try eassumption.
     clear eq3. symmetry in eq2. apply decompose_stack_eq in eq2. subst.
@@ -3819,15 +3812,15 @@ Section Conversion.
     clear eq3.
     rewrite stack_context_appstack in hx.
     destruct hx as [hx].
-    eapply conv_trans' ; try eassumption.
+    etransitivity ; try eassumption.
     unfold zipp.
     rewrite stack_cat_appstack.
     rewrite decompose_stack_appstack.
     erewrite decompose_stack_twice ; eauto. simpl.
     rewrite app_nil_r.
-    eapply conv_context_convp.
+    eapply conv_cum_context_convp.
     - assumption.
-    - eapply red_conv_r. 1: assumption.
+    - eapply red_conv_cum_r. 1: assumption.
       rewrite stack_context_appstack in r1.
       eapply red_trans ; try eassumption.
       symmetry in eq2. apply decompose_stack_eq in eq2. subst.
@@ -3909,7 +3902,7 @@ Section Conversion.
   Theorem isconv_sound :
     forall Γ leq t1 π1 h1 t2 π2 h2 hx,
       isconv Γ leq t1 π1 h1 t2 π2 h2 hx = Success I ->
-      conv leq Σ (Γ ,,, stack_context π1) (zipp t1 π1) (zipp t2 π2).
+      conv_cum leq Σ (Γ ,,, stack_context π1) (zipp t1 π1) (zipp t2 π2).
   Proof.
     unfold isconv.
     intros Γ leq t1 π1 h1 t2 π2 h2 hx.
@@ -3924,7 +3917,7 @@ Section Conversion.
   Theorem isconv_term_sound :
     forall Γ leq t1 h1 t2 h2,
       isconv_term Γ leq t1 h1 t2 h2 = Success I ->
-      conv leq Σ Γ t1 t2.
+      conv_cum leq Σ Γ t1 t2.
   Proof.
     intros Γ leq t1 h1 t2 h2.
     unfold isconv_term. intro h.

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -687,6 +687,16 @@ Proof.
   intros [l r]. now eapply leq_universe_antisym.
 Defined.
 
+
+Definition eq_universe_leq_universe' {cf} φ u u'
+  := @eq_universe_leq_universe cf φ u u'.
+Definition leq_universe_refl' φ u
+  := @leq_universe_refl φ u.
+
+Hint Resolve eq_universe_leq_universe' leq_universe_refl'.
+
+
+
 (* This universe is a hack used in plugings to generate fresh universes *)
 Definition fresh_universe : universe. exact Universe.type0. Qed.
 (* This level is a hack used in plugings to generate fresh levels *)

--- a/template-coq/theories/utils.v
+++ b/template-coq/theories/utils.v
@@ -1537,6 +1537,12 @@ Lemma mapi_mapi {A B C} (g : nat -> A -> B) (f : nat -> B -> C) (l : list A) :
   mapi f (mapi g l) = mapi (fun n x => f n (g n x)) l.
 Proof. unfold mapi. generalize 0. induction l; simpl; try congruence. Qed.
 
+
+Lemma mapi_cst_map {A B} (f : A -> B) l : mapi (fun _ => f) l = map f l.
+Proof.
+  unfold mapi. generalize 0. induction l; cbn; auto. intros. now rewrite IHl.
+Qed.
+
 Lemma mapi_rec_ext {A B} (f g : nat -> A -> B) (l : list A) n :
   (forall k x, n <= k -> k < length l + n -> f k x = g k x) ->
   mapi_rec f l n = mapi_rec g l n.
@@ -3006,6 +3012,23 @@ Proof.
   induction 1.
   - repeat constructor.
   - sq; now constructor.
+Qed.
+
+Lemma All_All2_refl {A : Type} {R} {l : list A} :
+  All (fun x : A => R x x) l -> All2 R l l.
+Proof.
+  induction 1; constructor; auto.
+Qed.
+
+Lemma All2_app_r {A} (P : A -> A -> Type) l l' r r' :
+  All2 P (l ++ [r]) (l' ++ [r']) -> (All2 P l l') * (P r r').
+Proof.
+  induction l in l', r |- *. simpl. intros. destruct l'. simpl in *.
+  depelim X; intuition auto.
+  depelim X. destruct l'; depelim X.
+  intros.
+  depelim l'; depelim X. destruct l; depelim X.
+  specialize (IHl _ _ X). intuition auto.
 Qed.
 
 Section ListSize.


### PR DESCRIPTION
This PR si a revival of #332. It orders several things about reduction, cumulativity and conversion.

- Conversion is no longer the cumulativity in both directions. Now `conv` refers to the old `conv_alt`.
  If you need cumulativity in both direction you can use `conv_cumul2` or `cumul2_conv`.

- The second `conv` is renamed `conv_cum` to avoid the clash (it is only used for safe conversion checker).

- Instances for reflexivity/transitivity of some relations are added.

- Various boring cleaning.

It would be nice to have a clear politic about Hint Db: do we use core? pcuic? What do we add in it? ...

The lemmas `conv_alt` and `cumul_alt` remain to be updated with respect to eta.

@mattam82 and @TheoWinterhalter Is the first point okay for you?
