### PR TITLE
Validity principality

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -217,7 +217,7 @@ Lemma tConstruct_no_Type (Σ : global_env_ext) ind c u x1 : wf Σ ->
 Proof.
   intros wfΣ (? & ? & [ | (? & ? & ?)]).
   - exfalso.
-    eapply type_mkApps_inv in t as (? & ? & [] & ?); eauto.
+    eapply PCUICValidity.inversion_mkApps in t as (? & ? & ? & ? & ?); eauto.
     assert (HWF : isWfArity_or_Type Σ [] x2).
     { eapply PCUICValidity.validity.
       - eauto.
@@ -466,7 +466,7 @@ Lemma Is_type_app (Σ : global_env_ext) Γ t L T :
 Proof.
   intros wfΣ wfΓ ? ?.
   assert (HW : isWfArity_or_Type Σ Γ T). eapply PCUICValidity.validity; eauto.
-  eapply type_mkApps_inv in X as (? & ? & [] & ?); try eassumption.
+  eapply PCUICValidity.inversion_mkApps in X as (? & ? & ? & ? & ?); try eassumption.
   destruct X0 as (? & ? & [ | [u]]).
   - eapply PCUICPrincipality.principal_typing in t2 as (? & ? & ? & ?). 2:eauto. 2:exact t0.
     eapply invert_cumul_arity_r in c1; eauto.
@@ -508,8 +508,8 @@ Proof.
   destruct s as [ | (u & ? & ?)].
   - eapply invert_cumul_arity_r in c; eauto. destruct c as (? & [] & ?).
     eapply invert_red_prod in X1 as (? & ? & [] & ?); eauto; subst. cbn in H.
-    econstructor. exists x3. econstructor. eapply type_reduction; eauto. econstructor; eauto. eexists; eauto.
-    eauto.
+    econstructor. exists x3. econstructor. 
+    eapply type_reduction; eauto. econstructor; eauto.
   - sq. eapply cumul_prop1 in c; eauto.
     eapply inversion_Prod in c as (? & ? & ? & ? & ?) ; auto.
     eapply cumul_Sort_inv in c.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -354,7 +354,7 @@ Proof.
   - eapply IHL in H; eauto.
     destruct H as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)].
     + subst. left. exists (a :: x), x0, x1. repeat split; eauto.
-    + subst. eapply type_mkApps_inv in X as (? & ? & [] & ?); eauto.
+    + subst. eapply PCUICValidity.inversion_mkApps in X as (? & ? & ? & ? & ?); eauto.
       eapply erases_App in H0 as [ (-> & []) | (? & ? & ? & ? & ?)].
       * left. exists [a], L, x0. cbn. repeat split. eauto.
         econstructor; eauto.  eauto.
