### PR TITLE
Move universe-related admits to Universes

### DIFF
--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -436,7 +436,7 @@ Next Obligation.
        eapply invert_red_sort in r.
        eapply invert_red_sort in r1. subst. inv r1.
 
-       eapply leq_universe_prop in l0 as []; cbn; eauto.
+       eapply leq_universe_prop in l0 as []; cbn; intuition eauto.
        eapply leq_universe_prop in l as []; cbn; eauto.
        2:reflexivity. now right; exists x0.
        now apply PCUICValidity.validity in X1.
@@ -615,7 +615,7 @@ Proof.
     eapply isArity_subst_instance.
     eapply isArity_ind_type; eauto.
   - econstructor.
-    eapply elim_restriction_works. eauto. eauto. eauto. intros.
+    eapply elim_restriction_works. eauto. eauto. eauto. eauto. intros.
     eapply f, isErasable_Proof. eauto. eauto.
 
     pose proof (Prelim.monad_map_All2 _ _ _ brs a2 E2).

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -28,35 +28,6 @@ Qed.
 
 Definition Is_proof `{cf : checker_flags} Σ Γ t := ∑ T u, Σ ;;; Γ |- t : T × Σ ;;; Γ |- T : tSort u × Universe.is_prop u.
 
-Lemma declared_inductive_inj `{cf : checker_flags} {Σ mdecl mdecl' ind idecl idecl'} :
-  declared_inductive Σ mdecl' ind idecl' ->
-  declared_inductive Σ mdecl ind idecl ->
-  mdecl = mdecl' /\ idecl = idecl'.
-Proof.
-  intros [] []. unfold declared_minductive in *.
-  rewrite H in H1. inversion H1. subst. rewrite H2 in H0. inversion H0. eauto.
-Qed.
-
-Lemma declared_constructor_inj `{cf : checker_flags} {Σ mdecl mdecl' idecl idecl' cdecl cdecl' c} :
-  declared_constructor Σ mdecl' idecl' c cdecl ->
-  declared_constructor Σ mdecl idecl c cdecl' ->
-  mdecl = mdecl' /\ idecl = idecl'  /\ cdecl = cdecl'.
-Proof.
-  intros [] []. 
-  destruct (declared_inductive_inj H H1); subst.
-  rewrite H0 in H2. noconf H2. intuition congruence.
-Qed.
-
-Lemma declared_projection_inj `{cf : checker_flags} {Σ mdecl mdecl' idecl idecl' pdecl pdecl' p} :
-  declared_projection Σ mdecl' idecl' p pdecl ->
-  declared_projection Σ mdecl idecl p pdecl' ->
-  mdecl = mdecl' /\ idecl = idecl'  /\ pdecl = pdecl'.
-Proof.
-  intros [] []. 
-  destruct (declared_inductive_inj H H1); subst.
-  destruct H0, H2.
-  rewrite H0 in H2. noconf H2. intuition congruence.
-Qed.
 
 Definition SingletonProp `{cf : checker_flags} (Σ : global_env_ext) (ind : inductive) :=
   forall mdecl idecl,
@@ -637,24 +608,6 @@ Context `{cf : checker_flags}.
 Variable Hcf : prop_sub_type = false.
 Variable Hcf' : check_univs = true.
 
-Definition projection_context mdecl idecl ind := 
-  smash_context [] (PCUICEnvironment.ind_params mdecl),,
-       PCUICEnvironment.vass (nNamed (PCUICEnvironment.ind_name idecl))
-         (mkApps
-            (tInd
-               {|
-               inductive_mind := inductive_mind ind;
-               inductive_ind := inductive_ind ind |}
-               (polymorphic_instance (PCUICEnvironment.ind_universes mdecl)))
-            (PCUICEnvironment.to_extended_list
-               (smash_context [] (PCUICEnvironment.ind_params mdecl)))).
-
-Lemma projection_subslet Σ Γ mdecl idecl ind u c args : 
-  Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
-  subslet Σ Γ (c :: List.rev args) (projection_context mdecl idecl ind). 
-Proof.
-  todo "Projections"%string.
-Qed.
 
 Lemma typing_leq_term (Σ : global_env_ext) Γ t t' T T' : 
   wf Σ.1 ->

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -12,6 +12,20 @@ Require Equations.Prop.DepElim.
 From Equations Require Import Equations.
 Require Import ssreflect.
 
+Lemma consistent_instance_ext_noprop {cf:checker_flags} {Σ univs u} : 
+  consistent_instance_ext Σ univs u ->
+  forallb (fun x1 : Level.t => negb (Level.is_prop x1)) u.
+Proof.
+  unfold consistent_instance_ext, consistent_instance.
+  destruct univs. destruct u; simpl; try discriminate; auto.
+  firstorder.
+Qed.
+
+Lemma not_prop_not_leq_prop sf : sf <> InProp -> ~ leb_sort_family sf InProp.
+Proof.
+  destruct sf; simpl; try congruence.
+Qed.
+
 Definition Is_proof `{cf : checker_flags} Σ Γ t := ∑ T u, Σ ;;; Γ |- t : T × Σ ;;; Γ |- T : tSort u × Universe.is_prop u.
 
 Lemma declared_inductive_inj `{cf : checker_flags} {Σ mdecl mdecl' ind idecl idecl'} :
@@ -357,24 +371,6 @@ Proof.
         intros. now apply H.
 Qed.
 
-Lemma consistent_instance_ext_noprop {cf:checker_flags} {Σ univs u} : 
-    consistent_instance_ext Σ univs u ->
-  forallb (fun x1 : Level.t => negb (Level.is_prop x1)) u.
-Proof.
-  unfold consistent_instance_ext, consistent_instance.
-  destruct univs. destruct u; simpl; try discriminate; auto.
-  firstorder.
-Qed.
-
-Lemma is_prop_leq {cf:checker_flags} Σ u v : leq_universe Σ u v -> 
-  Universe.is_prop v -> Universe.is_prop u.
-Proof. todo "Simon"%string. Qed.
-
-Lemma not_prop_not_leq_prop sf : sf <> InProp -> ~ leb_sort_family sf InProp.
-Proof.
-  destruct sf; simpl; try congruence.
-Qed.
-
 Lemma check_ind_sorts_is_prop {cf:checker_flags} (Σ : global_env_ext) mdecl idecl ind
   (onib : on_ind_body (lift_typing typing) (Σ.1, ind_universes mdecl)
     (inductive_mind ind) mdecl (inductive_ind ind) idecl) : 
@@ -413,13 +409,14 @@ Qed.
    that elimination to any type is allowed. *)
 
 Lemma Is_proof_mkApps_tConstruct `{cf : checker_flags} (Σ : global_env_ext) Γ ind n u mdecl idecl args :
+  check_univs = true ->
   wf Σ ->
   declared_inductive (fst Σ) mdecl ind idecl ->
   ind_kelim idecl <> InProp ->
   Is_proof Σ Γ (mkApps (tConstruct ind n u) args) ->
   #|ind_ctors idecl| <= 1 /\ ∥ All (Is_proof Σ Γ) (skipn (ind_npars mdecl) args) ∥.
 Proof.
-  intros wfΣ decli kelim [tyc [tycs [hc [hty hp]]]].
+  intros checkunivs wfΣ decli kelim [tyc [tycs [hc [hty hp]]]].
   eapply inversion_mkApps in hc as [? [? [hc [hsp hcum]]]]; auto.
   eapply inversion_Construct in hc as [mdecl' [idecl' [cdecl' [wfΓ [declc [cu cum']]]]]]; auto.
   destruct (on_declared_constructor _ declc) as [[oi oib] [cs [Hnth onc]]].
@@ -459,7 +456,7 @@ Proof.
     assert (Universe.is_prop (ind_sort onib)).
     { rewrite -(is_prop_subst_instance_univ u).
       apply (consistent_instance_ext_noprop cu).
-      eapply is_prop_leq; eauto. }
+      eapply leq_universe_prop in l0; intuition eauto. }
     eapply check_ind_sorts_is_prop in X1 as [nctors X1]; eauto.
     assert(#|ind_ctors_sort onib| = #|ind_ctors idecl|).
     clear wat X. clear -onib. pose proof (onib.(onConstructors)).
@@ -504,28 +501,33 @@ Proof.
     eapply typing_spine_proofs in sp; eauto.
     { rewrite -(is_prop_subst_instance_univ u).
       apply (consistent_instance_ext_noprop cu).
-      eapply is_prop_leq; eauto. eapply sp. eauto. }
+      destruct sp as [_ Hs].
+      specialize (Hs _ _ decli onib).
+      eapply leq_universe_prop in Hs; intuition eauto. }
 Qed.
     
 Lemma elim_restriction_works_kelim `{cf : checker_flags} (Σ : global_env_ext) ind mind idecl :
