### PR TITLE
Adapt to Coq PR #12146: tactic subst now inactive on section variables with indirect dependency in goal

### DIFF
--- a/template-coq/theories/common/uGraph.v
+++ b/template-coq/theories/common/uGraph.v
@@ -920,7 +920,7 @@ Section CheckLeq.
       -> gc_leq_universe_n n uctx.2 (Universe.make l) (Universe.make l').
   Proof.
     intro HH. apply leq_universe_vertices0.
-    apply leqb_vertices_correct; tas; subst G; exact _.
+    apply leqb_vertices_correct; tas; clear HH; subst G; exact _.
   Qed.
 
   Lemma leqb_no_prop_n_spec n (l l' : NoPropLevel.t)


### PR DESCRIPTION
The fix is a priori backward-compatible and can be merged now.

See [coq/coq#12139](https://github.com/coq/coq/issues/12139#issuecomment-622743684) for the motivation.