### PR TITLE
Monad universe annotation

### DIFF
--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -66,7 +66,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 From MetaCoq.Template Require Import monad_utils.
 
 (** This allow to use notations of MonadNotation *)
-Instance TemplateMonad_Monad : Monad TemplateMonad :=
+Instance TemplateMonad_Monad@{t u} : Monad@{t u} TemplateMonad@{t u} :=
   {| ret := @tmReturn ; bind := @tmBind |}.
 
 Import MonadNotation.


### PR DESCRIPTION
This avoids agressive minimization in coq/coq#12449 to lower the "u" universe to Set, which in turn makes the overloaded bind notation more restrictive than tmBind w.r.t. universes.