### PR TITLE
Fix evaluation relations to compute properly with stuck fixpoints

### DIFF
--- a/erasure/theories/ETyping.v
+++ b/erasure/theories/ETyping.v
@@ -74,17 +74,6 @@ Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
   | None => None
   end.
 
-Definition is_constructor n ts :=
-  match List.nth_error ts n with
-  | Some a =>
-    let (f, a) := decompose_app a in
-    match f with
-    | tConstruct _ _ => true
-    | _ => false
-    end
-  | None => false
-  end.
-
 Definition is_constructor_or_box n ts :=
   match List.nth_error ts n with
   | Some tBox => true

--- a/erasure/theories/ETyping.v
+++ b/erasure/theories/ETyping.v
@@ -74,15 +74,20 @@ Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
   | None => None
   end.
 
-Definition is_constructor_or_box n ts :=
-  match List.nth_error ts n with
-  | Some tBox => true
-  | Some a =>
+Definition is_constructor_app_or_box t :=
+  match t with
+  | tBox => true
+  | a =>
     let (f, a) := decompose_app a in
     match f with
     | tConstruct _ _ => true
     | _ => false
     end
+  end.
+
+Definition is_nth_constructor_app_or_box n ts :=
+  match List.nth_error ts n with
+  | Some a => is_constructor_app_or_box a
   | None => false
   end.
 

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -390,6 +390,7 @@ Qed.
 
 Derive NoConfusionHom for EAst.global_decl.
 
+Unset SsrRewrite.
 Lemma eval_deterministic {t v v'} :
   eval t v ->
   eval t v' ->
@@ -457,7 +458,7 @@ Proof.
       now apply negb_true_iff in H.
     + apply IHev1 in ev'1.
       subst.
-      rewrite isFixApp_mkApps in H2; [easy|].
+      rewrite isFixApp_mkApps in H2 by easy.
       cbn in *.
       now rewrite orb_true_r in H2.
     + easy.
@@ -478,7 +479,7 @@ Proof.
       now apply mkApps_eq_inj in ev'1 as (ev'1 & <-).
     + apply IHev1 in ev'1.
       subst.
-      rewrite isFixApp_mkApps in H1; [easy|].
+      rewrite isFixApp_mkApps in H1 by easy.
       cbn in H1.
       now rewrite orb_true_r in H1.
     + easy.
@@ -529,7 +530,7 @@ Proof.
     + apply IHev1 in ev'1.
       apply IHev2 in ev'2.
       subst.
-      rewrite isFixApp_mkApps in H; [easy|].
+      rewrite isFixApp_mkApps in H by easy.
       cbn in H.
       now rewrite orb_true_r in H.
     + apply IHev1 in ev'1.
@@ -541,6 +542,7 @@ Proof.
     + easy.
   - now depelim ev'.
 Qed.
+Set SsrRewrite.
 
 End Wcbv.
 

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -45,7 +45,7 @@ Definition isStuckFix t args :=
   | tFix mfix idx =>
     match unfold_fix mfix idx with
     | Some (narg, fn) =>
-      ~~ is_constructor narg args
+      ~~ is_constructor_or_box narg args
     | None => false
     end
   | _ => false

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -543,3 +543,5 @@ Proof.
 Qed.
 
 End Wcbv.
+
+Arguments eval_deterministic {_ _ _ _}.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -888,46 +888,40 @@ Proof.
   - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
