### PR TITLE
Turn one admit into a todo on projections, an prove wellformed_R_pres

### DIFF
--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List Arith Lia.
+From Coq Require Import String Bool List Arith Lia.
 From MetaCoq.Template Require Import config monad_utils utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICPrincipality PCUICConfluence
@@ -266,6 +266,37 @@ Section Lemmata.
   Lemma wellformed_irr :
     forall {Σ Γ t} (h1 h2 : wellformed Σ Γ t), h1 = h2.
   Proof. intros. apply ProofIrrelevance.proof_irrelevance. Qed.
+(* 
+  Lemma typing_eq_term :
+    forall Γ u v A,
+      wf Σ.1 ->
+      Σ ;;; Γ |- u : A ->
+      eq_term (global_ext_constraints Σ) u v ->
+      Σ ;;; Γ |- v : A.
+  Abort. *)
+
+  (* TODO MOVE It needs wf Σ entirely *)
+  (* Lemma subject_conversion :
+    forall Γ u v A B,
+      wf Σ.1 ->
+      Σ ;;; Γ |- u : A ->
+      Σ ;;; Γ |- v : B ->
+      Σ ;;; Γ |- u = v ->
+      ∑ C,
+        Σ ;;; Γ |- u : C ×
+        Σ ;;; Γ |- v : C.
+  Proof.
+    intros Γ u v A B hΣ hu hv h.
+    apply conv_alt_red in h as [u' [v' [[? ?] ?]]].
+    pose proof (subject_reduction _ Γ _ _ _ hΣ hu r) as hu'.
+    pose proof (subject_reduction _ Γ _ _ _ hΣ hv r0) as hv'.
+    pose proof (typing_eq_term _ _ _ _ hΣ hu' e) as hv''.
+    pose proof (principal_typing _ hΣ hv' hv'') as [C [? [? hvC]]]. *)
+    (* apply eq_term_sym in e as e'. *)
+    (* pose proof (typing_alpha _ _ _ _ hvC e') as huC. *)
+    (* Not clear.*)
+  (* Abort.
+   *)
 
   Context (hΣ : ∥ wf Σ ∥).
 
@@ -1328,28 +1359,7 @@ Section Lemmata.
       + assumption.
   Qed.
 
-  (* TODO MOVE It needs wf Σ entirely *)
-  Lemma subject_conversion :
-    forall Γ u v A B,
-      Σ ;;; Γ |- u : A ->
-      Σ ;;; Γ |- v : B ->
-      Σ ;;; Γ |- u = v ->
-      ∑ C,
-        Σ ;;; Γ |- u : C ×
-        Σ ;;; Γ |- v : C.
-  Proof.
-    intros Γ u v A B hu hv h.
-    (* apply conv_conv_alt in h. *)
-    (* apply conv_alt_red in h as [u' [v' [? [? ?]]]]. *)
-    (* pose proof (subject_reduction _ Γ _ _ _ hΣ hu r) as hu'. *)
-    (* pose proof (subject_reduction _ Γ _ _ _ hΣ hv r0) as hv'. *)
-    (* pose proof (typing_alpha _ _ _ _ hu' e) as hv''. *)
-    (* pose proof (principal_typing _ hv' hv'') as [C [? [? hvC]]]. *)
-    (* apply eq_term_sym in e as e'. *)
-    (* pose proof (typing_alpha _ _ _ _ hvC e') as huC. *)
-    (* Not clear.*)
-  Abort.
-  
+
   Derive Signature for typing.
 
   Lemma Proj_red_cond :
@@ -1362,11 +1372,12 @@ Section Lemmata.
     destruct hΣ.
     apply inversion_Proj in h; auto.
     destruct h as [uni [mdecl [idecl [pdecl [args' [d [hc [? ?]]]]]]]].
-    eapply on_declared_projection in d; auto. destruct d as [? [? ?]]; auto.
+    eapply on_declared_projection in d; auto. simpl in d. destruct d as [? [? ?]]; auto.
     simpl in *.
     destruct p.
     destruct o0; auto.
-  Admitted.
+    todo "projection invariant"%string.
+  Qed.
 
   Lemma cored_zipc :
     forall Γ t u π,

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -963,7 +963,13 @@ Section Reduce.
 
   Lemma wellformed_R_pres Γ :
     forall x y : term × stack, wellformed Σ Γ (zip x) -> R Σ Γ y x -> wellformed Σ Γ (zip y).
-  Proof. intros. todo "wellformed_R_pres proof"%string. Admitted.
+  Proof.
+    intros x y H HR.
+    depelim HR.
+    - eapply cored_wellformed; eauto.
+    - simpl in H1. revert H1; intros [= H2 _].
+      now rewrite <- H2.
+  Qed.
 
   Equations reduce_stack_full (Γ : context) (t : term) (π : stack)
            (h : wellformed Σ Γ (zip (t,π))) : { t' : term * stack | Req Σ Γ t' (t, π) /\ Pr t' π /\ Pr' t' } :=


### PR DESCRIPTION
This cleans the safechecker of the last remaining admitted proofs. I will now work on filling the projection-related todos.