+  check_univs = true ->
   wf Σ ->
   declared_inductive (fst Σ) mind ind idecl ->
   ind_kelim idecl <> InProp -> Informative Σ ind.
 Proof.
-  intros.
-  destruct (PCUICWeakeningEnv.on_declared_inductive X H) as [[]]; eauto.
+  intros cu wfΣ H indk.
+  destruct (PCUICWeakeningEnv.on_declared_inductive wfΣ H) as [[]]; eauto.
   intros ?. intros.
   eapply declared_inductive_inj in H as []; eauto; subst idecl0 mind.
-  eapply Is_proof_mkApps_tConstruct in X2; eauto.
+  eapply Is_proof_mkApps_tConstruct in X1; eauto.
   now eapply weakening_env_declared_inductive.
 Qed.
 
-Lemma elim_restriction_works `{cf : checker_flags} (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : wf Σ ->
+Lemma elim_restriction_works `{cf : checker_flags} (Σ : global_env_ext) Γ T ind npar p c brs mind idecl : 
+  check_univs = true ->
+  wf Σ ->
   declared_inductive (fst Σ) mind ind idecl ->
   Σ ;;; Γ |- tCase (ind, npar) p c brs : T ->
   (Is_proof Σ Γ (tCase (ind, npar) p c brs) -> False) -> Informative Σ ind.
 Proof.
