### PR TITLE
Add `tmQuoteRecTransp` that respects the opaqueness settings (for issue #446)

### DIFF
--- a/erasure/src/g_metacoq_erasure.mlg
+++ b/erasure/src/g_metacoq_erasure.mlg
@@ -33,7 +33,7 @@ let time prefix f x =
 
 let check env evm c =
   Feedback.msg_debug (str"Quoting");
-  let term = time (str"Quoting") (Ast_quoter.quote_term_rec env) (EConstr.to_constr evm c) in
+  let term = time (str"Quoting") (Ast_quoter.quote_term_rec true env) (EConstr.to_constr evm c) in
   let checker_flags = Config0.extraction_checker_flags in
   let erase = time (str"Erasing")
       (SafeTemplateErasure.erase_and_print_template_program checker_flags)

--- a/safechecker/src/g_metacoq_safechecker.mlg
+++ b/safechecker/src/g_metacoq_safechecker.mlg
@@ -20,7 +20,7 @@ let time prefix f x =
 
 let check env evm (c, ustate) =
   Feedback.msg_debug (str"Quoting");
-  let term = time (str"Quoting") (Ast_quoter.quote_term_rec env) (EConstr.to_constr evm c) in
+  let term = time (str"Quoting") (Ast_quoter.quote_term_rec true env) (EConstr.to_constr evm c) in
   let uctx = UState.context_set ustate in
   Feedback.msg_debug (str"Universes added: " ++ Printer.pr_universe_ctx_set evm uctx);
   let uctx = Universes0.Monomorphic_ctx (Ast_quoter.quote_univ_contextset uctx) in

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -373,7 +373,7 @@ struct
     Ind of Names.inductive
   | Const of KerName.t
 
-  let quote_term_rec env trm =
+  let quote_term_rec bypass env trm =
     let visited_terms = ref Names.KNset.empty in
     let visited_types = ref Mindset.empty in
     let constants = ref [] in
@@ -404,13 +404,15 @@ struct
         | Undef _ -> None
         | Primitive _ -> CErrors.user_err Pp.(str "Primitives are unsupported by TemplateCoq")
 	      | Def cs -> Some (Mod_subst.force_constr cs)
-	      | OpaqueDef lc -> 
+	      | OpaqueDef lc ->
+          if bypass then
           let c, univs = Opaqueproof.force_proof Library.indirect_accessor (Environ.opaque_tables env) lc in
           let () = match univs with
           | Opaqueproof.PrivateMonomorphic () -> ()
           | Opaqueproof.PrivatePolymorphic (n, csts) -> if not (Univ.ContextSet.is_empty csts && Int.equal n 0) then 
             CErrors.user_err Pp.(str "Private polymorphic universes not supported by TemplateCoq")
           in Some c
+          else None
         in
         let tm, acc =
           match body with

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -357,12 +357,12 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
           k (env, evm, EConstr.to_constr evm t)) in  (* todo better *)
     ignore (Obligations.add_definition ~name:ident ~term:c cty ctx ~poly ~kind ~hook obls)
 
-  | TmQuote (false, trm) ->
+  | TmQuote (false, _, trm) ->
     (* user should do the reduction (using tmEval) if they want *)
     let qt = quote_term env trm
     in k (env, evm, qt)
-  | TmQuote (true, trm) ->
-    let qt = quote_term_rec env trm in
+  | TmQuote (true, bypass, trm) ->
+    let qt = quote_term_rec bypass env trm in
     k (env, evm, qt)
   | TmQuoteInd (name, strict) ->
        let kn = unquote_kn (reduce_all env evm name) in

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -357,11 +357,12 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
           k (env, evm, EConstr.to_constr evm t)) in  (* todo better *)
     ignore (Obligations.add_definition ~name:ident ~term:c cty ctx ~poly ~kind ~hook obls)
 
-  | TmQuote (false, _, trm) ->
+  | TmQuote trm ->
     (* user should do the reduction (using tmEval) if they want *)
     let qt = quote_term env trm
     in k (env, evm, qt)
