### PR TITLE
[coq] Adapt to coq/coq#11836

### DIFF
--- a/template-coq/src/g_template_coq.mlg
+++ b/template-coq/src/g_template_coq.mlg
@@ -65,9 +65,8 @@ let ltac_apply (f : Value.t) (args: Tacinterp.Value.t list) =
 
 let to_ltac_val c = Tacinterp.Value.of_constr c
 
-
-let run_template_program env evm ~poly pgm =
-  Run_template_monad.run_template_program_rec ~poly (fun _ -> ()) env (evm, pgm)
+let run_template_program ~pm env evm ~poly pgm =
+  Run_template_monad.run_template_program_rec ~poly (fun ~st _ _ _ -> st) ~st:pm env (evm, pgm)
 
 let fresh_env () = 
   let env = Global.env () in
@@ -79,17 +78,17 @@ let to_constr_evars sigma c = EConstr.to_constr ~abort_on_undefined_evars:false 
  
 (** ********* Commands ********* *)
 
-VERNAC COMMAND EXTEND TemplateCoq_Test_Quote CLASSIFIED AS QUERY
+VERNAC COMMAND EXTEND TemplateCoq_Test_Quote CLASSIFIED AS QUERY STATE program
     | #[ poly = polymorphic ] [ "MetaCoq" "Test" "Quote" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
         let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmTestQuote) in
-        let pgm = Constr.mkApp (EConstr.to_constr evm pgm, 
+        let pgm = Constr.mkApp (EConstr.to_constr evm pgm,
           [|Constr.mkRel 0; to_constr_evars evm def|]) in
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Quote_Definition CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND TemplateCoq_Quote_Definition CLASSIFIED AS SIDEFF STATE program
     | #[ poly = polymorphic ] [ "MetaCoq" "Quote" "Definition" ident(name) ":=" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -99,7 +98,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Quote_Definition CLASSIFIED AS SIDEFF
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Quote_Definition_Eval CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND TemplateCoq_Quote_Definition_Eval CLASSIFIED AS SIDEFF STATE program
   | #[ poly = polymorphic ] [ "MetaCoq" "Quote" "Definition" ident(name) ":=" "Eval" red_expr(rd) "in" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -111,7 +110,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Quote_Definition_Eval CLASSIFIED AS SIDEFF
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Quote_Recursively_Definition CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND TemplateCoq_Quote_Recursively_Definition CLASSIFIED AS SIDEFF STATE program
   | #[ poly = polymorphic ] [ "MetaCoq" "Quote" "Recursively" "Definition" ident(name) ":=" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -125,7 +124,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Quote_Recursively_Definition CLASSIFIED AS SID
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Test_Unquote CLASSIFIED AS QUERY
+VERNAC COMMAND EXTEND TemplateCoq_Test_Unquote CLASSIFIED AS QUERY STATE program
     | #[ poly = polymorphic ] [ "MetaCoq" "Test" "Unquote" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -135,7 +134,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Test_Unquote CLASSIFIED AS QUERY
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Make_Definition CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND TemplateCoq_Make_Definition CLASSIFIED AS SIDEFF STATE program
   | #[ poly = polymorphic ] [ "MetaCoq" "Unquote" "Definition" ident(name) ":=" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -146,7 +145,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Make_Definition CLASSIFIED AS SIDEFF
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Make_Inductive CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND TemplateCoq_Make_Inductive CLASSIFIED AS SIDEFF STATE program
   | #[ poly = polymorphic ] [ "MetaCoq" "Unquote" "Inductive" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -156,7 +155,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Make_Inductive CLASSIFIED AS SIDEFF
         run_template_program env evm ~poly pgm }
 END
 
-VERNAC COMMAND EXTEND TemplateCoq_Run_Template_Program CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND TemplateCoq_Run_Template_Program CLASSIFIED AS SIDEFF STATE program
   | #[ poly = polymorphic ] [ "MetaCoq" "Run" constr(def) ] ->
       { let (env, evm) = fresh_env () in
         let (evm, def) = Constrintern.interp_open_constr env evm def in
@@ -196,11 +195,16 @@ TACTIC EXTEND TemplateCoq_run_template_program
          let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let ret = ref None in
-         Run_template_monad.run_template_program_rec ~poly ~intactic:true (fun x -> ret := Some x) env (evm, to_constr_evars evm c);
+         (* We don't allow opening obligations / updating the vernacular inside proofs / as tactics *)
+         let pm = Declare.OblState.empty in
+         let _pm = Run_template_monad.run_template_program_rec
+             ~poly ~intactic:true ~st:pm (fun ~st env evm t -> ret := Some (env,evm,t); st)
+             env (evm, to_constr_evars evm c)
+         in
          match !ret with
-           Some (env, evm, t) ->
+         | Some (env, evm, t) ->
             Proofview.tclTHEN
-              (Proofview.Unsafe.tclEVARS evm) 
+              (Proofview.Unsafe.tclEVARS evm)
               (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr t]))
          | None -> Proofview.tclUNIT ()
        end) }