-  intros wfΣ decli HT H.
+  intros cu wfΣ decli HT H.
   eapply elim_restriction_works_kelim1 in HT; eauto.
   eapply elim_restriction_works_kelim; eauto.
   destruct HT; congruence.
@@ -565,12 +567,12 @@ Proof.
 Qed. (* elim_restriction_works_proj *)
 
 Lemma elim_restriction_works_proj `{cf : checker_flags} (Σ : global_env_ext) Γ  p c mind idecl T :
-  wf Σ ->
+  check_univs = true -> wf Σ ->
   declared_inductive (fst Σ) mind (fst (fst p)) idecl ->
   Σ ;;; Γ |- tProj p c : T ->
   (Is_proof Σ Γ (tProj p c) -> False) -> Informative Σ (fst (fst p)).
 Proof.
-  intros. eapply elim_restriction_works_kelim; eauto.
+  intros cu; intros. eapply elim_restriction_works_kelim; eauto.
   eapply elim_restriction_works_proj_kelim1 in H0; eauto.
   congruence.
 Qed.
@@ -634,35 +636,6 @@ Section no_prop_leq_type.
 Context `{cf : checker_flags}.
 Variable Hcf : prop_sub_type = false.
 Variable Hcf' : check_univs = true.
-
-Lemma leq_universe_super Σ l l' : leq_universe Σ (Universe.make l) (Universe.make l') ->
-   leq_universe Σ (Universe.super l) (Universe.super l').
-Proof.
-  todo "Simon"%string.
-Qed.
-
-Lemma principal_type_ind {Σ Γ c ind u u' args args'} {wfΣ: wf Σ.1} :
-  Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
-  Σ ;;; Γ |- c : mkApps (tInd ind u') args' ->
-  PCUICEquality.R_universe_instance (eq_universe (global_ext_constraints Σ)) u u' * 
-  All2 (conv Σ Γ) args args'.
-Proof.
-  intros h h'.
-  destruct (principal_typing _ wfΣ h h') as [C [l [r ty]]].
-  eapply invert_cumul_ind_r in l as [ui' [l' [red [Ru eqargs]]]]; auto.
-  eapply invert_cumul_ind_r in r as [ui'' [l'' [red' [Ru' eqargs']]]]; auto.
-  destruct (red_confluence wfΣ red red') as [nf [redl redr]].
-  eapply red_mkApps_tInd in redl as [args'' [-> eq0]]; auto.
-  eapply red_mkApps_tInd in redr as [args''' [eqnf eq1]]; auto.
-  solve_discr.
-  split. transitivity ui'; eauto. now symmetry.
-  eapply All2_trans; [|eapply eqargs|]. intro; intros. eapply conv_trans; eauto.
-  eapply All2_trans. intro; intros. eapply conv_trans; eauto.
-  2:{ eapply All2_sym. eapply (All2_impl eqargs'). intros. now apply conv_sym. }
-  eapply All2_trans. intro; intros. eapply conv_trans; eauto.
-  eapply (All2_impl eq0). intros. now apply red_conv.
-  eapply All2_sym; eapply (All2_impl eq1). intros. symmetry. now apply red_conv.
-Qed.
 
 Definition projection_context mdecl idecl ind := 
   smash_context [] (PCUICEnvironment.ind_params mdecl),,
@@ -887,33 +860,6 @@ Proof.
     constructor. now apply PCUICEquality.eq_term_leq_term.
 Qed.
 
-Lemma leq_prop_is_prop {Σ x s} : leq_universe Σ x s -> 
-  (Universe.is_prop s <-> Universe.is_prop x).
-Proof.
-  intros leq.
-  split; intros isp.
-  apply is_prop_leq in leq; auto.
-  red in leq. rewrite Hcf' in leq.
-  todo "Simon"%string.
-Admitted.
-
-Lemma prop_leq_left {Σ l l'} : 
-  wf Σ.1 ->
-  Universe.is_prop l -> 
-  leq_universe (global_ext_constraints Σ) l l'.
-Proof.
-  todo "Simon"%string.
-Admitted.
- 
-Lemma impredicative_product {Σ l u} : 
-  wf Σ.1 ->
-  Universe.is_prop u -> 
-  leq_universe (global_ext_constraints Σ) (Universe.sort_of_product l u) u.
-Proof.
-  unfold Universe.sort_of_product.
-  intros wfΣ ->. reflexivity.
-Qed.
-
 Lemma is_prop_bottom {Σ Γ T s s'} :
   wf Σ.1 ->
   Σ ;;; Γ |- T <= tSort s ->
@@ -923,8 +869,8 @@ Proof.
   intros wfΣ hs hs'.
   destruct (cumul_sort_confluence _ wfΣ hs hs') as [x' [conv [leq leq']]].
   intros isp.
-  apply (leq_prop_is_prop leq').
-  now apply (leq_prop_is_prop leq).
+  unshelve eapply (leq_prop_is_prop _ _ leq'); auto.
+  now unshelve eapply (leq_prop_is_prop _ _ leq).
 Qed.
 
 Lemma leq_term_prop_sorted_l {Σ Γ v v' u u'} :
@@ -939,7 +885,7 @@ Proof.
   eapply typing_leq_term in hv. 4:eapply leq. all:eauto.
   destruct (principal_typing _ wfΣ hv hv0) as [C [cum0 [cum1 tyC]]].
   pose proof (is_prop_bottom wfΣ cum1 cum0 isp).
-  apply prop_leq_left; auto.
+  apply leq_prop_prop; auto.
 Qed.
 
 Lemma leq_term_prop_sorted_r {Σ Γ v v' u u'} :
@@ -954,7 +900,7 @@ Proof.
   eapply typing_leq_term in hv. 4:eapply leq. all:eauto.
   destruct (principal_typing _ wfΣ hv hv0) as [C [cum0 [cum1 tyC]]].
   pose proof (is_prop_bottom wfΣ cum0 cum1 isp).
-  apply prop_leq_left; auto.
+  now apply leq_prop_prop.
 Qed.
 
 Lemma cumul_prop (Σ : global_env_ext) Γ A B u u' :
@@ -980,11 +926,6 @@ Proof.
     eapply type_Cumul with (tSort u'); eauto.
     left; eexists _, _; simpl; intuition eauto. now apply typing_wf_local in HA.
     constructor. constructor. auto.
-Qed.
-
-Lemma is_prop_gt Σ l l' : leq_universe Σ (Universe.super l) l' -> Universe.is_prop l' -> False.
-Proof.
-  todo "Simon"%string.
 Qed.
 
 Lemma cumul_prop_r_is_type (Σ : global_env_ext) Γ A B u :
@@ -1142,15 +1083,5 @@ Proof.
   eapply cumul_prop in H. 4:eauto. firstorder. auto.
   left; eauto.
 Qed.
-
-Lemma leq_universe_prop (Σ : global_env_ext) u1 u2 :
-  wf Σ ->
-  @leq_universe cf (global_ext_constraints Σ) u1 u2 ->
-  (Universe.is_prop u1 \/ Universe.is_prop u2) ->
-  (Universe.is_prop u1 /\ Universe.is_prop u2).
-Proof.
-  intros. unfold leq_universe in *. rewrite Hcf' in H.
-  todo "Simon"%string.
-Admitted.                       (* leq_universe_prop *)
 
 End no_prop_leq_type.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -34,26 +34,6 @@ Proof.
   rewrite rev_map_spec. rewrite -(map_length f l) -nth_error_rev ?map_length //.
   now rewrite nth_error_map.
 Qed.
-  
-Lemma declared_inductive_unique {Σ ind mdecl mdecl' idecl idecl'} : 
-  declared_inductive Σ mdecl ind idecl ->
-  declared_inductive Σ mdecl' ind idecl' ->
-  (mdecl = mdecl') * (idecl = idecl').
-Proof.
-  unfold declared_inductive, declared_minductive.
-  intros [-> ?] [eq ?].
-  noconf eq; split; congruence.
-Qed.
-
-Lemma declared_constructor_unique {Σ c mdecl mdecl' idecl idecl' cdecl cdecl'} : 
-  declared_constructor Σ mdecl idecl c cdecl ->
-  declared_constructor Σ mdecl' idecl' c cdecl' ->
-  (mdecl = mdecl') * (idecl = idecl') * (cdecl = cdecl').
-Proof.
-  unfold declared_constructor.
-  intros [? ?] [eq ?]. destruct (declared_inductive_unique H eq).
-  subst mdecl' idecl'. rewrite H0 in H1. intuition congruence.
-Qed.
 
 Lemma build_case_predicate_type_spec {cf:checker_flags} Σ ind mdecl idecl pars u ps pty :
   forall (o : on_ind_body (lift_typing typing) Σ (inductive_mind ind) mdecl (inductive_ind ind) idecl),
@@ -335,7 +315,21 @@ Proof.
   simpl. move=> [] <-. now simpl.
 Qed.
 
-Lemma declared_inductive_minductive Σ ind mdecl idecl :
-  declared_inductive Σ mdecl ind idecl -> declared_minductive Σ (inductive_mind ind) mdecl.
-Proof. now intros []. Qed.
-Hint Resolve declared_inductive_minductive : pcuic.
+Definition projection_context mdecl idecl ind := 
+  smash_context [] (PCUICEnvironment.ind_params mdecl),,
+       PCUICEnvironment.vass (nNamed (PCUICEnvironment.ind_name idecl))
+         (mkApps
+            (tInd
+               {|
+               inductive_mind := inductive_mind ind;
+               inductive_ind := inductive_ind ind |}
+               (polymorphic_instance (PCUICEnvironment.ind_universes mdecl)))
+            (PCUICEnvironment.to_extended_list
+               (smash_context [] (PCUICEnvironment.ind_params mdecl)))).
+
+Lemma projection_subslet {cf:checker_flags} Σ Γ mdecl idecl ind u c args : 
+  Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
+  subslet Σ Γ (c :: List.rev args) (projection_context mdecl idecl ind). 
+Proof.
+  todo "Projections"%string.
+Qed.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -78,13 +78,6 @@ Section Principality.
     exists u'u. split; auto.
   Qed.
 
-  Lemma leq_universe_product_mon u u' v v' :
-    leq_universe (global_ext_constraints Σ) u u' ->
-    leq_universe (global_ext_constraints Σ) v v' ->
-    leq_universe (global_ext_constraints Σ) (Universe.sort_of_product u v) (Universe.sort_of_product u' v').
-  Proof.
-  Admitted.
-
   Lemma isWfArity_sort Γ u :
     wf_local Σ Γ ->
     isWfArity typing Σ Γ (tSort u).
@@ -375,3 +368,26 @@ Section Principality.
   Qed.
 
 End Principality.
+
+Lemma principal_type_ind {cf:checker_flags} {Σ Γ c ind u u' args args'} {wfΣ: wf Σ.1} :
+  Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
+  Σ ;;; Γ |- c : mkApps (tInd ind u') args' ->
+  PCUICEquality.R_universe_instance (eq_universe (global_ext_constraints Σ)) u u' * 
+  All2 (conv Σ Γ) args args'.
+Proof.
+  intros h h'.
+  destruct (principal_typing _ wfΣ h h') as [C [l [r ty]]].
+  eapply invert_cumul_ind_r in l as [ui' [l' [red [Ru eqargs]]]]; auto.
+  eapply invert_cumul_ind_r in r as [ui'' [l'' [red' [Ru' eqargs']]]]; auto.
+  destruct (red_confluence wfΣ red red') as [nf [redl redr]].
+  eapply red_mkApps_tInd in redl as [args'' [-> eq0]]; auto.
+  eapply red_mkApps_tInd in redr as [args''' [eqnf eq1]]; auto.
+  solve_discr.
+  split. transitivity ui'; eauto. now symmetry.
+  eapply All2_trans; [|eapply eqargs|]. intro; intros. eapply conv_trans; eauto.
+  eapply All2_trans. intro; intros. eapply conv_trans; eauto.
+  2:{ eapply All2_sym. eapply (All2_impl eqargs'). intros. now apply conv_sym. }
+  eapply All2_trans. intro; intros. eapply conv_trans; eauto.
+  eapply (All2_impl eq0). intros. now apply red_conv.
+  eapply All2_sym; eapply (All2_impl eq1). intros. symmetry. now apply red_conv.
+Qed.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -281,8 +281,8 @@ Section Principality.
       subst.
       destruct d, d0. red in H, H1.
       rewrite H in H1. noconf H1. rewrite H0 in H2. noconf H2.
-      specialize (IHu1 _ _ _ t t1). clear t t1.
-      specialize (IHu2 _ _ _ t0 t2). clear t0 t2.
+      specialize (IHu1 _ _ _ t t1). clear t. eapply PCUICValidity.validity in t1.
+      specialize (IHu2 _ _ _ t0 t2).
       repeat outsum. repeat outtimes.
       eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]]; auto.
       eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]]; auto.
@@ -305,22 +305,13 @@ Section Principality.
           apply (All2_trans _ (conv_trans _ _) _ _ _ X0 a2).
       }
       clear redr redr' a1 a2.
-      todo "case"%string.
-      (* exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto. *)
-
-      (* 2:{ revert e2. *)
-      (*     rewrite /types_of_case. *)
-      (*     destruct instantiate_params eqn:Heq => //. *)
-      (*     destruct (destArity [] t1) as [[args s']|] eqn:eqar => //. *)
-      (*     destruct (destArity [] x12) as [[args' s'']|] eqn:eqx12 => //. *)
-      (*     destruct (destArity [] x2) as [[ctxx2 sx2]|] eqn:eqx2 => //. *)
-      (*     destruct map_option_out eqn:eqbrs => //. *)
-      (*     intros [=]. subst. *)
-      (*     eapply (type_Case _ _ _ x8). eauto. repeat split; eauto. auto. *)
-      (*     eapply t0. rewrite /types_of_case. *)
-      (*     rewrite Heq eqar eqx2 eqbrs. reflexivity. *)
-      (*     admit. admit. eapply type_Cumul. eauto. *)
-      (*     all:admit. } *)
+      exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto.
+      transitivity (mkApps u1 (skipn (ind_npars x8) x0 ++ [u2])); auto.
+      eapply conv_cumul, mkApps_conv_args; auto.
+      eapply All2_app. 2:constructor; auto.
+      eapply All2_skipn. eapply All2_sym, (All2_impl X0); firstorder.
+      econstructor;  eauto. simpl. split; auto.
+      eapply type_Cumul; eauto. auto.
 
     - destruct s as [[ind k] pars]; simpl in *.
       eapply inversion_Proj in hA=>//.
@@ -391,3 +382,4 @@ Proof.
   eapply (All2_impl eq0). intros. now apply red_conv.
   eapply All2_sym; eapply (All2_impl eq1). intros. symmetry. now apply red_conv.
 Qed.
+

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -485,7 +485,7 @@ Proof.
   eapply typing_spine_weaken_concl in hs.
   3:{ eapply cumul_trans; eauto with pcuic. } all:auto.
   clear hc htc.
-  destruct (declared_constructor_unique isdecl declc) as [[? ?] ?].
+  destruct (declared_constructor_inj isdecl declc) as [? [? ?]].
   subst mdecl' idecl' cdecl'. clear isdecl.
   destruct p as [onmind onind]. clear onc.
   destruct declc as [decli declc].
@@ -892,7 +892,7 @@ Proof.
     unfold on_declared_inductive in typec'.
     destruct declared_constructor_inv as [cs [Hnth onc]].
     simpl in typec'.
-    destruct (declared_inductive_unique isdecl decli) as []; subst mdecl' idecl'.
+    destruct (declared_inductive_inj isdecl decli) as []; subst mdecl' idecl'.
     set(oib := declared_inductive_inv _ _ _ _ _ _ _ _ _) in *. clearbody oib.
     eapply (build_branches_type_lookup _  Γ ind mdecl idecl cdecl' _ _ _ brs) in heq_map_option_out; eauto.
     2:{ eapply All2_impl; eauto. simpl; intuition eauto. }
@@ -1655,7 +1655,7 @@ Proof.
     destruct declared_inductive_inv. simpl in  *.
     pose proof isdecl as isdecl'.
     destruct isdecl' as [decli' [H0 Hi]].
-    destruct (declared_inductive_unique decli' decli) as []; subst mdecl' idecl'.
+    destruct (declared_inductive_inj decli' decli) as []; subst mdecl' idecl'.
     forward onProjections.
     eapply nth_error_Some_length in H0. simpl in H0.
     intros Hp. apply (f_equal (@length _)) in Hp. rewrite  Hp /=   in H0. lia.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -160,7 +160,7 @@ Section Validity.
       destruct (on_declared_inductive wfΣ decli) as [onmind oib].
       eapply typing_spine_app; eauto.
     - noconf H0. subst.
-      destruct (PCUICInductives.declared_inductive_unique isdecl decli) as [-> ->].
+      destruct (declared_inductive_inj isdecl decli) as [-> ->].
       clear decli. split; auto.
       constructor; [|reflexivity].
       destruct (on_declared_inductive wfΣ isdecl) as [onmind oib].

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -385,6 +385,8 @@ Proof.
   - red in onP |- *. eapply All_local_env_impl; eauto.
 Qed.
 
+Local Open Scope list_scope.
+
 Lemma weakening_env_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
   weaken_env_prop P ->
   wf Σ' -> extends Σ Σ' -> on_global_env P Σ ->
@@ -525,6 +527,41 @@ Proof.
   intros. unfold declared_constant in *. rewrite H in H0.
   now inv H0.
 Qed.
+
+Lemma declared_inductive_inj `{cf : checker_flags} {Σ mdecl mdecl' ind idecl idecl'} :
+  declared_inductive Σ mdecl' ind idecl' ->
+  declared_inductive Σ mdecl ind idecl ->
+  mdecl = mdecl' /\ idecl = idecl'.
+Proof.
+  intros [] []. unfold declared_minductive in *.
+  rewrite H in H1. inversion H1. subst. rewrite H2 in H0. inversion H0. eauto.
+Qed.
+
+Lemma declared_constructor_inj `{cf : checker_flags} {Σ mdecl mdecl' idecl idecl' cdecl cdecl' c} :
+  declared_constructor Σ mdecl' idecl' c cdecl ->
+  declared_constructor Σ mdecl idecl c cdecl' ->
+  mdecl = mdecl' /\ idecl = idecl'  /\ cdecl = cdecl'.
+Proof.
+  intros [] []. 
+  destruct (declared_inductive_inj H H1); subst.
+  rewrite H0 in H2. intuition congruence.
+Qed.
+
+Lemma declared_projection_inj `{cf : checker_flags} {Σ mdecl mdecl' idecl idecl' pdecl pdecl' p} :
+  declared_projection Σ mdecl' idecl' p pdecl ->
+  declared_projection Σ mdecl idecl p pdecl' ->
+  mdecl = mdecl' /\ idecl = idecl'  /\ pdecl = pdecl'.
+Proof.
+  intros [] []. 
+  destruct (declared_inductive_inj H H1); subst.
+  destruct H0, H2.
+  rewrite H0 in H2. intuition congruence.
+Qed.
+
+Lemma declared_inductive_minductive Σ ind mdecl idecl :
+  declared_inductive Σ mdecl ind idecl -> declared_minductive Σ (inductive_mind ind) mdecl.
+Proof. now intros []. Qed.
+Hint Resolve declared_inductive_minductive : pcuic.
 
 Lemma on_declared_minductive `{checker_flags} {Σ ref decl} :
   wf Σ ->

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -1755,3 +1755,67 @@ Definition print_constraint_set t :=
                          print_constraint_type d ++ " " ++ string_of_level l2)
              " /\ " (ConstraintSet.elements t).
   
+
+Lemma leq_universe_product_mon {cf: checker_flags} ϕ u u' v v' :
+  leq_universe ϕ u u' ->
+  leq_universe ϕ v v' ->
+  leq_universe (ϕ) (Universe.sort_of_product u v) (Universe.sort_of_product u' v').
+Proof.
+Admitted.
+
+Lemma impredicative_product {cf:checker_flags} {ϕ l u} : 
+  Universe.is_prop u -> 
+  leq_universe ϕ (Universe.sort_of_product l u) u.
+Proof.
+  unfold Universe.sort_of_product.
+  intros ->. reflexivity.
+Qed.
+
+Section no_prop_leq_type.
+  Context {cf:checker_flags}.
+  Context (Hcf : check_univs = true).
+  Context (no_prop_leq : prop_sub_type = false).
+  Context (ϕ : ConstraintSet.t).
+  (* MS: we need these lemmas on constraints coming from a well-formed environment,
+    maybe that's a necessary additional assumption. *)
+    
+
+  Lemma leq_universe_super l l' : 
+    leq_universe ϕ (Universe.make l) (Universe.make l') ->
+    leq_universe ϕ (Universe.super l) (Universe.super l').
+  Proof.
+    todo "Simon"%string.
+  Qed.
+
+  Lemma leq_universe_prop u1 u2 :
+    @leq_universe cf ϕ u1 u2 ->
+    (Universe.is_prop u1 \/ Universe.is_prop u2) ->
+    (Universe.is_prop u1 /\ Universe.is_prop u2).
+  Proof.
+    intros. unfold leq_universe in *. rewrite Hcf in H.
+    intuition auto. red in H.
+    red in H.
+    all:todo "Simon"%string.
+  Admitted.                       (* leq_universe_prop *)
+
+  Lemma leq_prop_prop {l l'} : 
+    Universe.is_prop l -> Universe.is_prop l' ->
+    leq_universe ϕ l l'.
+  Proof.
+    todo "Simon"%string.
+  Admitted.
+
+  Lemma leq_prop_is_prop {x s} : 
+    leq_universe ϕ x s -> 
+    (Universe.is_prop s <-> Universe.is_prop x).
+  Proof.
+    intros leq.
+    split; intros isp;  apply leq_universe_prop in leq; intuition auto.
+  Qed.
+
+  Lemma is_prop_gt l l' : leq_universe ϕ   (Universe.super l) l' -> Universe.is_prop l' -> False.
+  Proof.
+    todo "Simon"%string.
+  Qed.
+
+End no_prop_leq_type.


### PR DESCRIPTION
These are the lemmas about universes and in particular Prop </= Type needed for erasure correctness. It might be that we need some invariants on the constraints that are valid for well-formed global environment constraints to prove them, not sure.