### PR TITLE
Moving names of primitive atomic tactics from Coq.Init.Notations to Coq.Init.Ltac

### DIFF
--- a/translations/MiniHoTT.v
+++ b/translations/MiniHoTT.v
@@ -64,7 +64,7 @@ Arguments symmetry {A R _} / _ _ _.
 Arguments transitivity {A R _} / {_ _ _} _ _.
 
 Ltac reflexivity :=
-  Coq.Init.Notations.reflexivity
+  Coq.Init.Ltac.reflexivity
   || (intros;
       let R := match goal with |- ?R ?x ?y => constr:(R) end in
       let pre_proof_term_head := constr:(@reflexivity _ R _) in

--- a/translations/MiniHoTT_paths.v
+++ b/translations/MiniHoTT_paths.v
@@ -68,7 +68,7 @@ Arguments symmetry {A R _} / _ _ _.
 Arguments transitivity {A R _} / {_ _ _} _ _.
 
 Ltac reflexivity :=
-  Coq.Init.Notations.reflexivity
+  Coq.Init.Ltac.reflexivity
   || (intros;
       let R := match goal with |- ?R ?x ?y => constr:(R) end in
       let pre_proof_term_head := constr:(@reflexivity _ R _) in


### PR DESCRIPTION
There is a Coq PR coq/coq#12023 which introduces a specific file `Ltac.v` to activate the ltac plugin. This implies a change of qualification of the primitive atomic tactics from Coq.Init.Notations to Coq.Init.Ltac.

This PR adapts MetaCoq to the change.

Maybe a backward-compatible fix is possible but the proposed PR is not: I just adapted the code word by word.