### PR TITLE
Factorize tRel in lift

### DIFF
--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -431,8 +431,6 @@ Lemma lift_destArity ctx t n k : Ast.wf t ->
 Proof.
   intros wf; revert ctx.
   induction wf in n, k |- * using term_wf_forall_list_ind; intros ctx; simpl; trivial.
-  destruct Nat.leb; reflexivity.
-
   specialize (IHwf0 n k (ctx,, vass n0 t)). rewrite lift_context_snoc in IHwf0.
   simpl in IHwf0. unfold lift_decl, map_decl in IHwf0. unfold vass. simpl in IHwf0. rewrite IHwf0.
   reflexivity.
@@ -443,7 +441,6 @@ Qed.
 Lemma lift_strip_outer_cast n k t : lift n k (strip_outer_cast t) = strip_outer_cast (lift n k t).
 Proof.
   induction t; simpl; try reflexivity.
-  destruct Nat.leb; reflexivity.
   now rewrite IHt1.
 Qed.
 
@@ -460,7 +457,6 @@ Proof.
   - simpl. simpl.
     destruct a as [na [body|] ty]; simpl; try congruence.
     destruct t; simpl; try congruence.
-    -- now destruct (Nat.leb (#|s| + k) n0).
     -- specialize (IHparams n k args (subst0 s body :: s) t3).
        rewrite <- Nat.add_succ_r. simpl in IHparams.
        rewrite Nat.add_succ_r.
@@ -468,7 +464,6 @@ Proof.
        rewrite <- IHparams.
        rewrite distr_lift_subst. reflexivity.
     -- destruct t; simpl; try congruence.
-       now destruct (Nat.leb (#|s| + k) n0).
        destruct args; simpl; try congruence.
        specialize (IHparams n k args (t :: s) t2). simpl in IHparams.
        replace (#|s| + k + S #|params|) with (S (#|s| + k + #|params|)) by lia.
@@ -552,7 +547,6 @@ Lemma lift_decompose_prod_assum_rec ctx t n k :
 Proof.
   induction t in n, k, ctx |- *; simpl;
     try rewrite -> Nat.sub_diag, Nat.add_0_r; try (eauto; congruence).
-  - now destruct (Nat.leb (#|ctx| + k) n0).
   - eapply IHt1.
   - specialize (IHt2 (ctx ,, vass na t1) n k).
     destruct decompose_prod_assum. rewrite IHt2. simpl.
@@ -570,8 +564,7 @@ Proof. apply lift_decompose_prod_assum_rec. Qed.
 
 Lemma decompose_app_lift n k t f a :
   decompose_app t = (f, a) -> decompose_app (lift n k t) = (lift n k f, map (lift n k) a).
-Proof. destruct t; simpl; intros [= <- <-]; try reflexivity.
-       simpl. now destruct (Nat.leb k n0). Qed.
+Proof. destruct t; simpl; intros [= <- <-]; try reflexivity. Qed.
 Hint Rewrite decompose_app_lift using auto : lift.
 
 Lemma lift_it_mkProd_or_LetIn n k ctx t :
@@ -710,7 +703,6 @@ Lemma lift_eq_term_upto_univ Re Rl n k T U :
 Proof.
   induction T in n, k, U, Rl |- * using term_forall_list_rect;
     inversion 1; simpl; try (now constructor).
-  - destruct (k <=? n0); constructor.
   - constructor. subst. clear - X X1.
     induction l in X, args', X1 |- *.
     + inversion X1; constructor.

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -402,9 +402,6 @@ Proof.
   induction u in v, n, k, e, Rle |- * using term_forall_list_ind.
   all: dependent destruction e.
   all: try (cbn ; constructor ; try lih ; assumption).
-  - cbn. destruct (Nat.leb_spec0 k n0).
-    + constructor.
-    + constructor.
   - cbn. constructor. solve_all.
   - cbn. constructor ; try lih ; try assumption. solve_all.
   - cbn. constructor.

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -674,7 +674,6 @@ Proof.
   induction t in n, k |- * using term_forall_list_ind.
   all: simpl.
   all: try congruence.
-  - destruct (_ <=? _). all: reflexivity.
   - f_equal. rename X into H; induction H.
     + reflexivity.
     + simpl. f_equal.

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -21,7 +21,7 @@ Proof.
   revert n k t.
   fix size_list 3.
   destruct t; simpl; rewrite ?list_size_map_hom; try lia.
-  elim leb_spec_Set; simpl; auto. intros. auto.
+  intros. auto.
   now rewrite !size_list.
   now rewrite !size_list.
   now rewrite !size_list.

--- a/pcuic/theories/PCUICUnivSubst.v
+++ b/pcuic/theories/PCUICUnivSubst.v
@@ -50,8 +50,6 @@ Proof.
   induction c in k |- * using term_forall_list_ind; simpl; auto;
     rewrite ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
     try solve [f_equal; eauto; solve_all; eauto].
-
-  elim (Nat.leb k n0); reflexivity.
 Qed.
 
 Lemma subst_instance_constr_mkApps u f a :

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -136,8 +136,6 @@ Lemma decompose_app_rec_lift n k t l :
   decompose_app_rec (lift n k t) (map (lift n k) l)  = (lift n k f, map (lift n k) a).
 Proof.
   induction t in k, l |- *; simpl; auto with pcuic.
-
-  - destruct Nat.leb; reflexivity.
   - specialize (IHt1 k (t2 :: l)).
     destruct decompose_app_rec. now rewrite IHt1.
 Qed.
@@ -415,7 +413,6 @@ Lemma lift_destArity ctx t n k :
 Proof.
   revert ctx.
   induction t in n, k |- * using term_forall_list_ind; intros ctx; simpl; trivial.
-  - destruct Nat.leb; reflexivity.
   - move: (IHt2 n k (ctx,, vass n0 t1)).
     now rewrite lift_context_snoc /= /lift_decl /map_decl /vass /= => ->.
   - move: (IHt3 n k (ctx,, vdef n0 t1 t2)).
@@ -443,15 +440,13 @@ Proof.
     (* clear t; intros t. *)
     destruct a as [na [body|] ty]; simpl; try congruence.
     + destruct t; simpl; try congruence.
-      * now destruct (Nat.leb (#|s| + k) n0).
-      * specialize (IHparams n k args (subst0 s body :: s) t3).
-        rewrite <- Nat.add_succ_r. simpl in IHparams.
-        rewrite Nat.add_succ_r.
-        replace (#|s| + k + S #|params|) with (S (#|s| + k + #|params|)) by lia.
-        rewrite <- IHparams.
-        rewrite distr_lift_subst. reflexivity.
+      specialize (IHparams n k args (subst0 s body :: s) t3).
+      rewrite <- Nat.add_succ_r. simpl in IHparams.
+      rewrite Nat.add_succ_r.
+      replace (#|s| + k + S #|params|) with (S (#|s| + k + #|params|)) by lia.
+      rewrite <- IHparams.
+      rewrite distr_lift_subst. reflexivity.
     + destruct t; simpl; try congruence.
-      1: now destruct (Nat.leb (#|s| + k) n0).
       destruct args; simpl; try congruence.
       specialize (IHparams n k args (t :: s) t2). simpl in IHparams.
       replace (#|s| + k + S #|params|) with (S (#|s| + k + #|params|)) by lia.
@@ -540,7 +535,6 @@ Lemma lift_decompose_prod_assum_rec ctx t n k :
 Proof.
   induction t in n, k, ctx |- *; simpl;
     try rewrite -> Nat.sub_diag, Nat.add_0_r; try (eauto; congruence).
-  - now destruct (Nat.leb (#|ctx| + k) n0).
   - specialize (IHt2 (ctx ,, vass na t1) n k).
     destruct decompose_prod_assum. rewrite IHt2. simpl.
     rewrite lift_context_snoc. reflexivity.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -39,7 +39,6 @@ Lemma trans_lift n k t :
   trans (TL.lift n k t) = lift n k (trans t).
 Proof.
   revert k. induction t using Template.Induction.term_forall_list_ind; simpl; intros; try congruence.
-  - now destruct leb.
   - f_equal. rewrite !map_map_compose. solve_all.
   - rewrite lift_mkApps, IHt, map_map.
     f_equal. rewrite map_map; solve_all.

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -297,7 +297,6 @@ Proof.
   - destruct l; simpl in *; congruence.
   - destruct x; simpl in *; intuition eauto.
     destruct dbody; simpl in *; try discriminate. destruct Nat.leb; auto.
-    reflexivity.
 Qed.
 
 Lemma declared_projection_wf {cf:checker_flags}:

--- a/template-coq/theories/UnivSubst.v
+++ b/template-coq/theories/UnivSubst.v
@@ -50,8 +50,6 @@ Proof.
   induction c in k |- * using term_forall_list_ind; simpl; auto;
     rewrite ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
     try solve [f_equal; eauto; solve_all; eauto].
-
-  elim (Nat.leb k n0); reflexivity.
 Qed.
 
 Lemma subst_instance_constr_mkApps u f a :

--- a/template-coq/theories/utils.v
+++ b/template-coq/theories/utils.v
@@ -71,6 +71,9 @@ Tactic Notation "toProp" ident(H) :=
   | (_ <? _)%nat  = true => apply PeanoNat.Nat.ltb_lt in H
   | (_ <=? _)%nat = true => apply PeanoNat.Nat.leb_le in H
   | (_ =? _)%nat  = true => apply PeanoNat.Nat.eqb_eq in H
+  | (_ <? _)%nat  = false => apply PeanoNat.Nat.ltb_ge in H
+  | (_ <=? _)%nat = false => apply PeanoNat.Nat.leb_gt in H
+  | (_ =? _)%nat  = false => apply PeanoNat.Nat.eqb_neq in H
 
   | is_true (_ <? _)%Z => apply Z.ltb_lt in H
   | is_true (_ <=? _)%Z => apply Z.leb_le in H
@@ -78,6 +81,9 @@ Tactic Notation "toProp" ident(H) :=
   | (_ <? _)%Z  = true => apply Z.ltb_lt in H
   | (_ <=? _)%Z = true => apply Z.leb_le in H
   | (_ =? _)%Z  = true => apply Z.eqb_eq in H
+  | (_ <? _)%Z  = false => apply Z.ltb_ge in H
+  | (_ <=? _)%Z = false => apply Z.leb_gt in H
+  | (_ =? _)%Z  = false => apply Z.eqb_neq in H
      
   | is_true (_ && _) => apply andb_true_iff in H
   | (_ && _) = true  => apply andb_true_iff in H
@@ -96,6 +102,9 @@ Tactic Notation "toProp" :=
   | |- (_ <? _)%nat  = true => apply PeanoNat.Nat.ltb_lt
   | |- (_ <=? _)%nat = true => apply PeanoNat.Nat.leb_le
   | |- (_ =? _)%nat  = true => apply PeanoNat.Nat.eqb_eq
+  | |- ( _ <? _)%nat  = false => apply PeanoNat.Nat.ltb_ge
+  | |- (_ <=? _)%nat = false => apply PeanoNat.Nat.leb_gt
+  | |- (_ =? _)%nat  = false => apply PeanoNat.Nat.eqb_neq
 
   | |- is_true (_ <? _)%Z => apply Z.ltb_lt
   | |- is_true (_ <=? _)%Z => apply Z.leb_le
@@ -103,6 +112,9 @@ Tactic Notation "toProp" :=
   | |- (_ <? _)%Z  = true => apply Z.ltb_lt
   | |- (_ <=? _)%Z = true => apply Z.leb_le
   | |- (_ =? _)%Z  = true => apply Z.eqb_eq
+  | |- (_ <? _)%Z  = false => apply Z.ltb_ge
+  | |- (_ <=? _)%Z = false => apply Z.leb_gt
+  | |- (_ =? _)%Z  = false => apply Z.eqb_neq
 
   | |- is_true (_ && _) => apply andb_true_iff; split
   | |- (_ && _) = true => apply andb_true_iff; split


### PR DESCRIPTION
In the definition of `lift` I propose to use:
`tRel i => tRel (if Nat.leb k i then n + i else i)`
instead of:
`tRel i => if Nat.leb k i then tRel (n + i) else tRel i`

It simplifies a few proofs and allows to discriminate more easily.

By the way in this PR: a little of cleaning in PCUICLisftSubst and a more complete toProp in utils.
