### PR TITLE
Change evaluation to use capturing substitution

### DIFF
--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -5,6 +5,7 @@ theories/EAstUtils.v
 theories/EInduction.v
 theories/ELiftSubst.v
 theories/EPretty.v
+theories/ECSubst.v
 theories/EWcbvEval.v
 theories/EWndEval.v
 theories/ETyping.v

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -1,7 +1,10 @@
 
 From Coq Require Import Bool List Program ZArith Lia.
 From MetaCoq.Template Require Import config utils monad_utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination PCUICContextConversion PCUICConversion.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils 
+  PCUICClosed PCUICTyping PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICSR 
+  PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination
+  PCUICContextConversion PCUICConversion.
 
 From Equations Require Import Equations.
 Local Open Scope string_scope.
@@ -531,12 +534,16 @@ Proof.
   - eauto.
 Qed.
 
-Lemma Is_type_eval (Σ : global_env_ext) Γ t v:
+Lemma Is_type_eval (Σ : global_env_ext) t v:
   wf Σ ->
-  eval Σ Γ t v ->
-  isErasable Σ Γ t ->
-  isErasable Σ Γ v.
+  eval Σ t v ->
+  isErasable Σ [] t ->
+  isErasable Σ [] v.
 Proof.
   intros; eapply Is_type_red. eauto.
-  eapply wcbeval_red; eauto. eauto.
+  eapply wcbeval_red; eauto.
+  red in X1. destruct X1 as [T [HT _]].
+  eapply typecheck_closed in HT as [_ HT]; auto. 
+  apply andP in HT. now destruct HT.
+  eauto.
 Qed.