--- a/template-coq/src/plugin_core.mli
+++ b/template-coq/src/plugin_core.mli
@@ -21,11 +21,19 @@ val rs_unfold : Environ.env -> global_reference -> reduction_strategy
 
 type 'a tm
 
-val run : 'a tm -> Environ.env -> Evd.evar_map -> (Environ.env -> Evd.evar_map -> 'a -> unit) -> unit
+type coq_state = Declare.OblState.t
+type 'a cont = st:coq_state -> Environ.env -> Evd.evar_map -> 'a -> coq_state
+
+val run : st:coq_state
+  -> 'a tm
+  -> Environ.env
+  -> Evd.evar_map
+  -> 'a cont
+  -> coq_state
 
 val with_env_evm : (Environ.env -> Evd.evar_map -> 'a tm) -> 'a tm
 
-val run_vernac : 'a tm -> unit
+val run_vernac : st:coq_state -> 'a tm -> coq_state
 
 val tmReturn : 'a -> 'a tm
 val tmBind : 'a tm -> ('a -> 'b tm) -> 'b tm

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -227,5 +227,5 @@ let rec interp_tm (t : 'a coq_TM) : 'a tm =
           None -> Obj.magic None
         | Some inst -> Obj.magic (tmMap (fun x -> Some x) (tmOfConstr inst)))
 
-let run_vernac (c : 'a coq_TM) : unit =
-  Plugin_core.run_vernac (interp_tm (Obj.magic c))
+let run_vernac ~pm (c : 'a coq_TM) : Plugin_core.coq_state =
+  Plugin_core.run_vernac ~st:pm (interp_tm (Obj.magic c))

--- a/template-coq/src/run_extractable.mli
+++ b/template-coq/src/run_extractable.mli
@@ -5,7 +5,6 @@ open BasicAst
 open Quoter
 open Ast_quoter
 
-
 val interp_tm : Extractable.__ coq_TM -> Extractable.__ Plugin_core.tm
 
-val run_vernac : 'a coq_TM -> unit
+val run_vernac : pm:Plugin_core.coq_state -> 'a coq_TM -> Plugin_core.coq_state

--- a/template-coq/src/run_template_monad.mli
+++ b/template-coq/src/run_template_monad.mli
@@ -3,5 +3,7 @@ val declare_inductive : Environ.env -> Evd.evar_map -> Constr.t -> unit
 val run_template_program_rec :
     poly:bool ->
     ?intactic:bool ->
-    (Environ.env * Evd.evar_map * Constr.t -> unit) ->
-    Environ.env -> Evd.evar_map * Constr.t -> unit
+    Constr.t Plugin_core.cont ->
+    st:Plugin_core.coq_state ->
+    Environ.env -> Evd.evar_map * Constr.t ->
+    Plugin_core.coq_state

--- a/test-suite/plugin-demo/src/g_demo_plugin.mlg
+++ b/test-suite/plugin-demo/src/g_demo_plugin.mlg
@@ -5,19 +5,19 @@ open MyPlugin
 
 DECLARE PLUGIN "demo_plugin"
 
-VERNAC COMMAND EXTEND Make_vernac CLASSIFIED AS QUERY
+VERNAC COMMAND EXTEND Make_vernac CLASSIFIED AS QUERY STATE program
    | [ "Showoff" ] ->
      { Run_extractable.run_vernac showoff }
 END
 
 
-VERNAC COMMAND EXTEND Make_lens_vernac CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND Make_lens_vernac CLASSIFIED AS SIDEFF STATE program
 | [ "Make" "Lens" ident(name) ] ->
      { Run_extractable.run_vernac (genLensN (Tm_util.string_to_list (Names.Id.to_string name))) }
 END
 
 
-VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
+VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF STATE program
 | [ "LookupPrint" ident(name) ] ->
      { let nstr = Names.Id.to_string name in
        Run_extractable.run_vernac (lookupPrint (Tm_util.string_to_list nstr)) }


### PR DESCRIPTION
As parts of Coq are modified into a functional style of state passing,
we modify the MetaCoq monad to take this into account by making it
into a state-passing monad.

This is in particular needed as MetaCoq will add obligations; note
that this is for example not well defined upstream when used inside a
proof, we note so in the comments.