### PR TITLE
Do not rely on bash location

### DIFF
--- a/checker/update_plugin.sh
+++ b/checker/update_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TEMPLATE_LIB=../template-coq
 
 if [[ "src" -ot "${TEMPLATE_LIB}/gen-src" || ! -f "src/metacoq_checker_plugin.cmxa" \

--- a/erasure/clean_extraction.sh
+++ b/erasure/clean_extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/pcuic/clean_extraction.sh
+++ b/pcuic/clean_extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/safechecker/clean_extraction.sh
+++ b/safechecker/clean_extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/template-coq/update_plugin.sh
+++ b/template-coq/update_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TOCOPY="ast_denoter.ml ast_quoter.ml denoter.ml plugin_core.ml plugin_core.mli reification.ml quoter.ml run_extractable.ml run_extractable.mli tm_util.ml"
 


### PR DESCRIPTION
This will make Metacoq compatible with distributions which store bash in
custom location, like NixOS does.