-    (*assert (Σ |-p mkApps (tFix mfix idx) argsv ▷ res) by eauto.*)
-    eapply PCUICValidity.inversion_app in Hty' as (? & ? & ?); eauto.
+    (*assert (Σ |-p tApp (mkApps (tFix mfix idx) args ▷ res) by eauto.*)
+    eapply inversion_App in Hty' as (? & ? & ? & ? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
     2:now eapply PCUICClosed.subject_closed in Ht.
     assert (HT := t).
-    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
-    rewrite <- closed_unfold_fix_cunfold_eq in H0; first last.
-    eapply eval_closed; eauto. eapply PCUICClosed.subject_closed in Ht; eauto.
-    auto.
-    unfold unfold_fix in H0. rewrite e in H0. inv H0.
-
-    eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
-      exists EAst.tBox. split. 2:{
-        assert (exists x4, Forall2 (EWcbvEval.eval Σ') x3 x4) as [x4]. {
-          eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
-          clear a0. subst.
-          assert (forall x n, nth_error x2 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-          { intros. eapply typing_spine_inv with (arg := n + #|x1|) in t0 as [].
-            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
-            eauto.
-          }
-          clear - X0 a1 H5. revert X0 x3 H5; induction a1; intros.
-          ** inv H5. exists []; eauto.
-          ** inv H5. destruct (X0 x 0 eq_refl).
-             eapply r in t as (? & ? & ?); eauto.
-             eapply IHa1 in H3 as (? & ?); eauto.
-             intros. eapply (X0 x2 (S n)). eassumption.
-        }
-        eapply eval_box_apps. eassumption. econstructor; eauto. }
+    apply PCUICValidity.inversion_mkApps in HT as (? & ? & ?); auto.
+    assert (Ht1 := t1).
+    apply inversion_Fix in t1 as Hfix; auto.
+    destruct Hfix as (? & ? & ? & ? & ? & ? & ?).
+    rewrite <- closed_unfold_fix_cunfold_eq in e; first last.
+    eapply (PCUICClosed.subject_closed (Γ := [])); eauto.
+    assert (uf := e).
+    unfold unfold_fix in e. rewrite e0 in e. inv e.
+    depelim He; first last.
+    
+    + assert (X100 := X). eapply (Is_type_app _ _ _ []) in X100 as[]; eauto.
+      exists EAst.tBox. split; [|now constructor].
       econstructor.
       eapply Is_type_eval. eauto. eassumption.
-      rewrite <- mkApps_nested.
-      eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
-      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht.
-      eauto. eauto.
-      rewrite mkApps_nested; eauto.
-    + subst.
-      eapply IHeval1 in H4 as (? & ? & ?); eauto.
+      eapply Is_type_red. eauto. 2: exact X0.
+      cbn.
+      etransitivity.
+      eapply PCUICReduction.red_app.
+      eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in Ht.
+      eauto. eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in t0.
+      eauto.
+      rewrite <- !mkApps_snoc.
+      eapply PCUICReduction.red1_red.
+      eapply red_fix.
+      eauto.
+      unfold is_constructor.
+      rewrite nth_error_snoc; eauto.
+    + eapply IHeval1 in H4 as (? & ? & ?); eauto.
       inv H0.
       * assert (Hmfix' := X2).
         eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -885,43 +885,52 @@ Proof.
            eapply value_app_inv in H2. subst. eassumption.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
-  - assert (Hty' := Hty).
+
+  - todo "fix case".
+    (*
+    assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
-    (*assert (Σ |-p tApp (mkApps (tFix mfix idx) args ▷ res) by eauto.*)
-    eapply inversion_App in Hty' as (? & ? & ? & ? & ? & ?); eauto.
+    assert (Σ |-p mkApps (tFix mfix idx) args ▷ res) by eauto.
+    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
     2:now eapply PCUICClosed.subject_closed in Ht.
     assert (HT := t).
-    apply PCUICValidity.inversion_mkApps in HT as (? & ? & ?); auto.
-    assert (Ht1 := t1).
-    apply inversion_Fix in t1 as Hfix; auto.
-    destruct Hfix as (? & ? & ? & ? & ? & ? & ?).
-    rewrite <- closed_unfold_fix_cunfold_eq in e; first last.
-    eapply (PCUICClosed.subject_closed (Γ := [])); eauto.
-    assert (uf := e).
-    unfold unfold_fix in e. rewrite e0 in e. inv e.
-    depelim He; first last.
-    
-    + assert (X100 := X). eapply (Is_type_app _ _ _ []) in X100 as[]; eauto.
-      exists EAst.tBox. split; [|now constructor].
+    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
+    rewrite <- closed_unfold_fix_cunfold_eq in H0; first last.
+    eapply eval_closed; eauto. eapply PCUICClosed.subject_closed in Ht; eauto.
+    auto.
+    unfold unfold_fix in H0. rewrite e in H0. inv H0.
+
+    eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
+    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
+      exists EAst.tBox. split. 2:{
+        assert (exists x4, Forall2 (EWcbvEval.eval Σ') x3 x4) as [x4]. {
+          eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
+          clear a0. subst.
+          assert (forall x n, nth_error x2 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
+          { intros. eapply typing_spine_inv with (arg := n + #|x1|) in t0 as [].
+            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
+            eauto.
+          }
+          clear - X0 a1 H5. revert X0 x3 H5; induction a1; intros.
+          ** inv H5. exists []; eauto.
+          ** inv H5. destruct (X0 x 0 eq_refl).
+             eapply r in t as (? & ? & ?); eauto.
+             eapply IHa1 in H3 as (? & ?); eauto.
+             intros. eapply (X0 x2 (S n)). eassumption.
+        }
+        eapply eval_box_apps. eassumption. econstructor; eauto. }
       econstructor.
       eapply Is_type_eval. eauto. eassumption.
-      eapply Is_type_red. eauto. 2: exact X0.
-      cbn.
-      etransitivity.
-      eapply PCUICReduction.red_app.
-      eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in Ht.
-      eauto. eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in t0.
-      eauto.
-      rewrite <- !mkApps_snoc.
-      eapply PCUICReduction.red1_red.
-      eapply red_fix.
-      eauto.
-      unfold is_constructor.
-      rewrite nth_error_snoc; eauto.
-    + eapply IHeval1 in H4 as (? & ? & ?); eauto.
+      rewrite <- mkApps_nested.
+      eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
+      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht.
+      eauto. eauto.
+      rewrite mkApps_nested; eauto.
+    + subst.
+      eapply IHeval1 in H4 as (? & ? & ?); eauto.
       inv H0.
       * assert (Hmfix' := X2).
         eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
@@ -1053,8 +1062,11 @@ Proof.
            now eapply wcbeval_red; eauto.
           eapply All_All2_refl.
           clear. induction args. econstructor. econstructor; eauto.
+    *)
 
-  - assert (Hty' := Hty).
+  - todo "fix_value case".
+    (*
+    assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H0).
     assert (Σ |-p mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
@@ -1124,9 +1136,20 @@ Proof.
               ** assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x6)) by now rewrite H6.
                  rewrite !EAstUtils.decompose_app_mkApps in H7; try reflexivity.
                  inv H7.
-              ** unfold is_constructor, ETyping.is_constructor_or_box in *.
+              ** unfold is_constructor, ETyping.is_constructor in *.
                  destruct nth_error eqn:En; try now inv Hcon.
-                 --- todo "cannot have stuck fixpoint with enough args when axiom free".
+                 --- eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
+                     inv H0.
+                     +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
+                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
+                         inv H0.
+                         rewrite H4.
+                         eapply is_construct_erases in Hcon; eauto.
+                         unfold EisConstruct_app in *.
+                         destruct ?; eauto.
+                     +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x5)) by now rewrite H.
+                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
+                         inv H0.
                  ---  eapply Forall2_nth_error_None_l in H4; eauto.
                       inv H0.
                       +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
@@ -1179,7 +1202,7 @@ Proof.
         now eapply wcbeval_red. auto.
         eapply All_All2_refl.
         clear. induction args. econstructor. econstructor; eauto.
-
+    *)
 
   - destruct ip.
     assert (Hty' := Hty).
@@ -1203,8 +1226,8 @@ Proof.
       destruct (EAstUtils.isBox x2) eqn:E.
       * destruct x2; inv E. exists EAst.tBox. split. 2: econstructor; eauto.
         pose proof (Is_type_app Σ [] f'[a']).
-        inversion H2.
-        edestruct H8; eauto. cbn. eapply subject_reduction. eauto.
+        inversion H1.
+        edestruct H7; eauto. cbn. eapply subject_reduction. eauto.
         exact Hty. eapply PCUICReduction.red_app.
         eapply PCUICClosed.subject_closed in t'; auto.
         eapply wcbeval_red; eauto.
@@ -1216,14 +1239,14 @@ Proof.
                    eapply ssrbool.negbT.
                    repeat eapply orb_false_intro.
                    - destruct x2; try reflexivity.
-                     inv H2. inv H0.
+                     inv H1. inv i.
                    - destruct x2 eqn:Ex; try reflexivity.
-                     + cbn. inv H2. cbn in *.
+                     + cbn. inv H1. cbn in *.
                        eapply ssrbool.negbTE, is_FixApp_erases.
                        econstructor; eauto.
-                       now rewrite orb_false_r in H0.
+                       now rewrite orb_false_r in i.
                      + cbn in *.
-                       inv H2. inv H0.
+                       inv H1. inv i.
                    - eauto. }
         econstructor; eauto.
     + exists EAst.tBox. split. 2: now econstructor.
@@ -1236,7 +1259,7 @@ Proof.
       eapply PCUICClosed.subject_closed in Ha; auto.
       eapply wcbeval_red; eauto.
       
-  - destruct t; try now inversion H.
+  - destruct t; try easy.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -921,265 +921,9 @@ Proof.
       eauto.
       unfold is_constructor.
       rewrite nth_error_snoc; eauto.
-    + eapply IHeval1 in H4 as (? & ? & ?); eauto.
-      inv H0.
-      * assert (Hmfix' := X2).
-        eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
-        destruct x0. cbn in *. subst.
+    + todo "unerasable fix case".
 
-        enough(Σ;;; [] ,,, PCUICLiftSubst.subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ 
-          subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x3)).
-        destruct p. destruct p.
-
-        clear e3. rename H into e3.
-        -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x2 L).
-           ++ cbn in e3. destruct H as (L & ? & ?).
-              assert (Hv : Forall Ee.value L).
-              { eapply Forall2_Forall_right; eauto.
-                intros. eapply EWcbvEval.eval_to_value. eauto.
-              }
-
-              eapply erases_mkApps in H0; eauto.
-              eapply IHeval2 in H0 as (? & ? & ?); cbn; eauto.
-              exists x0. split. eauto.
-              econstructor. eauto.
-              rewrite <- Ee.closed_unfold_fix_cunfold_eq; first last.
-              { eapply eval_closed in e3.
-                pose proof (All2_length _ _ Hmfix').
-                clear -e3 Hmfix' H8.
-                simpl in e3 |- *. solve_all.
-                rewrite app_context_nil_l in b.
-                eapply erases_closed in b. simpl in b.
-                rewrite <-H8.
-                unfold EAst.test_def. 
-                simpl in b.
-                rewrite fix_context_length in b.
-                now rewrite Nat.add_0_r.
-                unfold test_def in a. apply andP in a as [_ Hbod].
-                rewrite fix_context_length.
-                now rewrite Nat.add_0_r in Hbod.
-                eauto with pcuic.
-                now eapply PCUICClosed.subject_closed in Ht.  }
-              unfold ETyping.unfold_fix.
-              rewrite e0. reflexivity.
-              all:eauto.
-              ** unfold is_constructor in *.
-                 destruct ?; inv H1.
-                 unfold is_constructor_or_box.
-                 eapply Forall2_nth_error_Some in H as (? & ? & ?); eauto.
-                 rewrite H.
-
-                 unfold isConstruct_app in H9.
-                 destruct (decompose_app t) eqn:EE.
-                 assert (E2 : fst (decompose_app t) = t1) by now rewrite EE.
-                 destruct t1.
-                 all:inv H9.
-                 (* erewrite <- PCUICConfluence.fst_decompose_app_rec in E2. *)
-
-                 pose proof (decompose_app_rec_inv EE).
-                 cbn in H8. subst.
-                 assert (∑ T, Σ ;;; [] |- mkApps (tConstruct ind n ui) l : T) as [T' HT'].
-                 { eapply typing_spine_eval in t0; eauto.
-                   eapply typing_spine_inv in t0; eauto.  reflexivity.
-                   eapply PCUICValidity.validity; eauto.
-                 }
-                 eapply erases_mkApps_inv in H1.
-                 destruct H1 as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-                 --- subst.
-                     eapply nth_error_forall in Hv; eauto.
-                     eapply value_app_inv in Hv. subst. reflexivity.
-                 --- subst. inv H8.
-                     +++ eapply nth_error_forall in Hv; eauto.
-                         destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity.
-                         rewrite emkApps_snoc at 1.
-                         generalize (x6 ++ [x4])%list. clear. intros.
-                         rewrite EAstUtils.decompose_app_mkApps. reflexivity.
-                         reflexivity.
-                     +++ eapply nth_error_forall in Hv; eauto.
-                         eapply value_app_inv in Hv. subst. eauto.
-                 --- eauto.
-                 --- eauto.
-              ** subst. rewrite H2.
-                 now eapply Forall2_length in H5.
-              ** eapply subject_reduction. eauto. exact Hty.
-                 etransitivity.
-                 eapply PCUICReduction.red_mkApps. eapply wcbeval_red; eauto.
-                 now eapply PCUICClosed.subject_closed in Ht.
-                 eapply typing_spine_closed in t0.
-                 eapply All2_All_mix_left in X; eauto.
-                 eapply All2_impl. exact X. intros. simpl in X2.
-                 eapply wcbeval_red; intuition eauto. auto.
-                 econstructor 2. econstructor.
-                 econstructor. unfold unfold_fix. now rewrite e. exact Hcon.
-           ++ clear - t0 X0 H5. revert x t0 x2 H5; induction X0; intros.
-              ** inv H5. exists []; eauto.
-              ** inv H5. inv t0. eapply r in H1 as (? & ? & ?); eauto.
-                 eapply IHX0 in X3 as (? & ? & ?); eauto.
-        -- cbn. destruct p. destruct p.
-           eapply (erases_subst Σ [] (PCUICLiftSubst.fix_context mfix) [] dbody (fix_subst mfix)) in e3; cbn; eauto.
-           ++ eapply subslet_fix_subst. now eapply wf_ext_wf. all: eassumption.
-           ++ eapply nth_error_all in a0; eauto. cbn in a0.
-              eapply a0.
-           ++ eapply All2_from_nth_error.
-              erewrite fix_subst_length, ETyping.fix_subst_length, All2_length; eauto.
-              intros.
-              rewrite fix_subst_nth in H6. 2:{ now rewrite fix_subst_length in H0. }
-              rewrite efix_subst_nth in H7. 2:{ rewrite fix_subst_length in H0.
-                                                erewrite <- All2_length; eauto. }
-              inv H6; inv H7.
-              erewrite All2_length; eauto.
-      * eapply Is_type_app in X2 as []; tas.
-        -- exists EAst.tBox. split. econstructor.
-           eapply Is_type_eval; eauto. eauto.
-
-          assert (exists x4, Forall2 (EWcbvEval.eval Σ') x2 x4) as [x4]. {
-            assert (forall x n, nth_error args n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-            { intros. eapply typing_spine_inv with (arg := n) in t0 as [].
-              2:{ eassumption. } eauto.
-            }
-            clear - X3 X0 H5. revert X3 x2 H5; induction X0; intros.
-            ** inv H5. exists []; eauto.
-            ** inv H5. destruct (X3 x 0 eq_refl).
-               eapply r in t as (? & ? & ?); eauto.
-               eapply IHX0 in H3 as (? & ?); eauto.
-               intros. eapply (X3 x2 (S n)). eassumption.
-          }
-
-          eapply eval_box_apps; eauto.
-        -- constructor.
-        -- eapply subject_reduction. eauto. exact Hty.
-           eapply PCUICReduction.red_mkApps. 
-           eapply PCUICClosed.subject_closed in Ht; auto.
-           now eapply wcbeval_red; eauto.
-          eapply All_All2_refl.
-          clear. induction args. econstructor. econstructor; eauto.
-
-  - assert (Hty' := Hty).
-    assert (Hunf := H).
-    assert (Hcon := H0).
-    assert (Σ |-p mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
-    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ?); eauto.
-    assert (Ht := t).
-    eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
-    2:now eapply PCUICClosed.subject_closed in Ht.
-    assert (HT := t).
-    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
-
-    eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
-      exists EAst.tBox. split. 2:{
-        assert (exists x4, Forall2 (EWcbvEval.eval Σ') x3 x4) as [x4]. {
-          eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
-          clear a0. subst.
-          assert (forall x n, nth_error x2 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-          { intros. eapply typing_spine_inv with (arg := n + #|x1|) in t0 as [].
-            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
-            eauto.
-          }
-          clear - X0 a1 H3. revert X0 x3 H3; induction a1; intros.
-          ** inv H3. exists []; eauto.
-          ** inv H3. destruct (X0 x 0 eq_refl).
-             eapply r in t as (? & ? & ?); eauto.
-             eapply IHa1 in H4 as (? & ?); eauto.
-             intros. eapply (X0 x2 (S n)). eassumption.
-        }
-        eapply eval_box_apps. eassumption. econstructor; eauto. }
-      econstructor.
-      eapply Is_type_eval. eauto. eassumption.
-      rewrite <- mkApps_nested.
-      eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
-      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht. eauto. eauto.
-      rewrite mkApps_nested; eauto.
-    + subst.
-      eapply IHeval in H2 as (? & ? & ?); eauto.
-      assert (H2' := H1).
-      inv H1.
-      * assert (Hmfix' := X2).
-        eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
-        destruct x0. cbn in *. subst.
-
-        (* enough(Σ;;; [] ,,, subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x4)). *)
-        destruct p. destruct p.
-
-        clear e3. rename H into e3.
-        -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x2 L).
-           ++ cbn in e3. destruct H as (L & ? & ?).
-              assert (Hv : Forall Ee.value L).
-              { eapply Forall2_Forall_right; eauto.
-                intros. eapply EWcbvEval.eval_to_value. eauto.
-              }
-
-              eapply erases_mkApps in H; eauto.
-              eexists. split. eauto.
-              eapply Ee.eval_fix_value; eauto.
-              cbn.
-
-              eapply All2_nth_error_Some in Hmfix' as (? & ? & ?); eauto.
-              destruct p. destruct p. cbn in *. subst.
-              unfold ETyping.unfold_fix, unfold_fix in *. rewrite e4.
-              rewrite e in Hcon.
-              clear H0. cbn in *.
-              rewrite e6 in *.
-              eapply erases_mkApps_inv in H as [ (? & ? & ? & ? & ? & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-              ** assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x6)) by now rewrite H6.
-                 rewrite !EAstUtils.decompose_app_mkApps in H7; try reflexivity.
-                 inv H7.
-              ** unfold is_constructor, ETyping.is_constructor_or_box in *.
-                 destruct nth_error eqn:En; try now inv Hcon.
-                 --- todo "cannot have stuck fixpoint with enough args when axiom free".
-                 ---  eapply Forall2_nth_error_None_l in H4; eauto.
-                      inv H0.
-                      +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-                         rewrite H4. eauto.
-                      +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-              ** auto.
-              ** eapply subject_reduction. eauto. exact Hty.
-                 etransitivity.
-                 eapply PCUICReduction.red_mkApps.
-                 eapply PCUICClosed.subject_closed in Ht.
-                 eapply wcbeval_red; eauto. auto.
-                 eapply typing_spine_closed in t0.
-                 eapply All2_All_mix_left in X; eauto. 
-                 eapply All2_impl. exact X. intros. destruct X2.
-                 now eapply wcbeval_red. auto.
-                 econstructor.
-           ++ clear - t0 H3 X0. revert x t0 x2 H3; induction X0; intros.
-              ** inv H3. exists []; eauto.
-              ** inv H3. inv t0. eapply r in X2 as (? & ? & ?); eauto.
-                 eapply IHX0 in X3 as (? & ? & ?); eauto.
-
-      * eapply Is_type_app in X2 as []; tas.
-        exists EAst.tBox. split.
-        econstructor.
-        eapply Is_type_eval. eauto. eassumption.
-        eauto.
-
-        assert (exists x5, Forall2 (EWcbvEval.eval Σ') x2 x5) as [x5]. {
-          assert (forall x n, nth_error args n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-          { intros. eapply typing_spine_inv with (arg := n) in t0 as [].
-            2:{ eassumption. } eauto.
-          }
-          clear - X3 H3 X0. revert X3 x2 H3; induction X0; intros.
-          ** inv H3. exists []; eauto.
-          ** inv H3. destruct (X3 x 0 eq_refl).
-             eapply r in t as (? & ? & ?); eauto.
-             eapply IHX0 in H4 as (? & ?); eauto.
-             intros. eapply (X3 x2 (S n)). eassumption.
-        }
-
-        eapply eval_box_apps. eauto. eauto.
-        constructor.
-        eapply subject_reduction. eauto. exact Hty.
-        eapply PCUICReduction.red_mkApps.
-        eapply PCUICClosed.subject_closed in Ht.
-        now eapply wcbeval_red. auto.
-        eapply All_All2_refl.
-        clear. induction args. econstructor. econstructor; eauto.
-
+  - todo "stuck fix case".
 
   - destruct ip.
     assert (Hty' := Hty).
@@ -1203,8 +947,8 @@ Proof.
       destruct (EAstUtils.isBox x2) eqn:E.
       * destruct x2; inv E. exists EAst.tBox. split. 2: econstructor; eauto.
         pose proof (Is_type_app Σ [] f'[a']).
-        inversion H2.
-        edestruct H8; eauto. cbn. eapply subject_reduction. eauto.
+        inversion H1.
+        edestruct H7; eauto. cbn. eapply subject_reduction. eauto.
         exact Hty. eapply PCUICReduction.red_app.
         eapply PCUICClosed.subject_closed in t'; auto.
         eapply wcbeval_red; eauto.
@@ -1216,14 +960,14 @@ Proof.
                    eapply ssrbool.negbT.
                    repeat eapply orb_false_intro.
                    - destruct x2; try reflexivity.
-                     inv H2. inv H0.
+                     inv H1. inv i.
                    - destruct x2 eqn:Ex; try reflexivity.
-                     + cbn. inv H2. cbn in *.
+                     + cbn. inv H1. cbn in *.
                        eapply ssrbool.negbTE, is_FixApp_erases.
                        econstructor; eauto.
-                       now rewrite orb_false_r in H0.
+                       now rewrite orb_false_r in i.
                      + cbn in *.
-                       inv H2. inv H0.
+                       inv H1. inv i.
                    - eauto. }
         econstructor; eauto.
     + exists EAst.tBox. split. 2: now econstructor.
@@ -1236,7 +980,7 @@ Proof.
       eapply PCUICClosed.subject_closed in Ha; auto.
       eapply wcbeval_red; eauto.
       
-  - destruct t; try now inversion H.
+  - destruct t; try easy.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1082,6 +1082,11 @@ Proof.
 
   - apply inversion_App in Hty as Hty'; [|eauto].
     destruct Hty' as (? & ? & ? & ? & ? & ?).
+
+    eapply subject_reduction in t as typ_stuck_fix; [|eauto|]; first last.
+    { eapply wcbeval_red; [eauto| |eauto].
+      eapply PCUICClosed.subject_closed in t; eauto. }
+    
     eapply erases_App in He as He'; [|eauto].
     destruct He' as [(-> & [])|(? & ? & -> & ? & ?)].
     + exists E.tBox.
@@ -1095,13 +1100,13 @@ Proof.
         -- eapply wcbeval_red; [eauto| |eauto].
            eapply PCUICClosed.subject_closed in t0; eauto.
       * eauto.
-    + eapply IHeval1 in H1 as (? & ? & ?); [|eauto].
+    + eapply subject_reduction in t0 as typ_arg; [|eauto|]; first last.
+      { eapply wcbeval_red; [eauto| |eauto].
+        eapply PCUICClosed.subject_closed in t0; eauto. }
+
+      eapply IHeval1 in H1 as (? & ? & ?); [|eauto].
       eapply IHeval2 in H2 as (? & ? & ?); [|eauto].
-      eapply erases_mkApps_inv in H1; [|eauto|]; first last.
-      { eapply subject_reduction; [eauto| |]; first last.
-        - eapply wcbeval_red; [eauto| |eauto].
-          eapply PCUICClosed.subject_closed in t; eauto.
-        - eauto. }
+      eapply erases_mkApps_inv in H1; [|eauto|eauto].
       destruct H1 as [(? & ? & ? & -> & [] & ? & ? & ->)|(? & ? & -> & ? & ?)].
       * apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
         depelim H5.
@@ -1115,15 +1120,7 @@ Proof.
         -- eauto.
         -- eauto.
         -- cbn.
-           eapply type_App.
-           ++ eapply subject_reduction; [eauto| |]; first last.
-              ** eapply wcbeval_red; [eauto| |eauto].
-                 eapply PCUICClosed.subject_closed in t; eauto.
-              ** eauto.
-           ++ eapply subject_reduction; [eauto| |]; first last.
-              ** eapply wcbeval_red; [eauto| |eauto].
-                 eapply PCUICClosed.subject_closed in t0; eauto.
-              ** eauto.
+           eapply type_App; eauto.
       * depelim H1.
         -- exists (E.tApp (E.mkApps (E.tFix mfix' idx) x7) x5).
            split; [eauto using erases_tApp, erases_mkApps|].
@@ -1150,15 +1147,7 @@ Proof.
            ++ eauto.
            ++ eauto.
            ++ rewrite mkApps_snoc.
-              eapply type_App.
-              ** eapply subject_reduction; [eauto| |]; first last.
-                 --- eapply wcbeval_red; [eauto| |eauto].
-                     eapply PCUICClosed.subject_closed in t; eauto.
-                 --- eauto.
-              ** eapply subject_reduction; [eauto| |]; first last.
-                 --- eapply wcbeval_red; [eauto| |eauto].
-                     eapply PCUICClosed.subject_closed in t0; eauto.
-                 --- eauto.
+              eapply type_App; eauto.
 
   - destruct ip.
     assert (Hty' := Hty).

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -433,6 +433,14 @@ Proof.
       * eauto.
 Qed.
 
+(*
+Lemma erases_mkApps_head (Σ : global_env_ext) Γ f L T t :
+  wf Σ ->
+  Σ;;; Γ |- mkApps f L : T ->
+  Σ;;; Γ |- mkApps f l ⇝ℇ t ->
+  (
+*)
+
 (** ** Global erasure  *)
 
 Lemma lookup_env_erases (Σ : global_env_ext) c decl Σ' :
@@ -548,6 +556,46 @@ Lemma erases_closed Σ Γ  a e : PCUICLiftSubst.closedn #|Γ| a -> Σ ;;; Γ |- 
 Proof.
 Admitted.
 
+Lemma eval_tApp_inv_head Σ hd a v :
+  Σ |-p tApp hd a ▷ v ->
+  ∥ ∑ hdv, Σ |-p hd ▷ hdv ∥.
+Proof.
+  intros ev.
+  constructor.
+  now depelim ev.
+Qed.
+
+Lemma eval_tApp_inv_arg Σ hd a v :
+  Σ |-p tApp hd a ▷ v ->
+  ∥ ∑ av, Σ |-p a ▷ av ∥.
+Proof.
+  intros ev.
+  constructor.
+  now depelim ev.
+Qed.
+
+Lemma eval_to_mkApps_tFix_inv Σ t mfix idx argsv :
+  Σ |-p t ▷ mkApps (tFix mfix idx) argsv ->
+  ∥ Σ |-p tFix mfix idx ▷ tFix mfix idx × All (value Σ) argsv ∥.
+Proof.
+  intros ev.
+  apply eval_to_value in ev.
+  depelim ev.
+  - apply atom_mkApps in i as (-> & ?).
+    now constructor.
+  - now apply mkApps_eq_inj in x as (-> & ->); [|now destruct t0|easy].
+  - apply mkApps_eq_inj in x as (-> & ->); [|now destruct f|easy].
+    solve [constructor; split; eauto using eval].
+Qed.
+
+Lemma eval_to_mkApps_tBox_inv Σ t argsv :
+  Σ ⊢ t ▷ E.mkApps E.tBox argsv ->
+  argsv = [].
+Proof.
+  intros ev.
+  apply Ee.eval_to_value in ev.
+  now apply value_app_inv in ev.
+Qed.
 
 Lemma erases_correct Σ t T t' v Σ' :
   extraction_pre Σ ->
@@ -886,183 +934,192 @@ Proof.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
 
-  - todo "fix case".
-    (*
-    assert (Hty' := Hty).
+  - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
-    assert (Σ |-p mkApps (tFix mfix idx) args ▷ res) by eauto.
-    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ?); eauto.
+    (*assert (Σ |-p tApp (mkApps (tFix mfix idx) args ▷ res) by eauto.*)
+    eapply inversion_App in Hty' as (? & ? & ? & ? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
     2:now eapply PCUICClosed.subject_closed in Ht.
     assert (HT := t).
-    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
-    rewrite <- closed_unfold_fix_cunfold_eq in H0; first last.
-    eapply eval_closed; eauto. eapply PCUICClosed.subject_closed in Ht; eauto.
-    auto.
-    unfold unfold_fix in H0. rewrite e in H0. inv H0.
-
-    eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
-      exists EAst.tBox. split. 2:{
-        assert (exists x4, Forall2 (EWcbvEval.eval Σ') x3 x4) as [x4]. {
-          eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
-          clear a0. subst.
-          assert (forall x n, nth_error x2 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-          { intros. eapply typing_spine_inv with (arg := n + #|x1|) in t0 as [].
-            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
-            eauto.
-          }
-          clear - X0 a1 H5. revert X0 x3 H5; induction a1; intros.
-          ** inv H5. exists []; eauto.
-          ** inv H5. destruct (X0 x 0 eq_refl).
-             eapply r in t as (? & ? & ?); eauto.
-             eapply IHa1 in H3 as (? & ?); eauto.
-             intros. eapply (X0 x2 (S n)). eassumption.
-        }
-        eapply eval_box_apps. eassumption. econstructor; eauto. }
+    apply PCUICValidity.inversion_mkApps in HT as (? & ? & ?); auto.
+    assert (Ht1 := t1).
+    apply inversion_Fix in t1 as Hfix; auto.
+    destruct Hfix as (? & ? & ? & ? & ? & ? & ?).
+    rewrite <- closed_unfold_fix_cunfold_eq in e; first last.
+    eapply (PCUICClosed.subject_closed (Γ := [])); eauto.
+    assert (uf := e).
+    unfold unfold_fix in e. rewrite e0 in e. inv e.
+    depelim He; first last.
+    
+    + exists EAst.tBox. split; [|now constructor].
       econstructor.
       eapply Is_type_eval. eauto. eassumption.
-      rewrite <- mkApps_nested.
-      eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
-      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht.
-      eauto. eauto.
-      rewrite mkApps_nested; eauto.
-    + subst.
-      eapply IHeval1 in H4 as (? & ? & ?); eauto.
-      inv H0.
-      * assert (Hmfix' := X2).
-        eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
-        destruct x0. cbn in *. subst.
+      eapply Is_type_red. eauto. 2: exact X.
+      cbn.
+      etransitivity.
+      eapply PCUICReduction.red_app.
+      eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in Ht.
+      eauto. eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in t0.
+      eauto.
+      rewrite <- !mkApps_snoc.
+      eapply PCUICReduction.red1_red.
+      eapply red_fix.
+      eauto.
+      unfold is_constructor.
+      rewrite nth_error_snoc; eauto.
+    + eapply IHeval1 in He1 as IH1; eauto.
+      destruct IH1 as (er_stuck_v & er_stuck & ev_stuck).
+      eapply IHeval2 in He2 as IH2; eauto.
+      destruct IH2 as (er_argv & er_arg & ev_arg).
+      eapply erases_mkApps_inv in er_stuck; eauto.
+      destruct er_stuck as [(? & ? & ? & -> & ? & ? & ? & ->)|
+                            (? & ? & -> & ? & ?)].
+      { exists E.tBox.
+        eapply eval_to_mkApps_tBox_inv in ev_stuck as ?; subst.
+        cbn in *.
+        split; [|eauto using Ee.eval].
+        destruct H2.
+        eapply (Is_type_app _ _ _ (x5 ++ [av])) in X as []; eauto; first last.
+        - rewrite mkApps_nested, app_assoc, mkApps_snoc.
+          eapply type_App; eauto.
+          eapply subject_reduction; eauto.
+          eapply wcbeval_red; eauto.
+          eapply PCUICClosed.subject_closed in t0; eauto.
+        - eapply erases_box.
+          eapply Is_type_eval; eauto.
+          eapply Is_type_red; [eauto| |].
+          + rewrite <- mkApps_snoc.
+            eapply PCUICReduction.red1_red.
+            eapply red_fix; [eauto|].
+            unfold is_constructor.
+            now rewrite nth_error_snoc.
+          + rewrite <- app_assoc.
+            now rewrite <- mkApps_nested. }
+      
+      inv H2.
+      * assert (Hmfix' := X).
+        eapply All2_nth_error_Some in X as (? & ? & ?); eauto.
+        destruct x3. cbn in *. subst.
 
-        enough(Σ;;; [] ,,, PCUICLiftSubst.subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ 
-          subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x3)).
+        enough (Σ;;; [] ,,, PCUICLiftSubst.subst_context (fix_subst mfix) 0 []
+                |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody
+                ⇝ℇ subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x4)).
         destruct p. destruct p.
 
         clear e3. rename H into e3.
-        -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x2 L).
-           ++ cbn in e3. destruct H as (L & ? & ?).
-              assert (Hv : Forall Ee.value L).
-              { eapply Forall2_Forall_right; eauto.
-                intros. eapply EWcbvEval.eval_to_value. eauto.
-              }
+        -- cbn in e3. rename x5 into L.
+           eapply (erases_mkApps _ _ _ _ (argsv ++ [av])) in H2; first last.
+           { eapply Forall2_app.
+             - exact H4.
+             - eauto. }
+           rewrite <- mkApps_nested in H2.
+           rewrite EAstUtils.mkApps_app in H2.
+           cbn in *.
+           eapply IHeval3 in H2 as (? & ? & ?); cbn; eauto; first last.
+           { eapply subject_reduction. eauto. exact Hty.
+             etransitivity.
+             eapply PCUICReduction.red_app. eapply wcbeval_red; eauto.
+             now eapply PCUICClosed.subject_closed in Ht.
+             eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in t0.
+             eauto.
+             rewrite <- !mkApps_snoc.
+             eapply PCUICReduction.red1_red.
+             eapply red_fix.
+             eauto.
+             unfold is_constructor.
+             rewrite nth_error_snoc; eauto. }
+           
+           exists x3. split. eauto.
+           eapply Ee.eval_fix.
+           ++ eauto.
+           ++ eauto.
+           ++ rewrite <- Ee.closed_unfold_fix_cunfold_eq.
+              { unfold ETyping.unfold_fix. now rewrite e. }
+              eapply eval_closed in e3; eauto.
+              clear -e3 Hmfix'.
+              pose proof (All2_length _ _ Hmfix').
+              eapply PCUICClosed.closedn_mkApps_inv in e3.
+              apply andb_true_iff in e3 as (e3 & _).
+              change (?a = true) with (is_true a) in e3.
+              simpl in e3 |- *. solve_all.
+              rewrite app_context_nil_l in b.
+              eapply erases_closed in b. simpl in b.
+              rewrite <- H.
+              unfold EAst.test_def. 
+              simpl in b.
+              rewrite fix_context_length in b.
+              now rewrite Nat.add_0_r.
+              unfold test_def in a. apply andP in a as [_ Hbod].
+              rewrite fix_context_length.
+              now rewrite Nat.add_0_r in Hbod.
+              eauto with pcuic.
+              now eapply PCUICClosed.subject_closed in Ht.
+           ++ apply Forall2_length in H4.
+              congruence.
+           ++ unfold isConstruct_app in *.
+              destruct (decompose_app av) eqn:EE.
+              assert (E2 : fst (decompose_app av) = t3) by now rewrite EE.
+              destruct t3.
+              all:inv i.
 
-              eapply erases_mkApps in H0; eauto.
-              eapply IHeval2 in H0 as (? & ? & ?); cbn; eauto.
-              exists x0. split. eauto.
-              econstructor. eauto.
-              rewrite <- Ee.closed_unfold_fix_cunfold_eq; first last.
-              { eapply eval_closed in e3.
-                pose proof (All2_length _ _ Hmfix').
-                clear -e3 Hmfix' H8.
-                simpl in e3 |- *. solve_all.
-                rewrite app_context_nil_l in b.
-                eapply erases_closed in b. simpl in b.
-                rewrite <-H8.
-                unfold EAst.test_def. 
-                simpl in b.
-                rewrite fix_context_length in b.
-                now rewrite Nat.add_0_r.
-                unfold test_def in a. apply andP in a as [_ Hbod].
-                rewrite fix_context_length.
-                now rewrite Nat.add_0_r in Hbod.
-                eauto with pcuic.
-                now eapply PCUICClosed.subject_closed in Ht.  }
-              unfold ETyping.unfold_fix.
-              rewrite e0. reflexivity.
-              all:eauto.
-              ** unfold is_constructor in *.
-                 destruct ?; inv H1.
-                 unfold is_constructor_or_box.
-                 eapply Forall2_nth_error_Some in H as (? & ? & ?); eauto.
-                 rewrite H.
+              pose proof (decompose_app_rec_inv EE).
+              cbn in H3. subst.
 
-                 unfold isConstruct_app in H9.
-                 destruct (decompose_app t) eqn:EE.
-                 assert (E2 : fst (decompose_app t) = t1) by now rewrite EE.
-                 destruct t1.
-                 all:inv H9.
-                 (* erewrite <- PCUICConfluence.fst_decompose_app_rec in E2. *)
-
-                 pose proof (decompose_app_rec_inv EE).
-                 cbn in H8. subst.
-                 assert (∑ T, Σ ;;; [] |- mkApps (tConstruct ind n ui) l : T) as [T' HT'].
-                 { eapply typing_spine_eval in t0; eauto.
-                   eapply typing_spine_inv in t0; eauto.  reflexivity.
-                   eapply PCUICValidity.validity; eauto.
-                 }
-                 eapply erases_mkApps_inv in H1.
-                 destruct H1 as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-                 --- subst.
-                     eapply nth_error_forall in Hv; eauto.
-                     eapply value_app_inv in Hv. subst. reflexivity.
-                 --- subst. inv H8.
-                     +++ eapply nth_error_forall in Hv; eauto.
-                         destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity.
-                         rewrite emkApps_snoc at 1.
-                         generalize (x6 ++ [x4])%list. clear. intros.
-                         rewrite EAstUtils.decompose_app_mkApps. reflexivity.
-                         reflexivity.
-                     +++ eapply nth_error_forall in Hv; eauto.
-                         eapply value_app_inv in Hv. subst. eauto.
-                 --- eauto.
-                 --- eauto.
-              ** subst. rewrite H2.
-                 now eapply Forall2_length in H5.
-              ** eapply subject_reduction. eauto. exact Hty.
-                 etransitivity.
-                 eapply PCUICReduction.red_mkApps. eapply wcbeval_red; eauto.
-                 now eapply PCUICClosed.subject_closed in Ht.
-                 eapply typing_spine_closed in t0.
-                 eapply All2_All_mix_left in X; eauto.
-                 eapply All2_impl. exact X. intros. simpl in X2.
-                 eapply wcbeval_red; intuition eauto. auto.
-                 econstructor 2. econstructor.
-                 econstructor. unfold unfold_fix. now rewrite e. exact Hcon.
-           ++ clear - t0 X0 H5. revert x t0 x2 H5; induction X0; intros.
-              ** inv H5. exists []; eauto.
-              ** inv H5. inv t0. eapply r in H1 as (? & ? & ?); eauto.
-                 eapply IHX0 in X3 as (? & ? & ?); eauto.
+              eapply erases_mkApps_inv in er_arg
+                as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
+              ** subst.
+                 now apply eval_to_mkApps_tBox_inv in ev_arg as ->.
+              ** subst. inv H5.
+                 +++ destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity.
+                     unfold is_constructor_app_or_box.
+                     rewrite emkApps_snoc at 1.
+                     now rewrite EAstUtils.decompose_app_mkApps.
+                 +++ now apply eval_to_mkApps_tBox_inv in ev_arg as ->.
+              ** eauto.
+              ** eapply subject_reduction; last first.
+                 eapply wcbeval_red; last first.
+                 eauto.
+                 now eapply PCUICClosed.subject_closed in t0.
+                 eauto.
+                 eauto.
+                 eauto.
+           ++ eauto.
         -- cbn. destruct p. destruct p.
            eapply (erases_subst Σ [] (PCUICLiftSubst.fix_context mfix) [] dbody (fix_subst mfix)) in e3; cbn; eauto.
            ++ eapply subslet_fix_subst. now eapply wf_ext_wf. all: eassumption.
-           ++ eapply nth_error_all in a0; eauto. cbn in a0.
-              eapply a0.
+           ++ eapply nth_error_all in a1; eauto. cbn in a1.
+              eapply a1.
            ++ eapply All2_from_nth_error.
               erewrite fix_subst_length, ETyping.fix_subst_length, All2_length; eauto.
               intros.
-              rewrite fix_subst_nth in H6. 2:{ now rewrite fix_subst_length in H0. }
-              rewrite efix_subst_nth in H7. 2:{ rewrite fix_subst_length in H0.
+              rewrite fix_subst_nth in H3. 2:{ now rewrite fix_subst_length in H2. }
+              rewrite efix_subst_nth in H5. 2:{ rewrite fix_subst_length in H2.
                                                 erewrite <- All2_length; eauto. }
-              inv H6; inv H7.
+              inv H5; inv H3.
               erewrite All2_length; eauto.
-      * eapply Is_type_app in X2 as []; tas.
-        -- exists EAst.tBox. split. econstructor.
-           eapply Is_type_eval; eauto. eauto.
-
-          assert (exists x4, Forall2 (EWcbvEval.eval Σ') x2 x4) as [x4]. {
-            assert (forall x n, nth_error args n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-            { intros. eapply typing_spine_inv with (arg := n) in t0 as [].
-              2:{ eassumption. } eauto.
-            }
-            clear - X3 X0 H5. revert X3 x2 H5; induction X0; intros.
-            ** inv H5. exists []; eauto.
-            ** inv H5. destruct (X3 x 0 eq_refl).
-               eapply r in t as (? & ? & ?); eauto.
-               eapply IHX0 in H3 as (? & ?); eauto.
-               intros. eapply (X3 x2 (S n)). eassumption.
-          }
-
-          eapply eval_box_apps; eauto.
-        -- constructor.
-        -- eapply subject_reduction. eauto. exact Hty.
-           eapply PCUICReduction.red_mkApps. 
-           eapply PCUICClosed.subject_closed in Ht; auto.
-           now eapply wcbeval_red; eauto.
-          eapply All_All2_refl.
-          clear. induction args. econstructor. econstructor; eauto.
-    *)
+      * eapply Is_type_app in X as []; tas.
+        -- exists EAst.tBox.
+           split.
+           ++ econstructor.
+              eapply Is_type_eval; eauto.
+              eapply Is_type_red; [eauto| |].
+              ** eapply PCUICReduction.red1_red.
+                 rewrite <- mkApps_snoc.
+                 eapply red_fix; [eauto|].
+                 unfold is_constructor.
+                 now rewrite nth_error_snoc.
+              ** eauto.
+           ++ eapply Ee.eval_box; [|eauto].
+              apply eval_to_mkApps_tBox_inv in ev_stuck as ?; subst.
+              eauto.
+        -- eauto.
+        -- rewrite mkApps_snoc.
+           eapply type_App; eauto.
+           eapply subject_reduction; eauto.
+           eapply wcbeval_red; eauto.
+           eapply PCUICClosed.subject_closed in t0; eauto.
 
   - todo "fix_value case".
     (*

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -433,14 +433,6 @@ Proof.
       * eauto.
 Qed.
 
-(*
-Lemma erases_mkApps_head (Σ : global_env_ext) Γ f L T t :
-  wf Σ ->
-  Σ;;; Γ |- mkApps f L : T ->
-  Σ;;; Γ |- mkApps f l ⇝ℇ t ->
-  (
-*)
-
 (** ** Global erasure  *)
 
 Lemma lookup_env_erases (Σ : global_env_ext) c decl Σ' :
@@ -555,38 +547,6 @@ Qed.
 Lemma erases_closed Σ Γ  a e : PCUICLiftSubst.closedn #|Γ| a -> Σ ;;; Γ |- a ⇝ℇ e -> closedn #|Γ| e.
 Proof.
 Admitted.
-
-Lemma eval_tApp_inv_head Σ hd a v :
-  Σ |-p tApp hd a ▷ v ->
-  ∥ ∑ hdv, Σ |-p hd ▷ hdv ∥.
-Proof.
-  intros ev.
-  constructor.
-  now depelim ev.
-Qed.
-
-Lemma eval_tApp_inv_arg Σ hd a v :
-  Σ |-p tApp hd a ▷ v ->
-  ∥ ∑ av, Σ |-p a ▷ av ∥.
-Proof.
-  intros ev.
-  constructor.
-  now depelim ev.
-Qed.
-
-Lemma eval_to_mkApps_tFix_inv Σ t mfix idx argsv :
-  Σ |-p t ▷ mkApps (tFix mfix idx) argsv ->
-  ∥ Σ |-p tFix mfix idx ▷ tFix mfix idx × All (value Σ) argsv ∥.
-Proof.
-  intros ev.
-  apply eval_to_value in ev.
-  depelim ev.
-  - apply atom_mkApps in i as (-> & ?).
-    now constructor.
-  - now apply mkApps_eq_inj in x as (-> & ->); [|now destruct t0|easy].
-  - apply mkApps_eq_inj in x as (-> & ->); [|now destruct f|easy].
-    solve [constructor; split; eauto using eval].
-Qed.
 
 Lemma eval_to_mkApps_tBox_inv Σ t argsv :
   Σ ⊢ t ▷ E.mkApps E.tBox argsv ->
@@ -937,7 +897,6 @@ Proof.
   - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
-    (*assert (Σ |-p tApp (mkApps (tFix mfix idx) args ▷ res) by eauto.*)
     eapply inversion_App in Hty' as (? & ? & ? & ? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -559,7 +559,7 @@ Lemma erases_correct Σ t T t' v Σ' :
 Proof.
   intros pre Hty He Heg H.
   revert T Hty t' He.
-  induction H using PCUICWcbvEval.eval_evals_ind; intros T Hty t' He; inv pre.
+  induction H; intros T Hty t' He; inv pre.
   - assert (Hty' := Hty).
     assert (eval Σ (PCUICAst.tApp f a) res) by eauto.
     eapply inversion_App in Hty as (? & ? & ? & ? & ? & ?).
@@ -641,36 +641,35 @@ Proof.
   - destruct Σ as (Σ, univs).
     unfold erases_global in Heg.
     assert (Σ |-p tConst c u ▷ res) by eauto.
-    eapply inversion_Const in Hty as (? & ? & ? & ? & ?).
+    eapply inversion_Const in Hty as (? & ? & ? & ? & ?); [|easy].
     inv He.
-    + assert (H' := H).
-      eapply lookup_env_erases in H; eauto.
-      destruct H as (decl' & ? & ?).
-      unfold erases_constant_body in H2. rewrite H0 in *.
+    + assert (isdecl' := isdecl).
+      eapply lookup_env_erases in isdecl; eauto.
+      destruct isdecl as (decl' & ? & ?).
+      unfold erases_constant_body in *. rewrite e in *.
       destruct ?; try tauto. cbn in *.
       eapply declared_constant_inj in d; eauto; subst.
       edestruct IHeval.
       * cbn in *. pose proof (wf_ext_wf _ extr_env_wf'0). cbn in X0.
-        assert (H'' := H').
-        eapply PCUICWeakeningEnv.declared_constant_inv in H'; eauto.
+        assert (isdecl'' := isdecl').
+        eapply PCUICWeakeningEnv.declared_constant_inv in isdecl'; eauto.
         2:eapply PCUICWeakeningEnv.weaken_env_prop_typing.
-        unfold on_constant_decl in H'. rewrite H0 in H'. red in H'.
-        unfold declared_constant in H''.
+        unfold on_constant_decl in isdecl'. rewrite e in isdecl'. red in isdecl'.
+        unfold declared_constant in isdecl''.
         eapply typing_subst_instance_decl with (Σ0 := (Σ, univs)) (Γ := []); eauto.
       * pose proof (wf_ext_wf _ extr_env_wf'0). cbn in X0.
-        assert (H'' := H').
-        eapply PCUICWeakeningEnv.declared_constant_inv in H'; eauto.
-        unfold on_constant_decl in H'. rewrite H0 in H'. cbn in *.
+        assert (isdecl'' := isdecl').
+        eapply PCUICWeakeningEnv.declared_constant_inv in isdecl'; eauto.
+        unfold on_constant_decl in isdecl'. rewrite e in isdecl'. cbn in *.
         2:eapply PCUICWeakeningEnv.weaken_env_prop_typing.
         eapply erases_subst_instance_decl with (Σ := (Σ, univs)) (Γ := []); eauto.
-      * destruct H3. exists x0. split; eauto. econstructor; eauto.
+      * destruct H2. exists x0. split; eauto. econstructor; eauto.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
-    + auto.
 
   - destruct Σ as (Σ, univs).
-    cbn in H.
-    eapply extr_env_axiom_free'0 in H. congruence.
+    cbn in *.
+    eapply extr_env_axiom_free'0 in isdecl. congruence.
 
   - assert (Hty' := Hty).
     assert (Σ |-p tCase (ind, pars) p discr brs ▷ res) by eauto.
@@ -829,10 +828,10 @@ Proof.
       eapply Is_type_eval; eauto. econstructor; eauto.
 
   - pose (Hty' := Hty).
-    eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?).
+    eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?); [|easy].
     inv He.
 
-    + eapply IHeval1 in H6 as (vc' & Hvc' & Hty_vc'); eauto.
+    + eapply IHeval1 in H5 as (vc' & Hvc' & Hty_vc'); eauto.
       eapply erases_mkApps_inv in Hvc'; eauto.
       2: eapply subject_reduction_eval; eauto.
       destruct Hvc' as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; subst.
@@ -841,30 +840,30 @@ Proof.
         eapply Is_type_app in X as []; eauto. 2:{ rewrite mkApps_nested. eapply subject_reduction_eval; eauto. }
         rewrite mkApps_nested in X.
 
-        eapply tConstruct_no_Type in X; eauto. eapply H4 in X as [? []]; eauto.
+        eapply tConstruct_no_Type in X; eauto. eapply H3 in X as [? []]; eauto.
         2: now destruct d. 2: now exists []; destruct Σ.
 
         econstructor.
         eapply Is_type_eval. eauto. eauto.
         eapply nth_error_all.
         erewrite nth_error_skipn. reflexivity. eassumption.
-        eapply All_impl. assert (pars = ind_npars x0). destruct d as (? & ? & ?). now rewrite H8. subst.
+        eapply All_impl. assert (pars = ind_npars x0). destruct d as (? & ? & ?). now rewrite H7. subst.
         eassumption.
         eapply isErasable_Proof. eauto.
 
         eapply eval_proj_box.
         pose proof (Ee.eval_to_value _ _ _ Hty_vc').
-        eapply value_app_inv in H2. subst. eassumption.
-      * rename H4 into Hinf.
-        eapply Forall2_nth_error_Some in H5 as (? & ? & ?); eauto.
+        eapply value_app_inv in H1. subst. eassumption.
+      * rename H3 into Hinf.
+        eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
         assert (Σ ;;; [] |- mkApps (tConstruct i k u) args : mkApps (tInd i x) x2).
         eapply subject_reduction_eval; eauto.
         eapply PCUICValidity.inversion_mkApps in X as (? & ? & ?); eauto.
         eapply typing_spine_inv in t2 as []; eauto.
-        eapply IHeval2 in H4 as (? & ? & ?); eauto.
-        inv H3.
+        eapply IHeval2 in H3 as (? & ? & ?); eauto.
+        inv H2.
         -- exists x8. split; eauto. econstructor. eauto.
-           rewrite <- nth_default_eq. unfold nth_default. now rewrite H2.
+           rewrite <- nth_default_eq. unfold nth_default. now rewrite H1.
         -- exists EAst.tBox. split.
 
 
@@ -877,21 +876,20 @@ Proof.
            eapply Is_type_eval. eauto. eauto.
            eapply nth_error_all.
            erewrite nth_error_skipn. reflexivity. eassumption.
-           eapply All_impl. assert (pars = ind_npars x0). destruct d as (? & ? & ?). now rewrite H8. subst.
+           eapply All_impl. assert (pars = ind_npars x0). destruct d as (? & ? & ?). now rewrite H7. subst.
            eassumption.
            eapply isErasable_Proof. eauto.
 
            eapply eval_proj_box.
            pose proof (Ee.eval_to_value _ _ _ Hty_vc').
-           eapply value_app_inv in H3. subst. eassumption.
+           eapply value_app_inv in H2. subst. eassumption.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
-    + auto.
   - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
-    assert (Σ |-p mkApps (tFix mfix idx) args ▷ res) by eauto.
-    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ?); eauto.
+    (*assert (Σ |-p mkApps (tFix mfix idx) argsv ▷ res) by eauto.*)
+    eapply PCUICValidity.inversion_app in Hty' as (? & ? & ?); eauto.
     assert (Ht := t).
     eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
     2:now eapply PCUICClosed.subject_closed in Ht.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1132,20 +1132,9 @@ Proof.
               ** assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x6)) by now rewrite H6.
                  rewrite !EAstUtils.decompose_app_mkApps in H7; try reflexivity.
                  inv H7.
-              ** unfold is_constructor, ETyping.is_constructor in *.
+              ** unfold is_constructor, ETyping.is_constructor_or_box in *.
                  destruct nth_error eqn:En; try now inv Hcon.
-                 --- eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
-                     inv H0.
-                     +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-                         rewrite H4.
-                         eapply is_construct_erases in Hcon; eauto.
-                         unfold EisConstruct_app in *.
-                         destruct ?; eauto.
-                     +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
+                 --- todo "cannot have stuck fixpoint with enough args when axiom free".
                  ---  eapply Forall2_nth_error_None_l in H4; eauto.
                       inv H0.
                       +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -921,9 +921,265 @@ Proof.
       eauto.
       unfold is_constructor.
       rewrite nth_error_snoc; eauto.
-    + todo "unerasable fix case".
+    + eapply IHeval1 in H4 as (? & ? & ?); eauto.
+      inv H0.
+      * assert (Hmfix' := X2).
+        eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
+        destruct x0. cbn in *. subst.
 
-  - todo "stuck fix case".
+        enough(Σ;;; [] ,,, PCUICLiftSubst.subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ 
+          subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x3)).
+        destruct p. destruct p.
+
+        clear e3. rename H into e3.
+        -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x2 L).
+           ++ cbn in e3. destruct H as (L & ? & ?).
+              assert (Hv : Forall Ee.value L).
+              { eapply Forall2_Forall_right; eauto.
+                intros. eapply EWcbvEval.eval_to_value. eauto.
+              }
+
+              eapply erases_mkApps in H0; eauto.
+              eapply IHeval2 in H0 as (? & ? & ?); cbn; eauto.
+              exists x0. split. eauto.
+              econstructor. eauto.
+              rewrite <- Ee.closed_unfold_fix_cunfold_eq; first last.
+              { eapply eval_closed in e3.
+                pose proof (All2_length _ _ Hmfix').
+                clear -e3 Hmfix' H8.
+                simpl in e3 |- *. solve_all.
+                rewrite app_context_nil_l in b.
+                eapply erases_closed in b. simpl in b.
+                rewrite <-H8.
+                unfold EAst.test_def. 
+                simpl in b.
+                rewrite fix_context_length in b.
+                now rewrite Nat.add_0_r.
+                unfold test_def in a. apply andP in a as [_ Hbod].
+                rewrite fix_context_length.
+                now rewrite Nat.add_0_r in Hbod.
+                eauto with pcuic.
+                now eapply PCUICClosed.subject_closed in Ht.  }
+              unfold ETyping.unfold_fix.
+              rewrite e0. reflexivity.
+              all:eauto.
+              ** unfold is_constructor in *.
+                 destruct ?; inv H1.
+                 unfold is_constructor_or_box.
+                 eapply Forall2_nth_error_Some in H as (? & ? & ?); eauto.
+                 rewrite H.
+
+                 unfold isConstruct_app in H9.
+                 destruct (decompose_app t) eqn:EE.
+                 assert (E2 : fst (decompose_app t) = t1) by now rewrite EE.
+                 destruct t1.
+                 all:inv H9.
+                 (* erewrite <- PCUICConfluence.fst_decompose_app_rec in E2. *)
+
+                 pose proof (decompose_app_rec_inv EE).
+                 cbn in H8. subst.
+                 assert (∑ T, Σ ;;; [] |- mkApps (tConstruct ind n ui) l : T) as [T' HT'].
+                 { eapply typing_spine_eval in t0; eauto.
+                   eapply typing_spine_inv in t0; eauto.  reflexivity.
+                   eapply PCUICValidity.validity; eauto.
+                 }
+                 eapply erases_mkApps_inv in H1.
+                 destruct H1 as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
+                 --- subst.
+                     eapply nth_error_forall in Hv; eauto.
+                     eapply value_app_inv in Hv. subst. reflexivity.
+                 --- subst. inv H8.
+                     +++ eapply nth_error_forall in Hv; eauto.
+                         destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity.
+                         rewrite emkApps_snoc at 1.
+                         generalize (x6 ++ [x4])%list. clear. intros.
+                         rewrite EAstUtils.decompose_app_mkApps. reflexivity.
+                         reflexivity.
+                     +++ eapply nth_error_forall in Hv; eauto.
+                         eapply value_app_inv in Hv. subst. eauto.
+                 --- eauto.
+                 --- eauto.
+              ** subst. rewrite H2.
+                 now eapply Forall2_length in H5.
+              ** eapply subject_reduction. eauto. exact Hty.
+                 etransitivity.
+                 eapply PCUICReduction.red_mkApps. eapply wcbeval_red; eauto.
+                 now eapply PCUICClosed.subject_closed in Ht.
+                 eapply typing_spine_closed in t0.
+                 eapply All2_All_mix_left in X; eauto.
+                 eapply All2_impl. exact X. intros. simpl in X2.
+                 eapply wcbeval_red; intuition eauto. auto.
+                 econstructor 2. econstructor.
+                 econstructor. unfold unfold_fix. now rewrite e. exact Hcon.
+           ++ clear - t0 X0 H5. revert x t0 x2 H5; induction X0; intros.
+              ** inv H5. exists []; eauto.
+              ** inv H5. inv t0. eapply r in H1 as (? & ? & ?); eauto.
+                 eapply IHX0 in X3 as (? & ? & ?); eauto.
+        -- cbn. destruct p. destruct p.
+           eapply (erases_subst Σ [] (PCUICLiftSubst.fix_context mfix) [] dbody (fix_subst mfix)) in e3; cbn; eauto.
+           ++ eapply subslet_fix_subst. now eapply wf_ext_wf. all: eassumption.
+           ++ eapply nth_error_all in a0; eauto. cbn in a0.
+              eapply a0.
+           ++ eapply All2_from_nth_error.
+              erewrite fix_subst_length, ETyping.fix_subst_length, All2_length; eauto.
+              intros.
+              rewrite fix_subst_nth in H6. 2:{ now rewrite fix_subst_length in H0. }
+              rewrite efix_subst_nth in H7. 2:{ rewrite fix_subst_length in H0.
+                                                erewrite <- All2_length; eauto. }
+              inv H6; inv H7.
+              erewrite All2_length; eauto.
+      * eapply Is_type_app in X2 as []; tas.
+        -- exists EAst.tBox. split. econstructor.
+           eapply Is_type_eval; eauto. eauto.
+
+          assert (exists x4, Forall2 (EWcbvEval.eval Σ') x2 x4) as [x4]. {
+            assert (forall x n, nth_error args n = Some x -> ∑ T,  Σ;;; [] |- x : T).
+            { intros. eapply typing_spine_inv with (arg := n) in t0 as [].
+              2:{ eassumption. } eauto.
+            }
+            clear - X3 X0 H5. revert X3 x2 H5; induction X0; intros.
+            ** inv H5. exists []; eauto.
+            ** inv H5. destruct (X3 x 0 eq_refl).
+               eapply r in t as (? & ? & ?); eauto.
+               eapply IHX0 in H3 as (? & ?); eauto.
+               intros. eapply (X3 x2 (S n)). eassumption.
+          }
+
+          eapply eval_box_apps; eauto.
+        -- constructor.
+        -- eapply subject_reduction. eauto. exact Hty.
+           eapply PCUICReduction.red_mkApps. 
+           eapply PCUICClosed.subject_closed in Ht; auto.
+           now eapply wcbeval_red; eauto.
+          eapply All_All2_refl.
+          clear. induction args. econstructor. econstructor; eauto.
+
+  - assert (Hty' := Hty).
+    assert (Hunf := H).
+    assert (Hcon := H0).
+    assert (Σ |-p mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
+    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ?); eauto.
+    assert (Ht := t).
+    eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
+    2:now eapply PCUICClosed.subject_closed in Ht.
+    assert (HT := t).
+    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
+
+    eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
+    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
+      exists EAst.tBox. split. 2:{
+        assert (exists x4, Forall2 (EWcbvEval.eval Σ') x3 x4) as [x4]. {
+          eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
+          clear a0. subst.
+          assert (forall x n, nth_error x2 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
+          { intros. eapply typing_spine_inv with (arg := n + #|x1|) in t0 as [].
+            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
+            eauto.
+          }
+          clear - X0 a1 H3. revert X0 x3 H3; induction a1; intros.
+          ** inv H3. exists []; eauto.
+          ** inv H3. destruct (X0 x 0 eq_refl).
+             eapply r in t as (? & ? & ?); eauto.
+             eapply IHa1 in H4 as (? & ?); eauto.
+             intros. eapply (X0 x2 (S n)). eassumption.
+        }
+        eapply eval_box_apps. eassumption. econstructor; eauto. }
+      econstructor.
+      eapply Is_type_eval. eauto. eassumption.
+      rewrite <- mkApps_nested.
+      eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
+      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht. eauto. eauto.
+      rewrite mkApps_nested; eauto.
+    + subst.
+      eapply IHeval in H2 as (? & ? & ?); eauto.
+      assert (H2' := H1).
+      inv H1.
+      * assert (Hmfix' := X2).
+        eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
+        destruct x0. cbn in *. subst.
+
+        (* enough(Σ;;; [] ,,, subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x4)). *)
+        destruct p. destruct p.
+
+        clear e3. rename H into e3.
+        -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x2 L).
+           ++ cbn in e3. destruct H as (L & ? & ?).
+              assert (Hv : Forall Ee.value L).
+              { eapply Forall2_Forall_right; eauto.
+                intros. eapply EWcbvEval.eval_to_value. eauto.
+              }
+
+              eapply erases_mkApps in H; eauto.
+              eexists. split. eauto.
+              eapply Ee.eval_fix_value; eauto.
+              cbn.
+
+              eapply All2_nth_error_Some in Hmfix' as (? & ? & ?); eauto.
+              destruct p. destruct p. cbn in *. subst.
+              unfold ETyping.unfold_fix, unfold_fix in *. rewrite e4.
+              rewrite e in Hcon.
+              clear H0. cbn in *.
+              rewrite e6 in *.
+              eapply erases_mkApps_inv in H as [ (? & ? & ? & ? & ? & ? & ? & ?) | (? & ? & ? & ? & ?) ].
+              ** assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x6)) by now rewrite H6.
+                 rewrite !EAstUtils.decompose_app_mkApps in H7; try reflexivity.
+                 inv H7.
+              ** unfold is_constructor, ETyping.is_constructor_or_box in *.
+                 destruct nth_error eqn:En; try now inv Hcon.
+                 --- todo "cannot have stuck fixpoint with enough args when axiom free".
+                 ---  eapply Forall2_nth_error_None_l in H4; eauto.
+                      inv H0.
+                      +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
+                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
+                         inv H0.
+                         rewrite H4. eauto.
+                      +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x5)) by now rewrite H.
+                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
+                         inv H0.
+              ** auto.
+              ** eapply subject_reduction. eauto. exact Hty.
+                 etransitivity.
+                 eapply PCUICReduction.red_mkApps.
+                 eapply PCUICClosed.subject_closed in Ht.
+                 eapply wcbeval_red; eauto. auto.
+                 eapply typing_spine_closed in t0.
+                 eapply All2_All_mix_left in X; eauto. 
+                 eapply All2_impl. exact X. intros. destruct X2.
+                 now eapply wcbeval_red. auto.
+                 econstructor.
+           ++ clear - t0 H3 X0. revert x t0 x2 H3; induction X0; intros.
+              ** inv H3. exists []; eauto.
+              ** inv H3. inv t0. eapply r in X2 as (? & ? & ?); eauto.
+                 eapply IHX0 in X3 as (? & ? & ?); eauto.
+
+      * eapply Is_type_app in X2 as []; tas.
+        exists EAst.tBox. split.
+        econstructor.
+        eapply Is_type_eval. eauto. eassumption.
+        eauto.
+
+        assert (exists x5, Forall2 (EWcbvEval.eval Σ') x2 x5) as [x5]. {
+          assert (forall x n, nth_error args n = Some x -> ∑ T,  Σ;;; [] |- x : T).
+          { intros. eapply typing_spine_inv with (arg := n) in t0 as [].
+            2:{ eassumption. } eauto.
+          }
+          clear - X3 H3 X0. revert X3 x2 H3; induction X0; intros.
+          ** inv H3. exists []; eauto.
+          ** inv H3. destruct (X3 x 0 eq_refl).
+             eapply r in t as (? & ? & ?); eauto.
+             eapply IHX0 in H4 as (? & ?); eauto.
+             intros. eapply (X3 x2 (S n)). eassumption.
+        }
+
+        eapply eval_box_apps. eauto. eauto.
+        constructor.
+        eapply subject_reduction. eauto. exact Hty.
+        eapply PCUICReduction.red_mkApps.
+        eapply PCUICClosed.subject_closed in Ht.
+        now eapply wcbeval_red. auto.
+        eapply All_All2_refl.
+        clear. induction args. econstructor. econstructor; eauto.
+
 
   - destruct ip.
     assert (Hty' := Hty).
@@ -947,8 +1203,8 @@ Proof.
       destruct (EAstUtils.isBox x2) eqn:E.
       * destruct x2; inv E. exists EAst.tBox. split. 2: econstructor; eauto.
         pose proof (Is_type_app Σ [] f'[a']).
-        inversion H1.
-        edestruct H7; eauto. cbn. eapply subject_reduction. eauto.
+        inversion H2.
+        edestruct H8; eauto. cbn. eapply subject_reduction. eauto.
         exact Hty. eapply PCUICReduction.red_app.
         eapply PCUICClosed.subject_closed in t'; auto.
         eapply wcbeval_red; eauto.
@@ -960,14 +1216,14 @@ Proof.
                    eapply ssrbool.negbT.
                    repeat eapply orb_false_intro.
                    - destruct x2; try reflexivity.
-                     inv H1. inv i.
+                     inv H2. inv H0.
                    - destruct x2 eqn:Ex; try reflexivity.
-                     + cbn. inv H1. cbn in *.
+                     + cbn. inv H2. cbn in *.
                        eapply ssrbool.negbTE, is_FixApp_erases.
                        econstructor; eauto.
-                       now rewrite orb_false_r in i.
+                       now rewrite orb_false_r in H0.
                      + cbn in *.
-                       inv H1. inv i.
+                       inv H2. inv H0.
                    - eauto. }
         econstructor; eauto.
     + exists EAst.tBox. split. 2: now econstructor.
@@ -980,7 +1236,7 @@ Proof.
       eapply PCUICClosed.subject_closed in Ha; auto.
       eapply wcbeval_red; eauto.
       
-  - destruct t; try easy.
+  - destruct t; try now inversion H.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He. eexists. split; eauto. now econstructor.
     + inv He.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1080,145 +1080,85 @@ Proof.
            eapply wcbeval_red; eauto.
            eapply PCUICClosed.subject_closed in t0; eauto.
 
-  - todo "fix_value case".
-    (*
-    assert (Hty' := Hty).
-    assert (Hunf := H).
-    assert (Hcon := H0).
-    assert (Σ |-p mkApps (tFix mfix idx) args ▷ mkApps (tFix mfix idx) args') by eauto.
-    eapply PCUICValidity.inversion_mkApps in Hty' as (? & ? & ?); eauto.
-    assert (Ht := t).
-    eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
-    2:now eapply PCUICClosed.subject_closed in Ht.
-    assert (HT := t).
-    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
-
-    eapply erases_mkApps_inv in He as [(? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; eauto.
-    + subst. assert (X100 := X2). eapply Is_type_app in X100 as[]; auto.
-      exists EAst.tBox. split. 2:{
-        assert (exists x4, Forall2 (EWcbvEval.eval Σ') x3 x4) as [x4]. {
-          eapply All2_app_inv in X0 as ([] & ? & ?). destruct p.
-          clear a0. subst.
-          assert (forall x n, nth_error x2 n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-          { intros. eapply typing_spine_inv with (arg := n + #|x1|) in t0 as [].
-            2:{ rewrite nth_error_app2. 2:lia. rewrite Nat.add_sub. eassumption. }
-            eauto.
-          }
-          clear - X0 a1 H3. revert X0 x3 H3; induction a1; intros.
-          ** inv H3. exists []; eauto.
-          ** inv H3. destruct (X0 x 0 eq_refl).
-             eapply r in t as (? & ? & ?); eauto.
-             eapply IHa1 in H4 as (? & ?); eauto.
-             intros. eapply (X0 x2 (S n)). eassumption.
-        }
-        eapply eval_box_apps. eassumption. econstructor; eauto. }
-      econstructor.
-      eapply Is_type_eval. eauto. eassumption.
-      rewrite <- mkApps_nested.
-      eapply Is_type_red. eauto. 2:exact X3. repeat eapply PCUICReduction.red_mkApps_f.
-      eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in Ht. eauto. eauto.
-      rewrite mkApps_nested; eauto.
-    + subst.
-      eapply IHeval in H2 as (? & ? & ?); eauto.
-      assert (H2' := H1).
-      inv H1.
-      * assert (Hmfix' := X2).
-        eapply All2_nth_error_Some in X2 as (? & ? & ?); eauto.
-        destruct x0. cbn in *. subst.
-
-        (* enough(Σ;;; [] ,,, subst_context (fix_subst mfix) 0 [] |- PCUICLiftSubst.subst (fix_subst mfix) 0 dbody ⇝ℇ subst (ETyping.fix_subst mfix') 0 (Extract.E.dbody x4)). *)
-        destruct p. destruct p.
-
-        clear e3. rename H into e3.
-        -- enough (exists L, Forall2 (erases Σ []) args' L /\ Forall2 (Ee.eval Σ') x2 L).
-           ++ cbn in e3. destruct H as (L & ? & ?).
-              assert (Hv : Forall Ee.value L).
-              { eapply Forall2_Forall_right; eauto.
-                intros. eapply EWcbvEval.eval_to_value. eauto.
-              }
-
-              eapply erases_mkApps in H; eauto.
-              eexists. split. eauto.
-              eapply Ee.eval_fix_value; eauto.
-              cbn.
-
-              eapply All2_nth_error_Some in Hmfix' as (? & ? & ?); eauto.
-              destruct p. destruct p. cbn in *. subst.
-              unfold ETyping.unfold_fix, unfold_fix in *. rewrite e4.
-              rewrite e in Hcon.
-              clear H0. cbn in *.
-              rewrite e6 in *.
-              eapply erases_mkApps_inv in H as [ (? & ? & ? & ? & ? & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-              ** assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x6)) by now rewrite H6.
-                 rewrite !EAstUtils.decompose_app_mkApps in H7; try reflexivity.
-                 inv H7.
-              ** unfold is_constructor, ETyping.is_constructor in *.
-                 destruct nth_error eqn:En; try now inv Hcon.
-                 --- eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
-                     inv H0.
-                     +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-                         rewrite H4.
-                         eapply is_construct_erases in Hcon; eauto.
-                         unfold EisConstruct_app in *.
-                         destruct ?; eauto.
-                     +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-                 ---  eapply Forall2_nth_error_None_l in H4; eauto.
-                      inv H0.
-                      +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix'0 idx) x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-                         rewrite H4. eauto.
-                      +++ assert (EAstUtils.decompose_app (EAst.mkApps (E.tFix mfix' idx) L) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox x5)) by now rewrite H.
-                         rewrite !EAstUtils.decompose_app_mkApps in H0; try reflexivity.
-                         inv H0.
-              ** auto.
-              ** eapply subject_reduction. eauto. exact Hty.
-                 etransitivity.
-                 eapply PCUICReduction.red_mkApps.
-                 eapply PCUICClosed.subject_closed in Ht.
-                 eapply wcbeval_red; eauto. auto.
-                 eapply typing_spine_closed in t0.
-                 eapply All2_All_mix_left in X; eauto. 
-                 eapply All2_impl. exact X. intros. destruct X2.
-                 now eapply wcbeval_red. auto.
-                 econstructor.
-           ++ clear - t0 H3 X0. revert x t0 x2 H3; induction X0; intros.
-              ** inv H3. exists []; eauto.
-              ** inv H3. inv t0. eapply r in X2 as (? & ? & ?); eauto.
-                 eapply IHX0 in X3 as (? & ? & ?); eauto.
-
-      * eapply Is_type_app in X2 as []; tas.
-        exists EAst.tBox. split.
-        econstructor.
-        eapply Is_type_eval. eauto. eassumption.
-        eauto.
-
-        assert (exists x5, Forall2 (EWcbvEval.eval Σ') x2 x5) as [x5]. {
-          assert (forall x n, nth_error args n = Some x -> ∑ T,  Σ;;; [] |- x : T).
-          { intros. eapply typing_spine_inv with (arg := n) in t0 as [].
-            2:{ eassumption. } eauto.
-          }
-          clear - X3 H3 X0. revert X3 x2 H3; induction X0; intros.
-          ** inv H3. exists []; eauto.
-          ** inv H3. destruct (X3 x 0 eq_refl).
-             eapply r in t as (? & ? & ?); eauto.
-             eapply IHX0 in H4 as (? & ?); eauto.
-             intros. eapply (X3 x2 (S n)). eassumption.
-        }
-
-        eapply eval_box_apps. eauto. eauto.
-        constructor.
-        eapply subject_reduction. eauto. exact Hty.
-        eapply PCUICReduction.red_mkApps.
-        eapply PCUICClosed.subject_closed in Ht.
-        now eapply wcbeval_red. auto.
-        eapply All_All2_refl.
-        clear. induction args. econstructor. econstructor; eauto.
-    *)
+  - apply inversion_App in Hty as Hty'; [|eauto].
+    destruct Hty' as (? & ? & ? & ? & ? & ?).
+    eapply erases_App in He as He'; [|eauto].
+    destruct He' as [(-> & [])|(? & ? & -> & ? & ?)].
+    + exists E.tBox.
+      split; [|eauto using Ee.eval].
+      constructor.
+      eapply Is_type_red.
+      * eauto.
+      * eapply PCUICReduction.red_app.
+        -- eapply wcbeval_red; [eauto| |eauto].
+           eapply PCUICClosed.subject_closed in t; eauto.
+        -- eapply wcbeval_red; [eauto| |eauto].
+           eapply PCUICClosed.subject_closed in t0; eauto.
+      * eauto.
+    + eapply IHeval1 in H1 as (? & ? & ?); [|eauto].
+      eapply IHeval2 in H2 as (? & ? & ?); [|eauto].
+      eapply erases_mkApps_inv in H1; [|eauto|]; first last.
+      { eapply subject_reduction; [eauto| |]; first last.
+        - eapply wcbeval_red; [eauto| |eauto].
+          eapply PCUICClosed.subject_closed in t; eauto.
+        - eauto. }
+      destruct H1 as [(? & ? & ? & -> & [] & ? & ? & ->)|(? & ? & -> & ? & ?)].
+      * apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
+        depelim H5.
+        rewrite !app_nil_r in *.
+        cbn in *.
+        exists E.tBox.
+        split; [|eauto using Ee.eval].
+        eapply (Is_type_app _ _ _ [av]) in X as [].
+        -- constructor.
+           apply X.
+        -- eauto.
+        -- eauto.
+        -- cbn.
+           eapply type_App.
+           ++ eapply subject_reduction; [eauto| |]; first last.
+              ** eapply wcbeval_red; [eauto| |eauto].
+                 eapply PCUICClosed.subject_closed in t; eauto.
+              ** eauto.
+           ++ eapply subject_reduction; [eauto| |]; first last.
+              ** eapply wcbeval_red; [eauto| |eauto].
+                 eapply PCUICClosed.subject_closed in t0; eauto.
+              ** eauto.
+      * depelim H1.
+        -- exists (E.tApp (E.mkApps (E.tFix mfix' idx) x7) x5).
+           split; [eauto using erases_tApp, erases_mkApps|].
+           unfold cunfold_fix in *.
+           destruct (nth_error _ _) eqn:nth; [|congruence].
+           eapply All2_nth_error_Some in X as (? & ? & ? & ? & ?); [|eauto].
+           eapply Ee.eval_fix_value.
+           ++ eauto.
+           ++ eauto.
+           ++ unfold Ee.cunfold_fix.
+              rewrite e0.
+              reflexivity.
+           ++ eapply Forall2_length in H5.
+              destruct o as [|(<- & ?)]; [left; congruence|right].
+              split; [congruence|].
+              todo "contradiction: av must be a constructor when axiom free".
+        -- exists E.tBox.
+           apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
+           split; [|eauto using Ee.eval].
+           eapply Is_type_app in X as [].
+           ++ constructor.
+              rewrite <- mkApps_snoc.
+              exact X.
+           ++ eauto.
+           ++ eauto.
+           ++ rewrite mkApps_snoc.
+              eapply type_App.
+              ** eapply subject_reduction; [eauto| |]; first last.
+                 --- eapply wcbeval_red; [eauto| |eauto].
+                     eapply PCUICClosed.subject_closed in t; eauto.
+                 --- eauto.
+              ** eapply subject_reduction; [eauto| |]; first last.
+                 --- eapply wcbeval_red; [eauto| |eauto].
+                     eapply PCUICClosed.subject_closed in t0; eauto.
+                 --- eauto.
 
   - destruct ip.
     assert (Hty' := Hty).

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -651,19 +651,15 @@ Section Wcbv.
       now depelim ev.
     + rewrite <- mkApps_nested in ev.
       cbn in *.
-      depelim ev.
-      * apply IHargs in ev1 as (? & ?).
-        solve_discr.
-      * apply IHargs in ev1 as (? & ?).
-        solve_discr.
-      * apply IHargs in ev1 as (? & ?).
-        solve_discr.
+      depelim ev;
+        try solve [apply IHargs in ev1 as (? & ?); solve_discr].
       * apply IHargs in ev1 as (argsv & ->).
         exists (argsv ++ [a'])%list.
         now rewrite <- mkApps_nested.
       * easy.
   Qed.
  
+  Unset SsrRewrite.
   Lemma eval_deterministic {t v v'} :
     eval t v ->
     eval t v' ->
@@ -688,13 +684,13 @@ Section Wcbv.
       now apply IHev2 in ev'2.
     + easy.
   - depelim ev'.
-    + pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0); subst.
+    + rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
       replace body0 with body in * by congruence.
       now apply IHev in ev'.
-    + now pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0); subst.
+    + now rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
     + easy.
   - depelim ev'.
-    + now pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0); subst.
+    + now rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
     + easy.
     + easy.
   - depelim ev'.
@@ -729,7 +725,7 @@ Section Wcbv.
       now apply Bool.negb_true_iff in H0.
     + apply IHev1 in ev'1.
       subst f'.
-      rewrite isFixApp_mkApps in i0; [easy|].
+      rewrite isFixApp_mkApps in i0 by easy.
       cbn in *.
       now rewrite Bool.orb_true_r in i0.
     + easy.
@@ -742,7 +738,7 @@ Section Wcbv.
     + apply IHev1 in ev'1; solve_discr.
       now apply IHev2 in ev'2; subst.
     + apply IHev1 in ev'1; subst.
-      rewrite isFixApp_mkApps in i; [easy|].
+      rewrite isFixApp_mkApps in i by easy.
       cbn in *.
       now rewrite Bool.orb_true_r in i.
     + easy.
@@ -763,11 +759,11 @@ Section Wcbv.
   - depelim ev'.
     + now apply IHev1 in ev'1; subst.
     + apply IHev1 in ev'1; subst.
-      rewrite isFixApp_mkApps in i; [easy|].
+      rewrite isFixApp_mkApps in i by easy.
       cbn in *.
       now rewrite Bool.orb_true_r in i.
     + apply IHev1 in ev'1; subst.
-      rewrite isFixApp_mkApps in i; [easy|].
+      rewrite isFixApp_mkApps in i by easy.
       cbn in *.
       now rewrite Bool.orb_true_r in i.
     + apply IHev1 in ev'1; subst.
@@ -775,6 +771,7 @@ Section Wcbv.
     + easy.
   - now depelim ev'.
   Qed.
+  Set SsrRewrite.
 
   Lemma eval_LetIn {n b ty t v} :
     eval (tLetIn n b ty t) v ->

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -688,13 +688,13 @@ Section Wcbv.
       now apply IHev2 in ev'2.
     + easy.
   - depelim ev'.
-    + replace decl0 with decl in * by (now eapply PCUICWeakeningEnv.declared_constant_inj).
+    + pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0); subst.
       replace body0 with body in * by congruence.
       now apply IHev in ev'.
-    + now replace decl0 with decl in * by (now eapply PCUICWeakeningEnv.declared_constant_inj).
+    + now pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0); subst.
     + easy.
   - depelim ev'.
-    + now replace decl0 with decl in * by (now eapply PCUICWeakeningEnv.declared_constant_inj).
+    + now pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0); subst.
     + easy.
     + easy.
   - depelim ev'.
@@ -748,85 +748,39 @@ Section Wcbv.
     + easy.
   - depelim ev'.
     + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + solve_discr.apply IHev in ev'.
-      noconf H1.
-      rewrite H0 in H.
-      noconf H.
+    + solve_discr.
+      rewrite e0 in e.
+      noconf e.
       now apply IHev in ev'.
-    + apply aeval_mkApps_tCoFix in ev'1 as (? & ?).
-      solve_discr.
-    + apply aeval_mkApps_tCoFix in ev' as (? & ?).
-      solve_discr.
     + easy.
   - depelim ev'.
-    + unfold ETyping.declared_constant in *.
-      rewrite H1 in H.
+    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + solve_discr.
+      rewrite e0 in e.
+      noconf e.
+      now apply IHev in ev'.
+    + easy.
+  - depelim ev'.
+    + now apply IHev1 in ev'1; subst.
+    + apply IHev1 in ev'1; subst.
+      rewrite isFixApp_mkApps in i; [easy|].
       cbn in *.
-      noconf H.
-      rewrite H2 in H0.
-      noconf H0.
-      now apply IHev in ev'.
-    + easy.
-  - depelim ev'.
-    + apply aeval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
-    + apply IHev1 in ev'1.
-      now apply mkApps_eq_inj in ev'1 as (ev'1 & <-).
-    + apply IHev1 in ev'.
-      solve_discr.
-    + easy.
-  - depelim ev'.
-    + apply aeval_mkApps_tCoFix in ev as (? & ?); solve_discr.
-    + apply IHev in ev'1.
-      solve_discr.
-    + easy.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      subst.
-      easy.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      subst.
-      easy.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      subst.
-      now rewrite mkApps_app.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      subst.
-      rewrite isFixApp_mkApps in H by easy.
-      cbn in H.
-      now rewrite orb_true_r in H.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      congruence.
+      now rewrite Bool.orb_true_r in i.
+    + apply IHev1 in ev'1; subst.
+      rewrite isFixApp_mkApps in i; [easy|].
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+    + apply IHev1 in ev'1; subst.
+      now apply IHev2 in ev'2; subst.
     + easy.
   - now depelim ev'.
-Qed.
-
-  Lemma eval_atom_inj t t' : atom t -> eval t t' -> t = t'.
-  Proof.
-    intros Ha H; depind H; try solve_discr; try now easy.
-    eapply atom_mkApps in Ha; intuition subst. discriminate.
-    eapply atom_mkApps in Ha; intuition subst. now depelim a.
   Qed.
 
   Lemma eval_LetIn {n b ty t v} :
     eval (tLetIn n b ty t) v ->
     ∑ b',
       eval b b' * eval (csubst b' 0 t) v.
-  Proof.
-    intros H; depind H; try solve_discr; try now easy.
-    - apply (f_equal nApp) in H1 as h. simpl in h.
-      rewrite nApp_mkApps in h. exfalso. lia.
-    - apply (f_equal nApp) in H0 as h. simpl in h.
-      rewrite nApp_mkApps in h. depelim a.
-      + simpl in *. subst.
-        eapply IHeval. reflexivity.
-      + simpl in h. exfalso. lia.
-  Qed.
+  Proof. now intros H; depelim H. Qed.
 
   Lemma eval_Const {c u v} :
     eval (tConst c u) v ->
@@ -836,51 +790,14 @@ Qed.
                  | None => v = tConst c u
                  end.
   Proof.
-    intros H; depind H; try solve_discr; try now easy.
-    - exists decl. intuition auto. now rewrite e.
-    - exists decl. intuition auto. now rewrite e.
-    - apply (f_equal nApp) in H1 as h.
-      simpl in h. rewrite nApp_mkApps in h.
-      exfalso. lia.
-    - apply (f_equal nApp) in H0 as h.
-      simpl in h. rewrite nApp_mkApps in h.
-      destruct a.
-      + simpl in *. subst.
-        eapply IHeval. reflexivity.
-      + exfalso. simpl in h. lia.
-  Qed.
-
-  Lemma eval_mkApps_tCoFix mfix idx l v :
-    eval (mkApps (tCoFix mfix idx) l) v ->
-    ∑ l', All2 eval l l' * (v = mkApps (tCoFix mfix idx) l').
-  Proof.
-    intros H.
-    depind H; try solve_discr'.
-    - destruct (mkApps_elim f [a]).
-      rewrite [tApp _ _](mkApps_nested f (firstn n l0) [a]) in H2.
-      solve_discr'.
-      specialize (IHeval1 _ _ _ _ eq_refl).
-      firstorder eauto.
-      solve_discr'.
-    - destruct (mkApps_elim f args). solve_discr'.
-      specialize (IHeval1 _ _ _ _ eq_refl).
-      firstorder eauto. solve_discr.
-    - destruct (mkApps_elim f args). solve_discr'.
-      specialize (IHeval _ _ _ _ eq_refl).
-      firstorder eauto. solve_discr.
-    - destruct (mkApps_elim f [a]).
-      replace (tApp (mkApps f (firstn n l0)) a)
-        with (mkApps f (firstn n l0 ++ [a])) in H1.
-      2:now rewrite -mkApps_nested.
-      solve_discr'.
-      specialize (IHeval1 _ _ _ _ eq_refl).
-      firstorder eauto. subst.
-      exists (x ++ [a'])%list.
-      split. eapply All2_app; auto.
-      now rewrite -mkApps_nested.
-    - eapply atom_mkApps in i; intuition try easy.
-      subst.
-      exists []. intuition auto.
+    intros H; depelim H.
+    - exists decl.
+      split; [easy|].
+      now rewrite e.
+    - exists decl.
+      split; [easy|].
+      now rewrite e.
+    - easy.
   Qed.
 
   Lemma eval_mkApps_cong f f' l l' :
@@ -906,107 +823,6 @@ Qed.
     forward IHl. simpl; lia. cbn -[removelast] in *. simpl removelast. simpl. lia.
   Qed.
 
-  Lemma eval_deterministic {t v v'} : eval t v -> eval t v' -> v = v'.
-  Proof.
-    intros tv. revert v'.
-    revert t v tv.
-    induction 1 using eval_evals_ind; intros v' tv'.
-    - depelim tv'; auto.
-      * specialize (IHtv1 _ tv'1); try congruence. inv IHtv1.
-        specialize (IHtv2 _ tv'2). subst.
-        specialize (IHtv3 _ tv'3). now subst.
-      * rewrite [args](app_removelast_last a) in H.
-        destruct args; discriminate.
-        rewrite -mkApps_nested in H. simpl in H. injection H. intros. clear H.
-        subst.
-        assert (eval (mkApps f0 (removelast args)) (mkApps (tFix mfix idx) (removelast args'))).
-        eapply eval_fix_value. auto. admit.
-        simpl. admit.
-(*        rewrite e /is_constructor. rewrite /is_constructor in i.
-        destruct (nth_error (removelast args') narg) eqn:Heq.
-        eapply nth_error_Some_length in Heq.
-        have H':= (removelast_length args').
-        forward H'. rewrite -(All2_length _ _ a0). lia.
-        elimtype False. rewrite -(All2_length _ _ a0) in H'. lia. 
-        constructor.*)
-        specialize (IHtv1 _ X).
-        solve_discr'.
-      * destruct (mkApps_elim f [a]).
-        destruct (mkApps_elim f0 args).
-(*
-    - depelim tv'; auto; try specialize (IHtv1 _ tv'1) || solve [depelim tv1]; try congruence.
-      inv IHtv1. specialize (IHtv2 _ tv'2). subst.
-      now specialize (IHtv3 _ tv'3).
-      now subst f'. easy.
-    - eapply eval_LetIn in tv' as [b' [evb evt]].
-      rewrite -(IHtv1 _ evb) in evt.
-      eapply (IHtv2 _ evt).
-    - depelim tv'; try solve_discr.
-      * specialize (IHtv1 _ tv'1).
-        solve_discr. inv H.
-        now specialize (IHtv2 _ tv'2).
-      * specialize (IHtv1 _ tv'1); solve_discr.
-      * eapply eval_mkApps_tCoFix in tv1 as [l' [ev' eq]]. solve_discr.
-      * easy.
-    - subst.
-      depelim tv'.
-      * specialize (IHtv1 _ tv'1).
-        solve_discr.
-      * specialize (IHtv1 _ tv'1).
-        now specialize (IHtv2 _ tv'2).
-      * pose proof tv1. eapply eval_mkApps_tCoFix in H0.
-        destruct H0 as [l' [evargs eq]]. solve_discr.
-      * easy.
-    - depelim tv' => //.
-      * depelim tv'1.
-      * depelim tv'1.
-      * rewrite H in H0. inv H0.
-        now specialize (IHtv _ tv').
-      * now depelim tv'1.
-*)
-  (*   - depelim tv'; try easy. *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * solve_discr. inv H1. rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv _ tv'). *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * solve_discr. inv H1. rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv _ tv'). *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv' as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-
-  (*   - eapply eval_Const in tv' as [decl' [body' [? ?]]]. *)
-  (*     intuition eauto. eapply IHtv. *)
-  (*     red in isdecl, H0. rewrite H0 in isdecl. inv isdecl. *)
-  (*     now rewrite H in H2; inv H2. *)
-
-  (*   - depelim tv'. *)
-  (*     * eapply eval_mkApps_tCoFix in tv1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv1 _ tv'1). *)
-  (*       solve_discr. inv H. *)
-  (*       now specialize (IHtv2 _ tv'2). *)
-  (*     * specialize (IHtv1 _ tv'). solve_discr. *)
-  (*     * easy. *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * eapply eval_mkApps_tCoFix in tv as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv _ tv'1). solve_discr. *)
-
-  (*   - depelim tv'; try specialize (IHtv1 _ tv'1); subst; try easy. *)
-  (*     depelim tv1. easy. *)
-  (*     specialize (IHtv2 _ tv'2). congruence. *)
-
-  (*   - depelim tv'; try easy. *)
-  (* Qed. *)
-  Admitted.
-
 End Wcbv.
 
 
@@ -1023,7 +839,7 @@ Lemma wcbeval_red `{checker_flags} : forall (Σ : global_env_ext) t u, wf Σ -> 
     eval Σ t u -> red Σ [] t u.
 Proof.
   intros Σ t u wfΣ Hc He. revert Hc.
-  induction He using eval_evals_ind; simpl; 
+  induction He; simpl; 
   (move/andP => [/andP[Hc Hc'] Hc''] || move/andP => [Hc Hc'] || move => Hc);
     try solve[econstructor; eauto].
 
@@ -1061,36 +877,45 @@ Proof.
     apply red1_red. econstructor; eauto.
     eapply eval_closed in He1; eauto. eapply closed_arg in He1; eauto.
 
-  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs]. 
-    redt (mkApps (tFix mfix idx) args'); eauto.
-    eapply red_mkApps; eauto. solve_all.
-    rewrite -closed_unfold_fix_cunfold_eq in H0; auto.
-    eapply eval_closed in He1; eauto.
-    redt (mkApps fn args'); eauto.
-    eapply red1_red. eapply red_fix; eauto.
-    eapply IHHe2. eapply eval_closed in He1; eauto.
-    eapply closedn_mkApps; eauto using closed_unfold_fix.
-    clear -wfΣ X Hargs. solve_all. now eapply eval_closed.
+  - redt (tApp (mkApps (tFix mfix idx) argsv) av);
+      [eapply red_app; eauto|].
+    assert (closed_fix: closed (mkApps (tFix mfix idx) argsv)).
+    { eapply eval_closed; [easy| |easy].
+      easy. }
+    eapply closedn_mkApps_inv in closed_fix.
+    apply andb_true_iff in closed_fix.
+    rewrite -closed_unfold_fix_cunfold_eq in e; [easy|].
+    redt (tApp (mkApps fn argsv) av).
+    + repeat change (tApp ?h ?a) with (mkApps h [a]).
+      rewrite !mkApps_nested.
+      apply red1_red.
+      eapply red_fix; [easy|].
+      unfold is_constructor.
+      now rewrite nth_error_snoc.
+    + eapply IHHe3.
+      cbn.
+      apply andb_true_iff.
+      split.
+      * apply closedn_mkApps; [|easy].
+        now eapply closed_unfold_fix.
+      * now eapply eval_closed; [| |easy].
 
-  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
-    eapply red_mkApps; eauto.
-    eauto using eval_closed.
-    solve_all.
+  - now apply red_app.
 
   - move/closedn_mkApps_inv/andP: Hc' => [Hf Hargs].
-    rewrite -closed_unfold_cofix_cunfold_eq in H0; auto.
+    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
     redt _. eapply red1_red.
     eapply PCUICTyping.red_cofix_case; eauto.
     eapply IHHe.
-    eapply closed_unfold_cofix in H0; eauto.
+    eapply closed_unfold_cofix in e; eauto.
     simpl. rewrite Hc closedn_mkApps; eauto.
 
   - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
-    rewrite -closed_unfold_cofix_cunfold_eq in H0; auto.
+    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
     redt _. 2:eapply IHHe.
     redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
     apply red1_red. econstructor; eauto.
-    simpl. eapply closed_unfold_cofix in H0; eauto.
+    simpl. eapply closed_unfold_cofix in e; eauto.
     rewrite closedn_mkApps; eauto.
 
   - eapply (red_mkApps _ _ [a] [a']); auto.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -664,7 +664,7 @@ Section Wcbv.
       * easy.
   Qed.
  
-  Lemma eval_deterministic t v v' :
+  Lemma eval_deterministic {t v v'} :
     eval t v ->
     eval t v' ->
     v = v'.
@@ -825,6 +825,7 @@ Section Wcbv.
 
 End Wcbv.
 
+Arguments eval_deterministic {_ _ _ _}.
 
 (** Well-typed closed programs can't go wrong: they always evaluate to a value. *)
 

--- a/template-coq/theories/utils/MCList.v
+++ b/template-coq/theories/utils/MCList.v
@@ -744,6 +744,15 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma nth_error_snoc {A} (l : list A) (a : A) i :
+  i = #|l| ->
+  nth_error (l ++ [a]) i = Some a.
+Proof.
+  intros ->.
+  rewrite nth_error_app_ge; [easy|].
+  now rewrite Nat.sub_diag.
+Qed.
+
 Lemma map_inj :
   forall A B (f : A -> B) l l',
     (forall x y, f x = f y -> x = y) ->


### PR DESCRIPTION
For PCUIC/erasure the old fix/fix_value rules are replaced by
```coq
  | eval_fix f mfix idx argsv a av narg fn res :
      eval f (mkApps (tFix mfix idx) argsv) ->
      eval a av ->
      cunfold_fix mfix idx = Some (narg, fn) ->
      #|argsv| = narg ->
      isConstruct_app av ->
      eval (tApp (mkApps fn argsv) av) res ->
      eval (tApp f a) res

  | eval_fix_value f mfix idx argsv a av narg fn :
      eval f (mkApps (tFix mfix idx) argsv) ->
      eval a av ->
      cunfold_fix mfix idx = Some (narg, fn) ->
      (#|argsv| <> narg \/ (#|argsv| = narg /\ ~~isConstruct_app av)) ->
      eval (tApp f a) (tApp (mkApps (tFix mfix idx) argsv) av)
```

Also prove these new relations deterministic. This required updating erasure's `eval_fix_value` to use `~is_constructor_or_box` instead of `~is_constructor` (see #432).

In checker's wcbv eval, replace the rules by
```coq
  | eval_fix f mfix idx fixargsv args argsv narg fn res :
      eval f (mkApps (tFix mfix idx) fixargsv) ->
      All2 eval args argsv ->
      unfold_fix mfix idx = Some (narg, fn) ->
      is_constructor narg (fixargsv ++ argsv) ->
      eval (mkApps fn (fixargsv ++ argsv)) res ->
      eval (mkApps f args) res 

  | eval_fix_value f mfix idx fixargsv args argsv narg fn :
      eval f (mkApps (tFix mfix idx) fixargsv) ->
      All2 eval args argsv ->
      unfold_fix mfix idx = Some (narg, fn) ->
      ~~is_constructor narg (fixargsv ++ argsv) ->
      eval (mkApps f args) (mkApps (tFix mfix idx) (fixargsv ++ argsv))
```
due to the n-ary applications.

TODO:
- [x] Template wcbv eval
- [X] PCUIC wcbv eval
- [X] Erasure wcbv eval
- [X] `erases_correct` new cases for fix/stuck fix
- [ ] Impossible case for stuck fixpoints with enough arguments

Fixes #436 and #432.