### PR TITLE
Remove Program form template-coq and pcuic

### DIFF
--- a/checker/theories/Substitution.v
+++ b/checker/theories/Substitution.v
@@ -1882,8 +1882,7 @@ Proof.
     * eapply All_map.
       eapply (All_impl X0); simpl.
       intros x [u [Hs Hs']]; exists u.
-      specialize (Hs' _ _ _ _ sub eq_refl).
-      now rewrite -map_dtype.
+      now specialize (Hs' _ _ _ _ sub eq_refl).
     * eapply All_map.
       eapply (All_impl X1); simpl.
       intros x [[Hb Hlam] IH].
@@ -1904,8 +1903,7 @@ Proof.
     * eapply All_map.
       eapply (All_impl X0); simpl.
       intros x [u [Hs Hs']]; exists u.
-      specialize (Hs' _ _ _ _ sub eq_refl).
-      now rewrite -map_dtype.
+      now specialize (Hs' _ _ _ _ sub eq_refl).
     * eapply All_map.
       eapply (All_impl X1); simpl.
       intros x [Hb IH].

--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -1037,8 +1037,7 @@ Proof.
     * eapply All_map.
       eapply (All_impl X0); simpl.
       intros x [s [Hs Hs']]; exists s.
-      specialize (Hs' _ _ _ wf eq_refl).
-      now rewrite -map_dtype.
+      now specialize (Hs' _ _ _ wf eq_refl).
     * eapply All_map.
       eapply (All_impl X1); simpl.
       intros x [[Hb Hlam] IH].
@@ -1059,8 +1058,7 @@ Proof.
     * eapply All_map.
       eapply (All_impl X0); simpl.
       intros x [s [Hs Hs']]; exists s.
-      specialize (Hs' _ _ _ wf eq_refl).
-      now rewrite -map_dtype.
+      now specialize (Hs' _ _ _ wf eq_refl).
     * eapply All_map.
       eapply (All_impl X1); simpl.
       intros x [Hb IH].

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -211,7 +211,7 @@ Qed.
 Hint Resolve map_def_id_spec : all.
 
 Lemma compose_map_def (f g : term -> term) :
-  compose (map_def f) (map_def g) = map_def (compose f g).
+  (map_def f) ∘ (map_def g) = map_def (f ∘ g).
 Proof. reflexivity. Qed.
 
 Hint Extern 10 (_ < _)%nat => lia : all.

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program Lia.
+From Coq Require Import Bool List Lia.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICLiftSubst PCUICTyping PCUICWeakening
@@ -175,14 +175,11 @@ Qed.
     eapply typing_ind_env.
     all: intros Σ wfΣ Γ wfΓ.
     - auto.
-    - intros n decl hnth ih v e.
-      dependent destruction e.
+    - intros n decl hnth ih v e; invs e.
       eapply type_Rel ; eassumption.
-    - intros l ih hl v e.
-      dependent destruction e. subst.
+    - intros l ih hl v e; invs e.
       eapply type_Sort; assumption.
-    - intros na A B s1 s2 ih hA ihA hB ihB v e.
-      dependent destruction e.
+    - intros na A B s1 s2 ih hA ihA hB ihB v e; invs e.
       econstructor.
       + eapply ihA. assumption.
       + eapply context_conversion'.
@@ -194,8 +191,7 @@ Qed.
           -- apply conv_ctx_refl ; auto.
           -- constructor. constructor.
              eapply upto_names_impl_eq_term. assumption.
-    - intros na A t s1 B ih hA ihA hB ihB v e.
-      dependent destruction e.
+    - intros na A t s1 B ih hA ihA hB ihB v e; invs e.
       econstructor.
       + econstructor.
         * eapply ihA. assumption.
@@ -216,8 +212,7 @@ Qed.
         constructor.
         all: try (eapply upto_names_impl_eq_term ; assumption).
         all: eapply eq_term_refl.
-    - intros na b B t s1 A ih hB ihB hb ihb hA ihA v e.
-      dependent destruction e.
+    - intros na b B t s1 A ih hB ihB hb ihb hA ihA v e; invs e.
       econstructor.
       + econstructor.
         * eapply ihB. assumption.
@@ -254,8 +249,7 @@ Qed.
         constructor.
         all: try (eapply upto_names_impl_eq_term ; assumption).
         all: eapply eq_term_refl.
-    - intros t na A B u ih ht iht hu ihu v e.
-      dependent destruction e.
+    - intros t na A B u ih ht iht hu ihu v e; invs e.
       econstructor.
       + econstructor.
         * eapply iht. assumption.
@@ -267,29 +261,25 @@ Qed.
         apply eq_term_sym.
         eapply upto_names_impl_eq_term.
         eapply eq_term_upto_univ_subst ; now auto.
-    - intros cst u decl ? ? hdecl hcons v e.
-      dependent destruction e.
-      apply Forall2_eq in r. apply map_inj in r ; revgoals.
+    - intros cst u decl ? ? hdecl hcons v e; invs e.
+      apply Forall2_eq in H2. apply map_inj in H2 ; revgoals.
       { apply Universe.make_inj. }
       subst.
       constructor ; auto.
-    - intros ind u mdecl idecl isdecl ? ? hcons v e.
-      dependent destruction e.
-      apply Forall2_eq in r. apply map_inj in r ; revgoals.
+    - intros ind u mdecl idecl isdecl ? ? hcons v e; invs e.
+      apply Forall2_eq in H2. apply map_inj in H2 ; revgoals.
       { apply Universe.make_inj. }
       subst.
       econstructor ; eauto.
-    - intros ind i u mdecl idecl cdecl isdecl ? ? ? v e.
-      dependent destruction e.
-      apply Forall2_eq in r. apply map_inj in r ; revgoals.
+    - intros ind i u mdecl idecl cdecl isdecl ? ? ? v e; invs e.
+      apply Forall2_eq in H4. apply map_inj in H4 ; revgoals.
       { apply Universe.make_inj. }
       subst.
       econstructor ; eauto.
     - intros ind u npar p c brs args mdecl idecl isdecl X X0 H pars ps pty
-             Hcpt X1 X2 H1 X3 X4 btys Hbbt Hbrs v e.
+             Hcpt X1 X2 H1 X3 X4 btys Hbbt Hbrs v e; invs e.
       (* intros ind u npar p c brs args mdecl idecl isdecl X X0 H pars pty X1 *)
       (*        indctx pctx ps btys htc H1 H2 ihp hc ihc ihbrs v e. *)
-      dependent destruction e.
       (* eapply types_of_case_eq_term in htc as htc' ; eauto. *)
       (* destruct htc' as [btys' [ebtys' he]]. *)
       econstructor.
@@ -312,7 +302,7 @@ Qed.
           intros v H. unshelve eapply (upto_names_trans _ _ _ _) in H; tea.
           eauto.
       + eapply validity_term ; eauto.
-        instantiate (1 := tCase (ind, npar) p c brs).
+        instantiate (1 := tCase (ind, ind_npars mdecl) p c brs).
         econstructor ; eauto.
         apply All2_prod_inv in Hbrs as [a1 a4].
         apply All2_prod_inv in a1 as [a1 a3].
@@ -327,8 +317,7 @@ Qed.
         * eapply All2_same. intro. eapply eq_term_refl.
         * constructor ; eauto.
           eapply upto_names_impl_eq_term. assumption.
-    - intros p c u mdecl idecl pdecl isdecl args X X0 hc ihc H ty v e.
-      dependent destruction e.
+    - intros p c u mdecl idecl pdecl isdecl args X X0 hc ihc H ty v e; invs e.
       econstructor.
       + econstructor. all: try eassumption.
         eapply ihc. assumption.
@@ -342,16 +331,15 @@ Qed.
         * constructor ; auto.
           eapply All2_same.
           intro. eapply eq_term_upto_univ_refl ; auto.
-    - intros mfix n decl types hguard hnth hwf ihmfix ihmfixb v e.
-      dependent destruction e.
+    - intros mfix n decl types hguard hnth hwf ihmfix ihmfixb v e; invs e.
       eapply All2_nth_error_Some in hnth as hnth' ; eauto.
       destruct hnth' as [decl' [hnth' hh]].
       destruct hh as [[ety ebo] era].
       assert (hwf' : wf_local Σ (Γ ,,, fix_context mfix')).
       { apply PCUICWeakening.All_mfix_wf; auto.
-        eapply (All2_All_mix_left ihmfix) in a.
-        clear -a.
-        induction a; constructor; simpl; auto.
+        eapply (All2_All_mix_left ihmfix) in X.
+        clear -X.
+        induction X; constructor; simpl; auto.
         destruct r as [[s [Hs IH]] [[eqty eqbod] eqrarg]].
         exists s; apply IH; eauto. }
       assert (convctx : conv_context Σ (Γ ,,, fix_context mfix) (Γ ,,, fix_context mfix')).
@@ -363,25 +351,25 @@ Qed.
         * apply eq_context_upto_refl. typeclasses eauto.
         * generalize 0.
           unfold fix_context_gen.
-          eapply (All2_All_mix_left ihmfix) in a.
-          clear -a.
-          induction a; try constructor; simpl; intros n; auto.
+          eapply (All2_All_mix_left ihmfix) in X.
+          clear -X.
+          induction X; try constructor; simpl; intros n; auto.
           destruct r as [[s [Hs IH]] [[eqty eqbod] eqrarg]].
           eapply eq_context_upto_cat.
           + constructor; [|constructor].
             now eapply eq_term_upto_univ_lift.
-          + apply IHa. }
+          + apply IHX. }
       assert(#|fix_context mfix| = #|fix_context mfix'|).
-      { now rewrite !fix_context_length, (All2_length _ _ a). } 
+      { now rewrite !fix_context_length, (All2_length _ _ X). } 
       eapply type_Cumul.
       + econstructor.
         * eapply fix_guard_eq_term ; eauto.
           constructor. assumption.
         * eassumption.
         * assumption.
-        * eapply (All2_All_mix_left ihmfix) in a.
-          clear -a.
-          induction a; constructor; simpl; auto.
+        * eapply (All2_All_mix_left ihmfix) in X.
+          clear -X.
+          induction X; constructor; simpl; auto.
           destruct r as [[s [Hs IH]] [[eqty eqbod] eqrarg]].
           exists s; apply IH; eauto.
         * solve_all.
@@ -410,16 +398,15 @@ Qed.
           * eapply leq_universe_refl.
 
 
-  - intros mfix n decl types hnth hwf ihmfix ihmfixb allow_cofix v e.
-    dependent destruction e.
+  - intros mfix n decl types hnth hwf ihmfix ihmfixb allow_cofix v e; invs e.
     eapply All2_nth_error_Some in hnth as hnth' ; eauto.
     destruct hnth' as [decl' [hnth' hh]].
     destruct hh as [[ety ebo] era].
     assert (hwf' : wf_local Σ (Γ ,,, fix_context mfix')).
     { apply PCUICWeakening.All_mfix_wf; auto.
-      eapply (All2_All_mix_left ihmfix) in a.
-      clear -a.
-      induction a; constructor; simpl; auto.
+      eapply (All2_All_mix_left ihmfix) in X.
+      clear -X.
+      induction X; constructor; simpl; auto.
       destruct r as [[s [Hs IH]] [[eqty eqbod] eqrarg]].
       exists s; apply IH; eauto. }
     assert (convctx : conv_context Σ (Γ ,,, fix_context mfix) (Γ ,,, fix_context mfix')).
@@ -431,24 +418,24 @@ Qed.
       * apply eq_context_upto_refl. typeclasses eauto.
       * generalize 0.
         unfold fix_context_gen.
-        eapply (All2_All_mix_left ihmfix) in a.
-        clear -a.
-        induction a; try constructor; simpl; intros n; auto.
+        eapply (All2_All_mix_left ihmfix) in X.
+        clear -X.
+        induction X; try constructor; simpl; intros n; auto.
         destruct r as [[s [Hs IH]] [[eqty eqbod] eqrarg]].
         eapply eq_context_upto_cat.
         + constructor; [|constructor].
           now eapply eq_term_upto_univ_lift.
-        + apply IHa. }
+        + apply IHX. }
     assert(#|fix_context mfix| = #|fix_context mfix'|).
-    { now rewrite !fix_context_length, (All2_length _ _ a). } 
+    { now rewrite !fix_context_length, (All2_length _ _ X). } 
     eapply type_Cumul.
     + econstructor.
       * eassumption.
       * eassumption.
       * now eapply All_local_env_app in hwf' as [? _]. 
-      * eapply (All2_All_mix_left ihmfix) in a.
-        clear -a.
-        induction a; constructor; simpl; auto.
+      * eapply (All2_All_mix_left ihmfix) in X.
+        clear -X.
+        induction X; constructor; simpl; auto.
         destruct r as [[s [Hs IH]] [[eqty eqbod] eqrarg]].
         exists s; apply IH; eauto.
       * solve_all.

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
+From Coq Require Import Bool String List BinPos Compare_dec Arith Lia
      Classes.CRelationClasses ProofIrrelevance ssreflect.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.

--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -1,4 +1,4 @@
-From Coq Require Import Ascii String OrderedType Lia Program Arith.
+From Coq Require Import Ascii String OrderedType Lia Arith.
 From MetaCoq.Template Require Import utils uGraph.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICSize.
 Import List.ListNotations.
@@ -9,6 +9,7 @@ From Equations Require Import Equations.
 Set Asymmetric Patterns.
 
 Derive NoConfusion for term.
+Derive Signature for All.
 Derive Signature for All2.
 
 Open Scope pcuic.
@@ -457,14 +458,16 @@ Qed.
 
 Lemma mkApps_eq_head {x l} : mkApps x l = x -> l = [].
 Proof.
-  assert (WF := _ : WellFounded (MR lt size)).
+  assert (WF : WellFounded (precompose lt size))
+    by apply wf_precompose, lt_wf.
   induction l. simpl. constructor.
   apply apply_noCycle_right. simpl. red. rewrite mkApps_size. simpl. lia.
 Qed.
 
 Lemma mkApps_eq_inv {x y l} : x = mkApps y l -> size y <= size x.
 Proof.
-  assert (WF := _ : WellFounded (MR lt size)).
+  assert (WF : WellFounded (precompose lt size))
+    by apply wf_precompose, lt_wf.
   induction l in x, y |- *. simpl. intros -> ; constructor.
   simpl. intros. specialize (IHl _ _ H). simpl in IHl. lia.
 Qed.

--- a/pcuic/theories/PCUICCSubst.v
+++ b/pcuic/theories/PCUICCSubst.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Program Lia CRelationClasses Arith.
+From Coq Require Import Bool List Lia CRelationClasses Arith.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICUnivSubst PCUICTyping
      PCUICInduction PCUICReduction PCUICClosed.

--- a/pcuic/theories/PCUICChecker.v
+++ b/pcuic/theories/PCUICChecker.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program.
-From MetaCoq.Template Require Import config monad_utils.
+From Coq Require Import Bool String List.
+From MetaCoq.Template Require Import utils config monad_utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICUnivSubst
      PCUICTyping.
 

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -1,5 +1,5 @@
 (* Distributed under the terms of the MIT license.   *)
-From Coq Require Import Bool List Program Arith Lia.
+From Coq Require Import Bool List Arith Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv.
@@ -36,7 +36,7 @@ Proof.
     simpl in *; rewrite -> ?andb_and in *;
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length, ?Nat.add_assoc;
     simpl closed in *; solve_all;
-    unfold compose, test_def, test_snd in *;
+    unfold test_def, test_snd in *;
       try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; solve_all)]; try easy.
 
   - elim (Nat.leb_spec k' n0); intros. simpl.
@@ -53,7 +53,7 @@ Proof.
     simpl in *;
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length, ?Nat.add_assoc in *;
     simpl closed in *; repeat (rtoProp; solve_all); try change_Sk;
-    unfold compose, test_def, on_snd, test_snd in *; simpl in *; eauto with all.
+    unfold test_def, on_snd, test_snd in *; simpl in *; eauto with all.
 
   - revert H0.
     elim (Nat.leb_spec k n0); intros. simpl in *.
@@ -93,7 +93,7 @@ Proof.
     simpl in *;
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
     simpl closed in *; try change_Sk; repeat (rtoProp; solve_all);
-    unfold compose, test_def, on_snd, test_snd in *; simpl in *; eauto with all.
+    unfold test_def, on_snd, test_snd in *; simpl in *; eauto with all.
 
   - elim (Nat.leb_spec k' n); intros. simpl.
     apply Nat.ltb_lt in H.
@@ -177,7 +177,7 @@ Proof.
     simpl in *;
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length, ?Nat.add_assoc in *;
     simpl closed in *; repeat (rtoProp; f_equal; solve_all); try change_Sk;
-    unfold compose, test_def, on_snd, test_snd in *; simpl in *; eauto with all.
+    unfold test_def, on_snd, test_snd in *; simpl in *; eauto with all.
 
   - revert Hs.
     unfold Upn.
@@ -218,11 +218,11 @@ Proof.
     f_equal; eauto.
   - red in X. rewrite forallb_map.
     eapply All_forallb_eq_forallb; eauto.
-    unfold test_def, compose, map_def. simpl.
+    unfold test_def, map_def. simpl.
     do 3 (f_equal; intuition eauto).
   - red in X. rewrite forallb_map.
     eapply All_forallb_eq_forallb; eauto.
-    unfold test_def, compose, map_def. simpl.
+    unfold test_def, map_def. simpl.
     do 3 (f_equal; intuition eauto).
 Qed.
 
@@ -234,7 +234,7 @@ Lemma destArity_spec ctx T :
   | None => True
   end.
 Proof.
-  induction T in ctx |- *; simpl; simplify_dep_elim; try easy.
+  induction T in ctx |- *; simpl; try easy.
   specialize (IHT2 (ctx,, vass na T1)). now destruct destArity.
   specialize (IHT3 (ctx,, vdef na T1 T2)). now destruct destArity.
 Qed.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -2,13 +2,11 @@
 Set Warnings "-notation-overridden".
 Require Import ssreflect.
 From Equations Require Import Equations.
-From Coq Require Import Bool List Program Utf8 Lia.
+From Coq Require Import Bool List Utf8 Lia.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst
-     PCUICLiftSubst PCUICTyping PCUICReduction PCUICWeakening
-     PCUICEquality
-     PCUICParallelReduction PCUICParallelReductionConfluence
-     PCUICUnivSubstitution.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping
+     PCUICReduction PCUICWeakening PCUICEquality PCUICUnivSubstitution
+     PCUICParallelReduction PCUICParallelReductionConfluence.
 
 (* Type-valued relations. *)
 Require Import CRelationClasses.
@@ -2591,7 +2589,8 @@ Section ConfluenceFacts.
   Proof.
     move => Hred. apply red_alt in Hred.
     eapply red_pred in Hred.
-    generalize_eqs Hred. induction Hred in ind, pars, k, args |- * ; simplify *.
+    generalize_eq x (mkApps (tConstruct ind pars k) args).
+    induction Hred in ind, pars, k, args |- * ; simplify *.
     - eapply pred1_mkApps_tConstruct in r as [r' [eq redargs]].
       subst y. exists r'. intuition auto. solve_all. now apply pred1_red in X.
     - exists args; split; eauto. apply All2_same; auto.
@@ -2609,8 +2608,9 @@ Section ConfluenceFacts.
     (c = mkApps (tInd ind u) args') * (All2 (red Σ Γ) args args').
   Proof.
     move => Hred. apply red_alt in Hred.
-    eapply red_pred in Hred.
-    generalize_eqs Hred. induction Hred in ind, u, args |- * ; simplify *.
+    eapply red_pred in Hred; tas.
+    generalize_eq x (mkApps (tInd ind u) args).
+    induction Hred in ind, u, args |- * ; simplify *.
     - eapply pred1_mkApps_tInd in r as [r' [eq redargs]].
       subst y. exists r'. intuition auto. solve_all. now apply pred1_red in X.
     - exists args; split; eauto. apply All2_same; auto.
@@ -2618,7 +2618,6 @@ Section ConfluenceFacts.
       specialize (IHHred2 _ _ _ eq_refl) as [? [? ?]]. subst z.
       exists x0. intuition auto. eapply All2_trans; eauto.
       intros ? ? ?; eapply red_trans.
-    - auto.
   Qed.
 
   Lemma red_mkApps_tConst_axiom (Γ : context)
@@ -2629,8 +2628,9 @@ Section ConfluenceFacts.
     (c = mkApps (tConst cst u) args') * (All2 (red Σ Γ) args args').
   Proof.
     move => Hdecl Hbody Hred. apply red_alt in Hred.
-    eapply red_pred in Hred.
-    generalize_eqs Hred. induction Hred in cst, u, args, Hdecl |- *; simplify *.
+    eapply red_pred in Hred; tas.
+    generalize_eq x (mkApps (tConst cst u) args).
+    induction Hred in cst, u, args, Hdecl |- *; simplify *.
     - eapply pred1_mkApps_tConst_axiom in r as [r' [eq redargs]]; eauto.
       subst y. exists r'. intuition auto. solve_all. now apply pred1_red in X.
     - exists args; split; eauto. apply All2_same; auto.
@@ -2638,7 +2638,6 @@ Section ConfluenceFacts.
       specialize (IHHred2 _ _ _ Hdecl eq_refl) as [? [? ?]]. subst z.
       exists x0. intuition auto. eapply All2_trans; eauto.
       intros ? ? ?; eapply red_trans.
-    - auto.
   Qed.
 
   (* Lemma red1_red1_ctx_inv Γ Δ Δ' t u : *)

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Program Arith Lia.
+From Coq Require Import Bool List Arith Lia.
 From Coq Require Import CRelationClasses.
 From Coq Require Import ssreflect.
 

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -1,4 +1,4 @@
-From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
+From Coq Require Import Bool String List BinPos Compare_dec Arith Lia
      Classes.CRelationClasses ProofIrrelevance.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.
@@ -402,7 +402,7 @@ Proof.
   intros ->.
   rewrite /to_extended_list_k.
   rewrite -{1}(Nat.add_0_r #|s|) reln_lift map_map_compose.
-  apply map_ext. intros x; unfold compose; simpl.
+  apply map_ext. intros x; simpl.
   rewrite subst_app_decomp.
   f_equal. rewrite -{1}(Nat.add_0_r #|s|) simpl_subst' ?lift0_id //.
   now rewrite map_length.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -1,11 +1,11 @@
 (* Distributed under the terms of the MIT license.   *)
-From Coq Require Import Bool List Program Lia Arith.
+From Coq Require Import Bool List Lia Arith.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
-     PCUICLiftSubst PCUICTyping
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICTyping
      PCUICSubstitution PCUICPosition PCUICCumulativity PCUICReduction
-     PCUICConfluence  PCUICParallelReductionConfluence PCUICEquality
-     PCUICContextConversion PCUICWeakening PCUICUnivSubst PCUICUnivSubstitution PCUICClosed.
+     PCUICConfluence PCUICClosed PCUICParallelReductionConfluence PCUICEquality
+     PCUICContextConversion PCUICWeakening PCUICUnivSubst PCUICUnivSubstitution
+.
 Require Import ssreflect.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -557,11 +557,11 @@ Section Inversions.
     red Σ Γ (tSort u) v -> v = tSort u.
   Proof.
     intros H; apply red_alt in H.
-    generalize_eqs H.
+    generalize_eq x (tSort u).
     induction H; simplify *.
     - depind r. solve_discr.
     - reflexivity.
-    - eapply IHclos_refl_trans2. auto.
+    - rewrite IHclos_refl_trans2; auto.
   Qed.
 
   Lemma invert_cumul_sort_r Γ C u :
@@ -591,7 +591,7 @@ Section Inversions.
              (red Σ (vass na A :: Γ) B B').
   Proof.
     intros H. apply red_alt in H.
-    generalize_eqs H. revert na A B.
+    generalize_eq x (tProd na A B). revert na A B.
     induction H; simplify_dep_elim.
     - depelim r.
       + solve_discr.

--- a/pcuic/theories/PCUICCtxShape.v
+++ b/pcuic/theories/PCUICCtxShape.v
@@ -1,4 +1,4 @@
-From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
+From Coq Require Import Bool String List BinPos Compare_dec Arith Lia
      Classes.CRelationClasses ProofIrrelevance.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program.
+From Coq Require Import Bool List.
 From MetaCoq.Template Require Import config utils Universes.
 From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst
      PCUICSR PCUICInversion PCUICSafeLemmata.

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -1,13 +1,14 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program Arith
-   CMorphisms.
+From Coq Require Import Bool List Arith CMorphisms.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICReflect PCUICLiftSubst.
 
 Require Import ssreflect.
+From Equations.Prop Require Import DepElim.
 Set Equations With UIP.
+
 
 Local Open Scope type_scope.
 

--- a/pcuic/theories/PCUICGeneration.v
+++ b/pcuic/theories/PCUICGeneration.v
@@ -1,10 +1,15 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool Program.
-From MetaCoq.PCUIC Require Import PCUICAst
-     PCUICLiftSubst PCUICTyping.
-Local Open Scope string_scope.
+From Coq Require Import Bool List.
+From MetaCoq.Template Require Import utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping.
 Set Asymmetric Patterns.
+
+Import ListNotations.
+
+Require Import Equations.Prop.DepElim.
+From Equations Require Import Equations.
+
 
 Section Generation.
   Context `{cf : config.checker_flags}.
@@ -55,14 +60,12 @@ Section Generation.
     - assumption.
     - simpl. cbn. eapply ih.
       simpl in h. pose proof (typing_wf_local h) as hc.
-      dependent induction hc. 
-      cbn in t1, t2. destruct t1.
-      econstructor ; eassumption.
+      dependent induction hc; inversion H; subst.
+      econstructor; try eassumption. exact t0.π2.
     - simpl. cbn. eapply ih.
       pose proof (typing_wf_local h) as hc. cbn in hc.
-      dependent induction hc.
-      cbn in t1. destruct t1.
-      econstructor ; eassumption.
+      dependent induction hc; inversion H; subst.
+      econstructor; try eassumption. exact t0.π2.
   Qed.
 
 End Generation.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -2,7 +2,7 @@
 Set Warnings "-notation-overridden".
 
 Require Import Equations.Prop.DepElim.
-From Coq Require Import Bool String List Program Lia Arith.
+From Coq Require Import Bool String List Lia Arith.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakening
@@ -233,7 +233,7 @@ Proof.
   f_equal.
   rewrite !subst_context_length subst_instance_context_length.
   f_equal. f_equal. f_equal. f_equal.
-  f_equal. rewrite -map_map_compose.
+  f_equal. rewrite -(map_map_compose _ _ _ _ (subst _ _ ∘ subst _ _)).
   rewrite subst_instance_to_extended_list_k.
   rewrite -map_map_compose.
   rewrite -to_extended_list_k_map_subst. rewrite subst_instance_context_length; lia.
@@ -335,4 +335,3 @@ Lemma declared_inductive_minductive Σ ind mdecl idecl :
   declared_inductive Σ mdecl ind idecl -> declared_minductive Σ (inductive_mind ind) mdecl.
 Proof. now intros []. Qed.
 Hint Resolve declared_inductive_minductive : pcuic.
-

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -1,15 +1,12 @@
 (* Distributed under the terms of the MIT license.   *)
 From Coq Require Import Bool List.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst
-     PCUICLiftSubst PCUICUnivSubst PCUICTyping
-     PCUICCumulativity PCUICConversion.
-Local Open Scope string_scope.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICUnivSubst
+     PCUICTyping PCUICCumulativity PCUICConversion.
 Set Asymmetric Patterns.
-Require Import Equations.Prop.DepElim.
 Import ListNotations.
 
-Set Equations With UIP.
+Require Import Equations.Prop.DepElim.
 
 Section Inversion.
 

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program Arith
+From Coq Require Import Bool String List Arith
      Classes.RelationClasses.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
@@ -1226,9 +1226,9 @@ Proof.
     + auto.
     + clear -X0.
       apply All_map. eapply All_impl; tea.
-      simpl. unfold compose. intros x [s Hs]. now exists s.
+      simpl. intros x [s Hs]. now exists s.
     + apply All_map. eapply All_impl; tea.
-      simpl. unfold compose. intros [] [s Hs].
+      simpl. intros [] [s Hs].
       simpl in *; intuition auto.
       * rewrite fix_context_length, map_length.
         rewrite fix_context_length in Hs.
@@ -1243,9 +1243,9 @@ Proof.
     + now rewrite nth_error_map, H.
     + clear -X0.
       apply All_map. eapply All_impl; tea.
-      simpl. unfold compose. intros x [s Hs]. now exists s.
+      simpl. intros x [s Hs]. now exists s.
     + apply All_map. eapply All_impl; tea.
-      simpl. unfold compose. intros [] [s Hs].
+      simpl. intros [] [s Hs].
       simpl in *; intuition auto.
       * rewrite fix_context_length, map_length.
         rewrite fix_context_length in Hs.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program.
+From Coq Require Import Bool List.
 From MetaCoq.Template
 Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICTyping.
@@ -36,9 +36,9 @@ Section Normal.
                     normal Γ (tLambda na A B)
   | nf_cstrapp i n u v : All (normal Γ) v -> normal Γ (mkApps (tConstruct i n u) v)
   | nf_indapp i u v : All (normal Γ) v -> normal Γ (mkApps (tInd i u) v)
-  | nf_fix mfix idx : All (compose (normal Γ) dbody) mfix ->
+  | nf_fix mfix idx : All ((normal Γ) ∘ dbody) mfix ->
                       normal Γ (tFix mfix idx)
-  | nf_cofix mfix idx : All (compose (normal Γ) dbody) mfix ->
+  | nf_cofix mfix idx : All ((normal Γ) ∘ dbody) mfix ->
                         normal Γ (tCoFix mfix idx)
 
   with neutral (Γ : context) : term -> Prop :=
@@ -51,7 +51,7 @@ Section Normal.
       lookup_env Σ c = Some (ConstantDecl decl) -> decl.(cst_body) = None ->
       neutral Γ (tConst c u)
   | ne_app f v : neutral Γ f -> normal Γ v -> neutral Γ (tApp f v)
-  | ne_case i p c brs : neutral Γ c -> Forall (compose (normal Γ) snd) brs ->
+  | ne_case i p c brs : neutral Γ c -> Forall ((normal Γ) ∘ snd) brs ->
                         neutral Γ (tCase i p c brs)
   | ne_proj p c : neutral Γ c -> neutral Γ (tProj p c).
 

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -1,8 +1,8 @@
 (* Distributed under the terms of the MIT license.   *)
 Require Import ssreflect.
-From Coq Require Import Bool List Program Lia.
+From Coq Require Import Bool List Lia.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICSize
+From MetaCoq.PCUIC Require Import PCUICUtils PCUICAst PCUICSize
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakening PCUICSubstitution.
 
 (* Type-valued relations. *)
@@ -97,7 +97,7 @@ Lemma term_forall_ctx_list_ind :
 Proof.
   intros.
   revert Γ t. set(foo:=CoreTactics.the_end_of_the_section). intros.
-  Subterm.rec_wf_rel aux t (MR lt size). simpl. clear H1.
+  Subterm.rec_wf_rel aux t (precompose lt size). simpl. clear H1.
   assert (auxl : forall Γ {A} (l : list A) (f : A -> term), list_size (fun x => size (f x)) l < size pr0 ->
                                                             All (fun x => P Γ (f x)) l).
   { induction l; constructor. eapply aux. red. simpl in H. lia. apply IHl. simpl in H. lia. }
@@ -1018,7 +1018,7 @@ Hint Constructors All2_local_env : pcuic.
 Hint Resolve pred1_ctx_refl : pcuic.
 
 Ltac pcuic_simplify :=
-  simpl || split || destruct_conjs || red.
+  simpl || split || rdest || red.
 
 Hint Extern 10 => progress pcuic_simplify : pcuic.
 

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program RelationClasses Lia.
+From Coq Require Import Bool List RelationClasses Lia.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction
      PCUICReflect PCUICEquality PCUICLiftSubst.
@@ -80,16 +80,16 @@ Definition pos (t : term) := { p : position | validpos t p = true }.
 Arguments exist {_ _} _ _.
 
 Definition dapp_l u v (p : pos u) : pos (tApp u v) :=
-  exist (app_l :: ` p) (proj2_sig p).
+  exist (app_l :: proj1_sig p) (proj2_sig p).
 
 Definition dapp_r u v (p : pos v) : pos (tApp u v) :=
-  exist (app_r :: ` p) (proj2_sig p).
+  exist (app_r :: proj1_sig p) (proj2_sig p).
 
 Definition dcase_p indn pr c brs (p : pos pr) : pos (tCase indn pr c brs) :=
-  exist (case_p :: ` p) (proj2_sig p).
+  exist (case_p :: proj1_sig p) (proj2_sig p).
 
 Definition dcase_c indn pr c brs (p : pos c) : pos (tCase indn pr c brs) :=
-  exist (case_c :: ` p) (proj2_sig p).
+  exist (case_c :: proj1_sig p) (proj2_sig p).
 
 (* Equations dcase_brs (n : nat) (indn : inductive × nat)
   (pr c : term) (brs : list (nat × term)) (m : nat) (br : term)
@@ -103,28 +103,28 @@ Qed.
 Transparent dcase_brs. *)
 
 Definition dproj_c pr c (p : pos c) : pos (tProj pr c) :=
-  exist (proj_c :: ` p) (proj2_sig p).
+  exist (proj_c :: proj1_sig p) (proj2_sig p).
 
 Definition dlam_ty na A t (p : pos A) : pos (tLambda na A t) :=
-  exist (lam_ty :: ` p) (proj2_sig p).
+  exist (lam_ty :: proj1_sig p) (proj2_sig p).
 
 Definition dlam_tm na A t (p : pos t) : pos (tLambda na A t) :=
-  exist (lam_tm :: ` p) (proj2_sig p).
+  exist (lam_tm :: proj1_sig p) (proj2_sig p).
 
 Definition dprod_l na A B (p : pos A) : pos (tProd na A B) :=
-  exist (prod_l :: ` p) (proj2_sig p).
+  exist (prod_l :: proj1_sig p) (proj2_sig p).
 
 Definition dprod_r na A B (p : pos B) : pos (tProd na A B) :=
-  exist (prod_r :: ` p) (proj2_sig p).
+  exist (prod_r :: proj1_sig p) (proj2_sig p).
 
 Definition dlet_bd na b B t (p : pos b) : pos (tLetIn na b B t) :=
-  exist (let_bd :: ` p) (proj2_sig p).
+  exist (let_bd :: proj1_sig p) (proj2_sig p).
 
 Definition dlet_ty na b B t (p : pos B) : pos (tLetIn na b B t) :=
-  exist (let_ty :: ` p) (proj2_sig p).
+  exist (let_ty :: proj1_sig p) (proj2_sig p).
 
 Definition dlet_in na b B t (p : pos t) : pos (tLetIn na b B t) :=
-  exist (let_in :: ` p) (proj2_sig p).
+  exist (let_in :: proj1_sig p) (proj2_sig p).
 
 Lemma eq_term_upto_valid_pos :
   forall {u v p Re Rle},
@@ -183,7 +183,7 @@ Inductive positionR : position -> position -> Prop :=
 Derive Signature for positionR.
 
 Definition posR {t} (p q : pos t) : Prop :=
-  positionR (` p) (` q).
+  positionR (proj1_sig p) (proj1_sig q).
 
 Lemma posR_Acc :
   forall t p, Acc (@posR t) p.
@@ -298,9 +298,9 @@ Proof.
   assert (
     forall n indn pr c brs m br (p : pos br)
       (e : nth_error brs n = Some (m, br))
-      (e1 : validpos (tCase indn pr c brs) (case_brs n :: ` p) = true),
+      (e1 : validpos (tCase indn pr c brs) (case_brs n :: proj1_sig p) = true),
       Acc posR p ->
-      Acc posR (exist (case_brs n :: ` p) e1)
+      Acc posR (exist (case_brs n :: proj1_sig p) e1)
   ) as Acc_case_brs.
   { intros n indn pr c brs m br p e e1 h.
     induction h as [p ih1 ih2] in e, e1 |- *.
@@ -313,9 +313,9 @@ Proof.
   assert (
     forall n mfix idx d (p : pos d.(dtype))
       (e : nth_error mfix n = Some d)
-      (e1 : validpos (tFix mfix idx) (fix_mfix_ty n :: ` p)),
+      (e1 : validpos (tFix mfix idx) (fix_mfix_ty n :: proj1_sig p)),
       Acc posR p ->
-      Acc posR (exist (fix_mfix_ty n :: `p) e1)
+      Acc posR (exist (fix_mfix_ty n :: proj1_sig p) e1)
   ) as Acc_fix_mfix_ty.
   { intros n mfix idx d p e e1 h.
     induction h as [p ih1 ih2] in e, e1 |- *.
@@ -328,9 +328,9 @@ Proof.
   assert (
     forall n mfix idx d (p : pos d.(dbody))
       (e : nth_error mfix n = Some d)
-      (e1 : validpos (tFix mfix idx) (fix_mfix_bd n :: ` p)),
+      (e1 : validpos (tFix mfix idx) (fix_mfix_bd n :: proj1_sig p)),
       Acc posR p ->
-      Acc posR (exist (fix_mfix_bd n :: `p) e1)
+      Acc posR (exist (fix_mfix_bd n :: proj1_sig p) e1)
   ) as Acc_fix_mfix_bd.
   { intros n mfix idx d p e e1 h.
     induction h as [p ih1 ih2] in e, e1 |- *.

--- a/pcuic/theories/PCUICPretty.v
+++ b/pcuic/theories/PCUICPretty.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import List Program String.
+From Coq Require Import List String.
 From MetaCoq.Template Require Import utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICChecker
      PCUICLiftSubst.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import String Bool List Program.
+From Coq Require Import String Bool List.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICTyping PCUICSubstitution PCUICEquality

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 Require Import ssreflect.
-From Coq Require Import Bool List Program Utf8
+From Coq Require Import Bool List Utf8
   ZArith Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
@@ -1106,7 +1106,7 @@ Section ReductionCongruence.
           intros y z e. cbn in e. inversion e. eauto.
         } subst.
         constructor.
-      - set (f := fun x : term => (x, ())) in *.
+      - set (f := fun x : term => (x, tt)) in *.
         set (g := (fun '(x, _) => x) : term × unit -> term).
         assert (el :  forall l, l = map f (map g l)).
         { clear. intros l. induction l.

--- a/pcuic/theories/PCUICRetyping.v
+++ b/pcuic/theories/PCUICRetyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program.
+From Coq Require Import Bool List.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping PCUICChecker PCUICConversion PCUICCumulativity.
 Local Open Scope string_scope.

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program.
+From Coq Require Import Bool List.
 From MetaCoq.Template
 Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst
@@ -11,6 +11,8 @@ From MetaCoq.PCUIC Require Import PCUICAst
 
 Import MonadNotation.
 Open Scope type_scope.
+
+Require Import Equations.Prop.DepElim.
 
 (* We assume normalisation of the reduction.
     We state is as well-foundedness of the reduction.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program Arith Lia.
+From Coq Require Import Bool List Arith Lia.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICPrincipality PCUICConfluence
@@ -273,7 +273,7 @@ Section Lemmata.
 
   Lemma wellformed_irr :
     forall {Σ Γ t} (h1 h2 : wellformed Σ Γ t), h1 = h2.
-  Proof. intros. apply proof_irrelevance. Qed.
+  Proof. intros. apply ProofIrrelevance.proof_irrelevance. Qed.
 
   Context (hΣ : ∥ wf Σ ∥).
 

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -1,7 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 From Equations Require Import Equations.
 From Coq Require Import Bool List ZArith Lia.
-Require Import Coq.Program.Syntax Coq.Program.Basics.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst PCUICUnivSubst
      PCUICTyping PCUICClosed PCUICEquality.
@@ -1697,11 +1696,9 @@ Proof.
       * apply hf.
       * apply All_map, (All_impl ihmfixt).
         intros x [s [Hs IHs]].
-        unfold compose; simpl.
         exists s. now apply IHs.
       * apply All_map, (All_impl ihmfixb).
         intros x [[Hb Hlam] IHb].
-        unfold compose; simpl.
         destruct x as [na ty bo rarg]. simpl in *.
         split.
         -- rewrite <- rename_fix_context.
@@ -1730,11 +1727,9 @@ Proof.
       * apply hf.
       * apply All_map, (All_impl ihmfixt).
         intros x [s [Hs IHs]].
-        unfold compose; simpl.
         exists s. now apply IHs.
       * apply All_map, (All_impl ihmfixb).
         intros x [Hb IHb].
-        unfold compose; simpl.
         destruct x as [na ty bo rarg]. simpl in *.
         rewrite <- rename_fix_context.
         eapply meta_conv.
@@ -1918,7 +1913,7 @@ Proof.
     (* + simpl. reflexivity. *)
     (* + simpl. intuition eauto. *)
     (*   f_equal. *)
-    (*   * unfold map_def. unfold compose. rewrite a. *)
+    (*   * unfold map_def. rewrite a. *)
     (*     rewrite map_length. autorewrite with sigma. *)
     (*     specialize (b (S (#|l| + k))). autorewrite with sigma in b. *)
     (*     rewrite b. reflexivity. *)
@@ -1940,7 +1935,7 @@ Proof.
   all: try solve [ f_equal ; eauto ; solve_all ; eauto ].
   - rewrite IHt1. f_equal. rewrite <- IHt2.
     eapply inst_ext. intro i.
-    unfold compose, Up, subst_compose, subst_cons.
+    unfold Up, subst_compose, subst_cons.
     destruct i.
     + reflexivity.
     + pose proof (shift_subst_instance_constr u (σ i) 0) as e.
@@ -2003,7 +1998,7 @@ Proof.
       end
     end.
     { eapply inst_ext. intro i.
-      unfold Upn, compose, subst_compose, subst_consn.
+      unfold Upn, subst_compose, subst_consn.
       rewrite arities_context_length.
       case_eq (nth_error (inds (inductive_mind ind) u (ind_bodies mdecl)) i).
       - intros t' e.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
+From Coq Require Import Bool String List BinPos Compare_dec Arith Lia
      Classes.CRelationClasses ProofIrrelevance ssreflect.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.
@@ -1114,8 +1114,8 @@ Proof.
             red Σ.1 (Γ ,,, Δ) t (subst0 (all_rels Δ 0 #|Δ|) (lift #|Δ| #|Δ| t))
         | None => unit  end))).
   clear t Δ Γ wf. intros Γ' t.
-  Subterm.rec_wf_rel IH (Γ', t) (Subterm.lexprod _ _ (MR lt (@length context_decl))
-     (MR lt (fun x => match x with Some t => S (PCUICSize.size t) | None => 0 end))).
+  Subterm.rec_wf_rel IH (Γ', t) (Subterm.lexprod _ _ (precompose lt (@length context_decl))
+     (precompose lt (fun x => match x with Some t => S (PCUICSize.size t) | None => 0 end))).
   simpl.
   rename pr1 into cf.
   rename pr0 into Σ.
@@ -1128,14 +1128,14 @@ Proof.
     destruct wf.
     constructor.
     constructor. 
-    apply (IH Γ t ltac:(left; unfold MR; simpl; lia) wf).
+    apply (IH Γ t ltac:(left; simpl; lia) wf).
     intros; subst Γ.
-    now apply (IH (Γ0 ,,, Δ) (Some t0) ltac:(left; unfold MR; simpl; lia) wf).
+    now apply (IH (Γ0 ,,, Δ) (Some t0) ltac:(left; simpl; lia) wf).
     constructor; auto.
-    apply (IH Γ t ltac:(left; unfold MR; simpl; lia) wf).
+    apply (IH Γ t ltac:(left; simpl; lia) wf).
     intros.
-    now apply (IH Γ (Some b) ltac:(left; unfold MR; simpl; lia) wf).
-    now apply (IH Γ (Some t0) ltac:(left; unfold MR; simpl; lia) wf).
+    now apply (IH Γ (Some b) ltac:(left; simpl; lia) wf).
+    now apply (IH Γ (Some t0) ltac:(left; simpl; lia) wf).
 
   - destruct t; [|exact tt].
     intros Γ0 Δ ->.
@@ -1150,7 +1150,7 @@ Proof.
      red Σ.1 (Γ ,,, Δ) t (subst0 (all_rels Δ 0 #|Δ|) (lift #|Δ| #|Δ| t)))
     Σ _ wf).
     { specialize (IH wfΣ (Γ ,,, Δ) None).
-      forward IH. simpl. right. unfold MR. lia.
+      forward IH. simpl. right. lia.
       apply (IH wf). }
     clear IH.
 
@@ -1537,8 +1537,7 @@ Proof.
   rewrite (reln_lift n 0).
   rewrite !map_map_compose.
   apply map_ext.
-  intros x. unfold compose.
-  rewrite (subst_app_decomp [a] s).
+  intros x. rewrite (subst_app_decomp [a] s).
   f_equal. simpl.
   rewrite -(commut_lift_subst_rec _ _ _ 0)  //.
   rewrite simpl_subst_k //.
@@ -1551,8 +1550,7 @@ Proof.
   rewrite (reln_lift n 0).
   rewrite !map_map_compose.
   apply map_ext.
-  intros x. unfold compose.
-  rewrite (subst_app_decomp [subst0 s b] s).
+  intros x. rewrite (subst_app_decomp [subst0 s b] s).
   f_equal. simpl.
   rewrite -(commut_lift_subst_rec _ _ _ 0)  //.
   rewrite simpl_subst_k //.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program Arith Lia.
+From Coq Require Import Bool String List Arith Lia.
 From MetaCoq.Template Require Import config utils monad_utils
 EnvironmentTyping.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
@@ -1156,8 +1156,8 @@ Proof.
    otherwise it takes forever to execure the "pose", for some reason *)
   pose (@Fix_F ({ Σ : _ & { wfΣ : wf Σ.1 & { Γ : context & 
                           { t : term & { T : term & Σ ;;; Γ |- t : T }}}}})) as p0.
-  specialize (p0 (dlexprod (MR lt (fun Σ => globenv_size (fst Σ)))
-                            (fun Σ => MR lt (fun x => typing_size (projT2 (projT2 (projT2 (projT2 x)))))))) as p.
+  specialize (p0 (dlexprod (precompose lt (fun Σ => globenv_size (fst Σ)))
+                            (fun Σ => precompose lt (fun x => typing_size (projT2 (projT2 (projT2 (projT2 x)))))))) as p.
   set(foo := existT _ Σ (existT _ wfΣ (existT _ Γ (existT _ t (existT _ _ H)))) : { Σ : _ & { wfΣ : wf Σ.1 & { Γ : context & { t : term & { T : term & Σ ;;; Γ |- t : T }}}}}).
   change Σ with (projT1 foo).
   change Γ with (projT1 (projT2 (projT2 foo))).
@@ -1168,11 +1168,11 @@ Proof.
   match goal with
     |- let foo := _ in @?P foo => specialize (p (fun x => P x))
   end.
-  forward p; [ | apply p; apply wf_dlexprod; intros; apply measure_wf; apply lt_wf].
+  forward p; [ | apply p; apply wf_dlexprod; intros; apply wf_precompose; apply lt_wf].
   clear p.
   clear Σ wfΣ Γ t T H.
   intros (Σ & wfΣ & Γ & t & t0 & H). simpl.
-  intros IH. unfold MR in IH. simpl in IH.
+  intros IH. simpl in IH.
   split. split.
   destruct Σ as [Σ φ]. destruct Σ.
   constructor.

--- a/pcuic/theories/PCUICUnivSubst.v
+++ b/pcuic/theories/PCUICUnivSubst.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program.
+From Coq Require Import Bool List.
 From MetaCoq.Template Require Import utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction PCUICLiftSubst.
 Local Open Scope string_scope.
@@ -132,6 +132,6 @@ Proof.
   induction t in |- * using term_forall_list_ind; simpl; auto; intros H';
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length, ?forallb_map;
     try f_equal; auto with substu;
-      unfold test_def, map_def, compose in *;
+      unfold test_def, map_def in *;
       try solve [f_equal; eauto; repeat (rtoProp; solve_all); intuition auto with substu].
 Qed.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -2,9 +2,7 @@
 
 (** * Universe Substitution lemmas for typing derivations. *)
 
-From Coq Require Import Bool List Lia ZArith
-     CRelationClasses.
-Require Import Coq.Program.Syntax Coq.Program.Basics.
+From Coq Require Import Bool List Lia ZArith CRelationClasses.
 From MetaCoq.Template Require Import utils config.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICEquality
@@ -435,7 +433,7 @@ Proof.
 Qed.
 
 Global Instance satisfies_subsets v :
-  Morphisms.Proper (Morphisms.respectful CS.Subset (flip impl))
+  Morphisms.Proper (Morphisms.respectful CS.Subset (fun A B : Prop => B -> A))
                    (satisfies v).
 Proof.
   intros φ1 φ2 H H2 c Hc; now apply H2, H.
@@ -608,7 +606,7 @@ Proof.
   intro c; split; intro Hc.
   - apply In_subst_instance_cstrs in Hc.
     destruct Hc as [c' [eq Hc]]; subst.
-    apply* CS.union_spec in Hc.
+    apply CS.union_spec in Hc. apply CS.union_spec.
     destruct Hc; [left|right]; now apply In_subst_instance_cstrs'.
   - apply In_subst_instance_cstrs.
     apply CS.union_spec in Hc.
@@ -673,7 +671,7 @@ Proof.
     induction inst; cbnr. rewrite HH; cbn. 1: apply IHinst.
     all: apply andP in H; try apply H.
   + rewrite forallb_map. apply forallb_forall.
-    intros l Hl. unfold global_ext_levels, compose in *; simpl in *.
+    intros l Hl. unfold global_ext_levels in *; simpl in *.
     eapply forallb_forall in H0; tea. clear -Hφ H0 H2 Hl.
     apply LevelSet_mem_union in H0. destruct H0 as [H|H].
     2: { destruct l; simpl; try (apply LevelSet_mem_union; right; assumption).
@@ -740,7 +738,7 @@ Proof.
   - destruct φ as [φ|[φ1 φ2]].
     + cbn. apply satisfies_subst_instance_ctr; tas.
       rewrite equal_subst_instance_cstrs_mono; aa.
-      * rewrite <- Hsub in Hv; assumption.
+      * intros c Hc; apply Hsub in Hc. now apply Hv in Hc.
       * intros c Hc; eapply monomorphic_global_constraint_ext; tea.
         apply CS.union_spec; now left.
     + destruct HH as [_ [_ [_ H1]]].
@@ -1423,7 +1421,6 @@ Proof.
     + rewrite nth_error_map, H0. reflexivity.
     + eapply H1; eauto. 
     + apply All_map, (All_impl X); simpl; intuition auto.
-      unfold compose; simpl.
       destruct X1 as [s Hs]. exists (subst_instance_univ u s).
       now apply Hs.
     + eapply All_map, All_impl; tea.
@@ -1443,7 +1440,6 @@ Proof.
     + rewrite nth_error_map, H. reflexivity.
     + apply X; eauto.
     + apply All_map, (All_impl X0); simpl; intuition auto.
-      unfold compose; simpl.
       destruct X2 as [s Hs]. exists (subst_instance_univ u s).
       now apply Hs.
     + eapply All_map, All_impl; tea.
@@ -1453,7 +1449,6 @@ Proof.
         rewrite fix_context_length, map_length in *.
         unfold subst_instance_context, map_context in *.
         rewrite map_app in *.
-        unfold compose.
         rewrite <- (fix_context_subst_instance u mfix).
         rewrite <- map_dtype. eapply X3.
 

--- a/pcuic/theories/PCUICUniverses.v
+++ b/pcuic/theories/PCUICUniverses.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia
+From Coq Require Import Bool String List BinPos Compare_dec Arith Lia
      Classes.CRelationClasses ProofIrrelevance.
 From MetaCoq.Template Require Import config Universes monad_utils utils BasicAst
      AstUtils UnivSubst.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -1,10 +1,10 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Program Lia CRelationClasses.
+From Coq Require Import Bool List Lia CRelationClasses.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICUnivSubst PCUICTyping
-     PCUICReduction PCUICClosed PCUICCSubst.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst
+     PCUICUnivSubst PCUICTyping PCUICReduction PCUICClosed PCUICCSubst.
 Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -395,14 +395,13 @@ Section Wcbv.
     value (mkApps t l) ->
     ((l = []) * atom t) + (value_head t * All value l) + (isStuckFix t l * All value l).
   Proof.
-    intros H H'. generalize_eqs H'. revert t H. induction H' using value_values_ind.
-    intros.
-    subst.
-    - now eapply atom_mkApps in H.
-    - intros * isapp appeq. move: (value_head_nApp H) => Ht.
-      apply mkApps_eq_inj in appeq; intuition subst; auto.
-    - intros * isapp appeq. move: (isStuckfix_nApp H) => Hf.
-      apply mkApps_eq_inj in appeq; intuition subst; auto.
+    intros H H'. set (x := mkApps t l) in *. cut (x = mkApps t l); [|reflexivity].
+    clearbody x. induction H' using value_values_ind; intro H1.
+    - subst. now eapply atom_mkApps in H0.
+    - move: (value_head_nApp H0) => Ht.
+      apply mkApps_eq_inj in H1; intuition subst; auto.
+    - move: (isStuckfix_nApp H0) => Hf.
+      apply mkApps_eq_inj in H1; intuition subst; auto.
   Qed.
 
   (** The codomain of evaluation is only values: *)
@@ -451,7 +450,6 @@ Section Wcbv.
     destruct t; simpl; intuition auto; eapply implybT.
   Qed.
 
-  Derive Signature for All.
   Derive Signature for eval.
 
   Lemma value_final e : value e -> eval e e.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -1,6 +1,5 @@
 (* Distributed under the terms of the MIT license.   *)
 From Coq Require Import Bool List ZArith Lia.
-Require Import Coq.Program.Syntax Coq.Program.Basics.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
   PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICTyping PCUICWeakeningEnv
@@ -1012,12 +1011,10 @@ Proof.
     * eapply All_map.
       eapply (All_impl X0); simpl.
       intros x [s [Hs Hs']]; exists s.
-      specialize (Hs' _ _ _ wf eq_refl).
-      now rewrite -map_dtype.
+      now specialize (Hs' _ _ _ wf eq_refl).
     * eapply All_map.
       eapply (All_impl X1); simpl.
       intros x [[Hb Hlam] IH].
-      unfold compose; simpl.
       rewrite lift_fix_context.
       specialize (IH Γ (Γ' ,,,  (fix_context mfix)) Γ'' wf).
       rewrite app_context_assoc in IH. specialize (IH eq_refl).
@@ -1034,12 +1031,10 @@ Proof.
     * eapply All_map.
       eapply (All_impl X0); simpl.
       intros x [s [Hs Hs']]; exists s.
-      specialize (Hs' _ _ _ wf eq_refl).
-      now rewrite -map_dtype.
+      now specialize (Hs' _ _ _ wf eq_refl).
     * eapply All_map.
       eapply (All_impl X1); simpl.
       intros x [Hb IH].
-      unfold compose; simpl.
       rewrite lift_fix_context.
       specialize (IH Γ (Γ' ,,,  (fix_context mfix)) Γ'' wf).
       rewrite app_context_assoc in IH. specialize (IH eq_refl).
@@ -1089,15 +1084,12 @@ Qed.
 Lemma weakening_typing `{cf : checker_flags} Σ Γ Γ' Γ'' (t : term) :
   wf Σ.1 ->
   wf_local Σ (Γ ,,, Γ'') ->
-  `(Σ ;;; Γ ,,, Γ' |- t : T ->
-    Σ ;;; Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ' |-
-    lift #|Γ''| #|Γ'| t : lift #|Γ''| #|Γ'| T).
+  forall T, Σ ;;; Γ ,,, Γ' |- t : T ->
+       Σ ;;; Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ' |-
+       lift #|Γ''| #|Γ'| t : lift #|Γ''| #|Γ'| T.
 Proof.
-  intros HΣ HΓ'' * H.
-  generalize_eqs H. intros eqw.
-  revert Γ Γ' Γ'' HΓ'' eqw.
-  revert Σ HΣ Γ0 t T H.
-  apply weakening_typing_prop.
+  intros HΣ HΓ'' T H.
+  exact ((weakening_typing_prop Σ HΣ _ t T H).2 _ _ _ HΓ'' eq_refl).
 Qed.
 
 Lemma weakening_wf_local `{cf : checker_flags} Σ Γ Γ' Γ'' :
@@ -1107,9 +1099,8 @@ Lemma weakening_wf_local `{cf : checker_flags} Σ Γ Γ' Γ'' :
   wf_local Σ (Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ').
 Proof.
   intros HΣ HΓΓ' HΓ''.
-  generalize_eqs HΓΓ'. intros eqw.
-  revert gen_x HΓΓ' Γ Γ' Γ'' eqw HΓ''.
-  now apply (env_prop_wf_local _ _ weakening_typing_prop).
+  exact (env_prop_wf_local _ _ weakening_typing_prop
+                           Σ HΣ _ HΓΓ' _ _ _ eq_refl HΓ'').
 Qed.
 
 Lemma weakening `{cf : checker_flags} Σ Γ Γ' (t : term) T :

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program Lia.
+From Coq Require Import Bool List Lia.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICEquality PCUICTyping.
 

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -1,12 +1,14 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Program Compare_dec PeanoNat.
+From Coq Require Import Bool List Compare_dec PeanoNat.
 From MetaCoq.Template Require Import config utils Ast TypingWf WfInv.
 
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCumulativity
      PCUICLiftSubst PCUICEquality PCUICUnivSubst PCUICTyping TemplateToPCUIC
      PCUICSubstitution PCUICGeneration.
+
+From Equations.Prop Require Import DepElim.
 
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -18,7 +20,6 @@ Module TEnv := Template.Ast.TemplateEnvironment.
 Local Existing Instance default_checker_flags.
 
 Module TL := Template.LiftSubst.
-Derive Signature for All.
 
 Lemma mkApps_morphism (f : term -> term) u v :
   (forall x y, f (tApp x y) = tApp (f x) (f y)) ->
@@ -531,174 +532,6 @@ Qed.
 
 Derive Signature for TTy.eq_term_upto_univ.
 
-(* We rederive this (also in Checker.Reflect) to avoid depending on Checker. *)
-Derive NoConfusion NoConfusionHom for Ast.term.
-
-Lemma trans_eq_term :
-  forall φ t u,
-    T.wf t ->
-    T.wf u ->
-    TTy.eq_term φ t u ->
-    eq_term φ (trans t) (trans u).
-Proof.
-  intros φ t u wt wu e.
-  induction t using Induction.term_forall_list_rect in wt, u, wu, e |- *.
-  all: dependent destruction e.
-  all: simpl.
-  all: try solve [ constructor ; auto ].
-  all: try solve [
-    constructor ;
-    match goal with
-    | ih : forall u : Tterm, _ |- _ =>
-      eapply ih ; [
-        inversion wt ; assumption
-      | inversion wu ; assumption
-      | assumption
-      ]
-    end
-  ].
-  - constructor.
-    assert (wl : Forall T.wf l).
-    { inversion wt. assumption. }
-    assert (wargs' : Forall T.wf args').
-    { inversion wu. assumption. }
-    apply Forall_All in wl.
-    apply Forall_All in wargs'.
-    eapply All2_All_mix_right in a; tea.
-    eapply All2_All_mix_left in a; try exact X.
-    eapply All2_All_mix_left in a; try exact wl.
-    eapply All2_map, All2_impl; tea.
-    clear; cbn. intros x y [H1 [H2 [H3 H4]]]. 
-    apply H2; assumption.
-  - constructor.
-    + constructor. 2: constructor.
-      eapply IHt2.
-      * inversion wt. assumption.
-      * inversion wu. assumption.
-      * assumption.
-    + eapply IHt1.
-      * inversion wt. assumption.
-      * inversion wu. assumption.
-      * assumption.
-  - eapply eq_term_mkApps.
-    + eapply IHt.
-      * inversion wt. assumption.
-      * inversion wu. assumption.
-      * assumption.
-    + pose proof (All2_All_mix_left X a) as h.
-      simpl in h.
-      assert (wl : Forall T.wf l).
-      { inversion wt. assumption. }
-      assert (wargs' : Forall T.wf args').
-      { inversion wu. assumption. }
-      apply Forall_All in wl.
-      apply Forall_All in wargs'.
-      pose proof (All2_All_mix_left wl h) as h1.
-      pose proof (All2_All_mix_right wargs' h1) as h2.
-      simpl in h2.
-      eapply All2_map.
-      eapply All2_impl. 1: exact h2.
-      simpl.
-      intros u v [[? [ih ?]] ?].
-      eapply ih. all: auto.
-  - constructor.
-    all: try solve [
-      match goal with
-      | ih : forall u : Tterm, _ |- _ =>
-        eapply ih ; [
-          inversion wt ; assumption
-        | inversion wu ; assumption
-        | assumption
-        ]
-      end
-    ].
-    assert (wl : All (T.wf ∘ snd) l).
-    { eapply Forall_All. inversion wt. assumption. }
-    assert (wbrs' : All (T.wf ∘ snd) brs').
-    { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
-    pose proof (All2_All_mix_left wl h1) as h2.
-    pose proof (All2_All_mix_right wbrs' h2) as h3.
-    simpl in h3.
-    eapply All2_map.
-    eapply All2_impl. 1: exact h3.
-    simpl.
-    intros [n u] [m v] [[? [ih [? ?]]] ?]. simpl in *.
-    intuition eauto.
-    eapply ih. all: auto.
-  - constructor.
-    assert (
-      w1 :
-        All (fun def =>
-          T.wf (dtype def) /\
-          T.wf (dbody def) /\
-          T.isLambda (dbody def) = true
-        ) m
-    ).
-    { eapply Forall_All. inversion wt. assumption. }
-    assert (
-      w2 :
-        All (fun def =>
-          T.wf (dtype def) /\
-          T.wf (dbody def) /\
-          T.isLambda (dbody def) = true
-        ) mfix'
-    ).
-    { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
-    pose proof (All2_All_mix_left w1 h1) as h2.
-    pose proof (All2_All_mix_right w2 h2) as h3.
-    simpl in h3.
-    eapply All2_map.
-    eapply All2_impl. 1: exact h3.
-    simpl.
-    intros [? ? ? ?] [? ? ? ?] [[[? [? ?]] [[ih1 ih2] [? [? ?]]]] [? [? ?]]].
-    simpl in *.
-    intuition eauto.
-    + eapply ih1. all: auto.
-    + eapply ih2. all: auto.
-  - constructor.
-    assert (
-      w1 :
-        All (fun def => T.wf (dtype def) /\ T.wf (dbody def)) m
-    ).
-    { eapply Forall_All. inversion wt. assumption. }
-    assert (
-      w2 :
-        All (fun def => T.wf (dtype def) /\ T.wf (dbody def)) mfix'
-    ).
-    { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
-    pose proof (All2_All_mix_left w1 h1) as h2.
-    pose proof (All2_All_mix_right w2 h2) as h3.
-    simpl in h3.
-    eapply All2_map.
-    eapply All2_impl. 1: exact h3.
-    simpl.
-    intros [? ? ? ?] [? ? ? ?] [[[? ?] [[ih1 ih2] [? [? ?]]]] [? ?]].
-    simpl in *.
-    intuition eauto.
-    + eapply ih1. all: auto.
-    + eapply ih2. all: auto.
-Qed.
-
-Lemma trans_eq_term_list :
-  forall φ l l',
-    List.Forall T.wf l ->
-    List.Forall T.wf l' ->
-    All2 (TTy.eq_term φ) l l' ->
-    All2 (eq_term φ) (List.map trans l) (List.map trans l').
-Proof.
-  intros φ l l' w w' h.
-  eapply All2_map.
-  apply Forall_All in w. apply Forall_All in w'.
-  pose proof (All2_All_mix_left w h) as h1.
-  pose proof (All2_All_mix_right w' h1) as h2.
-  simpl in h2.
-  apply (All2_impl h2).
-  intuition auto using trans_eq_term.
-Qed.
-
 Lemma leq_term_mkApps ϕ t u t' u' :
   eq_term ϕ t t' -> All2 (eq_term ϕ) u u' ->
   leq_term ϕ (mkApps t u) (mkApps t' u').
@@ -741,7 +574,7 @@ Proof.
       * assumption.
 Qed.
 
-(* TODO REMOVE trans_eq_term *)
+
 Lemma trans_eq_term_upto_univ :
   forall Re Rle t u,
     T.wf t ->
@@ -751,11 +584,10 @@ Lemma trans_eq_term_upto_univ :
 Proof.
   intros Re Rle  t u wt wu e.
   induction t using Induction.term_forall_list_rect in Rle, wt, u, wu, e |- *.
-  all: dependent destruction e.
-  all: simpl.
+  all: invs e; cbn.
   all: try solve [ constructor ; auto ].
   all: try solve [
-    constructor ;
+    repeat constructor ;
     match goal with
     | ih : forall Rle (u : Tterm), _ |- _ =>
       eapply ih ; [
@@ -770,7 +602,7 @@ Proof.
     { eapply Forall_All. inversion wt. assumption. }
     assert (w2 : All T.wf args').
     { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
+    pose proof (All2_All_mix_left X X0) as h1. simpl in h1.
     pose proof (All2_All_mix_left w1 h1) as h2.
     pose proof (All2_All_mix_right w2 h2) as h3.
     simpl in h3.
@@ -780,22 +612,12 @@ Proof.
     intros ? ? [[? [ih ?]] ?].
     simpl in *.
     eapply ih. all: auto.
-  - constructor.
-    + constructor. 2: constructor.
-      eapply IHt2.
-      * inversion wt. assumption.
-      * inversion wu. assumption.
-      * assumption.
-    + eapply IHt1.
-      * inversion wt. assumption.
-      * inversion wu. assumption.
-      * assumption.
   - eapply eq_term_upto_univ_mkApps.
     + eapply IHt.
       * inversion wt. assumption.
       * inversion wu. assumption.
       * assumption.
-    + pose proof (All2_All_mix_left X a) as h.
+    + pose proof (All2_All_mix_left X X1) as h.
       simpl in h.
       assert (wl : Forall T.wf l).
       { inversion wt. assumption. }
@@ -826,7 +648,7 @@ Proof.
     { eapply Forall_All. inversion wt. assumption. }
     assert (wbrs' : All (T.wf ∘ snd) brs').
     { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
+    pose proof (All2_All_mix_left X X2) as h1. simpl in h1.
     pose proof (All2_All_mix_left wl h1) as h2.
     pose proof (All2_All_mix_right wbrs' h2) as h3.
     simpl in h3.
@@ -854,7 +676,7 @@ Proof.
         ) mfix'
     ).
     { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
+    pose proof (All2_All_mix_left X X0) as h1. simpl in h1.
     pose proof (All2_All_mix_left w1 h1) as h2.
     pose proof (All2_All_mix_right w2 h2) as h3.
     simpl in h3.
@@ -875,7 +697,7 @@ Proof.
         All (fun def => T.wf (dtype def) /\ T.wf (dbody def)) mfix'
     ).
     { eapply Forall_All. inversion wu. assumption. }
-    pose proof (All2_All_mix_left X a) as h1. simpl in h1.
+    pose proof (All2_All_mix_left X X0) as h1. simpl in h1.
     pose proof (All2_All_mix_left w1 h1) as h2.
     pose proof (All2_All_mix_right w2 h2) as h3.
     simpl in h3.
@@ -893,6 +715,31 @@ Lemma trans_leq_term ϕ T U :
 Proof.
   intros HT HU H.
   eapply trans_eq_term_upto_univ ; eauto.
+Qed.
+
+Lemma trans_eq_term φ t u :
+    T.wf t -> T.wf u -> TTy.eq_term φ t u ->
+    eq_term φ (trans t) (trans u).
+Proof.
+  intros HT HU H.
+  eapply trans_eq_term_upto_univ ; eauto.
+Qed.
+
+Lemma trans_eq_term_list :
+  forall φ l l',
+    List.Forall T.wf l ->
+    List.Forall T.wf l' ->
+    All2 (TTy.eq_term φ) l l' ->
+    All2 (eq_term φ) (List.map trans l) (List.map trans l').
+Proof.
+  intros φ l l' w w' h.
+  eapply All2_map.
+  apply Forall_All in w. apply Forall_All in w'.
+  pose proof (All2_All_mix_left w h) as h1.
+  pose proof (All2_All_mix_right w' h1) as h2.
+  simpl in h2.
+  apply (All2_impl h2).
+  intuition auto using trans_eq_term.
 Qed.
 
 (* Lemma wf_mkApps t u : T.wf (T.mkApps t u) -> List.Forall T.wf u. *)
@@ -917,7 +764,7 @@ Qed.
 
 Lemma trans_iota_red pars ind c u args brs :
   T.wf (Template.Ast.mkApps (Template.Ast.tConstruct ind c u) args) ->
-  List.Forall (compose T.wf snd) brs ->
+  List.Forall (T.wf ∘ snd) brs ->
   trans (TTy.iota_red pars c args brs) =
   iota_red pars c (List.map trans args) (List.map (on_snd trans) brs).
 Proof.
@@ -1012,7 +859,7 @@ Lemma refine_red1_Γ Σ Γ Γ' t u : Γ = Γ' -> red1 Σ Γ t u -> red1 Σ Γ' t
 Proof.
   intros ->. trivial.
 Qed.
-Ltac wf_inv H := try apply wf_inv in H; simpl in H; repeat destruct_conjs.
+Ltac wf_inv H := try apply wf_inv in H; simpl in H; rdest.
 
 Lemma trans_red1 Σ Γ T U :
   TTy.on_global_env (fun Σ => wf_decl_pred) Σ ->
@@ -1071,7 +918,7 @@ Proof.
 
   - constructor. solve_all.
     apply OnOne2_map. apply (OnOne2_All_mix_left H1) in X. clear H1.
-    solve_all. red. unfold compose in *. simpl in *.
+    solve_all. red. simpl in *.
     intuition eauto.
     apply b2. all: solve_all.
 
@@ -1420,15 +1267,14 @@ Proof.
     now rewrite nth_error_map H0.
     -- eapply trans_wf_local; eauto.
     -- eapply All_map, (All_impl X0).
-       intros x [s [Hs Hts]]. unfold compose; simpl.
+       intros x [s [Hs Hts]].
        now exists s.
     -- apply All_map. eapply All_impl; eauto.
-       unfold compose. simpl. intuition eauto 3 with wf.
+       intuition eauto 3 with wf; cbn.
        rewrite H1. rewrite /trans_local map_length.
-       unfold Template.Ast.app_context in b.
-       rewrite /trans_local map_app in b.
-       rewrite <- trans_lift. apply b.
-       destruct (dbody x); simpl in *; congruence.
+       rewrite /trans_local map_app in X2.
+       rewrite <- trans_lift. apply X2.
+       rdest. destruct (dbody x); simpl in *; congruence.
     -- destruct decl; reflexivity.
 
   - eapply refine_type.
@@ -1442,14 +1288,13 @@ Proof.
     now rewrite nth_error_map H.
     -- eapply trans_wf_local; eauto.
     -- eapply All_map, (All_impl X0).
-       intros x [s [Hs Hts]]. unfold compose; simpl.
-       now exists s.
+       intros x [s [Hs Hts]]. now exists s.
     -- apply All_map. eapply All_impl; eauto.
-       unfold compose. simpl. intuition eauto 3 with wf.
+       intuition eauto 3 with wf.
        rewrite H1. rewrite /trans_local map_length.
-       unfold Template.Ast.app_context in b.
-       rewrite /trans_local map_app in b.
-       rewrite <- trans_lift. apply b.
+       unfold Template.Ast.app_context in X2.
+       rewrite /trans_local map_app in X2.
+       cbn. rewrite <- trans_lift. apply X2.
     -- destruct decl; reflexivity.
 
   - assert (T.wf B).

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -135,7 +135,7 @@ Section Measure.
   Qed.
 
   Lemma Req_trans :
-    forall {Γ}, transitive (Req Γ).
+    forall {Γ}, Transitive (Req Γ).
   Proof.
     intros Γ u v w h1 h2.
     destruct h1.

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -48,8 +48,6 @@ gen-src/environment.ml
 gen-src/environment.mli
 gen-src/equalities.ml
 gen-src/equalities.mli
-gen-src/equality0.ml
-gen-src/equality0.mli
 gen-src/extractable.ml
 gen-src/extractable.mli
 #gen-src/induction.ml

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -24,7 +24,6 @@ MSetDecide
 MSetList
 MSetProperties
 BinNums
-Equality0
 CRelationClasses
 Compare_dec
 MCList

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -116,7 +116,7 @@ Inductive wf : term -> Prop :=
 | wf_tConst k u : wf (tConst k u)
 | wf_tInd i u : wf (tInd i u)
 | wf_tConstruct i k u : wf (tConstruct i k u)
-| wf_tCase ci p c brs : wf p -> wf c -> Forall (Program.Basics.compose wf snd) brs -> wf (tCase ci p c brs)
+| wf_tCase ci p c brs : wf p -> wf c -> Forall (wf ∘ snd) brs -> wf (tCase ci p c brs)
 | wf_tProj p t : wf t -> wf (tProj p t)
 | wf_tFix mfix k : Forall (fun def => wf def.(dtype) /\ wf def.(dbody) /\ isLambda def.(dbody) = true) mfix ->
                    wf (tFix mfix k)

--- a/template-coq/theories/BasicAst.v
+++ b/template-coq/theories/BasicAst.v
@@ -1,5 +1,5 @@
 (* Distributed under the terms of the MIT license.   *)
-From Coq Require Import String Bool List Program.
+From Coq Require Import String Bool List.
 From MetaCoq.Template Require Import utils.
 Local Open Scope string_scope.
 
@@ -158,13 +158,13 @@ Definition tFixProp {A} (P P' : A -> Type) (m : mfixpoint A) :=
   All (fun x : def A => P x.(dtype) * P' x.(dbody))%type m.
 
 Lemma map_def_map_def {A B C} (f f' : B -> C) (g g' : A -> B) (d : def A) :
-  map_def f f' (map_def g g' d) = map_def (fun x => f (g x)) (fun x => f' (g' x)) d.
+  map_def f f' (map_def g g' d) = map_def (f ∘ g) (f' ∘ g') d.
 Proof.
   destruct d; reflexivity.
 Qed.
 
 Lemma compose_map_def {A B C} (f f' : B -> C) (g g' : A -> B) :
-  compose (A:=def A) (map_def f f') (map_def g g') = map_def (compose f g) (compose f' g').
+  (map_def f f') ∘ (map_def g g') = map_def (f ∘ g) (f' ∘ g').
 Proof. reflexivity. Qed.
 
 Lemma map_def_id {t} x : map_def (@id t) (@id t) x = id x.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import List Program BinPos String.
+From Coq Require Import List BinPos String.
 From MetaCoq Require Import utils Ast AstUtils LiftSubst Universes.
 
 (** Pretty printing *)

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -1,7 +1,8 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool String List Program.
-From MetaCoq.Template Require Import config utils Ast AstUtils Induction LiftSubst UnivSubst Typing.
+From Coq Require Import Bool String List.
+From MetaCoq.Template Require Import config utils Ast AstUtils Induction LiftSubst
+     UnivSubst Typing.
 
 Set Asymmetric Patterns.
 
@@ -134,10 +135,10 @@ Proof.
     destruct l; simpl in *; congruence.
     now apply Forall_map.
   - constructor; auto. solve_all.
-  - unfold compose. constructor. solve_all.
+  - constructor. solve_all.
     destruct x; simpl in *. repeat split; tas.
     destruct dbody; simpl in *; congruence.
-  - unfold compose. constructor. solve_all.
+  - constructor. solve_all.
 Qed.
 
 Lemma wf_nth:
@@ -291,7 +292,7 @@ Lemma wf_lift_wf n k t : Ast.wf (lift n k t) -> Ast.wf t.
 Proof.
   induction t in n, k |- * using term_forall_list_ind; simpl in *;
     intros Hwf; inv Hwf; try constructor; eauto;
-      repeat (unfold compose, snd, on_snd in *; simpl in *; solve_all).
+      repeat (unfold snd, on_snd in *; simpl in *; solve_all).
 
   - destruct t; try reflexivity. discriminate.
   - destruct l; simpl in *; congruence.
@@ -383,9 +384,9 @@ Lemma destArity_spec ctx T :
   | None => True
   end.
 Proof.
-  induction T in ctx |- *; simpl; simplify_dep_elim; try easy.
-  specialize (IHT2 (ctx,, vass na T1)). now destruct destArity.
-  specialize (IHT3 (ctx,, vdef na T1 T2)). now destruct destArity.
+  induction T in ctx |- *; simpl; try easy.
+  - specialize (IHT2 (ctx,, vass na T1)). now destruct destArity.
+  - specialize (IHT3 (ctx,, vdef na T1 T2)). now destruct destArity.
 Qed.
 
 
@@ -503,8 +504,7 @@ Proof.
   intros iQ hP hQ.
   induction hP in Q, iQ, hQ |- *.
   1: constructor.
-  dependent destruction hQ.
-  constructor.
+  invs hQ. constructor.
   - eapply IHhP. all: eauto.
   - assumption.
   - assumption.
@@ -616,11 +616,11 @@ Proof.
   - destruct a as [na [bo|] ty].
     + cbn in e. destruct t ; try discriminate.
       eapply IHparams ; try exact e.
-      dependent destruction h. assumption.
+      invs h. assumption.
     + cbn in e. destruct t ; try discriminate.
       destruct args ; try discriminate.
       eapply IHparams ; try exact e.
-      dependent destruction h. assumption.
+      invs h. assumption.
 Qed.
 
 Lemma wf_instantiate_params_subst_ctx :
@@ -638,14 +638,14 @@ Proof.
     subst. assumption.
   - destruct a as [na [bo|] ty].
     + cbn in e. destruct t ; try discriminate.
-      dependent destruction hp. destruct H as [h1 h2]. simpl in h1, h2.
+      invs hp. destruct H1 as [h1 h2]. simpl in h1, h2.
       eapply IHparams ; try exact e ; try assumption.
       constructor ; try assumption.
       eapply wf_subst ; assumption.
     + cbn in e. destruct t ; try discriminate.
       destruct args ; try discriminate.
-      dependent destruction hp. simpl in *.
-      dependent destruction ha.
+      invs hp. simpl in *.
+      invs ha.
       eapply IHparams ; try exact e ; try assumption.
       constructor ; assumption.
 Qed.

--- a/template-coq/theories/UnivSubst.v
+++ b/template-coq/theories/UnivSubst.v
@@ -140,6 +140,6 @@ Proof.
   induction t in |- * using term_forall_list_ind; simpl; auto; intros H';
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length, ?forallb_map;
     try f_equal; auto with substu;
-      unfold test_def, map_def, Basics.compose in *;
+      unfold test_def, map_def in *;
       try solve [f_equal; eauto; repeat (rtoProp; solve_all); intuition auto with substu].
 Qed.

--- a/template-coq/theories/WfInv.v
+++ b/template-coq/theories/WfInv.v
@@ -1,7 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Program Arith Lia
-     ssreflect ssrbool.
+From Coq Require Import Bool List Arith Lia ssreflect ssrbool.
 From MetaCoq.Template Require Import config utils Ast AstUtils.
 
 
@@ -17,7 +16,7 @@ Fixpoint wf_Inv (t : term) :=
   | tLetIn na t b b' => wf t /\ wf b /\ wf b'
   | tApp t u => isApp t = false /\ u <> nil /\ wf t /\ Forall wf u
   | tConst _ _ | tInd _ _ | tConstruct _ _ _ => True
-  | tCase ci p c brs => wf p /\ wf c /\ Forall (Program.Basics.compose wf snd) brs
+  | tCase ci p c brs => wf p /\ wf c /\ Forall (wf ∘ snd) brs
   | tProj p t => wf t
   | tFix mfix k => Forall (fun def => wf def.(dtype) /\ wf def.(dbody) /\ isLambda def.(dbody) = true) mfix
   | tCoFix mfix k => Forall (fun def => wf def.(dtype) /\ wf def.(dbody)) mfix
@@ -79,7 +78,7 @@ Fixpoint wf_term (t : term) : bool :=
   | tLetIn na t b b' => wf_term t && wf_term b && wf_term b'
   | tApp t u => ~~ isApp t && ~~ is_empty u && wf_term t && forallb wf_term u
   | tConst _ _ | tInd _ _ | tConstruct _ _ _ => true
-  | tCase ci p c brs => wf_term p && wf_term c && forallb (Program.Basics.compose wf_term snd) brs
+  | tCase ci p c brs => wf_term p && wf_term c && forallb (wf_term ∘ snd) brs
   | tProj p t => wf_term t
   | tFix mfix k =>
     forallb (fun def => wf_term def.(dtype) && wf_term def.(dbody) && isLambda def.(dbody)) mfix

--- a/template-coq/theories/utils.v
+++ b/template-coq/theories/utils.v
@@ -1,4 +1,4 @@
-From Coq Require Import Nat ZArith Bool Program.
+From Coq Require Import Nat ZArith Bool.
 Global Set Asymmetric Patterns.
 
 
@@ -29,10 +29,9 @@ Tactic Notation "destruct" "?" "in" hyp(H) :=
 Notation "'eta_compose'" := (fun g f x => g (f x)).
 
 (* \circ *)
-Notation "g ∘ f" := (eta_compose g f).
+Notation "g ∘ f" := (eta_compose g f) (at level 40, left associativity).
 
-Tactic Notation "apply*" constr(H) "in" hyp(H')
-  := apply H in H'; [..|apply H].
+Notation " ! " := (@False_rect _ _) : program_scope.
 
 Ltac cbnr := cbn; try reflexivity.
 
@@ -170,8 +169,10 @@ Tactic Notation "forward" constr(H) "by" tactic(tac) := forward_gen H tac.
 
 Hint Resolve Peano_dec.eq_nat_dec : eq_dec.
 
-
 Ltac invs H := inversion H; subst; clear H.
+
+Ltac generalize_eq x t :=
+  set (x := t) in *; cut (x = t); [|reflexivity]; clearbody x.
 
 
 Lemma iff_forall {A} B C (H : forall x : A, B x <-> C x)
@@ -203,7 +204,10 @@ Qed.
 
 Ltac tas := try assumption.
 Ltac tea := try eassumption.
+Ltac trea := try reflexivity; try eassumption.
 
 Axiom todo : String.string -> forall {A}, A.
 Ltac todo s := exact (todo s).
+
+From Coq Require Import Extraction.
 Extract Constant todo => "fun s -> failwith (String.concat """" (List.map (String.make 1) s))".

--- a/template-coq/theories/utils/MCEquality.v
+++ b/template-coq/theories/utils/MCEquality.v
@@ -3,3 +3,8 @@ Definition transport {A} (P : A -> Type) {x y : A} (e : x = y) : P x -> P y
   := fun u => eq_rect x P u y e.
 
 Notation "p # x" := (transport _ p x) (right associativity, at level 65).
+
+(* to convert some eq_rects into transports *)
+Lemma eq_rect_transport A x P u y p
+  : @eq_rect A x P u y p = transport P p u.
+Proof. reflexivity. Defined.

--- a/template-coq/theories/utils/MCList.v
+++ b/template-coq/theories/utils/MCList.v
@@ -1,6 +1,6 @@
-From Coq Require Import Bool Program Arith Lia SetoidList.
+From Coq Require Import Bool Arith Lia SetoidList.
 
-Import ListNotations.
+Export ListNotations.
 
 Notation "#| l |" := (List.length l) (at level 0, l at level 99, format "#| l |").
 Arguments nil {_}, _.
@@ -26,7 +26,7 @@ Definition mapi {A B} (f : nat -> A -> B) (l : list A) := mapi_rec f l 0.
 
 Program Fixpoint safe_nth {A} (l : list A) (n : nat | n < List.length l) : A :=
   match l with
-  | nil => !
+  | nil => _
   | hd :: tl =>
     match n with
     | 0 => hd
@@ -34,7 +34,7 @@ Program Fixpoint safe_nth {A} (l : list A) (n : nat | n < List.length l) : A :=
     end
   end.
 Next Obligation.
-  simpl in H. inversion H.
+  exfalso. simpl in H. inversion H.
 Defined.
 Next Obligation.
   simpl in H. auto with arith.
@@ -158,9 +158,8 @@ Defined.
 
 Lemma map_map_compose :
   forall (A B C : Type) (f : A -> B) (g : B -> C) (l : list A),
-    map g (map f l) = map (compose g f) l.
+    map g (map f l) = map (fun x => g (f x)) l.
 Proof. apply map_map. Qed.
-Hint Unfold compose : terms.
 
 Lemma map_id_f {A} (l : list A) (f : A -> A) :
   (forall x, f x = x) ->
@@ -325,18 +324,6 @@ Lemma nth_map {A} (f : A -> A) n l d :
   nth n (map f l) d = f (nth n l d).
 Proof.
   induction n in l |- *; destruct l; simpl; auto.
-Qed.
-
-Lemma nlt_map {A B} (l : list A) (f : A -> B) (n : {n | n < length l }) : `n < length (map f l).
-Proof. destruct n. simpl. now rewrite map_length. Defined.
-
-Lemma map_def_safe_nth {A B} (l : list A) (n : {n | n < length l}) (f : A -> B) :
-  f (safe_nth l n) = safe_nth (map f l) (exist _ (`n) (nlt_map l f n)).
-Proof.
-  destruct n.
-  induction l in x, l0 |- *. simpl. bang.
-  simpl. destruct x. reflexivity. simpl.
-  rewrite IHl. f_equal. f_equal. pi.
 Qed.
 
 Lemma mapi_map {A B C} (f : nat -> B -> C) (l : list A) (g : A -> B) :
@@ -597,7 +584,7 @@ Lemma nth_error_removelast {A} (args : list A) n :
   n < Nat.pred #|args| -> nth_error args n = nth_error (removelast args) n.
 Proof.
   induction n in args |- *; destruct args; intros; auto.
-  simpl. destruct args. depelim H. reflexivity.
+  simpl. destruct args. inversion H. reflexivity.
   simpl. rewrite IHn. simpl in H. auto with arith.
   destruct args, n; reflexivity.
 Qed.

--- a/template-coq/theories/utils/MCProd.v
+++ b/template-coq/theories/utils/MCProd.v
@@ -45,10 +45,8 @@ Qed.
 Lemma snd_on_snd {A B C} (f : B -> C) (p : A * B) : snd (on_snd f p) = f (snd p).
 Proof. destruct p; reflexivity. Qed.
 
-Require Import Program.
-
 Lemma compose_on_snd {A B C D} (f : C -> D) (g : B -> C) :
-  compose (A:=A * B) (on_snd f) (on_snd g) = on_snd (compose f g).
+  (fun (x : A * B) => (on_snd f) (on_snd g x)) = on_snd (fun x => f (g x)).
 Proof.
   reflexivity.
 Qed.

--- a/template-coq/theories/utils/MCRelations.v
+++ b/template-coq/theories/utils/MCRelations.v
@@ -12,3 +12,19 @@ Notation Trel_conj R S :=
 
 Notation on_Trel_eq R f g :=
   (fun x y => (R (f x) (f y) * (g x = g y)))%type.
+
+(* Definition MR {T M} (R : M -> M -> Prop) (m : T -> M) (x y: T): Prop := R (m x) (m y). *)
+
+(* From measure_wf of Program.Wf *)
+Lemma wf_precompose {T M} (R : M -> M -> Prop) (m : T -> M) :
+  well_founded R -> well_founded (precompose R m).
+Proof with auto.
+  unfold well_founded. intro wf.
+  cut (forall (a: M) (a0: T), m a0 = a -> Acc (precompose R m) a0).
+  + intros.
+    apply (H (m a))...
+  + apply (@well_founded_ind M R wf (fun mm => forall a, m a = mm -> Acc _ a)).
+    intros. apply Acc_intro.
+    intros. rewrite H0 in H1. apply (H (m y))...
+Defined.
+

--- a/template-coq/theories/utils/wGraph.v
+++ b/template-coq/theories/utils/wGraph.v
@@ -937,7 +937,7 @@ Module WeightedGraph (V : UsualOrderedType).
             clear -d.
             intro a; split; intro Ha.
             * apply VSet.remove_spec in Ha. pose proof (d.p1 a).
-              intuition.
+              intuition. now symmetry in H2.
             * apply VSet.remove_spec. split.
               apply d. right; assumption.
               intro H. apply proj2 in d. apply d. subst; assumption. }
@@ -1662,13 +1662,15 @@ Module WeightedGraph (V : UsualOrderedType).
       etransitivity. apply leq_vertices_caract. unfold leqb_vertices.
       destruct (VSet.mem y (V G)).
       - destruct (le_dec (Some n) (lsp G x y)); cbn; intuition.
+        discriminate.
       - symmetry; etransitivity. apply andb_and.
         apply Morphisms_Prop.and_iff_morphism.
         apply PeanoNat.Nat.eqb_eq.
         etransitivity. apply orb_true_iff.
         apply Morphisms_Prop.or_iff_morphism.
-        destruct (V.eq_dec x y); cbn; intuition.
+        destruct (V.eq_dec x y); cbn; intuition; try discriminate.
         destruct (le_dec (Some 0) (lsp G x (s G))); cbn; intuition.
+        discriminate.
     Qed.
 
   End graph2.


### PR DESCRIPTION
I **totally** removed Program from template-coq and pcuic.
As a drawbacks:
- we don't have access anymore to some useful tactics (especially depelim and do one) and notations

As advantage:
- no JMeq/UIP at all!
- no `unfold compose` anymore

I added the following replacement of `generalize_eqs` to utils:
```
Ltac generalize_eq x t :=
  set (x := t) in *; cut (x = t); [|reflexivity]; clearbody x.
```

Please use Equations instead of Program to do `dependent induction`, `depelim` and so one in pcuic.
You may need to add `Require Import Equations.Prop.DepElim.`.
And in template-coq, please ... do without both! Yes, it is very painful.

The work remains to be done in checker, safechecker and erasure.