### PR TITLE
Implement tmVariable command, again

### DIFF
--- a/template-coq/src/constr_quoted.ml
+++ b/template-coq/src/constr_quoted.ml
@@ -179,8 +179,8 @@ struct
   let tInductiveDecl = ast "InductiveDecl"
   let tglobal_env = ast "global_env"
 
-  let (tglobal_reference, tConstRef, tIndRef, tConstructRef) =
-    (ast "global_reference", ast "ConstRef", ast "IndRef", ast "ConstructRef")
+  let (tglobal_reference, tVarRef, tConstRef, tIndRef, tConstructRef) =
+    (ast "global_reference", ast "VarRef", ast "ConstRef", ast "IndRef", ast "ConstructRef")
 
   let tcontext_decl = ast "context_decl"
   let tcontext = ast "context"

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -293,7 +293,9 @@ struct
 
 
   let quote_global_reference : Names.GlobRef.t -> quoted_global_reference = function
-    | Names.GlobRef.VarRef _ -> CErrors.user_err (str "VarRef unsupported")
+    | Names.GlobRef.VarRef c ->
+       let kn = quote_ident c in
+       constr_mkApp (tVarRef, [|kn|])
     | Names.GlobRef.ConstRef c ->
        let kn = quote_kn (Names.Constant.canonical c) in
        constr_mkApp (tConstRef, [|kn|])

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -277,6 +277,16 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
   | TmBind (a,f) ->
     run_template_program_rec ~poly ~intactic:intactic
      (fun (env, evm, ar) -> run_template_program_rec ~poly ~intactic:intactic k env (evm, Constr.mkApp (f, [|ar|]))) env (evm, a)
+ | TmVariable (name, typ) ->
+    if intactic 
+    then not_in_tactic "tmVariable"
+    else
+      let name = unquote_ident (reduce_all env evm name) in
+      let univs = Evd.univ_entry ~poly evm in
+      let param = Declare.ParameterEntry (None, (typ, univs), None) in
+      let n = Declare.declare_constant ~name ~kind:Decls.(IsAssumption Logical) param in
+      let env = Global.env () in
+      k (env, evm, Constr.mkConst n)
   | TmDefinition (opaque,name,s,typ,body) ->
     if intactic
     then not_in_tactic "tmDefinition"

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -24,6 +24,7 @@ let (ptmReturn,
      ptmAxiomRed,
      ptmMkDefinition,
      ptmMkInductive,
+     ptmVariable,
 
      ptmFreshName,
 
@@ -61,6 +62,7 @@ let (ptmReturn,
    r_template_monad_prop_p "tmAxiomRed",
    r_template_monad_prop_p "tmMkDefinition",
    r_template_monad_prop_p "tmMkInductive",
+   r_template_monad_prop_p "tmVariable",
 
    r_template_monad_prop_p "tmFreshName",
 
@@ -155,6 +157,7 @@ type template_monad =
   | TmAxiom of Constr.t * Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
   | TmMkInductive of Constr.t
+  | TmVariable of Constr.t * Constr.t
 
   | TmFreshName of Constr.t
 
@@ -336,6 +339,10 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     match args with
     | mind::[] -> (TmMkInductive mind, universes)
     | _ -> monad_failure "tmMkInductive" 1
+  else if eq_gr ptmVariable then
+    match args with
+    | name::ty::[] -> (TmVariable (name,ty) , universes)
+    | _ -> monad_failure "tmVariable" 2
   else if eq_gr ttmInductive then
     match args with
     | mind::[] -> (TmMkInductive mind, universes)

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -29,6 +29,7 @@ type template_monad =
   | TmAxiom of Constr.t * Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
   | TmMkInductive of Constr.t
+  | TmVariable of Constr.t * Constr.t
 
   | TmFreshName of Constr.t
 

--- a/template-coq/theories/BasicAst.v
+++ b/template-coq/theories/BasicAst.v
@@ -78,7 +78,7 @@ Inductive recursivity_kind :=
 (** Kernel declaration references [global_reference] *)
 
 Inductive global_reference :=
-(* VarRef of Names.variable *)
+| VarRef : kername -> global_reference
 | ConstRef : kername -> global_reference
 | IndRef : inductive -> global_reference
 | ConstructRef : inductive -> nat -> global_reference.
@@ -86,6 +86,7 @@ Inductive global_reference :=
 
 Definition string_of_gref gr : string :=
   match gr with
+  | VarRef s => "Variable " ++ s
   | ConstRef s => s
   | IndRef (mkInd s n) =>
     "Inductive " ++ s ++ " " ++ (string_of_nat n)

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -31,6 +31,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmLemma : ident -> forall A : Type@{t}, TemplateMonad A
 | tmDefinitionRed_ : forall (opaque : bool), ident -> option reductionStrategy -> forall {A:Type@{t}}, A -> TemplateMonad A
 | tmAxiomRed : ident -> option reductionStrategy -> forall A : Type@{t}, TemplateMonad A
+| tmVariable : ident -> forall A : Type@{t}, TemplateMonad A
 
 (* Guaranteed to not cause "... already declared" error *)
 | tmFreshName : ident -> TemplateMonad ident

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -42,4 +42,5 @@ TypingTests.v
 unfold.v
 univ.v
 vs.v
+tmVariable.v
 order_rec.v

--- a/test-suite/tmVariable.v
+++ b/test-suite/tmVariable.v
@@ -1,0 +1,12 @@
+Require Import List Arith String.
+Require Import MetaCoq.Template.All.
+Import ListNotations MonadNotation.
+
+Section test.
+
+  MetaCoq Run (tmVariable "bla" nat).
+  MetaCoq Run (tmDefinition "test" 0).
+
+End test.
+
+Print test.


### PR DESCRIPTION
This is #311 again, relevant also for Vadim's request in #381. 

I get 
```
Error: not found in table: metacoq.templatemonad.prop.tmVariable
```
in `test-suite/tmVariable.v`, but actually I think I added `tmVariable` properly [here](https://github.com/yforster/template-coq/blob/tmVariable2/template-coq/src/template_monad.ml#L65). @SimonBoulier can you maybe have a quick look whether you see what's wrong? That would be great!
