### PR TITLE
Fill proofs about elimination restrictions

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -442,7 +442,7 @@ Proof.
   revert u H c0.
   induction t1; intros.
   - eapply cumul_prop2 in c0; eauto.
-  - eapply cumul_prop2 in c0. 2:eauto. 2:auto. 2:eauto. 2:eauto. 3:eauto.
+  - eapply cumul_prop2 in c0. 5:eauto. all:eauto.
     eapply invert_cumul_prod_r in c as (? & ? & ? & [] & ?); eauto.
     eapply subject_reduction in c0. 3:eauto. 2:eauto.
     eapply inversion_Prod in c0 as (? & ? & ? & ? & ?) ; auto.
@@ -453,7 +453,6 @@ Proof.
     change (tSort x3) with ((tSort x3) {0 := hd}).
     eapply PCUICSubstitution.substitution0. 2:eauto. eauto.
     econstructor. eassumption. 2: now destruct c. right; eauto.
-    apply i.
 Qed.
 
 Lemma arity_type_inv (Σ : global_env_ext) Γ t T1 T2 : wf Σ -> wf_local Σ Γ ->

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -421,17 +421,28 @@ Proof.
   - right. eexists. eapply subject_reduction ; eauto.
 Qed.
 
+Lemma typing_spine_wat (Σ : global_env_ext) (Γ : context) (L : list term)
+  (x x0 : term) :
+    wf Σ ->
+    typing_spine Σ Γ x L x0 -> 
+    isWfArity_or_Type Σ Γ x0.
+Proof.
+  intros wfΣ; induction 1; auto.
+Qed.
+
 Lemma sort_typing_spine:
   forall (Σ : global_env_ext) (Γ : context) (L : list term) (u : Universe.t) (x x0 : term),
     wf Σ ->
     Universe.is_prop u ->
-    typing_spine Σ Γ x L x0 -> Σ;;; Γ |- x : tSort u -> ∑ u', Σ;;; Γ |- x0 : tSort u' × Universe.is_prop u'.
+    typing_spine Σ Γ x L x0 -> 
+    Σ;;; Γ |- x : tSort u -> 
+    ∑ u', Σ;;; Γ |- x0 : tSort u' × Universe.is_prop u'.
 Proof.
   intros Σ Γ L u x x0 ? ? t1 c0.
   revert u H c0.
-  depind t1; intros.
+  induction t1; intros.
   - eapply cumul_prop2 in c0; eauto.
-  - eapply cumul_prop2 in c0. 2:eauto. 2:auto. 2:eauto. 2:eauto.
+  - eapply cumul_prop2 in c0. 2:eauto. 2:auto. 2:eauto. 2:eauto. 3:eauto.
     eapply invert_cumul_prod_r in c as (? & ? & ? & [] & ?); eauto.
     eapply subject_reduction in c0. 3:eauto. 2:eauto.
     eapply inversion_Prod in c0 as (? & ? & ? & ? & ?) ; auto.
@@ -442,6 +453,7 @@ Proof.
     change (tSort x3) with ((tSort x3) {0 := hd}).
     eapply PCUICSubstitution.substitution0. 2:eauto. eauto.
     econstructor. eassumption. 2: now destruct c. right; eauto.
+    apply i.
 Qed.
 
 Lemma arity_type_inv (Σ : global_env_ext) Γ t T1 T2 : wf Σ -> wf_local Σ Γ ->
@@ -495,6 +507,8 @@ Proof.
     eapply cumul_prop2 in c0; eauto.
     econstructor. exists x0. split. eapply type_mkApps. 2:eassumption. eassumption. right.
     eapply sort_typing_spine in t1; eauto.
+    now eapply PCUICValidity.validity in t0.
+    now apply PCUICValidity.validity in t2.
 Qed.
 
 Lemma Is_type_lambda (Σ : global_env_ext) Γ na T1 t :
@@ -504,7 +518,7 @@ Lemma Is_type_lambda (Σ : global_env_ext) Γ na T1 t :
   ∥isErasable Σ (vass na T1 :: Γ) t∥.
 Proof.
   intros ? ? (T & ? & ?).
-  eapply inversion_Lambda in t0 as (? & ? & ? & ? & ?).
+  eapply inversion_Lambda in t0 as (? & ? & ? & ? & ?); auto.
   destruct s as [ | (u & ? & ?)].
   - eapply invert_cumul_arity_r in c; eauto. destruct c as (? & [] & ?).
     eapply invert_red_prod in X1 as (? & ? & [] & ?); eauto; subst. cbn in H.
@@ -516,7 +530,8 @@ Proof.
     eapply leq_universe_prop in c as []; cbn; eauto.
     eexists. split. eassumption. right. eexists. split. eassumption.
     eapply is_prop_sort_prod; eassumption.
-  - auto.
+    eapply type_Lambda in t1; eauto.
+    now apply PCUICValidity.validity in t1.
 Qed.
 
 Lemma Is_type_red (Σ : global_env_ext) Γ t v:

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -438,7 +438,9 @@ Next Obligation.
 
        eapply leq_universe_prop in l0 as []; cbn; eauto.
        eapply leq_universe_prop in l as []; cbn; eauto.
-       reflexivity.
+       2:reflexivity. now right; exists x0.
+       now apply PCUICValidity.validity in X1.
+       now apply PCUICValidity.validity in t2.
   - sq. econstructor. eauto.
 Qed.
 

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -285,7 +285,9 @@ Next Obligation.
 
     eapply leq_universe_prop in l0 as []; cbn; eauto.
     eapply leq_universe_prop in l as []; cbn; eauto.