@@ -608,7 +608,7 @@ Proof.
   (*                                  [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]. *)
   (*   assert (Σ ;;; [] |- mkApps (tConstruct ind c u) args :  mkApps (tInd ind u') args'). *)
   (*   eapply subject_reduction_eval; eauto. *)
-  (*   eapply type_mkApps_inv in X0 as (? & ? & [] & ?); eauto. *)
+  (*   eapply PCUICValidity.inversion_mkApps in X0 as (? & ? & [] & ?); eauto. *)
   (*   eapply inversion_Construct in t1 as (mdecl' & idecl' & cdecl & ? & ? & ? & ?). *)
   (*   assert (d1 := d0). *)
   (*   destruct d0. *)
@@ -780,7 +780,7 @@ Proof.
         eapply Forall2_nth_error_Some in H5 as (? & ? & ?); eauto.
         assert (Σ ;;; [] |- mkApps (tConstruct i k u) args : mkApps (tInd i x) x2).
         eapply subject_reduction_eval; eauto.
-        eapply type_mkApps_inv in X as (? & ? & [] & ?); eauto.
+        eapply PCUICValidity.inversion_mkApps in X as (? & ? & ? & ? & ?); eauto.
         eapply typing_spine_inv in t2 as []; eauto.
         eapply IHeval2 in H4 as (? & ? & ?); eauto.
         inv H3.
@@ -812,7 +812,7 @@ Proof.
     assert (Hunf := H).
     assert (Hcon := H1).
     assert (Σ |-p mkApps (tFix mfix idx) args ▷ res) by eauto.
-    eapply type_mkApps_inv in Hty' as (? & ? & [] & ?); eauto.
+    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
     2:now eapply PCUICClosed.subject_closed in Ht.
@@ -987,7 +987,7 @@ Proof.
     assert (Hunf := H).
     assert (Hcon := H0).
     assert (Σ |-p mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
-    eapply type_mkApps_inv in Hty' as (? & ? & [] & ?); eauto.
+    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
     2:now eapply PCUICClosed.subject_closed in Ht.
@@ -1125,12 +1125,12 @@ Proof.
     eapply inversion_Case in Hty' as [u' [args' [mdecl [idecl [ps [pty [btys
                                    [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]];
     eauto.
-    eapply type_mkApps_inv in t0 as (? & ? & [] & ?); eauto.
+    eapply PCUICValidity.inversion_mkApps in t0 as (? & ? & ? & ? & ?); eauto.
     eapply inversion_CoFix in t0 as (? & ? & ? &?); eauto.
     inversion i1.
   - assert (Hty' := Hty).
     eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?).
-    eapply type_mkApps_inv in t0 as (? & ? & [] & ?); eauto.
+    eapply PCUICValidity.inversion_mkApps in t0 as (? & ? & ? & ? & ?); eauto.
     eapply inversion_CoFix in t0 as (? & ? & ? &?); eauto.
     inversion i0. eauto.
   - pose (Hty' := Hty).

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -3,7 +3,8 @@ From Coq Require Import Bool String List Program.
 From MetaCoq.Template Require Import config utils monad_utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICTyping PCUICLiftSubst PCUICInversion
-     PCUICConfluence PCUICCumulativity PCUICSR PCUICNormal PCUICSafeLemmata
+     PCUICConfluence PCUICConversion 
+     PCUICCumulativity PCUICSR PCUICNormal PCUICSafeLemmata
      PCUICValidity PCUICPrincipality PCUICElimination PCUICSN.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker.
 From Equations Require Import Equations.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -4,7 +4,8 @@ From MetaCoq.Template Require Import config utils monad_utils.
 From Equations Require Import Equations.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICTyping PCUICInversion
-     PCUICConfluence PCUICCumulativity PCUICSR PCUICSafeLemmata
+     PCUICConfluence PCUICConversion 
+     PCUICCumulativity PCUICSR PCUICSafeLemmata
      PCUICValidity PCUICPrincipality PCUICElimination PCUICSN.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker PCUICSafeRetyping.
 Local Open Scope string_scope.
@@ -233,7 +234,6 @@ Qed.
 Next Obligation.
   destruct H as [T' [redT' isar]].
   sq. econstructor. split. eapply type_reduction; eauto.
-  eauto using typing_wf_local.
   eauto.
 Qed.
 Next Obligation.
@@ -285,7 +285,7 @@ Next Obligation.
 
     eapply leq_universe_prop in l0 as []; cbn; eauto.
     eapply leq_universe_prop in l as []; cbn; eauto.
-    reflexivity. eauto using typing_wf_local.
+    reflexivity.
 Qed.
 
 (* Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (HΓ : ∥wf_local Sigma Gamma∥) (t : PCUICAst.term) : *)

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -19,7 +19,6 @@ theories/PCUICClosed.v
 theories/PCUICWeakening.v
 theories/PCUICUnivSubstitution.v
 theories/PCUICSubstitution.v
-theories/PCUICSpine.v
 theories/PCUICCumulativity.v
 theories/PCUICReduction.v
 theories/PCUICParallelReduction.v
@@ -28,13 +27,16 @@ theories/PCUICConfluence.v
 theories/PCUICContextConversion.v
 theories/PCUICConversion.v
 theories/PCUICGeneration.v
-theories/PCUICValidity.v
 theories/PCUICAlpha.v
 theories/PCUICPrincipality.v
 theories/PCUICCtxShape.v
 theories/PCUICContexts.v
 theories/PCUICUniverses.v
 theories/PCUICArities.v
+theories/PCUICSpine.v
+theories/PCUICInductives.v
+
+theories/PCUICValidity.v
 theories/PCUICSR.v
 theories/PCUICMetaTheory.v
 theories/PCUICCSubst.v

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -7,8 +7,8 @@ From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICUnivSubstitution
      PCUICCumulativity PCUICPosition PCUICEquality PCUICNameless
-     PCUICAlpha PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
-     PCUICConfluence PCUICConversion PCUICContextConversion PCUICValidity
+     PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
+     PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
      PCUICClosed PCUICPrincipality PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils PCUICCtxShape PCUICContexts
@@ -315,31 +315,6 @@ Qed.
 Hint Extern 4 (_ ;;; _ |- _ <= _) => reflexivity : pcuic.
 Ltac pcuic := eauto 5 with pcuic.
 
-(** Requires Validity *)
-Lemma type_mkApps_inv {cf:checker_flags} (Σ : global_env_ext) Γ f u T : wf Σ ->
-  Σ ;;; Γ |- mkApps f u : T ->
-  { T' & { U & ((Σ ;;; Γ |- f : T') * (typing_spine Σ Γ T' u U) * (Σ ;;; Γ |- U <= T))%type } }.
-Proof.
-  intros wfΣ; induction u in f, T |- *. simpl. intros.
-  { exists T, T. intuition pcuic. constructor. eapply validity; auto with pcuic.
-    eauto. eapply cumul_refl'. }
-  intros Hf. simpl in Hf.
-  destruct u. simpl in Hf.
-  - eapply inversion_App in Hf as [na' [A' [B' [Hf' [Ha HA''']]]]].
-    eexists _, _; intuition eauto.
-    econstructor; eauto with pcuic. eapply validity; eauto with wf pcuic.
-    constructor. all:eauto with pcuic.
-    eapply validity; eauto with wf.
-    eapply type_App; eauto. 
-  - specialize (IHu (tApp f a) T).
-    specialize (IHu Hf) as [T' [U' [[H' H''] H''']]].
-    eapply inversion_App in H' as [na' [A' [B' [Hf' [Ha HA''']]]]]. 2:{ eassumption. }
-    exists (tProd na' A' B'), U'. intuition; eauto.
-    econstructor. eapply validity; eauto with wf.
-    eapply cumul_refl'. auto.
-    clear -H'' HA''' wfΣ. depind H''.
-    econstructor; eauto. eapply cumul_trans; eauto.  
-Qed.
 
 Lemma subslet_app_closed {cf:checker_flags} Σ Γ s s' Δ Δ' : 
   subslet Σ Γ s Δ ->

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -10,7 +10,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
      PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
-     PCUICClosed PCUICPrincipality PCUICSubstitution
+     PCUICClosed PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils PCUICCtxShape PCUICContexts
      PCUICUniverses.
 From Equations Require Import Equations.

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -5,8 +5,8 @@ From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICTyping
      PCUICCumulativity PCUICPosition PCUICEquality PCUICNameless
-     PCUICAlpha PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
-     PCUICConfluence PCUICConversion PCUICContextConversion PCUICValidity
+     PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
+     PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
      PCUICClosed PCUICPrincipality PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils PCUICCtxShape.

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -8,7 +8,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
      PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
-     PCUICClosed PCUICPrincipality PCUICSubstitution
+     PCUICClosed PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils PCUICCtxShape.
 
 From Equations Require Import Equations.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 From Coq Require Import Bool List Program Lia Arith.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICLiftSubst PCUICTyping
      PCUICSubstitution PCUICPosition PCUICCumulativity PCUICReduction
      PCUICConfluence  PCUICParallelReductionConfluence PCUICEquality
@@ -489,6 +489,512 @@ Proof.
   - admit.
 (* Qed. *)
 Admitted.
+
+Section Inversions.
+  Context {cf : checker_flags}.
+  Context (Σ : global_env_ext).
+  Context (wfΣ : wf Σ).
+
+  Definition Is_conv_to_Arity Σ Γ T :=
+    exists T', ∥ red Σ Γ T T' ∥ /\ isArity T'.
+
+  Lemma arity_red_to_prod_or_sort :
+    forall Γ T,
+      isArity T ->
+      (exists na A B, ∥ red Σ Γ T (tProd na A B) ∥) \/
+      (exists u, ∥ red Σ Γ T (tSort u) ∥).
+  Proof.
+    intros Γ T a.
+    induction T in Γ, a |- *. all: try contradiction.
+    - right. eexists. constructor. constructor.
+    - left. eexists _,_,_. constructor. constructor.
+    - simpl in a. eapply IHT3 in a as [[na' [A [B [r]]]] | [u [r]]].
+      + left. eexists _,_,_. constructor.
+        eapply red_trans.
+        * eapply red1_red. eapply red_zeta.
+        * eapply untyped_substitution_red with (s := [T1]) (Γ' := []) in r.
+          -- simpl in r. eassumption.
+          -- assumption.
+          -- instantiate (1 := [],, vdef na T1 T2).
+             replace (untyped_subslet Γ [T1] ([],, vdef na T1 T2))
+              with (untyped_subslet Γ [subst0 [] T1] ([],, vdef na T1 T2))
+              by (now rewrite subst_empty).
+             eapply untyped_cons_let_def.
+             constructor.
+      + right. eexists. constructor.
+        eapply red_trans.
+        * eapply red1_red. eapply red_zeta.
+        * eapply untyped_substitution_red with (s := [T1]) (Γ' := []) in r.
+          -- simpl in r. eassumption.
+          -- assumption.
+          -- replace (untyped_subslet Γ [T1] ([],, vdef na T1 T2))
+              with (untyped_subslet Γ [subst0 [] T1] ([],, vdef na T1 T2))
+              by (now rewrite subst_empty).
+            eapply untyped_cons_let_def.
+            constructor.
+  Qed.
+
+  Lemma Is_conv_to_Arity_inv :
+    forall Γ T,
+      Is_conv_to_Arity Σ Γ T ->
+      (exists na A B, ∥ red Σ Γ T (tProd na A B) ∥) \/
+      (exists u, ∥ red Σ Γ T (tSort u) ∥).
+  Proof.
+    intros Γ T [T' [r a]].
+    induction T'.
+    all: try contradiction.
+    - right. eexists. eassumption.
+    - left. eexists _, _, _. eassumption.
+    - destruct r as [r1].
+      eapply arity_red_to_prod_or_sort in a as [[na' [A [B [r2]]]] | [u [r2]]].
+      + left. eexists _,_,_. constructor.
+        eapply red_trans. all: eassumption.
+      + right. eexists. constructor.
+        eapply red_trans. all: eassumption.
+  Qed.
+
+  Lemma invert_red_sort Γ u v :
+    red Σ Γ (tSort u) v -> v = tSort u.
+  Proof.
+    intros H; apply red_alt in H.
+    generalize_eqs H.
+    induction H; simplify *.
+    - depind r. solve_discr.
+    - reflexivity.
+    - eapply IHclos_refl_trans2. auto.
+  Qed.
+
+  Lemma invert_cumul_sort_r Γ C u :
+    Σ ;;; Γ |- C <= tSort u ->
+               ∑ u', red Σ Γ C (tSort u') * leq_universe (global_ext_constraints Σ) u' u.
+  Proof.
+    intros Hcum.
+    eapply cumul_alt in Hcum as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_sort in redv' as ->.
+    depelim leqvv'. exists s. intuition eauto.
+  Qed.
+
+  Lemma invert_cumul_sort_l Γ C u :
+    Σ ;;; Γ |- tSort u <= C ->
+               ∑ u', red Σ Γ C (tSort u') * leq_universe (global_ext_constraints Σ) u u'.
+  Proof.
+    intros Hcum.
+    eapply cumul_alt in Hcum as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_sort in redv as ->.
+    depelim leqvv'. exists s'. intuition eauto.
+  Qed.
+
+  Lemma invert_red_prod Γ na A B v :
+    red Σ Γ (tProd na A B) v ->
+    ∑ A' B', (v = tProd na A' B') *
+             (red Σ Γ A A') *
+             (red Σ (vass na A :: Γ) B B').
+  Proof.
+    intros H. apply red_alt in H.
+    generalize_eqs H. revert na A B.
+    induction H; simplify_dep_elim.
+    - depelim r.
+      + solve_discr.
+      + do 2 eexists. repeat split; eauto with pcuic.
+      + do 2 eexists. repeat split; eauto with pcuic.
+    - do 2 eexists. repeat split; eauto with pcuic.
+    - specialize (IHclos_refl_trans1 _ _ _ eq_refl).
+      destruct IHclos_refl_trans1 as (? & ? & (-> & ?) & ?).
+      specialize (IHclos_refl_trans2 _ _ _ eq_refl).
+      destruct IHclos_refl_trans2 as (? & ? & (-> & ?) & ?).
+      do 2 eexists. repeat split; eauto with pcuic.
+      + now transitivity x.
+      + transitivity x0; auto.
+        eapply PCUICConfluence.red_red_ctx. 1: auto. 1: eauto.
+        constructor.
+        * eapply All2_local_env_red_refl.
+        * red. auto.
+  Qed.
+
+  Lemma invert_cumul_prod_r Γ C na A B :
+    Σ ;;; Γ |- C <= tProd na A B ->
+    ∑ na' A' B', red Σ.1 Γ C (tProd na' A' B') *
+                 (Σ ;;; Γ |- A = A') *
+                 (Σ ;;; (Γ ,, vass na A) |- B' <= B).
+  Proof.
+    intros Hprod.
+    eapply cumul_alt in Hprod as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_prod in redv' as (A' & B' & ((-> & Ha') & ?)) => //.
+    depelim leqvv'.
+    do 3 eexists; intuition eauto.
+    - eapply conv_trans with A'; auto.
+      eapply conv_sym; auto.
+      constructor; auto.
+    - eapply cumul_trans with B'; auto.
+      + constructor. eapply leqvv'2.
+      + now eapply red_cumul_inv.
+  Qed.
+
+  Lemma eq_term_upto_univ_conv_arity_l :
+    forall Re Rle Γ u v,
+      isArity u ->
+      eq_term_upto_univ Re Rle u v ->
+      Is_conv_to_Arity Σ Γ v.
+  Proof.
+    intros Re Rle Γ u v a e.
+    induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
+    all: dependent destruction e.
+    - eexists. split.
+      + constructor. constructor.
+      + reflexivity.
+    - simpl in a.
+      eapply IHu2 in e2. 2: assumption.
+      destruct e2 as [b'' [[r] ab]].
+      exists (tProd na' a' b''). split.
+      + constructor. eapply red_prod_r. eassumption.
+      + simpl. assumption.
+    - simpl in a.
+      eapply IHu3 in e3. 2: assumption.
+      destruct e3 as [u'' [[r] au]].
+      exists (tLetIn na' t' ty' u''). split.
+      + constructor. eapply red_letin.
+        all: try solve [ constructor ].
+        eassumption.
+      + simpl. assumption.
+  Qed.
+
+  Lemma eq_term_upto_univ_conv_arity_r :
+    forall Re Rle Γ u v,
+      isArity u ->
+      eq_term_upto_univ Re Rle v u ->
+      Is_conv_to_Arity Σ Γ v.
+  Proof.
+    intros Re Rle Γ u v a e.
+    induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
+    all: dependent destruction e.
+    - eexists. split.
+      + constructor. constructor.
+      + reflexivity.
+    - simpl in a.
+      eapply IHu2 in e2. 2: assumption.
+      destruct e2 as [b'' [[r] ab]].
+      exists (tProd na0 a0 b''). split.
+      + constructor. eapply red_prod_r. eassumption.
+      + simpl. assumption.
+    - simpl in a.
+      eapply IHu3 in e3. 2: assumption.
+      destruct e3 as [u'' [[r] au]].
+      exists (tLetIn na0 t ty u''). split.
+      + constructor. eapply red_letin.
+        all: try solve [ constructor ].
+        eassumption.
+      + simpl. assumption.
+  Qed.
+
+  Lemma isArity_subst :
+    forall u v k,
+      isArity u ->
+      isArity (u { k := v }).
+  Proof.
+    intros u v k h.
+    induction u in v, k, h |- *. all: try contradiction.
+    - simpl. constructor.
+    - simpl in *. eapply IHu2. assumption.
+    - simpl in *. eapply IHu3. assumption.
+  Qed.
+
+  Lemma isArity_red1 :
+    forall Γ u v,
+      red1 Σ Γ u v ->
+      isArity u ->
+      isArity v.
+  Proof.
+    intros Γ u v h a.
+    induction u in Γ, v, h, a |- *. all: try contradiction.
+    - dependent destruction h.
+      apply (f_equal nApp) in H as eq. simpl in eq.
+      rewrite nApp_mkApps in eq. simpl in eq.
+      destruct args. 2: discriminate.
+      simpl in H. discriminate.
+    - dependent destruction h.
+      + apply (f_equal nApp) in H as eq. simpl in eq.
+        rewrite nApp_mkApps in eq. simpl in eq.
+        destruct args. 2: discriminate.
+        simpl in H. discriminate.
+      + assumption.
+      + simpl in *. eapply IHu2. all: eassumption.
+    - dependent destruction h.
+      + simpl in *. apply isArity_subst. assumption.
+      + apply (f_equal nApp) in H as eq. simpl in eq.
+        rewrite nApp_mkApps in eq. simpl in eq.
+        destruct args. 2: discriminate.
+        simpl in H. discriminate.
+      + assumption.
+      + assumption.
+      + simpl in *. eapply IHu3. all: eassumption.
+  Qed.
+
+  Lemma invert_cumul_arity_r :
+    forall (Γ : context) (C : term) T,
+      isArity T ->
+      Σ;;; Γ |- C <= T ->
+      Is_conv_to_Arity Σ Γ C.
+  Proof.
+    intros Γ C T a h.
+    induction h.
+    - eapply eq_term_upto_univ_conv_arity_r. all: eassumption.
+    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
+      exists v'. split.
+      + constructor. eapply red_trans.
+        * eapply trans_red.
+          -- constructor.
+          -- eassumption.
+        * assumption.
+      + assumption.
+    - eapply IHh. eapply isArity_red1. all: eassumption.
+    - admit.
+    - admit.
+  (* Qed. *)
+  Admitted.
+
+  Lemma invert_cumul_arity_l :
+    forall (Γ : context) (C : term) T,
+      isArity C ->
+      Σ;;; Γ |- C <= T ->
+      Is_conv_to_Arity Σ Γ T.
+  Proof.
+    intros Γ C T a h.
+    induction h.
+    - eapply eq_term_upto_univ_conv_arity_l. all: eassumption.
+    - eapply IHh. eapply isArity_red1. all: eassumption.
+    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
+      exists v'. split.
+      + constructor. eapply red_trans.
+        * eapply trans_red.
+          -- constructor.
+          -- eassumption.
+        * assumption.
+      + assumption.
+    - admit.
+    - admit.
+  (* Qed. *)
+  Admitted.
+
+  Lemma invert_cumul_prod_l Γ C na A B :
+    Σ ;;; Γ |- tProd na A B <= C ->
+               ∑ na' A' B', red Σ.1 Γ C (tProd na' A' B') *
+                            (Σ ;;; Γ |- A = A') *
+                            (Σ ;;; (Γ ,, vass na A) |- B <= B').
+  Proof.
+    intros Hprod.
+    eapply cumul_alt in Hprod as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_prod in redv as (A' & B' & ((-> & Ha') & ?)) => //.
+    depelim leqvv'.
+    do 3 eexists; intuition eauto.
+    - eapply conv_trans with A'; auto.
+      now constructor.
+    - eapply cumul_trans with B'; eauto.
+      + now eapply red_cumul.
+      + now constructor; apply leqvv'2.
+  Qed.
+
+  Lemma invert_red_letin Γ C na d ty b :
+    red Σ.1 Γ (tLetIn na d ty b) C ->
+    (∑ na' d' ty' b',
+     (red Σ.1 Γ C (tLetIn na' d' ty' b') *
+      red Σ.1 Γ d d' *
+      red Σ.1 Γ ty ty' *
+      red Σ.1 (Γ ,, vdef na d ty) b b')) +
+    (red Σ.1 Γ (subst10 d b) C)%type.
+  Proof.
+    intros Hlet.
+    (* eapply cumul_alt in Hlet. *)
+    (* destruct Hlet as [v [v' [[redv redv'] leqvv']]]. *)
+    (* eapply cumul_alt. *)
+    (* exists v, v'. repeat split; auto. *)
+  Admitted.
+(*
+  Lemma invert_red_letin_subst Γ C na d ty b :
+  red Σ.1 Γ (tLetIn na d ty b) C ->
+    ∑ d' ty' b', red Σ.1 Γ (tLetIn na d ty b) (tLetIn na d' ty' b') *
+    red Σ.1 Γ d d' *
+    red Σ.1 Γ ty ty' *
+    red Σ.1 (Γ ,, vdef na d ty) b b' *
+    red Σ.1 Γ C (subst10 d' b').
+Proof.
+  intros Hlet.
+  eapply invert_red_letin in Hlet as [[na' [d' [ty' [b' red]]]]|red] => //.
+  - exists d', ty', b'. intuition auto.
+    * eapply red_letin_alt; auto.
+    * etransitivity; eauto.
+      eapply red1_red; constructor.
+  - exists d, ty, b; intuition auto.
+  eapply red_alt in Hlet.
+  eapply Relation_Properties.clos_rt_rt1n in Hlet.
+  depind Hlet.
+  - exists d, ty, b. repeat split; auto.
+    eapply red1_red. constructor.
+  - 
+    eapply Relation_Properties.clos_rt1n_rt in Hlet.
+  depind Hlet.*)
+
+    (* destruct Hlet as [v [v' [[redv redv'] leqvv']]]. *)
+  (* eapply cumul_alt. *)
+  (* exists v, v'. repeat split; auto. *)
+  (*Admitted. *)
+
+
+  Lemma invert_cumul_letin_l Γ C na d ty b :
+    Σ ;;; Γ |- tLetIn na d ty b <= C ->
+               (* (∑ na' d' ty' b', *)
+               (*  (red Σ Γ C (tLetIn na' d' ty' b') * *)
+               (*   (Σ ;;; Γ |- d = d') * *)
+               (*   (Σ ;;; Γ |- ty = ty') * *)
+                                                          (*   (Σ ;;; (Γ ,, vdef na d ty) |- b <= b'))) + *)
+               (Σ ;;; Γ |- subst10 d b <= C).
+  Proof.
+    intros Hlet.
+    eapply cumul_alt in Hlet.
+    destruct Hlet as [v [v' [[redv redv'] leqvv']]].
+    eapply cumul_alt.
+    exists v, v'. repeat split; auto.
+  Admitted.
+  (* depelim redv. *)
+  (* - depelim leqvv'. *)
+  (*   exists na', ty', t', u'. *)
+  (*   split. split. *)
+  (*   split. auto. eapply conv_conv_alt. *)
+  (*   now eapply conv_refl. *)
+  (*   now eapply conv_conv_alt, conv_refl. *)
+  (*   constructor. auto. *)
+  (* - *)
+  (*   eapply conv_conv_alt, conv_refl. *)
+  (*   eapply *)
+
+  (*   eapply red_conv. *)
+  (*   repeat split; auto. *)
+  (*   eapply *)
+
+  (* eapply red_ *)
+
+
+  Lemma invert_cumul_letin_r Γ C na d ty b :
+    Σ ;;; Γ |- C <= tLetIn na d ty b ->
+               (* (∑ na' d' ty' b', *)
+               (*  (red Σ Γ C (tLetIn na' d' ty' b') * *)
+               (*   (Σ ;;; Γ |- d = d') * *)
+               (*   (Σ ;;; Γ |- ty = ty') * *)
+                                                          (*   (Σ ;;; (Γ ,, vdef na d ty) |- b <= b'))) + *)
+               (Σ ;;; Γ |- C <= subst10 d b).
+  Proof.
+    intros Hlet.
+    eapply cumul_alt in Hlet.
+    destruct Hlet as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_letin in redv' as [[na' [d' [ty' [b' red]]]]|red] => //.
+    - destruct red as [[[redv' redd] redty] convb]. 
+      eapply fill_le in leqvv'; eauto.
+      destruct leqvv' as [t'' [u'' [[redl redr] eq]]].
+      eapply cumul_alt. exists t'', u''. repeat split; auto.
+      * now transitivity v.
+      * admit.
+    - eapply cumul_alt.
+      exists v, v'. repeat split; auto.
+  Admitted.
+
+  Lemma app_mkApps :
+    forall u v t l,
+      isApp t = false ->
+      tApp u v = mkApps t l ->
+      ∑ l',
+        (l = l' ++ [v])%list ×
+        u = mkApps t l'.
+  Proof.
+    intros u v t l h e.
+    induction l in u, v, t, e, h |- * using list_rect_rev.
+    - cbn in e. subst. cbn in h. discriminate.
+    - rewrite <- mkApps_nested in e. cbn in e.
+      exists l. inversion e. subst. auto.
+  Qed.
+
+  (* TODO Duplicate of red_mkApps_tInd?? *)
+  Lemma invert_red_ind :
+    forall Γ ind ui l T,
+      red Σ.1 Γ (mkApps (tInd ind ui) l) T ->
+      ∑ l',
+        T = mkApps (tInd ind ui) l' ×
+        All2 (red Σ Γ) l l'.
+  Proof.
+    intros Γ ind ui l T h.
+    dependent induction h.
+    - exists l. split ; auto. apply All2_same. intro. constructor.
+    - clear h.
+      destruct IHh as [l'' [? ha]]. subst.
+      dependent induction r.
+      all: try solve [
+        apply (f_equal decompose_app) in H ;
+        rewrite !decompose_app_mkApps in H ; auto ;
+        cbn in H ; inversion H
+      ].
+      + symmetry in H. apply app_mkApps in H ; auto.
+        destruct H as [l' [? ?]]. subst.
+        specialize IHr with (1 := eq_refl).
+        apply All2_app_inv_r in ha as [l1 [l2 [? [h1 h2]]]]. subst.
+        specialize IHr with (1 := h1).
+        destruct IHr as [l [? ha]]. subst.
+        exists (l ++ [M2])%list. rewrite <- mkApps_nested. split ; auto.
+        apply All2_app ; auto.
+      + symmetry in H. apply app_mkApps in H ; auto.
+        destruct H as [l' [? ?]]. subst.
+        exists (l' ++ [N2])%list. rewrite <- mkApps_nested. split ; auto.
+        apply All2_app_inv_r in ha as [l1 [l2 [? [h1 h2]]]]. subst.
+        apply All2_app ; auto.
+        dependent destruction h2. dependent destruction h2.
+        repeat constructor. eapply red_trans ; eauto.
+  Qed.
+
+  Lemma invert_cumul_ind_l :
+    forall Γ ind ui l T,
+      Σ ;;; Γ |- mkApps (tInd ind ui) l <= T ->
+      ∑ ui' l',
+        red Σ.1 Γ T (mkApps (tInd ind ui') l') ×
+        R_universe_instance (eq_universe Σ) ui ui' ×
+        All2 (fun a a' => Σ ;;; Γ |- a = a') l l'.
+  Proof.
+    intros Γ ind ui l T h.
+    eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_ind in redv as [l' [? ha]]. subst.
+    eapply eq_term_upto_univ_mkApps_l_inv in leqvv'
+      as [u [l'' [[e ?] ?]]].
+    subst.
+    dependent destruction e.
+    eexists _,_. split ; eauto. split ; auto.
+    eapply All2_trans.
+    - intros x y z h1 h2. eapply conv_trans ; eauto.
+    - eapply All2_impl ; eauto.
+    - eapply All2_impl ; eauto.
+      intros x y h. eapply conv_refl. assumption.
+  Qed.
+
+  Lemma invert_cumul_ind_r :
+    forall Γ ind ui l T,
+      Σ ;;; Γ |- T <= mkApps (tInd ind ui) l ->
+      ∑ ui' l',
+        red Σ.1 Γ T (mkApps (tInd ind ui') l') ×
+        R_universe_instance (eq_universe Σ) ui' ui ×
+        All2 (fun a a' => Σ ;;; Γ |- a = a') l l'.
+  Proof.
+    intros Γ ind ui l T h.
+    eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
+    eapply invert_red_ind in redv' as [l' [? ?]]. subst.
+    eapply eq_term_upto_univ_mkApps_r_inv in leqvv'
+      as [u [l'' [[e ?] ?]]].
+    subst.
+    dependent destruction e.
+    eexists _,_. split ; eauto. split ; auto.
+    eapply All2_trans.
+    - intros x y z h1 h2. eapply conv_trans ; eauto.
+    - eapply All2_impl ; eauto.
+    - eapply All2_swap.
+      eapply All2_impl ; eauto.
+      intros x y h. eapply conv_sym; auto. now constructor.
+  Qed.
+
+End Inversions.
 
 Lemma assumption_context_app Γ Γ' :
   assumption_context (Γ' ,,, Γ) ->

--- a/pcuic/theories/PCUICCtxShape.v
+++ b/pcuic/theories/PCUICCtxShape.v
@@ -5,8 +5,8 @@ From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICTyping
      PCUICCumulativity PCUICPosition PCUICEquality PCUICNameless
-     PCUICAlpha PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
-     PCUICConfluence PCUICConversion PCUICContextConversion PCUICValidity
+     PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
+     PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
      PCUICClosed PCUICPrincipality PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils.

--- a/pcuic/theories/PCUICCtxShape.v
+++ b/pcuic/theories/PCUICCtxShape.v
@@ -8,7 +8,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
      PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
-     PCUICClosed PCUICPrincipality PCUICSubstitution
+     PCUICClosed PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils.
 
 From Equations Require Import Equations.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -1,0 +1,338 @@
+(* Distributed under the terms of the MIT license.   *)
+Set Warnings "-notation-overridden".
+
+Require Import Equations.Prop.DepElim.
+From Coq Require Import Bool String List Program Lia Arith.
+From MetaCoq.Template Require Import config utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening
+     PCUICSubstitution PCUICClosed PCUICCumulativity PCUICGeneration PCUICReduction
+     PCUICEquality PCUICConfluence PCUICParallelReductionConfluence
+     PCUICContextConversion PCUICUnivSubstitution
+     PCUICConversion PCUICInversion PCUICPrincipality PCUICContexts PCUICArities
+     PCUICParallelReduction PCUICSpine.
+     
+Close Scope string_scope.
+
+Require Import ssreflect. 
+
+Set Asymmetric Patterns.
+Set SimplIsCbn.
+
+From Equations Require Import Equations.
+
+Arguments subst_context !s _ !Γ.
+Arguments it_mkProd_or_LetIn !l _.
+
+
+Lemma nth_error_rev_map {A B} (f : A -> B) l i : 
+  i < #|l| ->
+  nth_error (rev_map f l) (#|l| - S i) = 
+  option_map f (nth_error l i).
+Proof.
+  move=> Hi.
+  rewrite rev_map_spec. rewrite -(map_length f l) -nth_error_rev ?map_length //.
+  now rewrite nth_error_map.
+Qed.
+  
+Lemma declared_inductive_unique {Σ ind mdecl mdecl' idecl idecl'} : 
+  declared_inductive Σ mdecl ind idecl ->
+  declared_inductive Σ mdecl' ind idecl' ->
+  (mdecl = mdecl') * (idecl = idecl').
+Proof.
+  unfold declared_inductive, declared_minductive.
+  intros [-> ?] [eq ?].
+  noconf eq; split; congruence.
+Qed.
+
+Lemma declared_constructor_unique {Σ c mdecl mdecl' idecl idecl' cdecl cdecl'} : 
+  declared_constructor Σ mdecl idecl c cdecl ->
+  declared_constructor Σ mdecl' idecl' c cdecl' ->
+  (mdecl = mdecl') * (idecl = idecl') * (cdecl = cdecl').
+Proof.
+  unfold declared_constructor.
+  intros [? ?] [eq ?]. destruct (declared_inductive_unique H eq).
+  subst mdecl' idecl'. rewrite H0 in H1. intuition congruence.
+Qed.
+
+Lemma build_case_predicate_type_spec {cf:checker_flags} Σ ind mdecl idecl pars u ps pty :
+  forall (o : on_ind_body (lift_typing typing) Σ (inductive_mind ind) mdecl (inductive_ind ind) idecl),
+  build_case_predicate_type ind mdecl idecl pars u ps = Some pty ->
+  ∑ parsubst, (context_subst (subst_instance_context u (ind_params mdecl)) pars parsubst *
+  (pty = it_mkProd_or_LetIn (subst_context parsubst 0 (subst_instance_context u o.(ind_indices))) 
+      (tProd (nNamed (ind_name idecl))
+          (mkApps (tInd ind u) (map (lift0 #|o.(ind_indices)|) pars ++ to_extended_list o.(ind_indices))) 
+          (tSort ps)))).
+Proof.
+  intros []. unfold build_case_predicate_type.
+  destruct instantiate_params eqn:Heq=> //.
+  eapply instantiate_params_make_context_subst in Heq =>  /=.
+  destruct destArity eqn:Har => //.
+  move=> [=] <-. destruct Heq as [ctx'  [ty'' [s' [? [? ?]]]]].
+  subst t. exists s'. split. apply make_context_subst_spec in H0.
+  now rewrite List.rev_involutive in H0.
+  clear onProjections. clear onConstructors.
+  assert (p.1 = subst_context s' 0 (subst_instance_context u ind_indices)) as ->.
+  move: H. rewrite ind_arity_eq subst_instance_constr_it_mkProd_or_LetIn.
+  rewrite decompose_prod_n_assum_it_mkProd app_nil_r => [=].
+  move=> Hctx' Hty'.
+  subst ty''  ctx'.
+  move: Har. rewrite subst_instance_constr_it_mkProd_or_LetIn subst_it_mkProd_or_LetIn.
+  rewrite destArity_it_mkProd_or_LetIn. simpl. move=> [=] <- /=. 
+  now rewrite app_context_nil_l.
+  f_equal. rewrite subst_context_length subst_instance_context_length.
+  simpl.
+  f_equal. f_equal.  f_equal.
+  unfold to_extended_list.
+  rewrite to_extended_list_k_subst PCUICSubstitution.map_subst_instance_constr_to_extended_list_k.
+  reflexivity.
+Qed.
+
+Hint Resolve conv_ctx_refl : pcuic.
+
+Definition branch_type ind mdecl (idecl : one_inductive_body) params u p i (br : ident * term * nat) :=
+  let inds := inds ind.(inductive_mind) u mdecl.(ind_bodies) in
+  let '(id, t, ar) := br in
+  let ty := subst0 inds (subst_instance_constr u t) in
+  match instantiate_params (subst_instance_context u mdecl.(ind_params)) params ty with
+  | Some ty =>
+  let '(sign, ccl) := decompose_prod_assum [] ty in
+  let nargs := List.length sign in
+  let allargs := snd (decompose_app ccl) in
+  let '(paramrels, args) := chop mdecl.(ind_npars) allargs in
+  let cstr := tConstruct ind i u in
+  let args := (args ++ [mkApps cstr (paramrels ++ to_extended_list sign)])%list in
+  Some (ar, it_mkProd_or_LetIn sign (mkApps (lift0 nargs p) args))
+| None => None
+end.
+
+Lemma nth_branches_type ind mdecl idecl args u p i t btys : map_option_out (build_branches_type ind mdecl idecl args u p) = Some btys ->
+  nth_error btys i = Some t -> 
+  (∑ br, (nth_error idecl.(ind_ctors) i = Some br) /\
+    (branch_type ind mdecl idecl args u p i br = Some t)).
+Proof.
+  intros Htys Hnth.
+  eapply nth_map_option_out in Htys; eauto.
+Qed.
+
+Lemma build_branches_type_lookup {cf:checker_flags} Σ Γ ind mdecl idecl cdecl pars u p (brs :  list (nat * term)) btys : 
+  declared_inductive Σ.1 mdecl ind idecl ->
+  map_option_out (build_branches_type ind mdecl idecl pars u p) = Some btys ->
+  All2 (fun br bty => (br.1 = bty.1) * (Σ ;;; Γ |- br.2 : bty.2))%type brs btys ->
+  forall c, nth_error (ind_ctors idecl) c = Some cdecl ->
+  ∑ nargs br bty, 
+    (nth_error brs c = Some (nargs, br)) *
+    (nth_error btys c = Some (nargs, bty)) *
+    (Σ ;;; Γ |- br : bty) * (branch_type ind mdecl idecl pars u p c cdecl = Some (nargs, bty)).
+Proof.
+  intros decli Hbrs Hbrtys c Hc.
+  destruct decli as [declmi decli].
+  pose proof (map_option_out_length _ _ Hbrs) as hlen. 
+  rewrite mapi_length in hlen.
+  assert (H:∑ t', nth_error btys c = Some t').
+  pose proof (All2_length _ _ Hbrtys) as e. eapply nth_error_Some_length in Hc.
+  destruct (nth_error_spec btys c). eexists; eauto. elimtype False; lia.
+  destruct H as [[argty bty] Hbty].
+  assert (H:∑ t', nth_error brs c = Some t').
+  pose proof (All2_length _ _ Hbrtys) as e. eapply nth_error_Some_length in Hc.
+  destruct (nth_error_spec brs c). eexists; eauto. elimtype False; lia.
+  destruct H as [[argbr br] Hbr].
+  eapply All2_nth_error in Hbrtys; eauto.
+  destruct Hbrtys as [Harg tybr]. simpl in *. subst.
+  eapply nth_branches_type in Hbrs; eauto.
+  destruct Hbrs as [[[id brty] nargs] [Hnth' Hbrty]].
+  exists argty, br, bty.
+  intuition auto. rewrite -Hbrty. f_equal.
+  congruence.
+Qed.
+
+Arguments cshape_indices {mdecl i idecl ctype cargs}.
+Import PCUICEnvironment.
+
+From MetaCoq.PCUIC Require Import PCUICCtxShape.
+
+Lemma branch_type_spec {cf:checker_flags} Σ ind mdecl idecl cdecl pars u p c nargs bty : 
+  declared_inductive Σ mdecl ind idecl ->
+  forall (omib : on_inductive (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl),
+  forall (oib : on_ind_body (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl (inductive_ind ind) idecl),
+  forall csort (cs : on_constructor (lift_typing typing) (Σ, ind_universes mdecl) mdecl (inductive_ind ind) idecl (ind_indices oib) cdecl csort),
+  branch_type ind mdecl idecl pars u p c cdecl = Some (nargs, bty) ->
+  forall parsubst, 
+  context_subst (subst_instance_context u (PCUICAst.ind_params mdecl)) pars parsubst ->
+  let cshape := cshape cs in
+  let indsubst := (inds (inductive_mind ind) u (ind_bodies mdecl)) in
+  let nargs' := #|cshape.(cshape_args)| in
+  let npars := #|ind_params mdecl| in
+  let substargs := (subst_context parsubst 0 
+    (subst_context indsubst npars (map_context (subst_instance_constr u) cshape.(cshape_args)))) in
+  nargs = context_assumptions cshape.(cshape_args) /\
+  bty = 
+  it_mkProd_or_LetIn substargs
+    (mkApps (lift0 nargs' p)
+      (map (subst parsubst nargs' ∘ subst indsubst (nargs' + npars) ∘ subst_instance_constr u) cshape.(cshape_indices) ++ 
+       [mkApps (tConstruct ind c u)
+         (map (lift0 nargs') pars ++         
+          to_extended_list substargs)])).
+Proof.
+  move=> decli onmib [] indices ps aeq onAr indsorts onC onP inds.
+  intros cs onc brty parsubst Hpars cshape' indsubst nargs' na. simpl in onc, cshape'.
+  clear onP.
+  assert(lenbodies: inductive_ind ind < #|ind_bodies mdecl|).
+  { destruct decli as [_ Hnth]. now apply nth_error_Some_length in Hnth. }
+  clear decli.
+  destruct onc=> /=.
+  simpl in cshape'. subst cshape'.
+  destruct cshape as [args argslen head indi eqdecl] => /=. simpl in *. 
+  rewrite eqdecl in on_ctype.
+  unfold branch_type in brty.
+  destruct cdecl as [[id ty] nargs'']. simpl in *.
+  destruct instantiate_params eqn:Heq => //.
+  eapply instantiate_params_make_context_subst in Heq.
+  destruct Heq as [ctx' [ty'' [s' [? [? ?]]]]].
+  subst t. move: H.
+  rewrite eqdecl subst_instance_constr_it_mkProd_or_LetIn subst_it_mkProd_or_LetIn.
+  rewrite -(subst_context_length (PCUICTyping.inds (inductive_mind ind) u (ind_bodies mdecl)) 0).
+  rewrite decompose_prod_n_assum_it_mkProd.
+  move=> H;noconf H.
+  move: brty.
+  rewrite !subst_context_length !subst_instance_context_length
+    subst_instance_constr_it_mkProd_or_LetIn !subst_it_mkProd_or_LetIn.
+  rewrite subst_context_length subst_instance_context_length Nat.add_0_r.
+  rewrite subst_instance_constr_mkApps !subst_mkApps.
+  rewrite Nat.add_0_r.
+  assert((subst s' #|args|
+  (subst
+     (PCUICTyping.inds (inductive_mind ind) u
+        (PCUICAst.ind_bodies mdecl))
+     (#|args| + #|PCUICAst.ind_params mdecl|)
+     (subst_instance_constr u head))) = tInd ind u).
+  rewrite /head. simpl subst_instance_constr.
+  erewrite (subst_rel_eq _ _ (#|ind_bodies mdecl| -  S (inductive_ind ind))); try lia.
+  2:{ rewrite inds_spec nth_error_rev.
+      rewrite List.rev_length mapi_length; try lia.
+      rewrite List.rev_involutive List.rev_length mapi_length; try lia.
+      rewrite nth_error_mapi. simpl.
+      elim: (nth_error_spec _ _). simpl. reflexivity.
+      lia. }
+  simpl. f_equal. destruct ind as [mind k]=> /=.
+  f_equal. simpl in lenbodies. lia.
+  rewrite H.
+  rewrite decompose_prod_assum_it_mkProd ?is_ind_app_head_mkApps //.
+  rewrite decompose_app_mkApps //.
+  simpl.
+  rewrite !map_map_compose map_app.
+  rewrite chop_n_app.
+  rewrite map_length to_extended_list_k_length.
+  by rewrite (onmib.(onNpars _ _ _ _)).
+  move=> [=] Hargs Hbty. subst nargs. split;auto. rewrite -Hbty.
+  clear Hbty bty.
+  rewrite app_nil_r.
+  pose proof (make_context_subst_spec _ _ _ H0) as csubst.
+  rewrite rev_involutive in csubst.
+  pose proof (context_subst_fun csubst Hpars). subst s'. clear csubst.
+  f_equal.
+  rewrite !subst_context_length subst_instance_context_length.
+  f_equal. f_equal. f_equal. f_equal.
+  f_equal. rewrite -map_map_compose.
+  rewrite subst_instance_to_extended_list_k.
+  rewrite -map_map_compose.
+  rewrite -to_extended_list_k_map_subst. rewrite subst_instance_context_length; lia.
+  now rewrite (subst_to_extended_list_k _ _ pars).
+Qed.
+
+Lemma subst_inds_concl_head ind u mdecl (arity : context) :
+  let head := tRel (#|ind_bodies mdecl| - S (inductive_ind ind) + #|ind_params mdecl| + #|arity|) in
+  let s := (inds (inductive_mind ind) u (ind_bodies mdecl)) in
+  inductive_ind ind < #|ind_bodies mdecl| ->
+  subst s (#|arity| + #|ind_params mdecl|)
+        (subst_instance_constr u head)
+  = tInd ind u.
+Proof.
+  intros.
+  subst head. simpl subst_instance_constr.
+  rewrite (subst_rel_eq _ _ (#|ind_bodies mdecl| - S (inductive_ind ind)) (tInd ind u)) //; try lia.
+  subst s. rewrite inds_spec rev_mapi nth_error_mapi /=.
+  elim nth_error_spec. 
+  + intros. simpl.
+    f_equal. destruct ind; simpl. f_equal. f_equal. simpl in H. lia.
+  + rewrite List.rev_length. lia.
+Qed.
+
+
+Lemma on_minductive_wf_params_indices {cf : checker_flags} (Σ : global_env) mdecl ind idecl :
+  wf Σ ->
+  declared_minductive Σ (inductive_mind ind) mdecl ->
+  forall (oib : on_ind_body (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ind)
+    mdecl (inductive_ind ind) idecl),
+  wf_local (Σ, ind_universes mdecl) (ind_params mdecl ,,, ind_indices oib).
+Proof.
+  intros.
+  eapply on_declared_minductive in H; auto.
+  pose proof (oib.(onArity)).
+  rewrite oib.(ind_arity_eq) in X0.
+  destruct X0 as [s Hs].
+  rewrite -it_mkProd_or_LetIn_app in Hs.
+  eapply it_mkProd_or_LetIn_wf_local in Hs. 
+  now rewrite app_context_nil_l in Hs. now simpl.
+Qed.
+
+Lemma on_minductive_wf_params_indices_inst {cf : checker_flags} (Σ : global_env × universes_decl)
+    mdecl (u : Instance.t) ind idecl :
+   wf Σ.1 ->
+   declared_minductive Σ.1 (inductive_mind ind) mdecl ->
+   forall (oib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl) (inductive_mind ind)
+      mdecl (inductive_ind ind) idecl),
+  consistent_instance_ext Σ (ind_universes mdecl) u ->
+  wf_local Σ (subst_instance_context u (ind_params mdecl ,,, ind_indices oib)).
+Proof.
+  intros.
+  eapply (wf_local_instantiate _ (InductiveDecl mdecl)); eauto.
+  now apply on_minductive_wf_params_indices.
+Qed.
+
+Lemma on_inductive_inst {cf:checker_flags} Σ Γ ind u mdecl idecl : 
+  wf Σ.1 -> 
+  wf_local Σ Γ ->
+  declared_minductive Σ.1 (inductive_mind ind) mdecl ->
+  on_inductive (lift_typing typing) (Σ.1, ind_universes mdecl) (inductive_mind ind) mdecl ->
+  forall (oib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl) (inductive_mind ind) mdecl 
+           (inductive_ind ind) idecl),
+  consistent_instance_ext Σ (ind_universes mdecl) u ->
+  isWfArity_or_Type Σ Γ (it_mkProd_or_LetIn (subst_instance_context u (ind_params mdecl ,,, oib.(ind_indices)))
+        (tSort (subst_instance_univ u oib.(ind_sort)))).
+Proof.
+  move=> wfΣ wfΓ declm oi oib cext.
+  pose proof (oib.(onArity)) as ar.
+  rewrite oib.(ind_arity_eq) in ar.
+  destruct ar as [s ar].
+  eapply isWAT_weaken => //.
+  rewrite -(subst_instance_constr_it_mkProd_or_LetIn u _ (tSort _)).
+  rewrite -it_mkProd_or_LetIn_app in ar.
+  eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u) in ar.
+  right. eexists _. eapply ar. all:eauto.
+Qed.
+
+Lemma nth_errror_arities_context {cf:checker_flags} (Σ : global_env_ext) mdecl ind idecl decl : 
+  wf Σ.1 ->
+  declared_inductive Σ mdecl ind idecl ->
+  on_inductive (lift_typing typing) (Σ.1, ind_universes mdecl)
+    (inductive_mind ind) mdecl ->
+  on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl)
+    (inductive_mind ind) mdecl (inductive_ind ind) idecl ->
+  nth_error (arities_context (ind_bodies mdecl)) (#|ind_bodies mdecl| - S (inductive_ind ind)) = Some decl ->
+  decl.(decl_type) = idecl.(ind_type).
+Proof.
+  move=> wfΣ decli oni onib.
+  unfold arities_context.
+  rewrite nth_error_rev_map.
+  destruct decli as [declm decli]. now apply nth_error_Some_length in decli.
+  destruct nth_error eqn:Heq; try discriminate.
+  destruct decli. rewrite H0 in Heq. noconf Heq.
+  simpl. move=> [] <-. now simpl.
+Qed.
+
+Lemma declared_inductive_minductive Σ ind mdecl idecl :
+  declared_inductive Σ mdecl ind idecl -> declared_minductive Σ (inductive_mind ind) mdecl.
+Proof. now intros []. Qed.
+Hint Resolve declared_inductive_minductive : pcuic.
+

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -9,7 +9,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICSubstitution PCUICClosed PCUICCumulativity PCUICGeneration PCUICReduction
      PCUICEquality PCUICConfluence PCUICParallelReductionConfluence
      PCUICContextConversion PCUICUnivSubstitution
-     PCUICConversion PCUICInversion PCUICPrincipality PCUICContexts PCUICArities
+     PCUICConversion PCUICInversion PCUICContexts PCUICArities
      PCUICParallelReduction PCUICSpine.
      
 Close Scope string_scope.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -591,6 +591,7 @@ Proof.
   Proof.
     move=> wfΓ. red. exists [], u. intuition auto.
   Qed.
+  Hint Extern 10 (isWfArity _ _ _ (tSort _)) => apply isWfArity_sort : pcuic.
 
   (* Duplicate *)
   (* Lemma eq_term_upto_univ_mkApps_r_inv : *)

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -1,15 +1,16 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Program.
+From Coq Require Import String Bool List Program.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICTyping PCUICSubstitution PCUICEquality
      PCUICReduction PCUICCumulativity PCUICConfluence
-     PCUICContextConversion PCUICConversion PCUICInversion PCUICUnivSubst.
+     PCUICContextConversion PCUICConversion PCUICInversion PCUICUnivSubst
+     PCUICArities PCUICValidity PCUICSR.
 
 Require Import ssreflect.
-Local Open Scope string_scope.
+
 Set Asymmetric Patterns.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -17,511 +18,10 @@ From Equations Require Import Equations.
 Set Equations With UIP.
 Set Printing Universes.
 
-Set Default Goal Selector "!".
-
 Section Principality.
   Context {cf : checker_flags}.
   Context (Σ : global_env_ext).
   Context (wfΣ : wf Σ).
-
-  Definition Is_conv_to_Arity Σ Γ T :=
-    exists T', ∥ red Σ Γ T T' ∥ /\ isArity T'.
-
-  Lemma arity_red_to_prod_or_sort :
-    forall Γ T,
-      isArity T ->
-      (exists na A B, ∥ red Σ Γ T (tProd na A B) ∥) \/
-      (exists u, ∥ red Σ Γ T (tSort u) ∥).
-  Proof.
-    intros Γ T a.
-    induction T in Γ, a |- *. all: try contradiction.
-    - right. eexists. constructor. constructor.
-    - left. eexists _,_,_. constructor. constructor.
-    - simpl in a. eapply IHT3 in a as [[na' [A [B [r]]]] | [u [r]]].
-      + left. eexists _,_,_. constructor.
-        eapply red_trans.
-        * eapply red1_red. eapply red_zeta.
-        * eapply untyped_substitution_red with (s := [T1]) (Γ' := []) in r.
-          -- simpl in r. eassumption.
-          -- assumption.
-          -- instantiate (1 := [],, vdef na T1 T2).
-             replace (untyped_subslet Γ [T1] ([],, vdef na T1 T2))
-              with (untyped_subslet Γ [subst0 [] T1] ([],, vdef na T1 T2))
-              by (now rewrite subst_empty).
-             eapply untyped_cons_let_def.
-             constructor.
-      + right. eexists. constructor.
-        eapply red_trans.
-        * eapply red1_red. eapply red_zeta.
-        * eapply untyped_substitution_red with (s := [T1]) (Γ' := []) in r.
-          -- simpl in r. eassumption.
-          -- assumption.
-          -- replace (untyped_subslet Γ [T1] ([],, vdef na T1 T2))
-              with (untyped_subslet Γ [subst0 [] T1] ([],, vdef na T1 T2))
-              by (now rewrite subst_empty).
-            eapply untyped_cons_let_def.
-            constructor.
-  Qed.
-
-  Lemma Is_conv_to_Arity_inv :
-    forall Γ T,
-      Is_conv_to_Arity Σ Γ T ->
-      (exists na A B, ∥ red Σ Γ T (tProd na A B) ∥) \/
-      (exists u, ∥ red Σ Γ T (tSort u) ∥).
-  Proof.
-    intros Γ T [T' [r a]].
-    induction T'.
-    all: try contradiction.
-    - right. eexists. eassumption.
-    - left. eexists _, _, _. eassumption.
-    - destruct r as [r1].
-      eapply arity_red_to_prod_or_sort in a as [[na' [A [B [r2]]]] | [u [r2]]].
-      + left. eexists _,_,_. constructor.
-        eapply red_trans. all: eassumption.
-      + right. eexists. constructor.
-        eapply red_trans. all: eassumption.
-  Qed.
-
-  Lemma invert_red_sort Γ u v :
-    red Σ Γ (tSort u) v -> v = tSort u.
-  Proof.
-    intros H; apply red_alt in H.
-    generalize_eqs H.
-    induction H; simplify *.
-    - depind r. solve_discr.
-    - reflexivity.
-    - eapply IHclos_refl_trans2. auto.
-  Qed.
-
-  Lemma invert_cumul_sort_r Γ C u :
-    Σ ;;; Γ |- C <= tSort u ->
-               ∑ u', red Σ Γ C (tSort u') * leq_universe (global_ext_constraints Σ) u' u.
-  Proof.
-    intros Hcum.
-    eapply cumul_alt in Hcum as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_sort in redv' as ->.
-    depelim leqvv'. exists s. intuition eauto.
-  Qed.
-
-  Lemma invert_cumul_sort_l Γ C u :
-    Σ ;;; Γ |- tSort u <= C ->
-               ∑ u', red Σ Γ C (tSort u') * leq_universe (global_ext_constraints Σ) u u'.
-  Proof.
-    intros Hcum.
-    eapply cumul_alt in Hcum as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_sort in redv as ->.
-    depelim leqvv'. exists s'. intuition eauto.
-  Qed.
-
-  Lemma invert_red_prod Γ na A B v :
-    red Σ Γ (tProd na A B) v ->
-    ∑ A' B', (v = tProd na A' B') *
-             (red Σ Γ A A') *
-             (red Σ (vass na A :: Γ) B B').
-  Proof.
-    intros H. apply red_alt in H.
-    generalize_eqs H. revert na A B.
-    induction H; simplify_dep_elim.
-    - depelim r.
-      + solve_discr.
-      + do 2 eexists. repeat split; eauto with pcuic.
-      + do 2 eexists. repeat split; eauto with pcuic.
-    - do 2 eexists. repeat split; eauto with pcuic.
-    - specialize (IHclos_refl_trans1 _ _ _ eq_refl).
-      destruct IHclos_refl_trans1 as (? & ? & (-> & ?) & ?).
-      specialize (IHclos_refl_trans2 _ _ _ eq_refl).
-      destruct IHclos_refl_trans2 as (? & ? & (-> & ?) & ?).
-      do 2 eexists. repeat split; eauto with pcuic.
-      + now transitivity x.
-      + transitivity x0; auto.
-        eapply PCUICConfluence.red_red_ctx. 1: auto. 1: eauto.
-        constructor.
-        * eapply All2_local_env_red_refl.
-        * red. auto.
-  Qed.
-
-  Lemma invert_cumul_prod_r Γ C na A B :
-    Σ ;;; Γ |- C <= tProd na A B ->
-    ∑ na' A' B', red Σ.1 Γ C (tProd na' A' B') *
-                 (Σ ;;; Γ |- A = A') *
-                 (Σ ;;; (Γ ,, vass na A) |- B' <= B).
-  Proof.
-    intros Hprod.
-    eapply cumul_alt in Hprod as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_prod in redv' as (A' & B' & ((-> & Ha') & ?)) => //.
-    depelim leqvv'.
-    do 3 eexists; intuition eauto.
-    - eapply conv_trans with A'; auto.
-      eapply conv_sym; auto.
-      constructor; auto.
-    - eapply cumul_trans with B'; auto.
-      + constructor. eapply leqvv'2.
-      + now eapply red_cumul_inv.
-  Qed.
-
-  Lemma eq_term_upto_univ_conv_arity_l :
-    forall Re Rle Γ u v,
-      isArity u ->
-      eq_term_upto_univ Re Rle u v ->
-      Is_conv_to_Arity Σ Γ v.
-  Proof.
-    intros Re Rle Γ u v a e.
-    induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
-    all: dependent destruction e.
-    - eexists. split.
-      + constructor. constructor.
-      + reflexivity.
-    - simpl in a.
-      eapply IHu2 in e2. 2: assumption.
-      destruct e2 as [b'' [[r] ab]].
-      exists (tProd na' a' b''). split.
-      + constructor. eapply red_prod_r. eassumption.
-      + simpl. assumption.
-    - simpl in a.
-      eapply IHu3 in e3. 2: assumption.
-      destruct e3 as [u'' [[r] au]].
-      exists (tLetIn na' t' ty' u''). split.
-      + constructor. eapply red_letin.
-        all: try solve [ constructor ].
-        eassumption.
-      + simpl. assumption.
-  Qed.
-
-  Lemma eq_term_upto_univ_conv_arity_r :
-    forall Re Rle Γ u v,
-      isArity u ->
-      eq_term_upto_univ Re Rle v u ->
-      Is_conv_to_Arity Σ Γ v.
-  Proof.
-    intros Re Rle Γ u v a e.
-    induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
-    all: dependent destruction e.
-    - eexists. split.
-      + constructor. constructor.
-      + reflexivity.
-    - simpl in a.
-      eapply IHu2 in e2. 2: assumption.
-      destruct e2 as [b'' [[r] ab]].
-      exists (tProd na0 a0 b''). split.
-      + constructor. eapply red_prod_r. eassumption.
-      + simpl. assumption.
-    - simpl in a.
-      eapply IHu3 in e3. 2: assumption.
-      destruct e3 as [u'' [[r] au]].
-      exists (tLetIn na0 t ty u''). split.
-      + constructor. eapply red_letin.
-        all: try solve [ constructor ].
-        eassumption.
-      + simpl. assumption.
-  Qed.
-
-  Lemma isArity_subst :
-    forall u v k,
-      isArity u ->
-      isArity (u { k := v }).
-  Proof.
-    intros u v k h.
-    induction u in v, k, h |- *. all: try contradiction.
-    - simpl. constructor.
-    - simpl in *. eapply IHu2. assumption.
-    - simpl in *. eapply IHu3. assumption.
-  Qed.
-
-  Lemma isArity_red1 :
-    forall Γ u v,
-      red1 Σ Γ u v ->
-      isArity u ->
-      isArity v.
-  Proof.
-    intros Γ u v h a.
-    induction u in Γ, v, h, a |- *. all: try contradiction.
-    - dependent destruction h.
-      apply (f_equal nApp) in H as eq. simpl in eq.
-      rewrite nApp_mkApps in eq. simpl in eq.
-      destruct args. 2: discriminate.
-      simpl in H. discriminate.
-    - dependent destruction h.
-      + apply (f_equal nApp) in H as eq. simpl in eq.
-        rewrite nApp_mkApps in eq. simpl in eq.
-        destruct args. 2: discriminate.
-        simpl in H. discriminate.
-      + assumption.
-      + simpl in *. eapply IHu2. all: eassumption.
-    - dependent destruction h.
-      + simpl in *. apply isArity_subst. assumption.
-      + apply (f_equal nApp) in H as eq. simpl in eq.
-        rewrite nApp_mkApps in eq. simpl in eq.
-        destruct args. 2: discriminate.
-        simpl in H. discriminate.
-      + assumption.
-      + assumption.
-      + simpl in *. eapply IHu3. all: eassumption.
-  Qed.
-
-  Lemma invert_cumul_arity_r :
-    forall (Γ : context) (C : term) T,
-      isArity T ->
-      Σ;;; Γ |- C <= T ->
-      Is_conv_to_Arity Σ Γ C.
-  Proof.
-    intros Γ C T a h.
-    induction h.
-    - eapply eq_term_upto_univ_conv_arity_r. all: eassumption.
-    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
-      exists v'. split.
-      + constructor. eapply red_trans.
-        * eapply trans_red.
-          -- constructor.
-          -- eassumption.
-        * assumption.
-      + assumption.
-    - eapply IHh. eapply isArity_red1. all: eassumption.
-    - admit.
-    - admit.
-  (* Qed. *)
-  Admitted.
-
-  Lemma invert_cumul_arity_l :
-    forall (Γ : context) (C : term) T,
-      isArity C ->
-      Σ;;; Γ |- C <= T ->
-      Is_conv_to_Arity Σ Γ T.
-  Proof.
-    intros Γ C T a h.
-    induction h.
-    - eapply eq_term_upto_univ_conv_arity_l. all: eassumption.
-    - eapply IHh. eapply isArity_red1. all: eassumption.
-    - forward IHh by assumption. destruct IHh as [v' [[r'] a']].
-      exists v'. split.
-      + constructor. eapply red_trans.
-        * eapply trans_red.
-          -- constructor.
-          -- eassumption.
-        * assumption.
-      + assumption.
-    - admit.
-    - admit.
-  (* Qed. *)
-  Admitted.
-
-  Lemma invert_cumul_prod_l Γ C na A B :
-    Σ ;;; Γ |- tProd na A B <= C ->
-               ∑ na' A' B', red Σ.1 Γ C (tProd na' A' B') *
-                            (Σ ;;; Γ |- A = A') *
-                            (Σ ;;; (Γ ,, vass na A) |- B <= B').
-  Proof.
-    intros Hprod.
-    eapply cumul_alt in Hprod as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_prod in redv as (A' & B' & ((-> & Ha') & ?)) => //.
-    depelim leqvv'.
-    do 3 eexists; intuition eauto.
-    - eapply conv_trans with A'; auto.
-      now constructor.
-    - eapply cumul_trans with B'; eauto.
-      + now eapply red_cumul.
-      + now constructor; apply leqvv'2.
-  Qed.
-
-  Lemma invert_red_letin Γ C na d ty b :
-    red Σ.1 Γ (tLetIn na d ty b) C ->
-    (∑ na' d' ty' b',
-     (red Σ.1 Γ C (tLetIn na' d' ty' b') *
-      red Σ.1 Γ d d' *
-      red Σ.1 Γ ty ty' *
-      red Σ.1 (Γ ,, vdef na d ty) b b')) +
-    (red Σ.1 Γ (subst10 d b) C)%type.
-  Proof.
-    intros Hlet.
-    (* eapply cumul_alt in Hlet. *)
-    (* destruct Hlet as [v [v' [[redv redv'] leqvv']]]. *)
-    (* eapply cumul_alt. *)
-    (* exists v, v'. repeat split; auto. *)
-  Admitted.
-(*
-  Lemma invert_red_letin_subst Γ C na d ty b :
-  red Σ.1 Γ (tLetIn na d ty b) C ->
-    ∑ d' ty' b', red Σ.1 Γ (tLetIn na d ty b) (tLetIn na d' ty' b') *
-    red Σ.1 Γ d d' *
-    red Σ.1 Γ ty ty' *
-    red Σ.1 (Γ ,, vdef na d ty) b b' *
-    red Σ.1 Γ C (subst10 d' b').
-Proof.
-  intros Hlet.
-  eapply invert_red_letin in Hlet as [[na' [d' [ty' [b' red]]]]|red] => //.
-  - exists d', ty', b'. intuition auto.
-    * eapply red_letin_alt; auto.
-    * etransitivity; eauto.
-      eapply red1_red; constructor.
-  - exists d, ty, b; intuition auto.
-  eapply red_alt in Hlet.
-  eapply Relation_Properties.clos_rt_rt1n in Hlet.
-  depind Hlet.
-  - exists d, ty, b. repeat split; auto.
-    eapply red1_red. constructor.
-  - 
-    eapply Relation_Properties.clos_rt1n_rt in Hlet.
-  depind Hlet.*)
-
-    (* destruct Hlet as [v [v' [[redv redv'] leqvv']]]. *)
-  (* eapply cumul_alt. *)
-  (* exists v, v'. repeat split; auto. *)
-  (*Admitted. *)
-
-
-  Lemma invert_cumul_letin_l Γ C na d ty b :
-    Σ ;;; Γ |- tLetIn na d ty b <= C ->
-               (* (∑ na' d' ty' b', *)
-               (*  (red Σ Γ C (tLetIn na' d' ty' b') * *)
-               (*   (Σ ;;; Γ |- d = d') * *)
-               (*   (Σ ;;; Γ |- ty = ty') * *)
-                                                          (*   (Σ ;;; (Γ ,, vdef na d ty) |- b <= b'))) + *)
-               (Σ ;;; Γ |- subst10 d b <= C).
-  Proof.
-    intros Hlet.
-    eapply cumul_alt in Hlet.
-    destruct Hlet as [v [v' [[redv redv'] leqvv']]].
-    eapply cumul_alt.
-    exists v, v'. repeat split; auto.
-  Admitted.
-  (* depelim redv. *)
-  (* - depelim leqvv'. *)
-  (*   exists na', ty', t', u'. *)
-  (*   split. split. *)
-  (*   split. auto. eapply conv_conv_alt. *)
-  (*   now eapply conv_refl. *)
-  (*   now eapply conv_conv_alt, conv_refl. *)
-  (*   constructor. auto. *)
-  (* - *)
-  (*   eapply conv_conv_alt, conv_refl. *)
-  (*   eapply *)
-
-  (*   eapply red_conv. *)
-  (*   repeat split; auto. *)
-  (*   eapply *)
-
-  (* eapply red_ *)
-
-
-  Lemma invert_cumul_letin_r Γ C na d ty b :
-    Σ ;;; Γ |- C <= tLetIn na d ty b ->
-               (* (∑ na' d' ty' b', *)
-               (*  (red Σ Γ C (tLetIn na' d' ty' b') * *)
-               (*   (Σ ;;; Γ |- d = d') * *)
-               (*   (Σ ;;; Γ |- ty = ty') * *)
-                                                          (*   (Σ ;;; (Γ ,, vdef na d ty) |- b <= b'))) + *)
-               (Σ ;;; Γ |- C <= subst10 d b).
-  Proof.
-    intros Hlet.
-    eapply cumul_alt in Hlet.
-    destruct Hlet as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_letin in redv' as [[na' [d' [ty' [b' red]]]]|red] => //.
-    - destruct red as [[[redv' redd] redty] convb]. 
-      eapply fill_le in leqvv'; eauto.
-      destruct leqvv' as [t'' [u'' [[redl redr] eq]]].
-      eapply cumul_alt. exists t'', u''. repeat split; auto.
-      * now transitivity v.
-      * admit.
-    - eapply cumul_alt.
-      exists v, v'. repeat split; auto.
-  Admitted.
-
-  Lemma app_mkApps :
-    forall u v t l,
-      isApp t = false ->
-      tApp u v = mkApps t l ->
-      ∑ l',
-        (l = l' ++ [v])%list ×
-        u = mkApps t l'.
-  Proof.
-    intros u v t l h e.
-    induction l in u, v, t, e, h |- * using list_rect_rev.
-    - cbn in e. subst. cbn in h. discriminate.
-    - rewrite <- mkApps_nested in e. cbn in e.
-      exists l. inversion e. subst. auto.
-  Qed.
-
-  (* TODO Duplicate of red_mkApps_tInd?? *)
-  Lemma invert_red_ind :
-    forall Γ ind ui l T,
-      red Σ.1 Γ (mkApps (tInd ind ui) l) T ->
-      ∑ l',
-        T = mkApps (tInd ind ui) l' ×
-        All2 (red Σ Γ) l l'.
-  Proof.
-    intros Γ ind ui l T h.
-    dependent induction h.
-    - exists l. split ; auto. apply All2_same. intro. constructor.
-    - clear h.
-      destruct IHh as [l'' [? ha]]. subst.
-      dependent induction r.
-      all: try solve [
-        apply (f_equal decompose_app) in H ;
-        rewrite !decompose_app_mkApps in H ; auto ;
-        cbn in H ; inversion H
-      ].
-      + symmetry in H. apply app_mkApps in H ; auto.
-        destruct H as [l' [? ?]]. subst.
-        specialize IHr with (1 := eq_refl).
-        apply All2_app_inv_r in ha as [l1 [l2 [? [h1 h2]]]]. subst.
-        specialize IHr with (1 := h1).
-        destruct IHr as [l [? ha]]. subst.
-        exists (l ++ [M2])%list. rewrite <- mkApps_nested. split ; auto.
-        apply All2_app ; auto.
-      + symmetry in H. apply app_mkApps in H ; auto.
-        destruct H as [l' [? ?]]. subst.
-        exists (l' ++ [N2])%list. rewrite <- mkApps_nested. split ; auto.
-        apply All2_app_inv_r in ha as [l1 [l2 [? [h1 h2]]]]. subst.
-        apply All2_app ; auto.
-        dependent destruction h2. dependent destruction h2.
-        repeat constructor. eapply red_trans ; eauto.
-  Qed.
-
-  Lemma invert_cumul_ind_l :
-    forall Γ ind ui l T,
-      Σ ;;; Γ |- mkApps (tInd ind ui) l <= T ->
-      ∑ ui' l',
-        red Σ.1 Γ T (mkApps (tInd ind ui') l') ×
-        R_universe_instance (eq_universe Σ) ui ui' ×
-        All2 (fun a a' => Σ ;;; Γ |- a = a') l l'.
-  Proof.
-    intros Γ ind ui l T h.
-    eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_ind in redv as [l' [? ha]]. subst.
-    eapply eq_term_upto_univ_mkApps_l_inv in leqvv'
-      as [u [l'' [[e ?] ?]]].
-    subst.
-    dependent destruction e.
-    eexists _,_. split ; eauto. split ; auto.
-    eapply All2_trans.
-    - intros x y z h1 h2. eapply conv_trans ; eauto.
-    - eapply All2_impl ; eauto.
-    - eapply All2_impl ; eauto.
-      intros x y h. eapply conv_refl. assumption.
-  Qed.
-
-  Lemma invert_cumul_ind_r :
-    forall Γ ind ui l T,
-      Σ ;;; Γ |- T <= mkApps (tInd ind ui) l ->
-      ∑ ui' l',
-        red Σ.1 Γ T (mkApps (tInd ind ui') l') ×
-        R_universe_instance (eq_universe Σ) ui' ui ×
-        All2 (fun a a' => Σ ;;; Γ |- a = a') l l'.
-  Proof.
-    intros Γ ind ui l T h.
-    eapply cumul_alt in h as [v [v' [[redv redv'] leqvv']]].
-    eapply invert_red_ind in redv' as [l' [? ?]]. subst.
-    eapply eq_term_upto_univ_mkApps_r_inv in leqvv'
-      as [u [l'' [[e ?] ?]]].
-    subst.
-    dependent destruction e.
-    eexists _,_. split ; eauto. split ; auto.
-    eapply All2_trans.
-    - intros x y z h1 h2. eapply conv_trans ; eauto.
-    - eapply All2_impl ; eauto.
-    - eapply All2_swap.
-      eapply All2_impl ; eauto.
-      intros x y h. eapply conv_sym; auto. now constructor.
-  Qed.
 
   Ltac pih :=
     lazymatch goal with
@@ -593,48 +93,6 @@ Proof.
   Qed.
   Hint Extern 10 (isWfArity _ _ _ (tSort _)) => apply isWfArity_sort : pcuic.
 
-  (* Duplicate *)
-  (* Lemma eq_term_upto_univ_mkApps_r_inv : *)
-  (*   forall Re Rle u l t, *)
-  (*     eq_term_upto_univ Re Rle t (mkApps u l) -> *)
-  (*     ∑ u' l', *)
-  (*   eq_term_upto_univ Re Rle u' u * *)
-  (*   All2 (eq_term_upto_univ Re Re) l' l * *)
-  (*   (t = mkApps u' l'). *)
-  (* Proof. *)
-  (*   intros Re Rle u l t h. *)
-  (*   induction l in u, t, h, Rle |- *. *)
-  (*   - cbn in h. exists t, []. split ; auto. *)
-  (*   - cbn in h. apply IHl in h as [u' [l' [[h1 h2] h3]]]. *)
-  (*     dependent destruction h1. subst. *)
-  (*     eexists. eexists. split; [ split | ]. *)
-  (*     + eassumption. *)
-  (*     + constructor. *)
-  (*       * eassumption. *)
-  (*       * eassumption. *)
-  (*     + cbn. reflexivity. *)
-  (* Qed. *)
-
-  (* Duplicate *)
-  (* Lemma invert_cumul_ind_r Γ t ind u args : *)
-  (*   Σ ;;; Γ |- t <= mkApps (tInd ind u) args -> *)
-  (*              ∑ u' args', red Σ Γ t (mkApps (tInd ind u') args') * *)
-  (*                          All2 (leq_universe (global_ext_constraints Σ)) (map Universe.make u') (map Universe.make u) * *)
-  (*                          All2 (fun a a' => Σ ;;; Γ |- a = a') args args'. *)
-  (* Proof. *)
-  (*   intros H. eapply cumul_alt in H. *)
-  (*   destruct H as [v [v' [[redv redv'] leq]]]. *)
-  (*   eapply red_mkApps_tInd in redv' as [args' [-> ?]]; eauto. *)
-  (*   apply eq_term_upto_univ_mkApps_r_inv in leq as [u' [l' [[eqhd eqargs] Heq]]]. *)
-  (*   subst v. depelim eqhd. *)
-  (*   exists u0, l'. split; auto. *)
-  (*   clear -eqargs a0. *)
-  (*   induction eqargs in a0, args |- *; depelim a0. constructor. *)
-  (*   constructor. apply conv_trans with y. now eapply red_conv. *)
-  (*   apply conv_conv_alt. constructor. now apply eq_term_sym. *)
-  (*   now apply IHeqargs. *)
-  (* Qed. *)
-
   Theorem principal_typing {Γ u A B} : Σ ;;; Γ |- u : A -> Σ ;;; Γ |- u : B ->
     ∑ C, Σ ;;; Γ |- C <= A  ×  Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C.
   Proof.
@@ -656,7 +114,6 @@ Proof.
       assert (x0 = x) as ee. {
         clear -e. destruct x, x0; cbnr; invs e; reflexivity. }
       subst. repeat insum. repeat intimes; tea.
-      (* * left; eexists _, _; intuition auto. *)
       constructor ; assumption.
     - apply inversion_Prod in hA as [dom1 [codom1 iA]]; auto.
       apply inversion_Prod in hB as [dom2 [codom2 iB]]=> //.
@@ -675,7 +132,6 @@ Proof.
       + eapply cumul_trans. 1: auto. 2:eapply c.
         constructor. constructor.
         apply leq_universe_product_mon; auto.
-      (* * left; eexists _, _; intuition eauto. now eapply typing_wf_local in t4. *)
       + eapply type_Prod.
         * eapply type_Cumul; eauto.
           -- left; eapply isWfArity_sort. now eapply typing_wf_local in t1.
@@ -701,15 +157,6 @@ Proof.
         * eapply congr_cumul_prod => //.
           eapply cumul_trans with x0 => //.
         * now eapply red_cumul_inv.
-      (* * destruct i as [[ctx [s [? ?]]]|?]. *)
-      (*   ** left; eexists _, s. simpl. intuition eauto. *)
-      (*      generalize (destArity_spec [] x3). rewrite e. *)
-      (*      simpl. move => ->. rewrite destArity_it_mkProd_or_LetIn. simpl. *)
-      (*      intuition eauto. *)
-      (*      unfold snoc. simpl. now rewrite app_context_assoc. *)
-      (*   ** right. red. destruct i as [s us]. *)
-      (*      exists (Universe.sort_of_product x s). *)
-      (*      eapply type_Prod; auto. *)
       + eapply type_Lambda; eauto.
 
     - eapply inversion_LetIn in hA; auto.
@@ -750,16 +197,6 @@ Proof.
           -- pose proof (cons_let_def Σ Γ [] [] n u1 u2).
              rewrite !subst_empty in X. apply X. 1: constructor.
              auto.
-      (* * destruct i as [[ctx' [s' [? ?]]]|[s Hs]]. *)
-      (*   ** left. red. simpl. *)
-      (*      generalize (destArity_spec [] C'); rewrite e. *)
-      (*      simpl. move => ->. *)
-      (*      rewrite destArity_it_mkProd_or_LetIn. simpl. *)
-      (*      eexists _, _; intuition eauto. *)
-      (*      now rewrite app_context_assoc. *)
-      (*   ** right. exists s. eapply type_Cumul. econstructor; eauto. *)
-      (*      left. red. exists [], s. intuition auto. now eapply typing_wf_local in t2. *)
-      (*      eapply red_cumul. eapply red1_red. constructor. *)
       + eapply type_LetIn; eauto.
 
     - eapply inversion_App in hA as [na [dom [codom [tydom [tyarg tycodom]]]]] => //.
@@ -794,18 +231,21 @@ Proof.
         * eapply substitution_cumul0 => //. eapply conv_cumul in X0; eauto.
         * eapply cumul_trans with (codom' {0 := u2}) => //.
           eapply substitution_cumul0 => //. eauto.
-      + eapply type_App.
-        2:eapply tyarg.
+      + eapply (type_App _ _ _ x1 A').
         eapply type_Cumul.
         * eapply t0.
-        * instantiate (1 := x1).
-          (* Needs to show wf arity preservation? needing validity? or just inversion on tydom ? *)
-          admit.
-        * eapply cumul_trans with (tProd x1 A' B')=> //.
-          -- eapply red_cumul; eauto.
-          -- eapply congr_cumul_prod.
-             ++ eapply conv_sym; eauto.
-             ++ eapply cumul_refl'.
+        * have v := validity_term wfΣ t0; auto.
+          eapply isWfArity_or_Type_red in v.
+          3:eapply redA. now apply v. auto.
+        * apply red_cumul; eauto.
+        * eapply type_Cumul. eauto.
+          have v := validity_term wfΣ t0; auto.
+          eapply isWfArity_or_Type_red in v.
+          3:eapply redA.
+          eapply isWAT_tProd in v as [HA' _].
+          right; apply HA'. all:auto. now apply typing_wf_local in tydom'.
+          transitivity A''; eauto. now apply conv_cumul.
+          apply conv_cumul. now symmetry.
 
     - eapply inversion_Const in hA as [decl ?] => //.
       eapply inversion_Const in hB as [decl' ?] => //.
@@ -851,8 +291,8 @@ Proof.
       specialize (IHu1 _ _ _ t t1). clear t t1.
       specialize (IHu2 _ _ _ t0 t2). clear t0 t2.
       repeat outsum. repeat outtimes.
-      eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]].
-      eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]].
+      eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]]; auto.
+      eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]]; auto.
       assert (All2 (fun a a' => Σ ;;; Γ |- a = a') x0 x7).
       { destruct (red_confluence wfΣ redr redr').
         destruct p.
@@ -872,7 +312,8 @@ Proof.
           apply (All2_trans _ (conv_trans _ _) _ _ _ X0 a2).
       }
       clear redr redr' a1 a2.
-      exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto.
+      todo "case"%string.
+      (* exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto. *)
 
       (* 2:{ revert e2. *)
       (*     rewrite /types_of_case. *)
@@ -887,9 +328,6 @@ Proof.
       (*     rewrite Heq eqar eqx2 eqbrs. reflexivity. *)
       (*     admit. admit. eapply type_Cumul. eauto. *)
       (*     all:admit. } *)
-      + admit.
-
-      + admit.
 
     - destruct s as [[ind k] pars]; simpl in *.
       eapply inversion_Proj in hA=>//.
@@ -903,10 +341,11 @@ Proof.
       rewrite H2 in H; noconf H.
       rewrite -e in e0.
       specialize (IHu _ _ _ t t1) as [C' [? [? ?]]].
-      eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]].
-      eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]].
+      eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]]; auto.
+      eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]]; auto.
       exists (subst0 (u :: List.rev x3) (subst_instance_constr x t2)).
-      repeat split; auto.
+      todo "projections"%string.
+      (* repeat split; auto.
       + admit.
       + eapply refine_type.
         * eapply type_Proj.
@@ -918,7 +357,7 @@ Proof.
              admit.
           -- rewrite H3. simpl. simpl in H0.
              rewrite -H0. admit.
-        * simpl. admit.
+        * simpl. admit. *)
 
     - pose proof (typing_wf_local hA).
       apply inversion_Fix in hA as [decl [hguard [nthe [wfΓ [? ?]]]]]=>//.
@@ -933,6 +372,6 @@ Proof.
       rewrite nthe' in nthe; noconf nthe.
       exists (dtype decl); repeat split; eauto.
       eapply type_CoFix; eauto.
-  Admitted.
+  Qed.
 
 End Principality.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -13,7 +13,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICContextConversion PCUICUnivSubstitution
      PCUICConversion PCUICInversion PCUICContexts PCUICArities
      PCUICParallelReduction PCUICSpine PCUICInductives
-     PCUICCtxShape PCUICPrincipality.
+     PCUICCtxShape.
      
 Close Scope string_scope.
 
@@ -478,8 +478,8 @@ Proof.
   unfold on_declared_constructor.
   destruct (on_declared_constructor _ declc). destruct s as [? [_ onc]].
   unshelve epose proof (env_prop_typing _ _ validity _ _ _ _ _ h) as vi'; eauto using typing_wf_local.
-  eapply type_mkApps_inv in h; auto.
-  destruct h as [T [U [[hC hs] hc]]].
+  eapply inversion_mkApps in h; auto.
+  destruct h as [T [U [hC [hs hc]]]].
   apply inversion_Construct in hC
     as [mdecl' [idecl' [cdecl' [hΓ [isdecl [const htc]]]]]]; auto.
   assert (vty:=declared_constructor_valid_ty _ _ _ _ _ _ _ _ wfΣ hΓ isdecl const). 
@@ -846,7 +846,7 @@ Proof.
     rewrite mkApps_nonempty; auto.
     epose (last_nonempty_eq H0). rewrite <- Hu in e1. rewrite <- e1.
     clear e1.
-    specialize (type_mkApps_inv _ _ _ _ _ wf typet) as [T' [U' [[appty spty] Hcumul]]].
+    specialize (inversion_mkApps wf typet) as [T' [U' [appty [spty Hcumul]]]].
     specialize (validity _ wf _ _ _ appty) as [_ vT'].
     eapply type_tFix_inv in appty as [T [arg [fn' [[Hnth Hty]]]]]; auto.
     rewrite e in Hnth. noconf Hnth.
@@ -1545,7 +1545,7 @@ Proof.
 
   - (* Case congruence: on a cofix, impossible *)
     clear -wf typec heq_allow_cofix.
-    eapply type_mkApps_inv in typec as [? [? [[tcof _] _]]] =>  //.
+    eapply inversion_mkApps in typec as [? [? [tcof [_ _]]]] =>  //.
     eapply type_tCoFix_inv in tcof as [allowc _] => //.
     rewrite allowc in heq_allow_cofix. discriminate.
 
@@ -1627,7 +1627,7 @@ Proof.
 
   - (* Proj CoFix congruence *)
     pose proof (env_prop_typing _ _  validity _ _ _ _ _ typec).
-    eapply type_mkApps_inv in typec as [? [? [[tcof tsp] cum]]]; auto.
+    eapply inversion_mkApps in typec as [? [? [tcof [tsp cum]]]]; auto.
     eapply type_tCoFix_inv in tcof as [allow [?  [? [? [[unf tyunf] cum']]]]]; auto.
     (*
     rewrite e in unf. noconf unf.
@@ -2219,12 +2219,12 @@ Section SRContext.
    Qed.
 
   Lemma type_reduction {Σ Γ t A B}
-    : wf Σ.1 -> wf_local Σ Γ -> Σ ;;; Γ |- t : A -> red (fst Σ) Γ A B -> Σ ;;; Γ |- t : B.
+    : wf Σ.1 ->  Σ ;;; Γ |- t : A -> red (fst Σ) Γ A B -> Σ ;;; Γ |- t : B.
   Proof.
-    intros HΣ' HΓ Ht Hr.
+    intros HΣ' Ht Hr.
     econstructor. eassumption.
     2: now eapply cumul_red_l'.
-    destruct (validity_term HΣ' HΓ Ht).
+    destruct (validity_term HΣ' Ht).
     - left. eapply isWfArity_red; try eassumption.
     - destruct i as [s HA]. right.
       exists s. eapply subject_reduction; eassumption.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -11,8 +11,9 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICValidity PCUICConfluence
      PCUICParallelReductionConfluence
      PCUICContextConversion PCUICUnivSubstitution
-     PCUICConversion PCUICInversion PCUICPrincipality PCUICContexts PCUICArities
-     PCUICParallelReduction PCUICSpine.
+     PCUICConversion PCUICInversion PCUICContexts PCUICArities
+     PCUICParallelReduction PCUICSpine PCUICInductives
+     PCUICCtxShape PCUICPrincipality.
      
 Close Scope string_scope.
 
@@ -43,17 +44,6 @@ Proof.
   specialize (IHl _ H). forward IHl by congruence.
   apply IHl.
 Qed.
-
-Lemma nth_error_rev_map {A B} (f : A -> B) l i : 
-  i < #|l| ->
-  nth_error (rev_map f l) (#|l| - S i) = 
-  option_map f (nth_error l i).
-Proof.
-  move=> Hi.
-  rewrite rev_map_spec. rewrite -(map_length f l) -nth_error_rev ?map_length //.
-  now rewrite nth_error_map.
-Qed.
-  
 
 Lemma type_tFix_inv {cf:checker_flags} (Σ : global_env_ext) Γ mfix idx T : wf Σ ->
   Σ ;;; Γ |- tFix mfix idx : T ->
@@ -166,212 +156,6 @@ Proof.
     + destruct b. eapply cumul_trans; eauto.
 Qed.
 
-Arguments subst_context !s _ !Γ.
-Arguments it_mkProd_or_LetIn !l _.
-
-Lemma build_case_predicate_type_spec {cf:checker_flags} Σ ind mdecl idecl pars u ps pty :
-  forall (o : on_ind_body (lift_typing typing) Σ (inductive_mind ind) mdecl (inductive_ind ind) idecl),
-  build_case_predicate_type ind mdecl idecl pars u ps = Some pty ->
-  ∑ parsubst, (context_subst (subst_instance_context u (ind_params mdecl)) pars parsubst *
-  (pty = it_mkProd_or_LetIn (subst_context parsubst 0 (subst_instance_context u o.(ind_indices))) 
-      (tProd (nNamed (ind_name idecl))
-          (mkApps (tInd ind u) (map (lift0 #|o.(ind_indices)|) pars ++ to_extended_list o.(ind_indices))) 
-          (tSort ps)))).
-Proof.
-  intros []. unfold build_case_predicate_type.
-  destruct instantiate_params eqn:Heq=> //.
-  eapply instantiate_params_make_context_subst in Heq =>  /=.
-  destruct destArity eqn:Har => //.
-  move=> [=] <-. destruct Heq as [ctx'  [ty'' [s' [? [? ?]]]]].
-  subst t. exists s'. split. apply make_context_subst_spec in H0.
-  now rewrite List.rev_involutive in H0.
-  clear onProjections. clear onConstructors.
-  assert (p.1 = subst_context s' 0 (subst_instance_context u ind_indices)) as ->.
-  move: H. rewrite ind_arity_eq subst_instance_constr_it_mkProd_or_LetIn.
-  rewrite decompose_prod_n_assum_it_mkProd app_nil_r => [=].
-  move=> Hctx' Hty'.
-  subst ty''  ctx'.
-  move: Har. rewrite subst_instance_constr_it_mkProd_or_LetIn subst_it_mkProd_or_LetIn.
-  rewrite destArity_it_mkProd_or_LetIn. simpl. move=> [=] <- /=. 
-  now rewrite app_context_nil_l.
-  f_equal. rewrite subst_context_length subst_instance_context_length.
-  simpl.
-  f_equal. f_equal.  f_equal.
-  unfold to_extended_list.
-  rewrite to_extended_list_k_subst PCUICSubstitution.map_subst_instance_constr_to_extended_list_k.
-  reflexivity.
-Qed.
-
-Hint Resolve conv_ctx_refl : pcuic.
-
-Definition branch_type ind mdecl (idecl : one_inductive_body) params u p i (br : ident * term * nat) :=
-  let inds := inds ind.(inductive_mind) u mdecl.(ind_bodies) in
-  let '(id, t, ar) := br in
-  let ty := subst0 inds (subst_instance_constr u t) in
-  match instantiate_params (subst_instance_context u mdecl.(ind_params)) params ty with
-  | Some ty =>
-  let '(sign, ccl) := decompose_prod_assum [] ty in
-  let nargs := List.length sign in
-  let allargs := snd (decompose_app ccl) in
-  let '(paramrels, args) := chop mdecl.(ind_npars) allargs in
-  let cstr := tConstruct ind i u in
-  let args := (args ++ [mkApps cstr (paramrels ++ to_extended_list sign)])%list in
-  Some (ar, it_mkProd_or_LetIn sign (mkApps (lift0 nargs p) args))
-| None => None
-end.
-
-Lemma nth_branches_type ind mdecl idecl args u p i t btys : map_option_out (build_branches_type ind mdecl idecl args u p) = Some btys ->
-  nth_error btys i = Some t -> 
-  (∑ br, (nth_error idecl.(ind_ctors) i = Some br) /\
-    (branch_type ind mdecl idecl args u p i br = Some t)).
-Proof.
-  intros Htys Hnth.
-  eapply nth_map_option_out in Htys; eauto.
-Qed.
-
-Lemma build_branches_type_lookup {cf:checker_flags} Σ Γ ind mdecl idecl cdecl pars u p (brs :  list (nat * term)) btys : 
-  declared_inductive Σ.1 mdecl ind idecl ->
-  map_option_out (build_branches_type ind mdecl idecl pars u p) = Some btys ->
-  All2 (fun br bty => (br.1 = bty.1) * (Σ ;;; Γ |- br.2 : bty.2))%type brs btys ->
-  forall c, nth_error (ind_ctors idecl) c = Some cdecl ->
-  ∑ nargs br bty, 
-    (nth_error brs c = Some (nargs, br)) *
-    (nth_error btys c = Some (nargs, bty)) *
-    (Σ ;;; Γ |- br : bty) * (branch_type ind mdecl idecl pars u p c cdecl = Some (nargs, bty)).
-Proof.
-  intros decli Hbrs Hbrtys c Hc.
-  destruct decli as [declmi decli].
-  pose proof (map_option_out_length _ _ Hbrs) as hlen. 
-  rewrite mapi_length in hlen.
-  assert (H:∑ t', nth_error btys c = Some t').
-  pose proof (All2_length _ _ Hbrtys) as e. eapply nth_error_Some_length in Hc.
-  destruct (nth_error_spec btys c). eexists; eauto. elimtype False; lia.
-  destruct H as [[argty bty] Hbty].
-  assert (H:∑ t', nth_error brs c = Some t').
-  pose proof (All2_length _ _ Hbrtys) as e. eapply nth_error_Some_length in Hc.
-  destruct (nth_error_spec brs c). eexists; eauto. elimtype False; lia.
-  destruct H as [[argbr br] Hbr].
-  eapply All2_nth_error in Hbrtys; eauto.
-  destruct Hbrtys as [Harg tybr]. simpl in *. subst.
-  eapply nth_branches_type in Hbrs; eauto.
-  destruct Hbrs as [[[id brty] nargs] [Hnth' Hbrty]].
-  exists argty, br, bty.
-  intuition auto. rewrite -Hbrty. f_equal.
-  congruence.
-Qed.
-
-Arguments cshape_indices {mdecl i idecl ctype cargs}.
-Import PCUICEnvironment.
-
-From MetaCoq.PCUIC Require Import PCUICCtxShape.
-
-Lemma branch_type_spec {cf:checker_flags} Σ ind mdecl idecl cdecl pars u p c nargs bty : 
-  declared_inductive Σ mdecl ind idecl ->
-  forall (omib : on_inductive (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl),
-  forall (oib : on_ind_body (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl (inductive_ind ind) idecl),
-  forall csort (cs : on_constructor (lift_typing typing) (Σ, ind_universes mdecl) mdecl (inductive_ind ind) idecl (ind_indices oib) cdecl csort),
-  branch_type ind mdecl idecl pars u p c cdecl = Some (nargs, bty) ->
-  forall parsubst, 
-  context_subst (subst_instance_context u (PCUICAst.ind_params mdecl)) pars parsubst ->
-  let cshape := cshape cs in
-  let indsubst := (inds (inductive_mind ind) u (ind_bodies mdecl)) in
-  let nargs' := #|cshape.(cshape_args)| in
-  let npars := #|ind_params mdecl| in
-  let substargs := (subst_context parsubst 0 
-    (subst_context indsubst npars (map_context (subst_instance_constr u) cshape.(cshape_args)))) in
-  nargs = context_assumptions cshape.(cshape_args) /\
-  bty = 
-  it_mkProd_or_LetIn substargs
-    (mkApps (lift0 nargs' p)
-      (map (subst parsubst nargs' ∘ subst indsubst (nargs' + npars) ∘ subst_instance_constr u) cshape.(cshape_indices) ++ 
-       [mkApps (tConstruct ind c u)
-         (map (lift0 nargs') pars ++         
-          to_extended_list substargs)])).
-Proof.
-  move=> decli onmib [] indices ps aeq onAr indsorts onC onP inds.
-  intros cs onc brty parsubst Hpars cshape' indsubst nargs' na. simpl in onc, cshape'.
-  clear onP.
-  assert(lenbodies: inductive_ind ind < #|ind_bodies mdecl|).
-  { destruct decli as [_ Hnth]. now apply nth_error_Some_length in Hnth. }
-  clear decli.
-  destruct onc=> /=.
-  simpl in cshape'. subst cshape'.
-  destruct cshape as [args argslen head indi eqdecl] => /=. simpl in *. 
-  rewrite eqdecl in on_ctype.
-  unfold branch_type in brty.
-  destruct cdecl as [[id ty] nargs'']. simpl in *.
-  destruct instantiate_params eqn:Heq => //.
-  eapply instantiate_params_make_context_subst in Heq.
-  destruct Heq as [ctx' [ty'' [s' [? [? ?]]]]].
-  subst t. move: H.
-  rewrite eqdecl subst_instance_constr_it_mkProd_or_LetIn subst_it_mkProd_or_LetIn.
-  rewrite -(subst_context_length (PCUICTyping.inds (inductive_mind ind) u (ind_bodies mdecl)) 0).
-  rewrite decompose_prod_n_assum_it_mkProd.
-  move=> H;noconf H.
-  move: brty.
-  rewrite !subst_context_length !subst_instance_context_length
-    subst_instance_constr_it_mkProd_or_LetIn !subst_it_mkProd_or_LetIn.
-  rewrite subst_context_length subst_instance_context_length Nat.add_0_r.
-  rewrite subst_instance_constr_mkApps !subst_mkApps.
-  rewrite Nat.add_0_r.
-  assert((subst s' #|args|
-  (subst
-     (PCUICTyping.inds (inductive_mind ind) u
-        (PCUICAst.ind_bodies mdecl))
-     (#|args| + #|PCUICAst.ind_params mdecl|)
-     (subst_instance_constr u head))) = tInd ind u).
-  rewrite /head. simpl subst_instance_constr.
-  erewrite (subst_rel_eq _ _ (#|ind_bodies mdecl| -  S (inductive_ind ind))); try lia.
-  2:{ rewrite inds_spec nth_error_rev.
-      rewrite List.rev_length mapi_length; try lia.
-      rewrite List.rev_involutive List.rev_length mapi_length; try lia.
-      rewrite nth_error_mapi. simpl.
-      elim: (nth_error_spec _ _). simpl. reflexivity.
-      lia. }
-  simpl. f_equal. destruct ind as [mind k]=> /=.
-  f_equal. simpl in lenbodies. lia.
-  rewrite H.
-  rewrite decompose_prod_assum_it_mkProd ?is_ind_app_head_mkApps //.
-  rewrite decompose_app_mkApps //.
-  simpl.
-  rewrite !map_map_compose map_app.
-  rewrite chop_n_app.
-  rewrite map_length to_extended_list_k_length.
-  by rewrite (onmib.(onNpars _ _ _ _)).
-  move=> [=] Hargs Hbty. subst nargs. split;auto. rewrite -Hbty.
-  clear Hbty bty.
-  rewrite app_nil_r.
-  pose proof (make_context_subst_spec _ _ _ H0) as csubst.
-  rewrite rev_involutive in csubst.
-  pose proof (context_subst_fun csubst Hpars). subst s'. clear csubst.
-  f_equal.
-  rewrite !subst_context_length subst_instance_context_length.
-  f_equal. f_equal. f_equal. f_equal.
-  f_equal. rewrite -map_map_compose.
-  rewrite subst_instance_to_extended_list_k.
-  rewrite -map_map_compose.
-  rewrite -to_extended_list_k_map_subst. rewrite subst_instance_context_length; lia.
-  now rewrite (subst_to_extended_list_k _ _ pars).
-Qed.
-
-Lemma subst_inds_concl_head ind u mdecl (arity : context) :
-  let head := tRel (#|ind_bodies mdecl| - S (inductive_ind ind) + #|ind_params mdecl| + #|arity|) in
-  let s := (inds (inductive_mind ind) u (ind_bodies mdecl)) in
-  inductive_ind ind < #|ind_bodies mdecl| ->
-  subst s (#|arity| + #|ind_params mdecl|)
-        (subst_instance_constr u head)
-  = tInd ind u.
-Proof.
-  intros.
-  subst head. simpl subst_instance_constr.
-  rewrite (subst_rel_eq _ _ (#|ind_bodies mdecl| - S (inductive_ind ind)) (tInd ind u)) //; try lia.
-  subst s. rewrite inds_spec rev_mapi nth_error_mapi /=.
-  elim nth_error_spec. 
-  + intros. simpl.
-    f_equal. destruct ind; simpl. f_equal. f_equal. simpl in H. lia.
-  + rewrite List.rev_length. lia.
-Qed.
-
 Lemma declared_constructor_valid_ty {cf:checker_flags} Σ Γ mdecl idecl i n cdecl u :
   wf Σ.1 ->
   wf_local Σ Γ ->
@@ -403,103 +187,6 @@ Proof.
   + now rewrite !destArity_it_mkProd_or_LetIn destArity_app /= destArity_tInd in Hs.
 Qed.
 
-Lemma declared_inductive_unique {Σ ind mdecl mdecl' idecl idecl'} : 
-  declared_inductive Σ mdecl ind idecl ->
-  declared_inductive Σ mdecl' ind idecl' ->
-  (mdecl = mdecl') * (idecl = idecl').
-Proof.
-  unfold declared_inductive, declared_minductive.
-  intros [-> ?] [eq ?].
-  noconf eq. split; congruence.
-Qed.
-
-Lemma declared_constructor_unique {Σ c mdecl mdecl' idecl idecl' cdecl cdecl'} : 
-  declared_constructor Σ mdecl idecl c cdecl ->
-  declared_constructor Σ mdecl' idecl' c cdecl' ->
-  (mdecl = mdecl') * (idecl = idecl') * (cdecl = cdecl').
-Proof.
-  unfold declared_constructor.
-  intros [? ?] [eq ?]. destruct (declared_inductive_unique H eq).
-  subst mdecl' idecl'. rewrite H0 in H1. intuition congruence.
-Qed.
-
-Lemma on_minductive_wf_params_indices {cf : checker_flags} (Σ : global_env) mdecl ind idecl :
-  wf Σ ->
-  declared_minductive Σ (inductive_mind ind) mdecl ->
-  forall (oib : on_ind_body (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ind)
-    mdecl (inductive_ind ind) idecl),
-  wf_local (Σ, ind_universes mdecl) (ind_params mdecl ,,, ind_indices oib).
-Proof.
-  intros.
-  eapply on_declared_minductive in H; auto.
-  pose proof (oib.(onArity)).
-  rewrite oib.(ind_arity_eq) in X0.
-  destruct X0 as [s Hs].
-  rewrite -it_mkProd_or_LetIn_app in Hs.
-  eapply it_mkProd_or_LetIn_wf_local in Hs. 
-  now rewrite app_context_nil_l in Hs. now simpl.
-Qed.
-
-Lemma on_minductive_wf_params_indices_inst {cf : checker_flags} (Σ : global_env × universes_decl)
-    mdecl (u : Instance.t) ind idecl :
-   wf Σ.1 ->
-   declared_minductive Σ.1 (inductive_mind ind) mdecl ->
-   forall (oib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl) (inductive_mind ind)
-      mdecl (inductive_ind ind) idecl),
-  consistent_instance_ext Σ (ind_universes mdecl) u ->
-  wf_local Σ (subst_instance_context u (ind_params mdecl ,,, ind_indices oib)).
-Proof.
-  intros.
-  eapply (wf_local_instantiate _ (InductiveDecl mdecl)); eauto.
-  now apply on_minductive_wf_params_indices.
-Qed.
-
-Lemma on_inductive_inst {cf:checker_flags} Σ Γ ind u mdecl idecl : 
-  wf Σ.1 -> 
-  wf_local Σ Γ ->
-  declared_minductive Σ.1 (inductive_mind ind) mdecl ->
-  on_inductive (lift_typing typing) (Σ.1, ind_universes mdecl) (inductive_mind ind) mdecl ->
-  forall (oib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl) (inductive_mind ind) mdecl 
-           (inductive_ind ind) idecl),
-  consistent_instance_ext Σ (ind_universes mdecl) u ->
-  isWfArity_or_Type Σ Γ (it_mkProd_or_LetIn (subst_instance_context u (ind_params mdecl ,,, oib.(ind_indices)))
-        (tSort (subst_instance_univ u oib.(ind_sort)))).
-Proof.
-  move=> wfΣ wfΓ declm oi oib cext.
-  pose proof (oib.(onArity)) as ar.
-  rewrite oib.(ind_arity_eq) in ar.
-  destruct ar as [s ar].
-  eapply isWAT_weaken => //.
-  rewrite -(subst_instance_constr_it_mkProd_or_LetIn u _ (tSort _)).
-  rewrite -it_mkProd_or_LetIn_app in ar.
-  eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u) in ar.
-  right. eexists _. eapply ar. all:eauto.
-Qed.
-
-Lemma nth_errror_arities_context {cf:checker_flags} (Σ : global_env_ext) mdecl ind idecl decl : 
-  wf Σ.1 ->
-  declared_inductive Σ mdecl ind idecl ->
-  on_inductive (lift_typing typing) (Σ.1, ind_universes mdecl)
-    (inductive_mind ind) mdecl ->
-  on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl)
-    (inductive_mind ind) mdecl (inductive_ind ind) idecl ->
-  nth_error (arities_context (ind_bodies mdecl)) (#|ind_bodies mdecl| - S (inductive_ind ind)) = Some decl ->
-  decl.(decl_type) = idecl.(ind_type).
-Proof.
-  move=> wfΣ decli oni onib.
-  unfold arities_context.
-  rewrite nth_error_rev_map.
-  destruct decli as [declm decli]. now apply nth_error_Some_length in decli.
-  destruct nth_error eqn:Heq; try discriminate.
-  destruct decli. rewrite H0 in Heq. noconf Heq.
-  simpl. move=> [] <-. now simpl.
-Qed.
-
-Lemma declared_inductive_minductive Σ ind mdecl idecl :
-  declared_inductive Σ mdecl ind idecl -> declared_minductive Σ (inductive_mind ind) mdecl.
-Proof. now intros []. Qed.
-Hint Resolve declared_inductive_minductive : pcuic.
-  
 Lemma on_constructor_subst' {cf:checker_flags} Σ ind mdecl idecl csort cdecl : 
   wf Σ -> 
   declared_inductive Σ mdecl ind idecl ->
@@ -749,55 +436,6 @@ Proof.
         eapply type_Cumul; eauto. now eapply conv_cumul.
 Qed.
 
-Lemma isWAT_mkApps_Ind {cf:checker_flags} {Σ Γ ind u args} (wfΣ : wf Σ.1)
-  {mdecl idecl} (declm : declared_inductive Σ.1 mdecl ind idecl) :
-  wf_local Σ Γ ->
-  isWfArity_or_Type Σ Γ (mkApps (tInd ind u) args) ->
-  ∑ parsubst argsubst,
-    let oib := (on_declared_inductive wfΣ declm).2 in
-    let parctx := (subst_instance_context u (ind_params mdecl)) in
-    let argctx := (subst_context parsubst 0 (subst_instance_context u (oib.(ind_indices)))) in
-    spine_subst Σ Γ (firstn (ind_npars mdecl) args) parsubst parctx *
-    spine_subst Σ Γ (skipn (ind_npars mdecl) args) argsubst argctx *
-    consistent_instance_ext Σ (ind_universes mdecl) u.
-Proof.
-  move=> wfΓ isWAT.
-  destruct isWAT.
-  destruct i as [ctx [s Hs]].
-  destruct Hs. rewrite destArity_tInd in e => //.
-  destruct i as [s Hs].
-  eapply inversion_mkApps in Hs as [A [U [tyc [tyargs tycum]]]]; auto.
-  eapply typing_spine_weaken_concl in tyargs; eauto.
-  2:left; exists [], s; eauto.
-  clear tycum.
-  eapply inversion_Ind in tyc as [mdecl' [idecl' [wfl [decli [cu cum]]]]] => //.
-  pose proof (declared_inductive_unique decli declm) as [? ?]; subst mdecl' idecl'.
-  clear decli. rename declm into decli.
-  eapply typing_spine_strengthen in tyargs; eauto.
-  set (decli' := on_declared_inductive _ _). clearbody decli'.
-  destruct decli' as [declm decli'].
-  pose proof (decli'.(onArity)) as ar. 
-  rewrite decli'.(ind_arity_eq) in tyargs, ar. clear cum A.
-  hnf in ar. destruct ar as [s' ar].
-  rewrite !subst_instance_constr_it_mkProd_or_LetIn in tyargs.
-  simpl in tyargs. rewrite -it_mkProd_or_LetIn_app in tyargs.
-  eapply arity_typing_spine in tyargs as [[argslen leqs] [instsubst [wfdom wfcodom cs subs]]] => //.
-  apply context_subst_app in cs as [parsubst argsubst].
-  eexists _, _. move=> lk parctx argctx. subst lk.
-  rewrite subst_instance_context_assumptions in argsubst, parsubst.
-  rewrite declm.(onNpars _ _ _ _) in argsubst, parsubst.
-  eapply subslet_app_inv in subs as [subp suba].
-  rewrite subst_instance_context_length in subp, suba.
-  subst parctx argctx.
-  repeat split; eauto; rewrite ?subst_instance_context_length => //.
-  rewrite app_context_assoc in wfcodom. now apply All_local_env_app in wfcodom as [? ?].
-  simpl.
-  eapply substitution_wf_local; eauto. now rewrite app_context_assoc in wfcodom.
-  unshelve eapply on_inductive_inst in declm; pcuic.
-  rewrite subst_instance_context_app in declm.
-  now eapply isWAT_it_mkProd_or_LetIn_wf_local in declm.
-Qed.
-
 Lemma Construct_Ind_ind_eq {cf:checker_flags} {Σ} (wfΣ : wf Σ.1):
   forall {Γ n i args u i' args' u' mdecl idecl cdecl},
   Σ ;;; Γ |- mkApps (tConstruct i n u) args : mkApps (tInd i' u') args' ->
@@ -993,12 +631,6 @@ Proof.
 Qed.
 
 Notation "⋆" := ltac:(solve [pcuic]) (only parsing).
-
-Lemma consistent_instance_ext_eq {cf:checker_flags} Σ ext u u' :
-  consistent_instance_ext Σ ext u ->
-  R_universe_instance (eq_universe Σ) u u' ->
-  consistent_instance_ext Σ ext u'.
-Proof. todo "for Simon"%string. Qed.
 
 Lemma build_branches_type_red {cf:checker_flags} (p p' : term) (ind : inductive)
 	(mdecl : PCUICAst.mutual_inductive_body)
@@ -1435,11 +1067,6 @@ Proof.
     * right.
       pose proof (on_declared_inductive wf isdecl) as [onmind _].
       destruct (on_constructor_subst' _ _ _ _ _ _ wf isdecl onmind oib onc) as [[wfext wfc] insts].
-      (* eapply (spine_subst_inst _ _ u1) in insts.
-      2:{ eapply consistent_instance_ext_eq; eauto. now symmetry. }
-      rewrite !subst_instance_context_app map_app in insts.
-      eapply spine_subst_app_inv in insts as [instl instr]. 2:auto.
-      2:{ rewrite map_length to_extended_list_k_length. now autorewrite with len. } *)
       eexists.
       assert(wfparinds : wf_local Σ
         (subst_instance_context u (ind_params mdecl) ,,,

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1171,7 +1171,7 @@ Section Lemmata.
       apply inversion_App in hw' as ihw' ; auto.
       destruct ihw' as [na' [A' [B' [hP [? ?]]]]].
       apply inversion_Prod in hP as [s1 [s2 [? [? bot]]]] ; auto.
-      apply PCUICPrincipality.invert_cumul_prod_r in bot ; auto.
+      apply PCUICConversion.invert_cumul_prod_r in bot ; auto.
       destruct bot as [? [? [? [[r ?] ?]]]].
       exfalso. clear - r wΣ.
       revert r. generalize (Universe.sort_of_product s1 s2). intro s. clear.
@@ -1568,7 +1568,6 @@ Proof.
       apply cumul_Sort_r_inv in H.
       destruct H as [s' [H H']].
       right. exists s'. eapply type_reduction; tea.
-      1:{ constructor; tas. eexists; tea. }
       apply invert_red_letin in H; tas.
       destruct H as [[? [? [? [? [[[H ?] ?] ?]]]]]|H].
       * apply invert_red_sort in H; inv H.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -10,7 +10,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
      PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
-     PCUICClosed PCUICPrincipality PCUICSubstitution
+     PCUICClosed PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils PCUICCtxShape PCUICContexts
      PCUICUniverses PCUICArities.
 From Equations Require Import Equations.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -7,8 +7,8 @@ From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICUnivSubstitution
      PCUICCumulativity PCUICPosition PCUICEquality PCUICNameless
-     PCUICAlpha PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
-     PCUICConfluence PCUICConversion PCUICContextConversion PCUICValidity
+     PCUICNormal PCUICInversion PCUICCumulativity PCUICReduction
+     PCUICConfluence PCUICConversion PCUICContextConversion
      PCUICParallelReductionConfluence PCUICWeakeningEnv
      PCUICClosed PCUICPrincipality PCUICSubstitution
      PCUICWeakening PCUICGeneration PCUICUtils PCUICCtxShape PCUICContexts


### PR DESCRIPTION
Close those proofs as well (missing projections in both, and the `case` case in principality). 
Principality relies on SR for products, at least there is an easy proof using it. It does not seem entirely moral to me.
This required again a bit of moving around lemmas at the right places. We  can finally give a complete proof of type_mkApps_inv/inversion_mkApps from validity. 