--- a/erasure/theories/ECSubst.v
+++ b/erasure/theories/ECSubst.v
@@ -1,0 +1,116 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import List Program Lia Arith.
+From MetaCoq.Template Require Import utils.
+From MetaCoq.Erasure Require Import EAst EInduction ELiftSubst.
+
+Set Warnings "-notation-overridden".
+
+Require Import ssreflect ssrbool.
+
+From Equations Require Import Equations.
+
+Local Ltac inv H := inversion H; subst.
+
+(** Closed single substitution: no lifting involved and one term at a time. *)
+
+Fixpoint csubst t k u :=
+  match u with
+  | tBox => tBox
+  | tRel n =>
+     match Nat.compare k n with
+    | Datatypes.Eq => t
+    | Gt => tRel n
+    | Lt => tRel (Nat.pred n)
+    end
+  | tEvar ev args => tEvar ev (List.map (csubst t k) args)
+  | tLambda na M => tLambda na (csubst t (S k) M)
+  | tApp u v => tApp (csubst t k u) (csubst t k v)
+  | tLetIn na b b' => tLetIn na (csubst t k b) (csubst t (S k) b')
+  | tCase ind c brs =>
+    let brs' := List.map (on_snd (csubst t k)) brs in
+    tCase ind (csubst t k c) brs'
+  | tProj p c => tProj p (csubst t k c)
+  | tFix mfix idx =>
+    let k' := List.length mfix + k in
+    let mfix' := List.map (map_def (csubst t k')) mfix in
+    tFix mfix' idx
+  | tCoFix mfix idx =>
+    let k' := List.length mfix + k in
+    let mfix' := List.map (map_def (csubst t k')) mfix in
+    tCoFix mfix' idx
+  | x => x
+  end.
+
+(** It is equivalent to general substitution on closed terms. *)  
+Lemma closed_subst t k u : closed t ->
+    csubst t k u = subst [t] k u.
+Proof.
+  revert k; induction u using term_forall_list_ind; intros k Hs; 
+    simpl; try f_equal; eauto; solve_all.
+  - destruct (PeanoNat.Nat.compare_spec k n).
+    + subst k.
+      rewrite PeanoNat.Nat.leb_refl minus_diag /=.
+      now rewrite lift_closed.
+    + destruct (leb_spec_Set k n); try lia.
+      destruct (nth_error_spec [t] (n - k) ).
+      simpl in l0; lia.
+      now rewrite Nat.sub_1_r.
+    + now destruct (Nat.leb_spec k n); try lia.
+Qed.
+
+(*
+Lemma closedn_subst s k k' t :
+  forallb (closedn k) s -> closedn (k + k' + #|s|) t ->
+  closedn (k + k') (subst s k' t).
+Proof.
+  intros Hs. solve_all. revert H.
+  induction t in k' |- * using term_forall_list_ind; intros;
+    simpl in *;
+    rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
+    simpl closed in *; try change_Sk; repeat (rtoProp; solve_all);
+    unfold compose, test_def, on_snd, test_snd in *; simpl in *; eauto with all.
+
+  - elim (Nat.leb_spec k' n); intros. simpl.
+    apply Nat.ltb_lt in H.
+    destruct nth_error eqn:Heq.
+    -- eapply closedn_lift.
+       now eapply nth_error_all in Heq; simpl; eauto; simpl in *.
+    -- simpl. elim (Nat.ltb_spec); auto. intros.
+       apply nth_error_None in Heq. lia.
+    -- simpl. apply Nat.ltb_lt in H0.
+       apply Nat.ltb_lt. apply Nat.ltb_lt in H0. lia.
+
+  - specialize (IHt2 (S k')).
+    rewrite <- Nat.add_succ_comm in IHt2. eauto.
+  - specialize (IHt2 (S k')).
+    rewrite <- Nat.add_succ_comm in IHt2. eauto.
+  - specialize (IHt3 (S k')).
+    rewrite <- Nat.add_succ_comm in IHt3. eauto.
+  - rtoProp; solve_all. rewrite -> !Nat.add_assoc in *.
+    specialize (b0 (#|m| + k')). unfold is_true. rewrite <- b0. f_equal. lia.
+    unfold is_true. rewrite <- H0. f_equal. lia.
+  - rtoProp; solve_all. rewrite -> !Nat.add_assoc in *.
+    specialize (b0 (#|m| + k')). unfold is_true. rewrite <- b0. f_equal. lia.
+    unfold is_true. rewrite <- H0. f_equal. lia.
+Qed.
+
+Lemma closedn_subst0 s k t :
+  forallb (closedn k) s -> closedn (k + #|s|) t ->
+  closedn k (subst0 s t).
+Proof.
+  intros.
+  generalize (closedn_subst s k 0 t H).
+  rewrite Nat.add_0_r. eauto.
+Qed.
+
+
+
+Lemma closed_csubst t k u : closed t -> closedn (S k) u -> closedn k (csubst t 0 u).
+Proof.
+  intros.
+  rewrite closed_subst; auto.
+  eapply closedn_subst0. simpl. erewrite closed_upwards; eauto. lia.
+  simpl. now rewrite Nat.add_1_r.
+Qed.
+*)

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -3,7 +3,7 @@ Set Warnings "-notation-overridden".
 
 From Coq Require Import Bool List Program.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ETyping.
+From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst ETyping.
 
 Set Asymmetric Patterns.
 Require Import ssreflect ssrbool.
@@ -72,13 +72,13 @@ Section Wcbv.
   | eval_beta f na b a a' res :
       eval f (tLambda na b) ->
       eval a a' ->
-      eval (subst10 a' b) res ->
+      eval (csubst a' 0 b) res ->
       eval (tApp f a) res
 
   (** Let *)
   | eval_zeta na b0 b0' b1 res :
       eval b0 b0' ->
-      eval (subst10 b0' b1) res ->
+      eval (csubst b0' 0 b1) res ->
       eval (tLetIn na b0 b1) res
 
   (** Case *)
@@ -172,9 +172,9 @@ Section Wcbv.
       (forall a t t', eval a tBox -> P a tBox -> eval t t' -> P t t' -> eval (tApp a t) tBox -> P (tApp a t) tBox ) ->
       (forall (f : term) (na : name) (b a a' res : term),
           eval f (tLambda na b) ->
-          P f (tLambda na b) -> eval a a' -> P a a' -> eval (b {0 := a'}) res -> P (b {0 := a'}) res -> P (tApp f a) res) ->
+          P f (tLambda na b) -> eval a a' -> P a a' -> eval (csubst a' 0 b) res -> P (csubst a' 0 b) res -> P (tApp f a) res) ->
       (forall (na : name) (b0 b0' b1 res : term),
-          eval b0 b0' -> P b0 b0' -> eval (b1 {0 := b0'}) res -> P (b1 {0 := b0'}) res -> P (tLetIn na b0 b1) res) ->
+          eval b0 b0' -> P b0 b0' -> eval (csubst b0' 0 b1) res -> P (csubst b0' 0 b1) res -> P (tLetIn na b0 b1) res) ->
       (forall (c : ident) (decl : constant_body) (body : term),
           declared_constant Σ c decl ->
           forall (res : term),

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -477,11 +477,7 @@ Proof.
   rewrite PCUICCSubst.closed_subst; auto.
 Qed.
 
-Lemma eeval_closed Σ a e : closed a -> Σ ⊢ a ▷ e -> closed e.
-Proof.
-Admitted.
-
-Lemma erases_closed Σ a e : PCUICLiftSubst.closed a -> Σ ;;; [] |- a ⇝ℇ e -> closed e.
+Lemma erases_closed Σ Γ  a e : PCUICLiftSubst.closedn #|Γ| a -> Σ ;;; Γ |- a ⇝ℇ e -> closedn #|Γ| e.
 Proof.
 Admitted.
 
@@ -825,6 +821,9 @@ Proof.
     2:now eapply PCUICClosed.subject_closed in Ht.
     assert (HT := t).
     eapply inversion_Fix in t as (? & ? & ? & ? & ? & ?); auto.
+    rewrite <- closed_unfold_fix_cunfold_eq in H0; first last.
+    eapply eval_closed; eauto. eapply PCUICClosed.subject_closed in Ht; eauto.
+    auto.
     unfold unfold_fix in H0. rewrite e in H0. inv H0.
 
     eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
@@ -875,7 +874,25 @@ Proof.
               eapply erases_mkApps in H0; eauto.
               eapply IHeval2 in H0 as (? & ? & ?); cbn; eauto.
               exists x1. split. eauto.
-              econstructor. eauto. unfold ETyping.unfold_fix.
+              econstructor. eauto.
+              rewrite <- Ee.closed_unfold_fix_cunfold_eq; first last.
+              { eapply eval_closed in e3.
+                pose proof (All2_length _ _ Hmfix').
+                clear -e3 Hmfix' H8.
+                simpl in e3 |- *. solve_all.
+                rewrite app_context_nil_l in b.
+                eapply erases_closed in b. simpl in b.
+                rewrite <-H8.
+                unfold EAst.test_def. 
+                simpl in b.
+                rewrite fix_context_length in b.
+                now rewrite Nat.add_0_r.
+                unfold test_def in a. apply andP in a as [_ Hbod].
+                rewrite fix_context_length.
+                now rewrite Nat.add_0_r in Hbod.
+                eauto with pcuic.
+                now eapply PCUICClosed.subject_closed in Ht.  }
+              unfold ETyping.unfold_fix.
               rewrite e0. reflexivity.
               all:eauto.
               ** unfold is_constructor in *.
@@ -1108,7 +1125,7 @@ Proof.
 
   - destruct ip.
     assert (Hty' := Hty).
-  eapply inversion_Case in Hty' as [u' [args' [mdecl [idecl [ps [pty [btys
+    eapply inversion_Case in Hty' as [u' [args' [mdecl [idecl [ps [pty [btys
                                    [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]];
     eauto.
     eapply type_mkApps_inv in t0 as (? & ? & [] & ?); eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -64,7 +64,7 @@ Qed.
 
 (** * Correctness of erasure  *)
 
-Notation "Σ ;;; Γ |- s ▷ t" := (eval Σ Γ s t) (at level 50, Γ, s, t at next level) : type_scope.
+Notation "Σ |-p s ▷ t" := (eval Σ s t) (at level 50, s, t at next level) : type_scope.
 Notation "Σ ⊢ s ▷ t" := (Ee.eval Σ s t) (at level 50, s, t at next level) : type_scope.
 
 (** ** Erasure is stable under context conversion *)
@@ -468,45 +468,68 @@ Proof.
     cbn. rewrite fst_decompose_app_rec. eassumption.
 Qed.
 
+Lemma type_closed_subst {Σ t T} u : wf_ext Σ ->
+  Σ ;;; [] |- t : T ->
+  PCUICLiftSubst.subst1 t 0 u = PCUICCSubst.csubst t 0 u.
+Proof.
+  intros wfΣ tc.
+  apply PCUICClosed.subject_closed in tc; auto.
+  rewrite PCUICCSubst.closed_subst; auto.
+Qed.
+
+Lemma eeval_closed Σ a e : closed a -> Σ ⊢ a ▷ e -> closed e.
+Proof.
+Admitted.
+
+Lemma erases_closed Σ a e : PCUICLiftSubst.closed a -> Σ ;;; [] |- a ⇝ℇ e -> closed e.
+Proof.
+Admitted.
+
+
 Lemma erases_correct Σ t T t' v Σ' :
   extraction_pre Σ ->
   Σ;;; [] |- t : T ->
   Σ;;; [] |- t ⇝ℇ t' ->
-   erases_global Σ Σ' ->
-  Σ;;; [] |- t ▷ v ->
+  erases_global Σ Σ' ->
+  Σ |-p t ▷ v ->
   exists v', Σ;;; [] |- v ⇝ℇ v' /\ Σ' ⊢ t' ▷ v'.
 Proof.
   intros pre Hty He Heg H.
   revert T Hty t' He.
   induction H using PCUICWcbvEval.eval_evals_ind; intros T Hty t' He; inv pre.
   - assert (Hty' := Hty).
-    assert (eval Σ [] (PCUICAst.tApp f a) res) by eauto.
+    assert (eval Σ (PCUICAst.tApp f a) res) by eauto.
     eapply inversion_App in Hty as (? & ? & ? & ? & ? & ?).
-
     inv He.
+
     + eapply IHeval1 in H4 as (vf' & Hvf' & He_vf'); eauto.
       eapply IHeval2 in H6 as (vu' & Hvu' & He_vu'); eauto.
-      pose proof (subject_reduction_eval Σ [] _ _ _ (wf_ext_wf _ extr_env_wf'0) t0 H).
+      pose proof (subject_reduction_eval Σ _ _ _ (wf_ext_wf _ extr_env_wf'0) t0 H).
         eapply inversion_Lambda in X0 as (? & ? & ? & ? & ?).
         assert (Σ ;;; [] |- a' : t). {
           eapply subject_reduction_eval; eauto.
           eapply PCUICConversion.cumul_Prod_inv in c0 as [].
           econstructor. eassumption. eauto. eapply conv_sym in c0; eauto.
           now eapply conv_cumul. auto. auto. }
+      pose proof (eqs := type_closed_subst b extr_env_wf'0  X0).
       inv Hvf'.
       * assert (Σ;;; [] |- PCUICLiftSubst.subst1 a' 0 b ⇝ℇ subst1 vu' 0 t').
         eapply (erases_subst Σ [] [PCUICAst.vass na t] [] b [a'] t'); eauto.
         econstructor. econstructor. rewrite parsubst_empty. eassumption.
+        rewrite eqs in H2.
         eapply IHeval3 in H2 as (v' & Hv' & He_v').
         -- exists v'. split; eauto.
            econstructor; eauto.
-        -- eapply substitution0; eauto.
+           rewrite ECSubst.closed_subst; auto.
+           eapply erases_closed in Hvu'; auto.
+           now eapply PCUICClosed.subject_closed in X0.
+        -- rewrite <-eqs. eapply substitution0; eauto.
       * exists EAst.tBox. split.
         eapply Is_type_lambda in X1; eauto. destruct X1. econstructor.
         eapply (is_type_subst Σ [] [PCUICAst.vass na _] [] _ [a']) in X1 ; auto.
         cbn in X1.
         eapply Is_type_eval.
-        eauto. eapply H1. eassumption.
+        eauto. eapply H1. rewrite <-eqs. eassumption.
         all: eauto. econstructor. econstructor. rewrite parsubst_empty.
         eauto. econstructor. eauto. eauto.
       * auto.
@@ -515,15 +538,14 @@ Proof.
       eapply Is_type_eval; eauto.
     + auto.
   - assert (Hty' := Hty).
-    assert (Σ ;;; [] |- tLetIn na b0 t b1 ▷ res) by eauto.
-    eapply inversion_LetIn in Hty' as (? & ? & ? & ? & ? & ?).
-
-    inv He.
+    assert (Σ |-p tLetIn na b0 t b1 ▷ res) by eauto.
+    eapply inversion_LetIn in Hty' as (? & ? & ? & ? & ? & ?); auto.
+    inv He.     
     + eapply IHeval1 in H6 as (vt1' & Hvt2' & He_vt1'); eauto.
       assert (Hc : PCUICContextConversion.conv_context Σ ([],, vdef na b0 t) [vdef na b0' t]). {
         econstructor. econstructor. econstructor.
         eapply PCUICCumulativity.red_conv.
-        eapply wcbeval_red; eauto. reflexivity.
+        eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in t1. reflexivity.
       }
       assert (Σ;;; [vdef na b0' t] |- b1 : x0). {
         cbn in *. eapply PCUICContextConversion.context_conversion. 3:eauto. all:cbn; eauto.
@@ -541,17 +563,21 @@ Proof.
         all: cbn; eauto.
         econstructor. all: cbn; eauto. now eapply typing_wf_local in X0.
       }
+      unshelve epose proof (subject_reduction_eval _ _ _ _ _ t1 H); eauto.
+      pose proof (eqs := type_closed_subst b1 extr_env_wf'0 X1).
+      rewrite eqs in H1.
       eapply IHeval2 in H1 as (vres & Hvres & Hty_vres).
-      2:{ eapply substitution_let; eauto. }
+      2:{ rewrite <-eqs. eapply substitution_let; eauto. }
       exists vres. split. eauto. econstructor; eauto.
+      enough (ECSubst.csubst vt1' 0 t2'  = t2' {0 := vt1'}) as ->; auto.
+      eapply ECSubst.closed_subst. eapply erases_closed in Hvt2'; auto.
+      eapply eval_closed. eauto. 2:eauto. now eapply PCUICClosed.subject_closed in t1.
     + exists EAst.tBox. split. 2:econstructor; eauto.
       econstructor. eapply Is_type_eval; eauto.
-    + auto.
-  - destruct i; cbn in H; try congruence.
-  - destruct i; cbn in H; try congruence.
+
   - destruct Σ as (Σ, univs).
     unfold erases_global in Heg.
-    assert (Σ ;;; [] |- tConst c u ▷ res) by eauto.
+    assert (Σ |-p tConst c u ▷ res) by eauto.
     eapply inversion_Const in Hty as (? & ? & ? & ? & ?).
     inv He.
     + assert (H' := H).
@@ -578,6 +604,7 @@ Proof.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
     + auto.
+
   - destruct Σ as (Σ, univs).
     cbn in H.
     eapply extr_env_axiom_free'0 in H. congruence.
@@ -732,6 +759,7 @@ Proof.
   - pose (Hty' := Hty).
     eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?).
     inv He.
+
     + eapply IHeval1 in H6 as (vc' & Hvc' & Hty_vc'); eauto.
       eapply erases_mkApps_inv in Hvc'; eauto.
       2: eapply subject_reduction_eval; eauto.
@@ -790,16 +818,17 @@ Proof.
   - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
-    assert (Σ ;;; [] |- mkApps (tFix mfix idx) args ▷ res) by eauto.
+    assert (Σ |-p mkApps (tFix mfix idx) args ▷ res) by eauto.
     eapply type_mkApps_inv in Hty' as (? & ? & [] & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
+    2:now eapply PCUICClosed.subject_closed in Ht.
     assert (HT := t).
-    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ?).
+    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ?); auto.
     unfold unfold_fix in H0. rewrite e in H0. inv H0.
 
     eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[].
+    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
       exists EAst.tBox. split. 2:{
         assert (exists x5, Forall2 (EWcbvEval.eval Σ') x4 x5) as [x5]. {
           eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
@@ -821,7 +850,8 @@ Proof.
       eapply Is_type_eval. eauto. eassumption.
       rewrite <- mkApps_nested.
       eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
-      eapply wcbeval_red; eauto.  eauto. eauto.
+      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht.
+      eauto. eauto.
       rewrite mkApps_nested; eauto.
     + subst.
       destruct ?; inv H5.
@@ -833,6 +863,7 @@ Proof.
 
         enough(Σ;;; [] ,,, subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x4)).
         destruct p. destruct p.
+
         clear e3. rename H into e3.
         -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x3 L).
            ++ cbn in e3. destruct H as (L & ? & ?).
@@ -887,8 +918,12 @@ Proof.
                  now eapply Forall2_length in H6.
               ** eapply subject_reduction. eauto. exact Hty.
                  etransitivity.
-                 eapply PCUICReduction.red_mkApps. now eapply wcbeval_red.
-                 eapply All2_impl. exact X. intros. now eapply wcbeval_red.
+                 eapply PCUICReduction.red_mkApps. eapply wcbeval_red; eauto.
+                 now eapply PCUICClosed.subject_closed in Ht.
+                 eapply typing_spine_closed in t0.
+                 eapply All2_All_mix_left in X; eauto.
+                 eapply All2_impl. exact X. intros. simpl in X2.
+                 eapply wcbeval_red; intuition eauto. auto.
                  econstructor 2. econstructor.
                  econstructor. unfold unfold_fix. now rewrite e, E. exact Hcon.
            ++ clear - t0 X0 H6. revert x t0 x3 H6; induction X0; intros.
@@ -929,22 +964,24 @@ Proof.
 
         eapply eval_box_apps. eauto. eauto. eapply wf_ext_wf. eauto. eauto.
         eapply subject_reduction. eauto. exact Hty.
-        eapply PCUICReduction.red_mkApps. now eapply wcbeval_red.
+        eapply PCUICReduction.red_mkApps. 
+        eapply PCUICClosed.subject_closed in Ht; auto. now eapply wcbeval_red; eauto.
         eapply All_All2_refl.
         clear. induction args. econstructor. econstructor; eauto.
-    + auto.
+
   - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H0).
-    assert (Σ ;;; [] |- mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
+    assert (Σ |-p mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
     eapply type_mkApps_inv in Hty' as (? & ? & [] & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
+    2:now eapply PCUICClosed.subject_closed in Ht.
     assert (HT := t).
-    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ?).
+    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ?); auto.
 
     eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[].
+    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
       exists EAst.tBox. split. 2:{
         assert (exists x5, Forall2 (EWcbvEval.eval Σ') x4 x5) as [x5]. {
           eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
@@ -966,7 +1003,7 @@ Proof.
       eapply Is_type_eval. eauto. eassumption.
       rewrite <- mkApps_nested.
       eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
-      eapply wcbeval_red; eauto.  eauto. eauto.
+      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht. eauto. eauto.
       rewrite mkApps_nested; eauto.
     + subst.
       eapply IHeval in H2 as (? & ? & ?); eauto.
@@ -978,6 +1015,7 @@ Proof.
 
         (* enough(Σ;;; [] ,,, subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x4)). *)
         destruct p. destruct p.
+
         clear e3. rename H into e3.
         -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x3 L).
            ++ cbn in e3. destruct H as (L & ? & ?).
@@ -1027,13 +1065,19 @@ Proof.
               ** auto.
               ** eapply subject_reduction. eauto. exact Hty.
                  etransitivity.
-                 eapply PCUICReduction.red_mkApps. now eapply wcbeval_red.
-                 eapply All2_impl. exact X. intros. now eapply wcbeval_red.
+                 eapply PCUICReduction.red_mkApps.
+                 eapply PCUICClosed.subject_closed in Ht.
+                 eapply wcbeval_red; eauto. auto.
+                 eapply typing_spine_closed in t0.
+                 eapply All2_All_mix_left in X; eauto. 
+                 eapply All2_impl. exact X. intros. destruct X2.
+                 now eapply wcbeval_red. auto.
                  econstructor.
            ++ clear - t0 H3 X0. revert x t0 x3 H3; induction X0; intros.
               ** inv H3. exists []; eauto.
               ** inv H3. inv t0. eapply r in X2 as (? & ? & ?); eauto.
                  eapply IHX0 in X3 as (? & ? & ?); eauto.
+
       * eapply Is_type_app in X2 as [].
         exists EAst.tBox. split.
         econstructor.
@@ -1055,10 +1099,13 @@ Proof.
 
         eapply eval_box_apps. eauto. eauto. eapply wf_ext_wf. eauto. eauto.
         eapply subject_reduction. eauto. exact Hty.
-        eapply PCUICReduction.red_mkApps. now eapply wcbeval_red.
+        eapply PCUICReduction.red_mkApps.
+        eapply PCUICClosed.subject_closed in Ht.
+        now eapply wcbeval_red. auto.
         eapply All_All2_refl.
         clear. induction args. econstructor. econstructor; eauto.
-    + auto.
+
+
   - destruct ip.
     assert (Hty' := Hty).
   eapply inversion_Case in Hty' as [u' [args' [mdecl [idecl [ps [pty [btys
@@ -1083,7 +1130,10 @@ Proof.
         inversion H2.
         edestruct H8; eauto. cbn. eapply subject_reduction. eauto.
         exact Hty. eapply PCUICReduction.red_app.
+        eapply PCUICClosed.subject_closed in t'; auto.
         eapply wcbeval_red; eauto.
+        eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; auto.
+        eapply PCUICClosed.subject_closed in Ha; auto.
         eapply wcbeval_red; eauto.
       * exists (E.tApp x2 x3).
         split. 2:{ eapply Ee.eval_app_cong; eauto.
@@ -1101,10 +1151,15 @@ Proof.
                    - eauto. }
         econstructor; eauto.
     + exists EAst.tBox. split. 2: now econstructor.
-      econstructor. eapply Is_type_red. 3:eauto. eauto.
+      econstructor.
+      eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; auto.
+      eapply Is_type_red. 3:eauto. eauto.
       eapply PCUICReduction.red_app.
+      eapply PCUICClosed.subject_closed in Hf; auto.
       eapply wcbeval_red; eauto.
+      eapply PCUICClosed.subject_closed in Ha; auto.
       eapply wcbeval_red; eauto.
+      
   - destruct t; try now inversion H.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He. eexists. split; eauto. now econstructor.

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -32,6 +32,7 @@ theories/PCUICAlpha.v
 theories/PCUICPrincipality.v
 theories/PCUICSR.v
 theories/PCUICMetaTheory.v
+theories/PCUICCSubst.v
 theories/PCUICWcbvEval.v
 theories/PCUICChecker.v
 theories/PCUICPretty.v

--- a/pcuic/theories/PCUICCSubst.v
+++ b/pcuic/theories/PCUICCSubst.v
@@ -1,0 +1,64 @@
+(* Distributed under the terms of the MIT license.   *)
+Set Warnings "-notation-overridden".
+
+From Coq Require Import Bool List Program Lia CRelationClasses Arith.
+From MetaCoq.Template Require Import config utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICUnivSubst PCUICTyping
+     PCUICInduction PCUICReduction PCUICClosed.
+Require Import String.
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+
+Require Import ssreflect ssrbool.
+
+From Equations Require Import Equations.
+
+Local Ltac inv H := inversion H; subst.
+
+(** Closed single substitution: no lifting involved and one term at a time. *)
+
+Fixpoint csubst t k u :=
+  match u with
+  | tRel n =>
+     match Nat.compare k n with
+    | Datatypes.Eq => t
+    | Gt => tRel n
+    | Lt => tRel (Nat.pred n)
+    end
+  | tEvar ev args => tEvar ev (List.map (csubst t k) args)
+  | tLambda na T M => tLambda na (csubst t k T) (csubst t (S k) M)
+  | tApp u v => tApp (csubst t k u) (csubst t k v)
+  | tProd na A B => tProd na (csubst t k A) (csubst t (S k) B)
+  | tLetIn na b ty b' => tLetIn na (csubst t k b) (csubst t k ty) (csubst t (S k) b')
+  | tCase ind p c brs =>
+    let brs' := List.map (on_snd (csubst t k)) brs in
+    tCase ind (csubst t k p) (csubst t k c) brs'
+  | tProj p c => tProj p (csubst t k c)
+  | tFix mfix idx =>
+    let k' := List.length mfix + k in
+    let mfix' := List.map (map_def (csubst t k) (csubst t k')) mfix in
+    tFix mfix' idx
+  | tCoFix mfix idx =>
+    let k' := List.length mfix + k in
+    let mfix' := List.map (map_def (csubst t k) (csubst t k')) mfix in
+    tCoFix mfix' idx
+  | x => x
+  end.
+
+(** It is equivalent to general substitution on closed terms. *)  
+Lemma closed_subst t k u : closed t ->
+    csubst t k u = subst [t] k u.
+Proof.
+  revert k; induction u using term_forall_list_ind; intros k Hs; 
+    simpl; try f_equal; eauto with pcuic; solve_all.
+  - destruct (PeanoNat.Nat.compare_spec k n).
+    + subst k.
+      rewrite PeanoNat.Nat.leb_refl minus_diag /=.
+      now rewrite lift_closed.
+    + destruct (leb_spec_Set k n); try lia.
+      destruct (nth_error_spec [t] (n - k) ).
+      simpl in l0; lia.
+      now rewrite Nat.sub_1_r.
+    + now destruct (Nat.leb_spec k n); try lia.
+Qed.
+

--- a/pcuic/theories/PCUICCSubst.v
+++ b/pcuic/theories/PCUICCSubst.v
@@ -62,3 +62,10 @@ Proof.
     + now destruct (Nat.leb_spec k n); try lia.
 Qed.
 
+Lemma closed_csubst t k u : closed t -> closedn (S k) u -> closedn k (csubst t 0 u).
+Proof.
+  intros.
+  rewrite closed_subst; auto.
+  eapply closedn_subst0. simpl. erewrite closed_upwards; eauto. lia.
+  simpl. now rewrite Nat.add_1_r.
+Qed.

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -536,3 +536,25 @@ Proof.
   intros n [? [] ?]; unfold closed_decl; cbn.
   all: now rewrite !closedn_subst_instance_constr.
 Qed.
+
+Lemma subject_closed `{checker_flags} Σ Γ t T : 
+  wf Σ.1 ->
+  Σ ;;; Γ |- t : T ->
+  closedn #|Γ| t.
+Proof.
+  move=> wfΣ c.
+  pose proof (typing_wf_local c).
+  apply typecheck_closed in c; eauto.
+  now move: c => [_ /andP [ct _]].
+Qed.
+
+Lemma type_closed `{checker_flags} Σ Γ t T : 
+  wf Σ.1 ->
+  Σ ;;; Γ |- t : T ->
+  closedn #|Γ| T.
+Proof.
+  move=> wfΣ c.
+  pose proof (typing_wf_local c).
+  apply typecheck_closed in c; eauto.
+  now move: c => [_ /andP [_ ct]].
+Qed.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -4,7 +4,7 @@ Set Warnings "-notation-overridden".
 From Coq Require Import Bool List Program Lia CRelationClasses.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICUnivSubst PCUICTyping
-     PCUICReduction.
+     PCUICReduction PCUICClosed PCUICCSubst.
 Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -122,8 +122,8 @@ Proof.
 Qed.
 
 Section Wcbv.
-  Context (Σ : global_env) (Γ : context).
-  (* The local context is fixed: we are only doing weak reductions *)
+  Context (Σ : global_env).
+  (* The local context is empty: we are only doing weak reductions *)
 
   Inductive eval : term -> term -> Type :=
   (** Reductions *)
@@ -131,15 +131,16 @@ Section Wcbv.
   | eval_beta f na t b a a' res :
       eval f (tLambda na t b) ->
       eval a a' ->
-      eval (subst10 a' b) res ->
+      eval (csubst a' 0 b) res ->
       eval (tApp f a) res
 
   (** Let *)
   | eval_zeta na b0 b0' t b1 res :
       eval b0 b0' ->
-      eval (subst10 b0' b1) res ->
+      eval (csubst b0' 0 b1) res ->
       eval (tLetIn na b0 t b1) res
 
+  (**
   (** Local variables: defined or undefined *)
   | eval_rel_def i body res :
       option_map decl_body (nth_error Γ i) = Some (Some body) ->
@@ -149,6 +150,7 @@ Section Wcbv.
   | eval_rel_undef i :
       option_map decl_body (nth_error Γ i) = Some None ->
       eval (tRel i) (tRel i)
+  *)
 
   (** Constant unfolding *)
   | eval_delta c decl body (isdecl : declared_constant Σ c decl) u res :
@@ -233,13 +235,14 @@ Section Wcbv.
     forall P : term -> term -> Type,
       (forall (f : term) (na : name) (t b a a' res : term),
           eval f (tLambda na t b) ->
-          P f (tLambda na t b) -> eval a a' -> P a a' -> eval (b {0 := a'}) res -> P (b {0 := a'}) res -> P (tApp f a) res) ->
+          P f (tLambda na t b) -> eval a a' -> P a a' -> eval (csubst a' 0 b) res -> P (csubst a' 0 b) res -> P (tApp f a) res) ->
       (forall (na : name) (b0 b0' t b1 res : term),
-          eval b0 b0' -> P b0 b0' -> eval (b1 {0 := b0'}) res -> P (b1 {0 := b0'}) res -> P (tLetIn na b0 t b1) res) ->
-      (forall (i : nat) (body res : term),
+          eval b0 b0' -> P b0 b0' -> eval (csubst b0' 0 b1) res -> 
+          P (csubst b0' 0 b1) res -> P (tLetIn na b0 t b1) res) ->
+      (* (forall (i : nat) (body res : term),
           option_map decl_body (nth_error Γ i) = Some (Some body) ->
-          eval ((lift0 (S i)) body) res -> P ((lift0 (S i)) body) res -> P (tRel i) res) ->
-      (forall i : nat, option_map decl_body (nth_error Γ i) = Some None -> P (tRel i) (tRel i)) ->
+          eval ((lift0 (S i)) body) res -> P ((lift0 (S i)) body) res -> P (tRel i) res) -> *)
+      (* (forall i : nat, option_map decl_body (nth_error Γ i) = Some None -> P (tRel i) (tRel i)) -> *)
       (forall (c : ident) (decl : constant_body) (body : term),
           declared_constant Σ c decl ->
           forall (u : Instance.t) (res : term),
@@ -285,14 +288,14 @@ Section Wcbv.
           eval f11 f' -> P f11 f' -> ~~ (isLambda f' || isFixApp f' || isArityHead f') -> eval a a' -> P a a' -> P (tApp f11 a) (tApp f' a')) ->
       (forall t : term, atom t -> P t t) -> forall t t0 : term, eval t t0 -> P t t0.
   Proof.
-    intros P Hbeta Hlet Hreldef Hrelvar Hcst Hax Hcase Hproj Hfix Hstuckfix Hcofixcase Hcofixproj Happcong Hatom.
+    intros P Hbeta Hlet (*Hreldef Hrelvar*) Hcst Hax Hcase Hproj Hfix Hstuckfix Hcofixcase Hcofixproj Happcong Hatom.
     fix eval_evals_ind 3. destruct 1;
              try solve [match goal with [ H : _ |- _ ] =>
                              match type of H with
                                forall t t0, eval t t0 -> _ => fail 1
                              | _ => eapply H
                              end end; eauto].
-    - eapply Hrelvar, e.
+    (* - eapply Hrelvar, e. *)
     - eapply Hax; [eapply isdecl|eapply e].
     - eapply Hfix; eauto.
       clear -a eval_evals_ind.
@@ -314,7 +317,7 @@ Section Wcbv.
    *)
 
   Definition value_head x :=
-    isInd x || isConstruct x || isCoFix x || isAssRel Γ x || isAxiom Σ x.
+    isInd x || isConstruct x || isCoFix x || isAxiom Σ x.
 
   (* Lemma value_head_atom x : value_head x -> atom x. *)
   (* Proof. destruct x; auto. Qed. *)
@@ -395,7 +398,7 @@ Section Wcbv.
     induction 1 using eval_evals_ind; simpl; auto using value.
     (* eapply (value_app (tEvar n l') []). constructor. constructor. *)
 
-    - eapply (value_app (tRel i) []). now rewrite /value_head /= H. constructor.
+    (* - eapply (value_app (tRel i) []). now rewrite /value_head /= H. constructor. *)
     - eapply (value_app (tConst c u) []).
       red in H.
       rewrite /value_head /= H.
@@ -437,8 +440,8 @@ Section Wcbv.
       move/(_ H) => Ht.
       induction l using rev_ind. simpl.
       destruct t; try discriminate.
-      * constructor.
-        unfold value_head in H. simpl in H. destruct option_map as [[o|]|] => //.
+      (* * constructor.
+        unfold value_head in H. simpl in H. destruct option_map as [[o|]|] => //. *)
       * unfold value_head in H. simpl in H.
         destruct lookup_env eqn:Heq => //.
         destruct g eqn:Heq' => //.
@@ -469,12 +472,100 @@ Section Wcbv.
       constructor; auto.
   Qed.
 
-  (* (** Evaluation preserves closedness: *) *)
-  (* Lemma eval_closed : forall n t u, closedn n t = true -> eval t u -> closedn n u = true. *)
-  (* Proof. *)
-  (*   induction 2 using eval_ind; simpl in *; auto. eapply IHeval3. *)
-  (*   admit. *)
-  (* Admitted. (* closedness of evaluates for Eterms, not needed for verification *) *)
+  Lemma closed_beta na t b u : closed (tLambda na t b) -> closed u -> closed (csubst u 0 b).
+  Proof. simpl; move/andP => [ct cb] cu. now eapply closed_csubst. Qed.
+
+  Lemma closed_def `{checker_flags} c decl u b : wf Σ -> declared_constant Σ c decl -> 
+    cst_body decl = Some b ->
+    closed (subst_instance_constr u b).
+  Proof.
+    move=> wfΣ Hc Hb.
+    rewrite PCUICClosed.closedn_subst_instance_constr.
+    apply declared_decl_closed in Hc => //. simpl in Hc. red in Hc.
+    rewrite Hb in Hc. simpl in Hc. now move/andP: Hc.
+  Qed.
+  Lemma closed_iota ind pars c u args brs : forallb (test_snd (closedn 0)) brs ->
+    closed (mkApps (tConstruct ind c u) args) ->
+    closed (iota_red pars c args brs).
+  Proof.
+    unfold iota_red => cbrs cargs.
+    eapply closedn_mkApps. solve_all.
+    rewrite nth_nth_error.
+    destruct (nth_error_spec brs c) as [br e|e].
+    eapply All_nth_error in e; eauto. simpl in e. apply e.
+    auto.
+    eapply closedn_mkApps_inv in cargs.
+    move/andP: cargs => [Hcons Hargs]. now rewrite forallb_skipn.
+  Qed.
+
+  Lemma closed_arg f args n a :  
+    closed (mkApps f args) ->
+    nth_error args n = Some a -> closed a.
+  Proof.
+    move/closedn_mkApps_inv/andP => [cf cargs].
+    solve_all. eapply All_nth_error in cargs; eauto.
+  Qed.
+
+
+  Lemma closed_unfold_fix mfix idx narg fn : 
+    closed (tFix mfix idx) ->
+    unfold_fix mfix idx = Some (narg, fn) -> closed fn.
+  Proof.
+    unfold unfold_fix. destruct (nth_error mfix idx) eqn:Heq.
+    destruct (isLambda (dbody d)); try discriminate. move=> /= Hf Heq'; noconf Heq'.
+    eapply closedn_subst0. unfold fix_subst. clear -Hf. generalize #|mfix|.
+    induction n; simpl; auto. apply/andP; split; auto.
+    simpl. rewrite fix_subst_length. solve_all.
+    eapply All_nth_error in Hf; eauto. unfold test_def in Hf.
+    rewrite PeanoNat.Nat.add_0_r in Hf. now move/andP: Hf.
+    discriminate.
+  Qed.
+
+  Lemma closed_unfold_cofix mfix idx narg fn : 
+    closed (tCoFix mfix idx) ->
+    unfold_cofix mfix idx = Some (narg, fn) -> closed fn.
+  Proof.
+    unfold unfold_cofix. destruct (nth_error mfix idx) eqn:Heq.
+    move=> /= Hf Heq'; noconf Heq'.
+    eapply closedn_subst0. unfold cofix_subst. clear -Hf. generalize #|mfix|.
+    induction n; simpl; auto. apply/andP; split; auto.
+    simpl. rewrite cofix_subst_length. solve_all.
+    eapply All_nth_error in Hf; eauto. unfold test_def in Hf.
+    rewrite PeanoNat.Nat.add_0_r in Hf. now move/andP: Hf.
+    discriminate.
+  Qed.
+
+  (** Evaluation preserves closedness: *)
+  Lemma eval_closed `{checker_flags} {wfΣ : wf Σ} : forall t u, closed t -> eval t u -> closed u.
+  Proof.
+    move=> t u Hc ev. move: Hc.
+    induction ev using eval_evals_ind; simpl in *; auto;
+      (move/andP=> [/andP[Hc Hc'] Hc''] || move/andP=> [Hc Hc'] || move=>Hc); auto.
+    - eapply IHev3. unshelve eapply closed_beta. 3:eauto. exact na. simpl. eauto.
+    - eapply IHev2. now rewrite closed_csubst.
+    - apply IHev. eapply closed_def; eauto.
+    - eapply IHev2. eapply closed_iota in Hc''. eauto. eauto.
+    - eapply IHev2; auto. specialize (IHev1 Hc).
+      eapply closedn_mkApps_inv in IHev1.
+      move/andP: IHev1 => [Hcons Hargs]. solve_all.
+      eapply All_nth_error in Hargs; eauto.
+    - eapply IHev2.
+      eapply closedn_mkApps_inv in Hc. move/andP: Hc=> [cf cargs].
+      specialize (IHev1 cf).
+      eapply closed_unfold_fix in H0; eauto.
+      eapply closedn_mkApps; eauto.
+      solve_all.
+    - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs]. eapply closedn_mkApps; eauto.
+      solve_all.
+    - eapply IHev. move/closedn_mkApps_inv/andP: Hc' => [Hfix Hargs].
+      repeat (apply/andP; split; auto). eapply closedn_mkApps.
+      eapply closed_unfold_cofix in H0; eauto.
+      auto.
+    - eapply IHev. move/closedn_mkApps_inv/andP: Hc => [Hfix Hargs].
+      eapply closedn_mkApps; eauto.
+      eapply closed_unfold_cofix in H0; eauto.
+    - apply/andP; split; auto.
+    Qed.
 
   (* Lemma eval_tApp_tFix_inv mfix idx a v : *)
   (*   eval (tApp (tFix mfix idx) a) v -> *)
@@ -502,8 +593,24 @@ Section Wcbv.
   Qed.
 
   Lemma eval_tRel n t :
-    eval (tRel n) t ->
-    (match option_map decl_body (nth_error Γ n) with
+    eval (tRel n) t -> False.
+    Proof. intros H; depind H; solve_discr.
+    - destruct (mkApps_elim f args).
+      change (tRel n) with (mkApps (tRel n) []) in H1.
+      eapply mkApps_eq_inj in H1 => //. intuition subst.
+      rewrite firstn_nil in H, IHeval1.
+      specialize (IHeval1 _ _ eq_refl). rewrite skipn_nil in e0. discriminate.
+    - change (tRel n) with (mkApps (tRel n) []) in H0.
+    eapply mkApps_eq_inj in H0 => //.
+    + intuition subst.
+      now specialize (IHeval _ _ eq_refl).
+    + apply (f_equal nApp) in H0 as e. simpl in e.
+      rewrite nApp_mkApps in e. symmetry in e.
+      assert (nApp f = 0) as h by lia.
+      apply nApp_isApp_false in h. rewrite h. reflexivity.
+    - now simpl in i.
+  Qed.
+(*    (match option_map decl_body (nth_error Γ n) with
      | Some (Some b) => eval (lift0 (S n) b) t
      | _ => t = (tRel n)
      end).
@@ -524,7 +631,7 @@ Section Wcbv.
         rewrite nApp_mkApps in e. symmetry in e.
         assert (nApp f = 0) as h by lia.
         apply nApp_isApp_false in h. rewrite h. reflexivity.
-  Qed.
+  Qed. *)
 
   Lemma eval_tVar i t : eval (tVar i) t -> False.
   Proof.
@@ -561,7 +668,7 @@ Section Wcbv.
   Lemma eval_LetIn {n b ty t v} :
     eval (tLetIn n b ty t) v ->
     ∑ b',
-      eval b b' * eval (t {0 := b'}) v.
+      eval b b' * eval (csubst b' 0 t) v.
   Proof.
     intros H; depind H; try solve_discr; try now easy.
     - apply (f_equal nApp) in H1 as h. simpl in h.
@@ -757,57 +864,80 @@ End Wcbv.
 (** Well-typed closed programs can't go wrong: they always evaluate to a value. *)
 
 Conjecture closed_typed_wcbeval : forall {cf : checker_flags} (Σ : global_env_ext) t T,
-    Σ ;;; [] |- t : T -> ∑ u, eval (fst Σ) [] t u.
+    Σ ;;; [] |- t : T -> ∑ u, eval (fst Σ) t u.
 
 (** Evaluation is a subrelation of reduction: *)
 
 Tactic Notation "redt" uconstr(y) := eapply (transitivity (R:=red _ _) (y:=y)).
 
-Lemma wcbeval_red : forall (Σ : global_env_ext) Γ t u,
-    eval Σ Γ t u -> red Σ Γ t u.
+Lemma wcbeval_red `{checker_flags} : forall (Σ : global_env_ext) t u, wf Σ -> closed t ->
+    eval Σ t u -> red Σ [] t u.
 Proof.
-  intros Σ.
-  induction 1 using eval_evals_ind; try solve[ constructor; eauto].
+  intros Σ t u wfΣ Hc He. revert Hc.
+  induction He using eval_evals_ind; simpl; 
+  (move/andP => [/andP[Hc Hc'] Hc''] || move/andP => [Hc Hc'] || move => Hc);
+    try solve[econstructor; eauto].
 
   - redt (tApp (tLambda na t b) a); eauto.
     eapply red_app; eauto.
     redt (tApp (tLambda na t b) a'). eapply red_app; eauto.
-    redt (b {0 := a'}). do 2 econstructor. apply IHX3.
+    redt (csubst a' 0 b).
+    rewrite (closed_subst a' 0 b).
+    eapply eval_closed; eauto. eapply red1_red. constructor.
+    eapply IHHe3. eapply closed_csubst. eauto using eval_closed.
+    eapply eval_closed in He1; eauto. 
+    simpl in He1. now move/andP: He1.
 
   - redt (tLetIn na b0' t b1); eauto.
     eapply red_letin; auto.
     redt (b1 {0 := b0'}); auto.
     do 2 econstructor.
-
-  - redt (lift0 (S i) body); auto.
-    eapply red1_red. econstructor.
-    auto.
+    forward IHHe2.
+    eapply closed_csubst; eauto using eval_closed. unfold subst1.
+    rewrite -(closed_subst b0' 0 b1); eauto using eval_closed.
 
   - redt (subst_instance_constr u body); auto.
     eapply red1_red. econstructor; eauto.
+    apply IHHe. now eapply closed_def.
 
   - redt (tCase (ind, pars) p _ brs).
-    eapply red_case; eauto.
+    eapply red_case. eauto. eapply IHHe1; eauto.
     eapply All2_same. intros. split; auto.
-    redt (iota_red _ _ _ _); eauto.
+    redt (iota_red _ _ _ _); eauto. 2:eapply IHHe2.
     eapply red1_red. econstructor.
+    eapply closed_iota; eauto. now eapply eval_closed in He1.
 
-  - redt _. 2:eauto.
+  - redt _. 2:eapply IHHe2; eauto using eval_closed.
     redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
     apply red1_red. econstructor; eauto.
+    eapply eval_closed in He1; eauto. eapply closed_arg in He1; eauto.
 
-  - redt (mkApps (tFix mfix idx) args'); eauto.
-    eapply red_mkApps; eauto.
+  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs]. 
+    redt (mkApps (tFix mfix idx) args'); eauto.
+    eapply red_mkApps; eauto. solve_all. 
     redt (mkApps fn args'); eauto.
     eapply red1_red. eapply red_fix; eauto.
+    eapply IHHe2. eapply eval_closed in He1; eauto.
+    eapply closedn_mkApps; eauto using closed_unfold_fix.
+    clear -wfΣ X Hargs. solve_all. now eapply eval_closed.
 
-  - eapply red_mkApps; auto.
+  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
+    eapply red_mkApps; eauto.
+    eauto using eval_closed.
+    solve_all.
 
-  - redt _. eapply red1_red. eapply PCUICTyping.red_cofix_case; eauto. eauto.
+  - move/closedn_mkApps_inv/andP: Hc' => [Hf Hargs].
+    redt _. eapply red1_red. eapply PCUICTyping.red_cofix_case; eauto.
+    eapply IHHe.
+    eapply closed_unfold_cofix in H0; eauto.
+    simpl. rewrite Hc closedn_mkApps; eauto.
 
-  - redt _. 2:eauto.
+  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
+    redt _. 2:eapply IHHe.
     redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
     apply red1_red. econstructor; eauto.
+    simpl. eapply closed_unfold_cofix in H0; eauto.
+    rewrite closedn_mkApps; eauto.
 
   - eapply (red_mkApps _ _ [a] [a']); auto.
 Qed.


### PR DESCRIPTION
This changes the notions of weak call-by-value evaluation to not use local contexts anymore and to rely on a more efficient capturing (i.e. lift-free) substitution operation, as we always substitute closed terms. 
We adapt the proofs in the minimal way, i.e. erasure still has a general substitution lemma, we just show that the correctness proof only relies on substitutivity for closed terms, when the closed substitution and general substitution agree. Still need to port the general substitution calls in unfold_fix/unfold_cofix.