### PR TITLE
depelim and noconfusion fixes

### DIFF
--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -128,15 +128,15 @@ Qed.
 
 Lemma context_subst_fun {ctx args s s'} : context_subst ctx args s -> context_subst ctx args s' -> s = s'.
 Proof.
-  induction 1 in s' |- *; intros H'; depelim H'; try simpl in H; try noconf H; auto.
-  eapply app_inj_tail in H0. intuition subst.
+  induction 1 in s' |- *; intros H'; depelim H'; auto.
+  eapply app_inj_tail in H. intuition subst.
   now specialize (IHX _ H').
   now specialize (IHX _ H').
 Qed.
 
 Lemma context_subst_fun' {ctx args args' s s'} : context_subst ctx args s -> context_subst ctx args' s' -> #|args| = #|args'|.
 Proof.
-  induction 1 as [ | ? ? ? ? ? ? ? IHX | ? ? ? ? ? ? ? IHX ] in args', s' |- *; intros H'; depelim H'; try simpl in H; try noconf H; auto.
+  induction 1 as [ | ? ? ? ? ? ? ? IHX | ? ? ? ? ? ? ? IHX ] in args', s' |- *; intros H'; depelim H'; auto.
   now rewrite !app_length; specialize (IHX _ _ H').
   now specialize (IHX _ _ H').
 Qed.

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -253,7 +253,7 @@ Section Confluence.
     revert c. induction args using rev_ind; intros; simpl in *.
     depelim X... exists []. intuition auto.
     intros. rewrite <- mkApps_nested in X.
-    depelim X... simpl in H; noconf H. solve_discr.
+    depelim X... 
     prepare_discr. apply mkApps_eq_decompose_app in H.
     rewrite !decompose_app_rec_mkApps in H. noconf H.
     destruct (IHargs _ X1) as [args' [-> Hargs']].
@@ -288,6 +288,8 @@ Section Confluence.
     eapply All2_app; auto.
   Qed.
 
+  Derive NoConfusion for PCUICEnvironment.global_decl.
+
   Lemma pred1_mkApps_tConst_axiom (Σ : global_env) (Γ Δ : context)
         cst u (args : list term) cb c :
     declared_constant Σ cst cb -> cst_body cb = None ->
@@ -297,11 +299,10 @@ Section Confluence.
     revert c. induction args using rev_ind; intros; simpl in *.
     depelim X...
     - red in H, isdecl. rewrite isdecl in H; noconf H.
-      simpl in H. injection H. intros. subst. congruence.
+      congruence.
     - exists []. intuition auto.
     - rewrite <- mkApps_nested in X.
       depelim X...
-      * simpl in H1; noconf H1. solve_discr.
       * prepare_discr. apply mkApps_eq_decompose_app in H1.
         rewrite !decompose_app_rec_mkApps in H1. noconf H1.
       * destruct (IHargs _ H H0 X1) as [args' [-> Hargs']].
@@ -503,8 +504,6 @@ Section Confluence.
     - intros H.
       now exists ind, n, ui, [].
   Qed.
-
-  Derive NoConfusion for global_decl.
 
   Hint Resolve pred1_refl : pcuic.
 
@@ -1473,8 +1472,8 @@ Section Confluence.
         destruct (nth_error_pred1_ctx _ _ X H) as [bodyΓ [? ?]]; eauto.
         move e after H.
         pose proof (pred1_pred1_ctx _ (fst (Hrel i))).
-        destruct (nth_error Γ' i) eqn:HΓ'i; noconf H. hnf in H.
-        destruct (nth_error Γ i) eqn:HΓi; noconf e. hnf in H.
+        destruct (nth_error Γ' i) eqn:HΓ'i; noconf H.
+        destruct (nth_error Γ i) eqn:HΓi; noconf e.
         pose proof (Hσ _ _ HΓi) as Hc. rewrite H in Hc.
         destruct Hc as [σi [b' [eqi' [Hnth Hb']]]].
         pose proof (Hτ _ _ HΓ'i) as Hc'. rewrite H0 in Hc'.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -484,7 +484,7 @@ induction cv; intros; depelim cs ; depelim cs';
   constructor; auto.
 - depelim sl; depelim sl'; simpl in H; noconf H; simpl in H0; noconf H0;
     try (simpl in H1; noconf H1); try (simpl in H2; noconf H2).
-  depelim wf; simpl in H; noconf H.
+  depelim wf.
   specialize (IHcv _ _ cs wf sl _ _ cs' sl' X).
   constructor; auto.
   eapply (subst_conv _ _ _ []); eauto.
@@ -784,18 +784,18 @@ Proof.
       depelim cs'. discriminate.
       simpl in *. rewrite skipn_S skipn_0 in cs.
       rewrite subst_empty in t0.
-      depelim cs'; simpl in H; noconf H. depelim cs'. noconf H0.
-      rewrite H1 in H2. noconf H2.
+      depelim cs'. depelim cs'. noconf H.
+      rewrite H0 in H1. noconf H1.
       constructor; auto.
       rewrite /subst1 subst_it_mkProd_or_LetIn.
       rewrite Nat.add_0_r.
       specialize (X (subst_context (skipn #|Γ0| s) 0 Γ0) ltac:(now autorewrite with len) _ _ 
       (subst [t1] #|Γ0| T) cs subsl').
-      rewrite -{1}H1. apply X.
+      rewrite -{1}H0. apply X.
       rewrite -subst_app_simpl'.
       apply subslet_length in subsl'.
       now autorewrite with len in subsl'.
-      rewrite -H1. now rewrite firstn_skipn.
+      rewrite -H0. now rewrite firstn_skipn.
 Qed.
 
 

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -289,9 +289,9 @@ Section Conversion.
           eapply uip.
         * intros [t1 ht1] [t2 ht2] [e] [[q1 hq1] s1] [[q2 hq2] s2] h.
           simpl in *.
-          dependent destruction h.
+          dependent destruction h. 
           -- left. unfold posR in *. simpl in *. assumption.
-          -- simpl in H0. noconf H0. match goal with
+          -- match goal with
              | |- context [ exist q1 ?hq1 ] =>
                assert (ee : hq1 = hq2) by eapply uip
              end.
@@ -321,7 +321,7 @@ Section Conversion.
       + left. unfold posR in *.
         simpl in *.
         assumption.
-      + simpl in H0. noconf H0. match goal with
+      + match goal with
         | |- context [ exist p1 ?hp1 ] =>
           assert (ee : hp1 = hp2) by eapply uip
         end.
@@ -332,7 +332,7 @@ Section Conversion.
           dependent destruction H.
           -- left. unfold posR in *.
              simpl in *. assumption.
-          -- simpl in H0; noconf H0; right. assumption.
+          -- right. assumption.
     - eapply normalisation_upto. all: assumption.
   Qed.
 


### PR DESCRIPTION
Fixes metacoq w.r.t. mattam82/Coq-Equations#285
This removes some dirty tactics that had to manually apply noconfusion after simplifying some hypotheses because the equations tactics did not work up-to simplification. It's much cleaner now!