### PR TITLE
Clear universe axioms

### DIFF
--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -12,9 +12,6 @@ Derive NoConfusion for term.
 Derive Signature for All.
 Derive Signature for All2.
 
-Axiom todounivs : forall {A}, A.
-Ltac todounivs := apply todounivs.
-
 Open Scope pcuic.
 Local Open Scope string_scope.
 Fixpoint string_of_term (t : term) :=

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -1219,7 +1219,7 @@ Proof.
       rewrite subst_instance_context_smash.
       eapply iparsubst0. simpl.
       rewrite subst_instance_constr_mkApps subst_mkApps /=.
-      rewrite subst_instance_instance_id subst_instance_to_extended_list.
+      rewrite (subst_instance_instance_id Σ) // subst_instance_to_extended_list.
       rewrite firstn_all2 in iparsubst0. lia.
       eapply spine_subst_smash in iparsubst0; auto.
       rewrite subst_instance_context_smash /=.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -273,7 +273,7 @@ Section Validity.
       constructor. constructor.
       simpl. rewrite subst_empty.
       rewrite subst_instance_constr_mkApps subst_mkApps /=.
-      rewrite subst_instance_instance_id.
+      rewrite (subst_instance_instance_id Σ); auto.
       rewrite subst_instance_to_extended_list.
       rewrite subst_instance_context_smash.
       rewrite (spine_subst_subst_to_extended_list_k sppar).


### PR DESCRIPTION
Clear all todounivs from the proof (now SR only depends on todoeta, funext and the guard axioms).

@SimonBoulier reassuringly those universe lemmas were not too hard to prove :) 

We discussed today with Théo about doing a 1.0 release with the current state, just by removing the todoeta occurrences. Are you ok with this?