-    reflexivity.
+    2:reflexivity. now right; exists x0.
+    now apply PCUICValidity.validity in X1.
+    now apply PCUICValidity.validity in t2.
 Qed.
 
 (* Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (HΓ : ∥wf_local Sigma Gamma∥) (t : PCUICAst.term) : *)

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -69,17 +69,49 @@ induction n; intros ctx Hlen Γ T HT.
       rewrite -> app_length in Hlen.
       rewrite Nat.add_1_r in Hlen.
       destruct HT as [na' [A' [B' [[redT convT] HT]]]].
-      specialize (IHn ctx ltac:(lia) (Γ ,, vass na ty) B' HT). clear IHctx.
+      specialize (IHn ctx ltac:(lia) (Γ ,, vass na' A') B').
+      forward IHn. eapply cumul_conv_ctx; eauto.
+      constructor; pcuic. clear IHctx.
       destruct IHn as [T' [ctx' [s' [[[redT' destT] convctx] leq]]]].
       exists (tProd na' A' T'), (ctx' ++ [vass na' A'])%list, s'. intuition auto. 2:simpl.
       -- transitivity (tProd na' A' B'); auto.
-        eapply red_prod. reflexivity.
-        todo"red context conv"%string.
+        eapply red_prod. reflexivity. apply redT'.
       -- now rewrite destArity_app destT.
       -- rewrite smash_context_app /= .
-         rewrite !app_context_assoc. simpl.
-         eapply conv_context_trans with (Γ ,, vass na ty ,,, ctx'); auto.
-         todo "conv context"%string.
+         rewrite !app_context_assoc.
+         assert (#|smash_context [] ctx| = #|ctx'|).
+         { apply context_relation_length in convctx.
+          autorewrite with len in convctx.
+          simpl in convctx. lia. }
+        eapply context_relation_app_inv; auto.
+        apply context_relation_app in convctx; auto.
+        constructor; pcuic.
+        eapply context_relation_app in convctx as [_ convctx].
+        unshelve eapply (context_relation_impl _ convctx).
+        simpl; firstorder. destruct X. constructor.
+        eapply conv_conv_ctx; eauto.
+        eapply context_relation_app_inv. constructor; pcuic.
+        constructor; pcuic. constructor; pcuic. now symmetry.
+        apply context_relation_refl. intros.
+        destruct x as [na'' [b'|] ty']; constructor; reflexivity.
+        constructor; pcuic. 
+        eapply conv_conv_ctx; eauto.
+        eapply context_relation_app_inv. constructor; pcuic.
+        constructor; pcuic. constructor; pcuic. now symmetry.
+        apply context_relation_refl. intros.
+        destruct x as [na'' [b'|] ty']; constructor; reflexivity.
+        constructor; pcuic.
+        eapply conv_conv_ctx; eauto.
+        eapply context_relation_app_inv. constructor; pcuic.
+        constructor; pcuic. constructor; pcuic. now symmetry.
+        apply context_relation_refl. intros.
+        destruct x as [? [?|] ?]; constructor; reflexivity.
+        eapply conv_conv_ctx; eauto.
+        eapply context_relation_app_inv. constructor; pcuic.
+        constructor; pcuic. constructor; pcuic. now symmetry.
+        apply context_relation_refl. intros.
+        destruct x as [? [?|] ?]; constructor; reflexivity.
+        auto.
 Qed.
 
 

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -1,9 +1,15 @@
 (* Distributed under the terms of the MIT license.   *)
 
-From Coq Require Import Bool List.
+From Coq Require Import String Arith Bool List Lia.
 From MetaCoq.Template Require Import config utils Universes.
-From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst
-     PCUICSR PCUICInversion PCUICSafeLemmata.
+From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils
+     PCUICLiftSubst PCUICInductives PCUICGeneration PCUICSpine PCUICWeakeningEnv
+     PCUICSubstitution PCUICUnivSubst PCUICUnivSubstitution
+     PCUICCtxShape PCUICConversion PCUICCumulativity PCUICConfluence PCUICContexts
+     PCUICSR PCUICInversion PCUICValidity PCUICSafeLemmata PCUICContextConversion.
+Require Equations.Prop.DepElim.
+From Equations Require Import Equations.
+Require Import ssreflect.
 
 Definition Is_proof `{cf : checker_flags} Σ Γ t := ∑ T u, Σ ;;; Γ |- t : T × Σ ;;; Γ |- T : tSort u × Universe.is_prop u.
 
@@ -36,7 +42,7 @@ Definition Computational `{cf : checker_flags} (Σ : global_env_ext) (ind : indu
       welltyped Σ' Γ (mkApps (tConstruct ind n u) args) ->
       Is_proof Σ' Γ (mkApps (tConstruct ind n u) args) -> False.
 
-Definition Informative`{cf : checker_flags} (Σ : global_env_ext) (ind : inductive) :=
+Definition Informative `{cf : checker_flags} (Σ : global_env_ext) (ind : inductive) :=
   forall mdecl idecl,
     declared_inductive (fst Σ) mdecl ind idecl ->
     forall Γ args u n (Σ' : global_env_ext),
@@ -54,36 +60,452 @@ Qed.
 Lemma elim_restriction_works_kelim1 `{cf : checker_flags} (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
   declared_inductive (fst Σ) mind ind idecl ->
   Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
-  (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> ind_kelim idecl = InType.
+  (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) ->
+  ind_kelim idecl = InType \/ ind_kelim idecl = InSet.
 Proof.
   intros wfΣ. intros.
   assert (HT := X).
   eapply inversion_Case in X as [uni [args [mdecl [idecl' [ps [pty [btys
                                    [? [? [? [? [? [? [ht0 [? ?]]]]]]]]]]]]]]]; auto.
-  repeat destruct ?; try congruence. subst. inv e0.
+  repeat destruct ?; try congruence. subst.
   eapply declared_inductive_inj in d as []. 2:exact H. subst.
-  enough (universe_family ps = InType). rewrite H1 in i.
-  now apply leb_sort_family_intype in i. 
-Admitted.                       (* elim_restriction_works *)
+  enough (universe_family ps <> InProp).
+  { clear -i H1.
+    unfold universe_family in *.
+    unfold leb_sort_family in i.
+    destruct (Universe.is_prop ps); auto. congruence.
+    destruct (Universe.is_small ps);
+    destruct (ind_kelim idecl); intuition congruence. }
+  intros Huf. apply H0.
+  red. exists (mkApps p (skipn (ind, npar).2 args ++ [c])); intuition auto.
+  exists ps.
+  intuition auto.
+  econstructor; eauto.
+  assert (watiapp := env_prop_typing  _ _ validity _ _ _ _ _ t0).
+  simpl in watiapp.
+  eapply (isWAT_mkApps_Ind wfΣ H) in watiapp as [psub [asub [[spp spa] cuni]]]; eauto.
+  2:eapply typing_wf_local; eauto.
+  destruct on_declared_inductive as [oi oib] in *. simpl in *.
+  eapply (build_case_predicate_type_spec _ _ _ _ _ _ _ _ oib) in e0 as [parsubst [cs eq]].
+  rewrite eq in t.
+  eapply PCUICGeneration.type_mkApps. eauto.
+  eapply wf_arity_spine_typing_spine; auto.
+  split; auto.
+  now eapply validity in t.
+  eapply arity_spine_it_mkProd_or_LetIn; eauto.
+  subst npar.
+  pose proof (PCUICContexts.context_subst_fun cs spp). subst psub. clear cs.
+  eapply spa.
+  simpl. constructor.
+  rewrite PCUICLiftSubst.subst_mkApps. simpl.
+  rewrite map_app map_map_compose.
+  rewrite PCUICLiftSubst.map_subst_lift_id_eq. 
+  { rewrite - (PCUICSubstitution.context_subst_length _ _ _ spa).
+      now autorewrite with len. }
+  { unfold to_extended_list. 
+    rewrite (spine_subst_subst_to_extended_list_k_gen spa).
+    unfold subst_context; rewrite to_extended_list_k_fold_context.
+    apply PCUICSubstitution.map_subst_instance_constr_to_extended_list_k.
+    subst npar.
+    now rewrite firstn_skipn. }
+  - constructor.
+    * left; eexists _, _; intuition eauto. simpl.
+      eapply typing_wf_local; eauto.
+    * reflexivity.
+  - unfold universe_family in Huf.
+    destruct (Universe.is_prop ps); auto.
+    destruct (Universe.is_small ps); discriminate.
+Qed.
 
-Lemma elim_restriction_works_kelim `{cf : checker_flags} (Σ : global_env_ext) ind mind idecl : wf Σ ->
+Lemma family_InProp u : universe_family u = InProp <-> Universe.is_prop u.
+Proof.
+  unfold universe_family.
+  split; destruct (Universe.is_prop u); try congruence;
+    destruct (Universe.is_small u); try congruence.
+Qed.
+
+Lemma elim_sort_intype {cf:checker_flags} Σ mdecl ind idecl ind_indices ind_sort sorts :
+  universe_family ind_sort = InProp ->
+  leb_sort_family InType (elim_sort_prop_ind sorts) ->
+  on_constructors (lift_typing typing)
+    (Σ, ind_universes mdecl) mdecl 
+    (inductive_ind ind) idecl ind_indices
+    (ind_ctors idecl) sorts ->
+  (#|ind_ctors idecl| = 0) + 
+  (∑ cdecl sort, 
+    (ind_ctors idecl = [cdecl]) * 
+    (sorts = [sort]) * 
+    (universe_family sort = InProp) *
+    (on_constructor (lift_typing typing) (Σ, ind_universes mdecl) mdecl 
+        (inductive_ind ind) idecl ind_indices cdecl sort))%type.
+Proof.
+  intros uf lein onc.
+  induction onc; simpl in *.
+  left; auto.
+  destruct l' as [|c cs].
+  - simpl in *. depelim onc.
+    right.
+    destruct (universe_family y) eqn:heq; try discriminate.
+    eexists; eauto.
+  - discriminate.
+Qed.
+
+Lemma typing_spine_it_mkProd_or_LetIn_full_inv {cf:checker_flags} Σ Γ Δ s args s' : 
+  wf Σ.1 ->
+  typing_spine Σ Γ (it_mkProd_or_LetIn Δ (tSort s)) args (tSort s') -> 
+  leq_universe (global_ext_constraints Σ) s s'.
+Proof.
+  intros wfΣ.
+  induction Δ using ctx_length_rev_ind in args |- *.
+  - simpl. intros sp; depelim sp.
+    now eapply cumul_Sort_inv in c.
+    now eapply cumul_Sort_Prod_inv in c.
+  - rewrite it_mkProd_or_LetIn_app; destruct d as [na [b|] ty]; simpl.
+    * intros sp.
+      specialize (H (subst_context [b] 0 Γ0) ltac:(now autorewrite with len)).
+      eapply PCUICArities.typing_spine_letin_inv in sp; auto.
+      rewrite /subst1 subst_it_mkProd_or_LetIn in sp. simpl in sp. eauto.
+    * intros sp. depelim sp.
+      now eapply cumul_Prod_Sort_inv in c.
+      specialize (H (subst_context [hd] 0 Γ0) ltac:(now autorewrite with len) tl).
+      apply H.
+      eapply typing_spine_strengthen; eauto.
+      eapply cumul_Prod_Prod_inv in c as [conv cum]. simpl in *.
+      eapply (substitution_cumul _ Γ [vass na0 A] [] [hd]) in cum; auto.
+      simpl in cum.
+      now rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in cum.
+      constructor; auto. now eapply typing_wf_local.
+      eapply PCUICArities.isWAT_tProd in i; auto. destruct i as [? ?]; auto.
+      eapply typing_wf_local; eauto. constructor. constructor. now rewrite subst_empty.
+      auto.
+Qed.
+
+Inductive All_local_assum (P : context -> term -> Type) : context -> Type :=
+| localassum_nil :
+    All_local_assum P []
+
+| localassum_cons_abs Γ na t :
+    All_local_assum P Γ ->
+    P Γ t ->
+    All_local_assum P (Γ ,, vass na t)
+
+| localassum_cons_def Γ na b t :
+    All_local_assum P Γ ->
+    All_local_assum P (Γ ,, vdef na b t).
+
+Lemma All_local_assum_app P Γ Δ : All_local_assum P (Γ ++ Δ) ->
+  All_local_assum P Δ *
+  All_local_assum (fun Γ' => P (Δ ,,, Γ')) Γ.
+Proof.
+  induction Γ; simpl; constructor; intuition auto.
+  constructor. depelim X; apply IHΓ; auto.
+  depelim X; constructor; try apply IHΓ; auto.
+Qed.
+
+Lemma All_local_assum_subst {cf:checker_flags} (P Q : context -> term -> Type) c n k :
+  All_local_assum Q c ->
+  (forall Γ t,
+      Q Γ t ->
+      P (subst_context n k Γ) (subst n (#|Γ| + k) t)
+  ) ->
+  All_local_assum P (subst_context n k c).
+Proof.
+  intros Hq Hf.
+  induction Hq in |- *; try econstructor; eauto;
+    simpl; unfold snoc; rewrite subst_context_snoc; econstructor; eauto.
+Qed.
+
+Lemma typing_spine_proofs {cf:checker_flags} Σ Γ Δ ind u args' args T' s :
+  wf Σ.1 ->
+  Σ ;;; Γ |-  T' : tSort s ->
+  typing_spine Σ Γ (it_mkProd_or_LetIn Δ (mkApps (tInd ind u) args')) args T' ->
+  ((All_local_assum (fun Γ' t =>
+      (∑ s, (Σ ;;; Γ ,,, Γ' |- t : tSort s) * Universe.is_prop s)%type) Δ ->
+    ∥ All (Is_proof Σ Γ) args ∥) *
+    (forall mdecl idecl 
+    (Hdecl : declared_inductive Σ.1 mdecl ind idecl)
+    (oib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl)
+      (inductive_mind ind) mdecl (inductive_ind ind) idecl),
+      leq_universe (global_ext_constraints Σ)
+        (subst_instance_univ u oib.(ind_sort)) s))%type.
+Proof.
+  intros wfΣ Ht.
+  induction Δ using ctx_length_rev_ind in Γ, args', args, T', Ht |- *; simpl; intros sp.
+  - depelim sp. repeat constructor. 
+    * eapply invert_cumul_ind_l in c as [ui' [l' [red  [Req argeq]]]] => //.
+      intros mdecl idecl decli oib.
+      eapply subject_reduction in Ht; eauto.
+      eapply inversion_mkApps in Ht as [A [U [tInd [sp cum]]]]; auto.
+      eapply PCUICArities.typing_spine_weaken_concl in sp; eauto.
+      2:{ left; exists [], s; simpl; intuition auto. now eapply typing_wf_local. }
+      clear cum.
+      eapply inversion_Ind in tInd as [mdecl' [idecl' [wfΓ [decli' [cu cum]]]]]; auto.
+      destruct (declared_inductive_inj decli decli'); subst mdecl' idecl'.
+      clear decli'.
+      eapply typing_spine_strengthen in sp; eauto.
+      rewrite (oib.(ind_arity_eq)) in sp.
+      rewrite !subst_instance_constr_it_mkProd_or_LetIn in sp.
+      rewrite -it_mkProd_or_LetIn_app in sp.
+      eapply typing_spine_it_mkProd_or_LetIn_full_inv in sp; auto.
+      transitivity (subst_instance_univ ui' (ind_sort oib)).
+      apply eq_universe_leq_universe.
+      eapply Build_SubstUnivPreserving. 
+      eapply PCUICEquality.R_universe_instance_impl.
+      2:eauto. typeclasses eauto. eapply sp.
+      
+    * eapply cumul_Prod_r_inv in c; auto.
+      destruct c as [na' [dom' [codom' [[red _] ?]]]].
+      eapply red_mkApps_tInd in red as [? [? ?]] => //. solve_discr.
+
+  - destruct d as [na [b|] ty].
+    + rewrite it_mkProd_or_LetIn_app in sp.
+      simpl in sp.
+      eapply PCUICArities.typing_spine_letin_inv in sp => //.
+      rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in sp.
+      specialize (H (subst_context [b] 0 Γ0) ltac:(now autorewrite with len)).
+      rewrite subst_mkApps in sp.
+      specialize (H _ _ _ _ Ht sp).
+      split.
+      * intros prs;eapply All_local_assum_app in prs as [prd prs].
+      depelim prd; simpl in H0; noconf H0.
+      apply H.
+      clear -wfΣ prs.
+      eapply All_local_assum_subst; eauto.
+      simpl. intros.
+      destruct X as [s [Ht2 isp]].
+      exists s; firstorder.
+      rewrite Nat.add_0_r. eapply (substitution _ Γ [vdef na b ty] [b] Γ1 _ (tSort s)); auto.
+      rewrite -{1}(subst_empty 0 b).
+      repeat (constructor; auto). rewrite !subst_empty.
+      eapply typing_wf_local in Ht2.
+      rewrite app_context_assoc in Ht2. eapply All_local_env_app in Ht2 as [Ht2 _].
+      depelim Ht2; simpl in H; noconf H. apply l0.
+      now rewrite app_context_assoc in Ht2.
+      * intros mdecl idec decli oib.
+        now apply H.
+    + rewrite it_mkProd_or_LetIn_app in sp.
+      destruct args. repeat constructor.
+      * simpl in sp. depelim sp.
+        unfold mkProd_or_LetIn in c; simpl in c.
+        eapply cumul_Prod_l_inv in c as [na' [dom' [codom' [[red conv] cum]]]]; auto.
+        eapply subject_reduction in Ht; eauto.
+        intros. eapply inversion_Prod in Ht as [s1 [s2 [dom [codom cum']]]]; auto.
+        specialize (H Γ0 ltac:(reflexivity) (Γ ,, vass na' dom') args' []).
+        eapply (type_Cumul _ _ _ _ (tSort s)) in codom; cycle 1; eauto.
+        { left. eexists _, _; simpl; intuition eauto. now eapply typing_wf_local. }
+        { eapply cumul_Sort_inv in cum'.
+          do 2 constructor. etransitivity; eauto. eapply leq_universe_product. }
+        specialize (H _ codom).
+        forward H.
+        { constructor. now right; exists s.
+          eapply cumul_conv_ctx; eauto. constructor; auto.
+          apply conv_ctx_refl. now constructor. }
+        destruct H.
+        apply l. auto.
+      * simpl in sp. depelim sp.
+        eapply cumul_Prod_inv in c as [conv cum]; auto. 2:eauto using typing_wf_local.
+        eapply typing_spine_strengthen in sp; auto.
+        2:{ eapply (substitution_cumul0 _ _ _ _ _ _ t) in cum. eapply cum. auto. }
+        rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in sp.
+        specialize (H (subst_context [t] 0 Γ0) ltac:(now autorewrite with len)).
+        rewrite subst_mkApps in sp. simpl in sp.
+        specialize (H _ _ _ _ Ht sp).
+        split.
+        intros prs;eapply All_local_assum_app in prs as [prd prs].
+        depelim prd; simpl in H0; noconf H0.
+        eapply (type_Cumul _ _ _ _ ty) in t0.
+        2:{ right. destruct s0 as [s' [Hs' _]]. exists s'; auto. }
+        2:{ eapply conv_cumul. now symmetry. }
+        destruct H as [H _].
+        forward H. { 
+          clear -wfΣ prs t0.
+          eapply All_local_assum_subst; eauto.
+          simpl. intros.
+          destruct X as [s [Ht2 isp]].
+          exists s; firstorder.
+          rewrite Nat.add_0_r. eapply (substitution _ Γ [vass na ty] [t] Γ1 _ (tSort s)); auto.
+          repeat (constructor; auto). now rewrite subst_empty.
+          now rewrite app_context_assoc in Ht2. }
+        sq. constructor; auto. simpl in conv.
+        red. destruct s0 as [s' [Ht' sprop]].
+        exists ty, s'. intuition auto.
+        destruct H as [_ H].
+        intros. now apply H.
+Qed.
+
+Lemma consistent_instance_ext_noprop {cf:checker_flags} {Σ univs u} : 
+    consistent_instance_ext Σ univs u ->
+  forallb (fun x1 : Level.t => negb (Level.is_prop x1)) u.
+Proof.
+  unfold consistent_instance_ext, consistent_instance.
+  destruct univs. destruct u; simpl; try discriminate; auto.
+  firstorder.
+Qed.
+
+Lemma is_prop_leq {cf:checker_flags} Σ u v : leq_universe Σ u v -> 
+  Universe.is_prop v -> Universe.is_prop u.
+Proof. todo "Simon"%string. Qed.
+
+Lemma not_prop_not_leq_prop sf : sf <> InProp -> ~ leb_sort_family sf InProp.
+Proof.
+  destruct sf; simpl; try congruence.
+Qed.
+
+Lemma check_ind_sorts_is_prop {cf:checker_flags} (Σ : global_env_ext) mdecl idecl ind
+  (onib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl)
+    (inductive_mind ind) mdecl (inductive_ind ind) idecl) : 
+  ind_kelim idecl <> InProp ->
+  Universe.is_prop (ind_sort onib) -> 
+  check_ind_sorts (lift_typing typing) (Σ.1, ind_universes mdecl)
+    (PCUICEnvironment.ind_params mdecl) (PCUICEnvironment.ind_kelim idecl)
+    (ind_indices onib) (ind_ctors_sort onib) (ind_sort onib) ->
+  (#|ind_ctors_sort onib| <= 1) * All Universe.is_prop (ind_ctors_sort onib).
+Proof.
+  intros kelim isp.
+  unfold check_ind_sorts, universe_family. simpl.
+  rewrite isp. simpl.
+  induction (ind_ctors_sort onib); simpl; auto; try discriminate.
+  apply not_prop_not_leq_prop in kelim.
+  destruct l; simpl in *; try contradiction.
+  destruct (universe_family a) eqn:Heq; try contradiction.
+  intros leb.
+  apply family_InProp in Heq. now constructor.
+Qed.
+ 
+Lemma type_local_ctx_All_local_assum_impl {cf:checker_flags} Σ 
+  (P : context -> context -> term -> Type) {Γ Δ cs} : 
+  (forall Γ' t, Σ ;;; Γ ,,, Γ' |- t : tSort cs  -> P Γ Γ' t) ->
+  type_local_ctx (lift_typing typing) Σ Γ Δ cs ->
+  All_local_assum (P Γ) Δ.
+Proof.
+  intros H.
+  induction Δ; simpl; intros. constructor; intuition auto.
+  destruct a as [na [b|] ty]; constructor; intuition auto.
+Qed.
+
+(* We prove that if the (partial) constructor application's type lands in Prop
+   then the inductive type is in Prop and hence the constructor's sort is 
+   Prop. Finally, all its arguments are in Prop because we additionally know
+   that elimination to any type is allowed. *)
+
+Lemma Is_proof_mkApps_tConstruct `{cf : checker_flags} (Σ : global_env_ext) Γ ind n u mdecl idecl args :
+  wf Σ ->
+  declared_inductive (fst Σ) mdecl ind idecl ->
+  ind_kelim idecl <> InProp ->
+  Is_proof Σ Γ (mkApps (tConstruct ind n u) args) ->
+  #|ind_ctors idecl| <= 1 /\ ∥ All (Is_proof Σ Γ) (skipn (ind_npars mdecl) args) ∥.
+Proof.
+  intros wfΣ decli kelim [tyc [tycs [hc [hty hp]]]].
+  eapply inversion_mkApps in hc as [? [? [hc [hsp hcum]]]]; auto.
+  eapply inversion_Construct in hc as [mdecl' [idecl' [cdecl' [wfΓ [declc [cu cum']]]]]]; auto.
+  destruct (on_declared_constructor _ declc) as [[oi oib] [cs [Hnth onc]]].
+  set (onib := declared_inductive_inv _ _ _ _ _ _ _ _ _) in *.
+  clearbody onib. clear oib.
+  eapply typing_spine_strengthen in hsp; eauto.
+  eapply PCUICArities.typing_spine_weaken_concl in hsp; eauto.
+  2:{ right; eexists; eauto. }
+  pose proof (declared_inductive_inj decli (proj1 declc)) as [-> ->].
+  assert (isWfArity_or_Type Σ Γ (type_of_constructor mdecl cdecl' (ind, n) u)).
+  { eapply declared_constructor_valid_ty in declc; eauto. now right. }
+  move: X hsp.
+  unfold type_of_constructor.
+  rewrite (onc.(cshape).(cshape_eq)).
+  rewrite !subst_instance_constr_it_mkProd_or_LetIn !subst_it_mkProd_or_LetIn.
+  rewrite - {1}(firstn_skipn (ind_npars mdecl) args).
+  rewrite !subst_instance_constr_mkApps.
+  simpl.
+  autorewrite with len.
+  rewrite !subst_mkApps Nat.add_0_r.
+  rewrite !subst_inds_concl_head.
+  destruct decli. now apply nth_error_Some_length in H0.
+  destruct (le_dec (ind_npars mdecl) #|args|).
+  * intros X hsp.
+    eapply PCUICSpine.typing_spine_inv in hsp as [parsub [[sub wat] sp]]; auto.
+    2:{ rewrite context_assumptions_subst subst_instance_context_assumptions.
+        autorewrite with len.
+        rewrite firstn_length_le //. symmetry; eapply onNpars. eauto. }
+    rewrite !subst_it_mkProd_or_LetIn in X, sp.
+    rewrite !subst_mkApps in sp.
+    simpl in sp.
+    eapply typing_spine_proofs in sp; eauto.
+    destruct sp.
+    specialize (l0 _ _ (proj1 declc) onib).
+    pose proof (onc.(on_cargs)).
+    pose proof (onib.(ind_sorts)).
+    assert (Universe.is_prop (ind_sort onib)).
+    { rewrite -(is_prop_subst_instance_univ u).
+      apply (consistent_instance_ext_noprop cu).
+      eapply is_prop_leq; eauto. }
+    eapply check_ind_sorts_is_prop in X1 as [nctors X1]; eauto.
+    assert(#|ind_ctors_sort onib| = #|ind_ctors idecl|).
+    clear wat X. clear -onib. pose proof (onib.(onConstructors)).
+    eapply All2_length in X. now rewrite X. 
+    rewrite H0 in nctors; split; auto.
+
+    eapply nth_error_all in X1; eauto. simpl in X1.
+    eapply type_local_ctx_instantiate in X0. 4:eapply cu.
+    all: eauto. 2: destruct decli; eauto.
+    rewrite subst_instance_context_app in X0.
+    eapply weaken_type_local_ctx in X0; eauto.
+    eapply (subst_type_local_ctx _ _) in X0; eauto.
+    3:{ eapply subslet_app. 
+      2:{ eapply (weaken_subslet _ _ _ _ []), PCUICArities.subslet_inds; eauto. } 
+      eapply sub. }
+    2:{ eapply PCUICWeakening.weaken_wf_local; auto.
+        unshelve eapply on_constructor_inst in oi; eauto.
+        destruct oi as [oi _].
+        rewrite !subst_instance_context_app in oi.
+        now eapply wf_local_app in oi. }
+
+    apply s.
+    rewrite subst_app_context in X0.
+    rewrite -(context_subst_length _ _ _ sub) in X0.
+    autorewrite with len in X0.
+    eapply (type_local_ctx_All_local_assum_impl Σ 
+      (fun Γ Γ' t => 
+      ∑ s0 : Universe.t, Σ;;; Γ ,,, Γ' |- t : tSort s0 × Universe.is_prop s0)).
+    2:eauto.
+    intros. exists (subst_instance_univ u cs). intuition auto.
+    now eapply is_prop_subst_instance.
+  * intros _ sp.
+    rewrite List.skipn_all2. lia.
+    split; [|repeat constructor].
+    pose proof (onc.(on_cargs)).
+    pose proof (onib.(ind_sorts)).
+    eapply check_ind_sorts_is_prop in X0 as [nctors X1]; eauto.
+    assert(#|ind_ctors_sort onib| = #|ind_ctors idecl|).
+    clear -onib. pose proof (onib.(onConstructors)).
+    eapply All2_length in X. now rewrite X. now rewrite -H.
+    rewrite -it_mkProd_or_LetIn_app in sp.
+    eapply typing_spine_proofs in sp; eauto.
+    { rewrite -(is_prop_subst_instance_univ u).
+      apply (consistent_instance_ext_noprop cu).
+      eapply is_prop_leq; eauto. eapply sp. eauto. }
+Qed.
+    
+Lemma elim_restriction_works_kelim `{cf : checker_flags} (Σ : global_env_ext) ind mind idecl :
+  wf Σ ->
   declared_inductive (fst Σ) mind ind idecl ->
-  ind_kelim idecl = InType -> Informative Σ ind.
+  ind_kelim idecl <> InProp -> Informative Σ ind.
 Proof.
   intros.
   destruct (PCUICWeakeningEnv.on_declared_inductive X H) as [[]]; eauto.
-  intros ?. intros. inversion o.
-  eapply declared_inductive_inj in H as []; eauto; subst.
-  clear - onConstructors ind_sorts. try dependent induction onConstructors.
-  (* - cbn. split. lia. econstructor. admit. *)
-  (* -  *)
-Admitted.                       (* elim_restriction_works *)
+  intros ?. intros.
+  eapply declared_inductive_inj in H as []; eauto; subst idecl0 mind.
+  eapply Is_proof_mkApps_tConstruct in X2; eauto.
+  now eapply weakening_env_declared_inductive.
+Qed.
 
 Lemma elim_restriction_works `{cf : checker_flags} (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
   declared_inductive (fst Σ) mind ind idecl ->
   Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
   (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> Informative Σ ind.
-Admitted.
+Proof.
+  intros wfΣ decli HT H.
+  eapply elim_restriction_works_kelim1 in HT; eauto.
+  eapply elim_restriction_works_kelim; eauto.
+  destruct HT; congruence.
+Qed.
 
 Lemma declared_projection_projs_nonempty `{cf : checker_flags} {Σ : global_env_ext} { mind ind p a} :
   wf Σ ->
@@ -125,7 +547,8 @@ Lemma elim_restriction_works_proj `{cf : checker_flags} (Σ : global_env_ext) Γ
   (Is_proof Σ Γ (tProj p c) -> False) -> Informative Σ (fst (fst p)).
 Proof.
   intros. eapply elim_restriction_works_kelim; eauto.
-  eapply elim_restriction_works_proj_kelim1; eauto.
+  eapply elim_restriction_works_proj_kelim1 in H0; eauto.
+  congruence.
 Qed.
 
 Lemma length_of_btys {ind mdecl' idecl' args' u' p} :

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -23,6 +23,27 @@ Proof.
   rewrite H in H1. inversion H1. subst. rewrite H2 in H0. inversion H0. eauto.
 Qed.
 
+Lemma declared_constructor_inj `{cf : checker_flags} {Σ mdecl mdecl' idecl idecl' cdecl cdecl' c} :
+  declared_constructor Σ mdecl' idecl' c cdecl ->
+  declared_constructor Σ mdecl idecl c cdecl' ->
+  mdecl = mdecl' /\ idecl = idecl'  /\ cdecl = cdecl'.
+Proof.
+  intros [] []. 
+  destruct (declared_inductive_inj H H1); subst.
+  rewrite H0 in H2. noconf H2. intuition congruence.
+Qed.
+
+Lemma declared_projection_inj `{cf : checker_flags} {Σ mdecl mdecl' idecl idecl' pdecl pdecl' p} :
+  declared_projection Σ mdecl' idecl' p pdecl ->
+  declared_projection Σ mdecl idecl p pdecl' ->
+  mdecl = mdecl' /\ idecl = idecl'  /\ pdecl = pdecl'.
+Proof.
+  intros [] []. 
+  destruct (declared_inductive_inj H H1); subst.
+  destruct H0, H2.
+  rewrite H0 in H2. noconf H2. intuition congruence.
+Qed.
+
 Definition SingletonProp `{cf : checker_flags} (Σ : global_env_ext) (ind : inductive) :=
   forall mdecl idecl,
     declared_inductive (fst Σ) mdecl ind idecl ->
@@ -193,6 +214,8 @@ Inductive All_local_assum (P : context -> term -> Type) : context -> Type :=
 | localassum_cons_def Γ na b t :
     All_local_assum P Γ ->
     All_local_assum P (Γ ,, vdef na b t).
+
+Derive Signature for All_local_assum.
 
 Lemma All_local_assum_app P Γ Δ : All_local_assum P (Γ ++ Δ) ->
   All_local_assum P Δ *
@@ -618,6 +641,48 @@ Proof.
   todo "Simon"%string.
 Qed.
 
+Lemma principal_type_ind {Σ Γ c ind u u' args args'} {wfΣ: wf Σ.1} :
+  Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
+  Σ ;;; Γ |- c : mkApps (tInd ind u') args' ->
+  PCUICEquality.R_universe_instance (eq_universe (global_ext_constraints Σ)) u u' * 
+  All2 (conv Σ Γ) args args'.
+Proof.
+  intros h h'.
+  destruct (principal_typing _ wfΣ h h') as [C [l [r ty]]].
+  eapply invert_cumul_ind_r in l as [ui' [l' [red [Ru eqargs]]]]; auto.
+  eapply invert_cumul_ind_r in r as [ui'' [l'' [red' [Ru' eqargs']]]]; auto.
+  destruct (red_confluence wfΣ red red') as [nf [redl redr]].
+  eapply red_mkApps_tInd in redl as [args'' [-> eq0]]; auto.
+  eapply red_mkApps_tInd in redr as [args''' [eqnf eq1]]; auto.
+  solve_discr.
+  split. transitivity ui'; eauto. now symmetry.
+  eapply All2_trans; [|eapply eqargs|]. intro; intros. eapply conv_trans; eauto.
+  eapply All2_trans. intro; intros. eapply conv_trans; eauto.
+  2:{ eapply All2_sym. eapply (All2_impl eqargs'). intros. now apply conv_sym. }
+  eapply All2_trans. intro; intros. eapply conv_trans; eauto.
+  eapply (All2_impl eq0). intros. now apply red_conv.
+  eapply All2_sym; eapply (All2_impl eq1). intros. symmetry. now apply red_conv.
+Qed.
+
+Definition projection_context mdecl idecl ind := 
+  smash_context [] (PCUICEnvironment.ind_params mdecl),,
+       PCUICEnvironment.vass (nNamed (PCUICEnvironment.ind_name idecl))
+         (mkApps
+            (tInd
+               {|
+               inductive_mind := inductive_mind ind;
+               inductive_ind := inductive_ind ind |}
+               (polymorphic_instance (PCUICEnvironment.ind_universes mdecl)))
+            (PCUICEnvironment.to_extended_list
+               (smash_context [] (PCUICEnvironment.ind_params mdecl)))).
+
+Lemma projection_subslet Σ Γ mdecl idecl ind u c args : 
+  Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
+  subslet Σ Γ (c :: List.rev args) (projection_context mdecl idecl ind). 
+Proof.
+  todo "Projections"%string.
+Qed.
+
 Lemma typing_leq_term (Σ : global_env_ext) Γ t t' T T' : 
   wf Σ.1 ->
   Σ ;;; Γ |- t : T ->
@@ -659,7 +724,168 @@ Proof.
     eapply context_conversion; eauto.
     constructor; pcuic. constructor. symmetry;  now constructor.
     constructor; pcuic.
-Admitted.    
+
+  - eapply inversion_Lambda in X4 as (s & B & dom & codom & cum); auto.
+    specialize (X1 _ _ dom (PCUICEquality.eq_term_leq_term _ _ _ X5_1)).
+    assert(conv_context Σ (Γ ,, vass na ty) (Γ ,, vass n t)).
+    { repeat constructor; pcuic. }
+    specialize (X3 t0 B).
+    forward X3 by eapply context_conversion; eauto; pcuic.
+    econstructor.
+    econstructor. eauto. instantiate (1 := bty).
+    eapply context_conversion; eauto; pcuic.
+    constructor; pcuic. constructor; pcuic. symmetry; constructor; auto.
+    have tyl := type_Lambda _ _ _ _ _ _ _ X0 X2.
+    now eapply PCUICValidity.validity in tyl.
+    eapply congr_cumul_prod; eauto.
+    constructor; auto. reflexivity.
+    
+  - eapply inversion_LetIn in X6 as (s1' & A & dom & bod & codom & cum); auto.
+    specialize (X1 _ _ dom (PCUICEquality.eq_term_leq_term _ _ _ X7_2)).
+    specialize (X3 _ _ bod (PCUICEquality.eq_term_leq_term _ _ _ X7_1)).
+    assert(conv_context Σ (Γ ,, vdef na t ty) (Γ ,, vdef n b b_ty)).
+    { repeat constructor; pcuic. }
+    specialize (X5 u A).
+    forward X5 by eapply context_conversion; eauto; pcuic.
+    specialize (X5 X7_3).
+    econstructor.
+    econstructor. eauto. eauto.
+    instantiate (1 := b'_ty).
+    eapply context_conversion; eauto.
+    apply conv_context_sym; auto.
+    pcuic. eapply PCUICValidity.validity; eauto.
+    econstructor; eauto.
+    eapply cum_LetIn; pcuic.
+    
+  - eapply inversion_App in X4 as (na' & A' & B' & hf & ha & cum); auto.
+    specialize (X1 _ _ hf X5_1).
+    specialize (X3 _ _ ha (PCUICEquality.eq_term_leq_term _ _ _ X5_2)).
+    econstructor.
+    econstructor; [eapply X1|eapply X3].
+    eapply PCUICValidity.validity; pcuic.
+    eapply type_App; eauto.
+    eapply conv_cumul. eapply (subst_conv Γ [vass na A] [vass na A] []); pcuic.
+    repeat constructor. now rewrite subst_empty.
+    repeat constructor. now rewrite subst_empty.
+    eapply PCUICValidity.validity in X0; auto.
+    apply PCUICArities.isWAT_tProd in X0 as [tyA]; auto.
+    constructor; auto.
+
+  - eapply inversion_Const in X1 as [decl' [wf [declc [cu cum]]]]; auto.
+    econstructor; eauto.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    econstructor; eauto.
+    eapply conv_cumul. constructor.
+    pose proof (declared_constant_inj _ _ H declc); subst decl'.
+    eapply eq_term_upto_univ_subst_instance_constr; eauto; typeclasses eauto.
+  
+  - eapply inversion_Ind in X1 as [decl' [idecl' [wf [declc [cu cum]]]]]; auto.
+    econstructor; eauto.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    econstructor; eauto.
+    eapply conv_cumul. constructor.
+    pose proof (declared_inductive_inj isdecl declc) as [-> ->].
+    eapply eq_term_upto_univ_subst_instance_constr; eauto; typeclasses eauto.
+  
+  - eapply inversion_Construct in X1 as [decl' [idecl' [cdecl' [wf [declc [cu cum]]]]]]; auto.
+    econstructor; eauto.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    econstructor; eauto.
+    pose proof (declared_constructor_inj isdecl declc) as [-> [-> ->]].
+    unfold type_of_constructor.
+    transitivity (subst0 (inds (inductive_mind (ind, i).1) u (ind_bodies mdecl))
+    (subst_instance_constr u0 cdecl'.1.2)).
+    * eapply conv_cumul.
+      eapply (conv_subst_conv _ Γ _ _ []); eauto.
+      { unfold inds.
+        generalize #|ind_bodies mdecl|.
+        induction n; simpl; constructor; auto.
+        constructor. constructor. auto. }
+      eapply subslet_untyped_subslet.
+      eapply (weaken_subslet _ _ _ Γ []); eauto.
+      eapply PCUICArities.subslet_inds; eauto.
+      destruct declc; eauto.
+      eapply subslet_untyped_subslet.
+      eapply (weaken_subslet _ _ _ Γ []); eauto.
+      eapply PCUICArities.subslet_inds; eauto.
+      destruct declc; eauto.
+    * constructor. eapply PCUICEquality.subst_leq_term.
+      eapply PCUICEquality.eq_term_leq_term.
+      eapply eq_term_upto_univ_subst_instance_constr; eauto; typeclasses eauto.
+
+  - eapply inversion_Case in X6 as (u' & args' & mdecl' & idecl' & ps' & pty' & btys' & inv); auto.
+    intuition auto.
+    intuition auto.
+    eapply type_Cumul.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    eapply (type_Case _ _ (ind, npar)). eapply isdecl.
+    all:eauto.
+    eapply (All2_impl X5); firstorder.
+    eapply conv_cumul.
+    eapply mkApps_conv_args; pcuic.
+    eapply All2_app. simpl in *.
+    2:constructor; pcuic.
+    eapply All2_skipn.
+    clear -wfΣ a5 X4 X7_2.
+    specialize (X4 _ _ a5 (PCUICEquality.eq_term_leq_term _ _ _ X7_2)).
+    eapply (principal_type_ind a5 X4).
+    
+  - eapply inversion_Proj in X3 as (u' & mdecl' & idecl' & pdecl' & args' & inv); auto.
+    intuition auto.
+    eapply type_Cumul.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    eapply type_Proj; eauto.
+    specialize (X2 _ _ a0 (PCUICEquality.eq_term_leq_term _ _ _ X4)).
+    pose proof (principal_type_ind X2 a0) as [Ruu' X3].
+    transitivity (subst0 (c :: List.rev args) (subst_instance_constr u' pdecl'.2)).
+    eapply conv_cumul.
+    destruct (on_declared_projection wfΣ a) as [[oni oib] onp].
+    destruct p as [[ind n] k].
+    red in onp. simpl in onp.
+    match goal with 
+    [ _ : on_type _ _ ?Γ _ |- _ ] => set(ctx := Γ) in *
+    end.
+    eapply (conv_subst_conv _ Γ ctx ctx []); eauto.
+    constructor. now constructor.
+    eapply All2_rev. apply All2_sym. apply (All2_impl X3). intros; now symmetry.
+    eapply subslet_untyped_subslet; eauto.
+    eapply projection_subslet; eauto.
+    eapply subslet_untyped_subslet; eauto.
+    eapply projection_subslet; eauto.
+    constructor. eapply PCUICEquality.subst_leq_term.
+    destruct (declared_projection_inj a isdecl) as [<- [<- <-]].
+    subst ty.
+    eapply PCUICEquality.eq_term_leq_term.
+    eapply eq_term_upto_univ_subst_instance_constr; eauto; try typeclasses eauto.
+    now symmetry.
+
+  - eapply inversion_Fix in X2 as (decl' & fixguard' & Hnth & types' & bodies & cum); auto.
+    eapply type_Cumul.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    econstructor. 2:eapply H0. all:eauto.
+    eapply (All_impl X0); firstorder.
+    eapply (All_impl X1); firstorder.
+    eapply All2_nth_error in a; eauto.
+    destruct a as [[eqty _] _].
+    constructor. now apply PCUICEquality.eq_term_leq_term.
+  
+  - eapply inversion_CoFix in X2 as (decl' & fixguard' & Hnth & types' & bodies & cum); auto.
+    eapply type_Cumul.
+    econstructor; eauto.
+    eapply PCUICValidity.validity; eauto.
+    eapply type_CoFix. 2:eapply H. all:eauto.
+    eapply (All_impl X0); firstorder.
+    eapply (All_impl X1); firstorder.
+    eapply All2_nth_error in a; eauto.
+    destruct a as [[eqty _] _].
+    constructor. now apply PCUICEquality.eq_term_leq_term.
+Qed.
 
 Lemma leq_prop_is_prop {Σ x s} : leq_universe Σ x s -> 
   (Universe.is_prop s <-> Universe.is_prop x).

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -907,7 +907,9 @@ Proof.
     destruct H as [t' Ht'].
     rewrite Hbr in e. noconf e. simpl in H. rewrite <- H. simpl.  
     clear H.
-    destruct brtys as [-> ->].
+    destruct brtys as [-> brtys].
+    specialize (brtys  _ csubst).
+    simpl in brtys. subst brty.
     eapply type_mkApps. eauto.
     set argctx := cshape_args (cshape onc).
     clear Hbr brbrty Hbrty X5 Ht'.


### PR DESCRIPTION
Fill all the proofs in PCUICElimination on which erasure is relying.
I left quite a few admitted proofs about how `Universe.is_prop` and `leq_universe` interact, for @SimonBoulier :) None of them look particularly tricky.

The `cumul_prop` theorems require an additional `isWfArity_or_Type` property, which at first looked like it needed to be an even stronger IsType property. It turns out if `T : Prop` and `T <= S` the `S : Prop` as well, as S cannot be an arity (we don't have `Prop : Prop`!). This saves the day in the end.

One new structural lemma is proven, showing that if `t : T` and `t' : T'` and `leq_term t' t` then `t' : T` as well. In other words pulling back a syntactic inequality preserves typing.

Apart from those axioms, erasure now relies only on fix_guard/proof_irrelevance/normalisation.