### PR TITLE
Remove universe constraint between "option" and (non-extractable) Template Monad

### DIFF
--- a/template-coq/src/constr_quoted.ml
+++ b/template-coq/src/constr_quoted.ml
@@ -75,6 +75,9 @@ struct
   let cSome = resolve "metacoq.option.some"
   let cNone = resolve "metacoq.option.none"
 
+  let cSome_instance = resolve "metacoq.option_instance.some"
+  let cNone_instance = resolve "metacoq.option_instance.none"
+
   let unit_tt = resolve "metacoq.unit.intro"
   
   let tAscii = resolve "metacoq.ascii.intro"

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -482,9 +482,9 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
         | None -> evm, typ in
       try
         let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
-        k (env, evm, constr_mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
+        k (env, evm, constr_mkApp (cSome_instance, [| typ; EConstr.to_constr evm t|]))
       with
-        Not_found -> k (env, evm, constr_mkApp (cNone, [|typ|]))
+        Not_found -> k (env, evm, constr_mkApp (cNone_instance, [|typ|]))
     end
   | TmInferInstanceTerm typ ->
     let evm,typ = denote_term evm (reduce_all env evm typ) in

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -20,6 +20,8 @@ Register Coq.Init.Datatypes.false as metacoq.bool.false.
 Register Coq.Init.Datatypes.option as metacoq.option.type.
 Register Coq.Init.Datatypes.None as metacoq.option.none.
 Register Coq.Init.Datatypes.Some as metacoq.option.some.
+Register MetaCoq.Template.TemplateMonad.Common.my_None as metacoq.option_instance.none.
+Register MetaCoq.Template.TemplateMonad.Common.my_Some as metacoq.option_instance.some.
 
 Register Coq.Init.Datatypes.list as metacoq.list.type.
 Register Coq.Init.Datatypes.nil as metacoq.list.nil.

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -16,6 +16,10 @@ Record typed_term : Type := existT_typed_term
 ; my_projT2 : my_projT1
 }.
 
+Monomorphic Inductive option_instance (A : Type) : Type := my_Some : A -> option_instance A | my_None : option_instance A.
+
+Arguments Some {A} a.
+Arguments None {A}.
 
 Record TMInstance@{t u r} :=
 { TemplateMonad : Type@{t} -> Type@{r}

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -55,7 +55,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 
 (* Typeclass registration and querying for an instance *)
 | tmExistingInstance : qualid -> TemplateMonad unit
-| tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option A)
+| tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option_instance A)
 .
 
 From MetaCoq.Template Require Import monad_utils.

--- a/test-suite/tmInferInstance.v
+++ b/test-suite/tmInferInstance.v
@@ -8,3 +8,13 @@ Existing Instance I.
 
 MetaCoq Run (tmInferInstance None True >>= tmPrint).
 MetaCoq Run (tmInferInstance None False >>= tmPrint).
+
+Section noFixUniverse.
+  Set Printing Universes.
+
+  Universes u__opt u1 u2.
+  Let set_u__opt :=  (option : Type@{u__opt} -> Type).
+  Constraint u__opt < u1.
+
+  Check ( tmInferInstance@{u1 u2}).
+End noFixUniverse.


### PR DESCRIPTION
As `tmInferInstance` uses the `option`-type, it forces the constrain that the universe of the monadic result is not in a larger universe than the universe over which `option` operates (`option.u0`). This can be witnesses by `Set Printing Universes. Print TemplateMonad.`, printing the following:

```
  (* +t =u |= u < t
            Coq.MSets.MSetInterface.3 <= t
            mfixpoint.u0 <= t
            program.u0 <= t
            t <= option.u0 *)
```

This breaks our use in https://github.com/uds-psl/coq-library-undecidability , as I can not quote certain definitions using option. 

I fixed this by providing a copy of `option` for the use in the non-extractable monad. I also added a test that the option universe is not constrained to the test-suite.

The fix is very similar to something already in the monad: The same problem would occur with `tmUnquote`, but is circumvented as a custom copy of `sigT` (namely `typed_term`) is used. So I think this universe constraint is a bug and my approach is the `right` fix.

In general, I think that Template Coq should not introduce any constrains on universes of the standard library, as otherwise it can not operate with external definitions in general. So maybe something should be done about `Coq.MSets.MSetInterface.3 <= t`, too.

This fixes/subsumes #329 and #74 .