-  | TmQuote (true, bypass, trm) ->
+  | TmQuoteRecTransp  (bypass, trm) ->
+    let bypass = unquote_bool (reduce_all env evm bypass) in
     let qt = quote_term_rec bypass env trm in
     k (env, evm, qt)
   | TmQuoteInd (name, strict) ->

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -33,6 +33,7 @@ let (ptmReturn,
 
      ptmQuote,
      ptmQuoteRec,
+     ptmQuoteRecTransp,
      ptmQuoteInductive,
      ptmQuoteConstant,
      ptmQuoteUniverses,
@@ -71,6 +72,7 @@ let (ptmReturn,
 
    r_template_monad_prop_p "tmQuote",
    r_template_monad_prop_p "tmQuoteRec",
+   r_template_monad_prop_p "tmQuoteRecTransp",
    r_template_monad_prop_p "tmQuoteInductive",
    r_template_monad_prop_p "tmQuoteConstant",
    r_template_monad_prop_p "tmQuoteUniverses",
@@ -165,7 +167,7 @@ type template_monad =
   | TmCurrentModPath
 
     (* quoting *)
-  | TmQuote of bool * Constr.t  (* only Prop *)
+  | TmQuote of bool * bool * Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
@@ -300,13 +302,20 @@ let next_action env evd (pgm : constr) : template_monad * _ =
   else if eq_gr ptmQuote then
     match args with
     | _::trm::[] ->
-       (TmQuote (false,trm), universes)
+       (* NOTE : bypass really makes sense only for recursive quoting *)
+       (TmQuote (false,true,trm), universes)
     | _ -> monad_failure "tmQuote" 2
   else if eq_gr ptmQuoteRec then
     match args with
     | _::trm::[] ->
-       (TmQuote (true,trm), universes)
+       (TmQuote (true,true,trm), universes)
     | _ -> monad_failure "tmQuoteRec" 2
+  else if eq_gr ptmQuoteRecTransp then
+    match args with
+    | _::trm::[] ->
+       (TmQuote (true,false,trm), universes)
+    | _ -> monad_failure "tmQuoteRec" 3
+
 
   else if eq_gr ptmQuoteInductive then
     match args with

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -32,7 +32,6 @@ let (ptmReturn,
      ptmCurrentModPath,
 
      ptmQuote,
-     ptmQuoteRec,
      ptmQuoteRecTransp,
      ptmQuoteInductive,
      ptmQuoteConstant,
@@ -71,7 +70,6 @@ let (ptmReturn,
    r_template_monad_prop_p "tmCurrentModPath",
 
    r_template_monad_prop_p "tmQuote",
-   r_template_monad_prop_p "tmQuoteRec",
    r_template_monad_prop_p "tmQuoteRecTransp",
    r_template_monad_prop_p "tmQuoteInductive",
    r_template_monad_prop_p "tmQuoteConstant",
@@ -167,7 +165,8 @@ type template_monad =
   | TmCurrentModPath
 
     (* quoting *)
-  | TmQuote of bool * bool * Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
+  | TmQuote of Constr.t (* only Prop *)
+  | TmQuoteRecTransp of Constr.t * Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
@@ -302,18 +301,12 @@ let next_action env evd (pgm : constr) : template_monad * _ =
   else if eq_gr ptmQuote then
     match args with
     | _::trm::[] ->
-       (* NOTE : bypass really makes sense only for recursive quoting *)
-       (TmQuote (false,true,trm), universes)
-    | _ -> monad_failure "tmQuote" 2
-  else if eq_gr ptmQuoteRec then
-    match args with
-    | _::trm::[] ->
-       (TmQuote (true,true,trm), universes)
-    | _ -> monad_failure "tmQuoteRec" 2
+       (TmQuote trm, universes)
+    | _ -> monad_failure "tmQuote" 3
   else if eq_gr ptmQuoteRecTransp then
     match args with
-    | _::trm::[] ->
-       (TmQuote (true,false,trm), universes)
+    | _::trm::bypass::[] ->
+       (TmQuoteRecTransp (bypass,trm), universes)
     | _ -> monad_failure "tmQuoteRec" 3
 
 

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -37,7 +37,7 @@ type template_monad =
   | TmCurrentModPath
 
     (* quoting *)
-  | TmQuote of bool * Constr.t  (* only Prop *)
+  | TmQuote of bool * bool * Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -37,7 +37,8 @@ type template_monad =
   | TmCurrentModPath
 
     (* quoting *)
-  | TmQuote of bool * bool * Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
+  | TmQuote of Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
+  | TmQuoteRecTransp of Constr.t * Constr.t
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -209,6 +209,7 @@ Register MetaCoq.Template.TemplateMonad.Core.tmCurrentModPath as metacoq.templat
 
 Register MetaCoq.Template.TemplateMonad.Core.tmQuote as metacoq.templatemonad.prop.tmQuote.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteRec as metacoq.templatemonad.prop.tmQuoteRec.
+Register MetaCoq.Template.TemplateMonad.Core.tmQuoteRecTransp as metacoq.templatemonad.prop.tmQuoteRecTransp.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteInductive as metacoq.templatemonad.prop.tmQuoteInductive.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteConstant as metacoq.templatemonad.prop.tmQuoteConstant.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteUniverses as metacoq.templatemonad.prop.tmQuoteUniverses.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -47,6 +47,8 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmQuote : forall {A:Type@{t}}, A  -> TemplateMonad Ast.term
 (* Similar to MetaCoq Quote Recursively Definition ... := ...*)
 | tmQuoteRec : forall {A:Type@{t}}, A  -> TemplateMonad program
+(* Similar to [tmQuoteRec] but respect opacity (does not quote the bodies of opaque definitions) *)
+| tmQuoteRecTransp : forall {A:Type@{t}}, A -> TemplateMonad program
 (* Quote the body of a definition or inductive. Its name need not be fully qualified *)
 | tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
 | tmQuoteUniverses : TemplateMonad ConstraintSet.t

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -45,10 +45,10 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 (* Quoting and unquoting commands *)
 (* Similar to MetaCoq Quote Definition ... := ... *)
 | tmQuote : forall {A:Type@{t}}, A  -> TemplateMonad Ast.term
-(* Similar to MetaCoq Quote Recursively Definition ... := ...*)
-| tmQuoteRec : forall {A:Type@{t}}, A  -> TemplateMonad program
-(* Similar to [tmQuoteRec] but respect opacity (does not quote the bodies of opaque definitions) *)
-| tmQuoteRecTransp : forall {A:Type@{t}}, A -> TemplateMonad program
+(* Similar to MetaCoq Quote Recursively Definition but takes a boolean "bypass opacity" flag.
+  ([true] - quote bodies of all dependencies (transparent and opaque);
+   [false] -quote bodies of transparent definitions only) *)
+| tmQuoteRecTransp : forall {A:Type@{t}}, A -> bool(* bypass opacity? *) -> TemplateMonad program
 (* Quote the body of a definition or inductive. Its name need not be fully qualified *)
 | tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
 | tmQuoteUniverses : TemplateMonad ConstraintSet.t
@@ -92,6 +92,9 @@ Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
 
 Definition tmAxiom id := tmAxiomRed id None.
 Definition tmDefinition id {A} t := @tmDefinitionRed_ false id None A t.
+
+(** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
+Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
 
 Definition tmLocate1 (q : qualid) : TemplateMonad global_reference :=
   l <- tmLocate q ;;

--- a/test-suite/opaque.v
+++ b/test-suite/opaque.v
@@ -13,7 +13,7 @@ Axiom really_opaque : nat.
 
 MetaCoq Quote Recursively Definition really_opaque_syn := really_opaque.
 
-MetaCoq Run (foo_t <- tmQuoteRecTransp foo ;; (* quote respecting transparency *)
+MetaCoq Run (foo_t <- tmQuoteRecTransp foo false ;; (* quote respecting transparency *)
              foo_o <- tmQuoteRec foo ;; (* quote ignoring transparency settings  *)
              tmDefinition "foo_t" foo_t ;;
              tmDefinition "foo_o" foo_o).
@@ -27,7 +27,7 @@ Proof.
   split;eexists;eexists;cbn; now intuition.
 Qed.
 
-Time MetaCoq Run (t <- tmQuoteRecTransp Plus.le_plus_r ;;
+Time MetaCoq Run (t <- tmQuoteRecTransp Plus.le_plus_r false ;;
                   tmDefinition "add_comm_syn" t). (* quote respecting transparency *)
 
 Time MetaCoq Run (t <- tmQuoteRec Plus.le_plus_r ;;

--- a/test-suite/opaque.v
+++ b/test-suite/opaque.v
@@ -1,10 +1,34 @@
-Require Import MetaCoq.Template.Loader.
+From Coq Require Import String List Nat.
+From MetaCoq.Template Require Import All.
+
+Import MonadNotation String ListNotations.
 
 Definition foo : nat. exact 0. Qed.
 
 Local Open Scope string_scope.
 MetaCoq Quote Recursively Definition foo_syn := foo.
+MetaCoq Quote Recursively Definition comm_syn := PeanoNat.Nat.add_comm.
 
 Axiom really_opaque : nat.
 
 MetaCoq Quote Recursively Definition really_opaque_syn := really_opaque.
+
+MetaCoq Run (foo_t <- tmQuoteRecTransp foo ;; (* quote respecting transparency *)
+             foo_o <- tmQuoteRec foo ;; (* quote ignoring transparency settings  *)
+             tmDefinition "foo_t" foo_t ;;
+             tmDefinition "foo_o" foo_o).
+
+Example foo_quoted_correctly :
+  (exists c v, lookup_env (fst foo_t) (MPfile ["opaque"; "TestSuite"; "MetaCoq"], "foo") = Some v /\
+    v = ConstantDecl c /\ c.(cst_body) = None) /\
+    (exists c v, lookup_env (fst foo_o) (MPfile ["opaque"; "TestSuite"; "MetaCoq"], "foo") = Some v /\
+    v = ConstantDecl c /\ c.(cst_body) <> None ).
+Proof.
+  split;eexists;eexists;cbn; now intuition.
+Qed.
+
+Time MetaCoq Run (t <- tmQuoteRecTransp Plus.le_plus_r ;;
+                  tmDefinition "add_comm_syn" t). (* quote respecting transparency *)
+
+Time MetaCoq Run (t <- tmQuoteRec Plus.le_plus_r ;;
+                  tmDefinition "add_comm_syn'" t). (* quote ignoring transparency settings  *)


### PR DESCRIPTION
`tmQuoteRecTransp` quotes only transparent dependencies (opaque dependencies are quoted without bodies).
The original `tmQuoteRec` still works as before - bypasses the opaqueness and quotes all the dependencies.