### PR TITLE
Merge coq-8.11 into coq-8.12, newest Equations version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
   - NJOBS=2
   - COMPILER="4.07.1"
   - FINDLIB_VER="1.8.0"
-  - EQUATIONS_VER="1.2.2+8.12"
-  - COQ_VER="8.12+beta1"
+  - EQUATIONS_VER="1.2.3+8.12"
+  - COQ_VER="8.12.0"
 
 install:
 - curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > install.sh

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ MetaCoq
 
 <img src="https://raw.githubusercontent.com/MetaCoq/metacoq.github.io/master/assets/LOGO.png" alt="MetaCoq" width="50px"/>
 
-[![Build Status](https://travis-ci.org/MetaCoq/metacoq.svg?branch=master)](https://travis-ci.org/MetaCoq/metacoq)
-[![Gitter](https://badges.gitter.im/coq/metacoq.svg)](https://gitter.im/coq/metacoq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+<<<<<<< HEAD
+[![Build Status](https://travis-ci.com/MetaCoq/metacoq.svg?branch=coq-8.12)](https://travis-ci.com/MetaCoq/metacoq)
+[![MetaCoq Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://coq.zulipchat.com)
 
 MetaCoq is a project formalizing Coq in Coq and providing tools for
 manipulating Coq terms and developing certified plugins

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ The [master](https://github.com/MetaCoq/metacoq/tree/master) branch is following
 branch and gets regular updates from the the main development branch which follows the latest 
 stable release of Coq.
 
-Currently, the [coq-8.11](https://github.com/MetaCoq/metacoq/tree/coq-8.11) branch is the main stable branch.
-The branch [coq-8.10](https://github.com/MetaCoq/metacoq/tree/coq-8.10) 
-gets backports from `coq-8.11` when possible. Both `coq-8.11` and `coq-8.10` have associated 
+Currently, the [coq-8.12](https://github.com/MetaCoq/metacoq/tree/coq-8.12) branch is the main stable branch.
+The branch [coq-8.11](https://github.com/MetaCoq/metacoq/tree/coq-8.12) 
+gets backports from `coq-8.11` when possible. Both `coq-8.12` and `coq-8.11` have associated 
 "alpha"-quality `opam` packages.
+The `opam` packages of `coq-8.10` are usable, but are no longer updated.
 
 The branches [coq-8.6](https://github.com/MetaCoq/metacoq/tree/coq-8.6),
-[coq-8.7](https://github.com/MetaCoq/metacoq/tree/coq-8.7), [coq-8.8](https://github.com/MetaCoq/metacoq/tree/coq-8.8)
-and [coq-8.9](https://github.com/MetaCoq/metacoq/tree/coq-8.9) are frozen.
+[coq-8.7](https://github.com/MetaCoq/metacoq/tree/coq-8.7), [coq-8.8](https://github.com/MetaCoq/metacoq/tree/coq-8.8), [coq-8.9](https://github.com/MetaCoq/metacoq/tree/coq-8.9), and [coq-8.10](https://github.com/MetaCoq/metacoq/tree/coq-8.10) are frozen.
 
 Installation instructions (for developers only)
 =========================
@@ -63,7 +63,7 @@ To setup a fresh `opam` installation, you might want to create a
 one yet. You need to use **opam 2** to obtain the right version of
 `Equations`.
 
-    # opam switch create coq.8.11 4.07.1
+    # opam switch create coq.8.12 4.07.1
     # eval $(opam env)
 
 This creates the `coq.8.11` switch which initially contains only the
@@ -72,8 +72,8 @@ basic `OCaml` `4.07.1` compiler, and puts you in the right environment
 
 Once in the right switch, you can install `Coq` and the `Equations` package using:
 
-    # opam pin add coq 8.11.0
-    # opam pin add coq-equations 1.2.1+8.11
+    # opam pin add coq 8.12.0
+    # opam pin add coq-equations 1.2.3+8.12
 
 Pinning the packages prevents opam from trying to upgrade it afterwards, in
 this switch. If the commands are successful you should have `coq`
@@ -85,10 +85,10 @@ Installing from GitHub repository (for developers)
 To get the source code:
 
     # git clone https://github.com/MetaCoq/metacoq.git
-    # git checkout -b coq-8.11 origin/coq-8.11
+    # git checkout -b coq-8.12 origin/coq-8.12
     # git status
 
-This checks that you are indeed on the `coq-8.11` branch.
+This checks that you are indeed on the `coq-8.12` branch.
 
 You can create a [local
 switch](https://opam.ocaml.org/blog/opam-20-tips/#Local-switches) for
@@ -106,9 +106,9 @@ To compile the library, you need:
 
 - The `Coq` version corrsponding to your branch (you can use the `coq.dev` package 
   for the `master` branch).
-- `OCaml` (tested with `4.06.1` and `4.07.1`, beware that `OCaml 4.06.0`
+- `OCaml` (tested with `4.07.1` and `4.09.1`, beware that `OCaml 4.06.0`
   can produce linking errors on some platforms)
-- [`Equations 1.2.1`](http://mattam82.github.io/Coq-Equations/)
+- [`Equations 1.2.3`](http://mattam82.github.io/Coq-Equations/)
 
 When using `opam` you can get those using `opam install --deps-only .`.
 

--- a/coq-metacoq-checker.opam
+++ b/coq-metacoq-checker.opam
@@ -22,9 +22,9 @@ install: [
   [make "-C" "checker" "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { >= "8.12~" & < "8.13~" }
-  "coq-equations" {= "1.2.2+8.12" }
+  "coq-equations" {= "1.2.3+8.12" }
   "coq-metacoq-template" {= version}
 ]
 synopsis: "Specification of Coq's type theory and reference checker implementation"

--- a/coq-metacoq-erasure.opam
+++ b/coq-metacoq-erasure.opam
@@ -22,7 +22,7 @@ install: [
   [make "-C" "erasure" "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { >= "8.12~" & < "8.13~" }
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/coq-metacoq-pcuic.opam
+++ b/coq-metacoq-pcuic.opam
@@ -22,9 +22,9 @@ install: [
   [make "-C" "pcuic" "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { >= "8.12~" & < "8.13~" }
-  "coq-equations" {= "1.2.2+8.12" }
+  "coq-equations" {= "1.2.3+8.12" }
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}
 ]

--- a/coq-metacoq-safechecker.opam
+++ b/coq-metacoq-safechecker.opam
@@ -22,7 +22,7 @@ install: [
   [make "-C" "safechecker" "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { >= "8.12~" & < "8.13~" }
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/coq-metacoq-translations.opam
+++ b/coq-metacoq-translations.opam
@@ -18,7 +18,7 @@ install: [
   [make "-C" "translations" "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { >= "8.12~" & < "8.13~" }
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/coq-metacoq.opam
+++ b/coq-metacoq.opam
@@ -15,7 +15,7 @@ authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
 ]
 license: "MIT"
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { >= "8.12~" & < "8.13~" }
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/erasure/src/g_metacoq_erasure.mlg
+++ b/erasure/src/g_metacoq_erasure.mlg
@@ -33,7 +33,7 @@ let time prefix f x =
 
 let check env evm c =
   Feedback.msg_debug (str"Quoting");
-  let term = time (str"Quoting") (Ast_quoter.quote_term_rec env) (EConstr.to_constr evm c) in
+  let term = time (str"Quoting") (Ast_quoter.quote_term_rec true env) (EConstr.to_constr evm c) in
   let checker_flags = Config0.extraction_checker_flags in
   let erase = time (str"Erasing")
       (SafeTemplateErasure.erase_and_print_template_program checker_flags)

--- a/erasure/theories/ETyping.v
+++ b/erasure/theories/ETyping.v
@@ -74,26 +74,20 @@ Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
   | None => None
   end.
 
-Definition is_constructor n ts :=
-  match List.nth_error ts n with
-  | Some a =>
+Definition is_constructor_app_or_box t :=
+  match t with
+  | tBox => true
+  | a =>
     let (f, a) := decompose_app a in
     match f with
     | tConstruct _ _ => true
     | _ => false
     end
-  | None => false
   end.
 
-Definition is_constructor_or_box n ts :=
+Definition is_nth_constructor_app_or_box n ts :=
   match List.nth_error ts n with
-  | Some tBox => true
-  | Some a =>
-    let (f, a) := decompose_app a in
-    match f with
-    | tConstruct _ _ => true
-    | _ => false
-    end
+  | Some a => is_constructor_app_or_box a
   | None => false
   end.
 

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1,7 +1,8 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Program.
+From Coq Require Import Arith Bool List Program.
+From Equations Require Import Equations.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst ETyping.
 
@@ -40,23 +41,6 @@ Definition isFixApp t :=
   | _ => false
   end.
 
-Definition isStuckFix t args :=
-  match t with
-  | tFix mfix idx =>
-    match unfold_fix mfix idx with
-    | Some (narg, fn) =>
-      ~~ is_constructor narg args
-    | None => false
-    end
-  | _ => false
-  end.
-
-Lemma atom_mkApps f l : atom (mkApps f l) -> (l = []) /\ atom f.
-Proof.
-  revert f; induction l using rev_ind. simpl. intuition auto.
-  simpl. intros. now rewrite mkApps_app in H.
-Qed.
-
 Definition substl defs body : term :=
   fold_left (fun bod term => csubst term 0 bod)
     defs body.
@@ -67,6 +51,23 @@ Definition cunfold_fix (mfix : mfixpoint term) (idx : nat) :=
     Some (d.(rarg), substl (fix_subst mfix) d.(dbody))
   | None => None
   end.
+
+Definition isStuckFix t args :=
+  match t with
+  | tFix mfix idx =>
+    match cunfold_fix mfix idx with
+    | Some (narg, fn) =>
+      ~~ is_nth_constructor_app_or_box narg args
+    | None => false
+    end
+  | _ => false
+  end.
+
+Lemma atom_mkApps f l : atom (mkApps f l) -> (l = []) /\ atom f.
+Proof.
+  revert f; induction l using rev_ind. simpl. intuition auto.
+  simpl. intros. now rewrite mkApps_app in H.
+Qed.
 
 Definition cunfold_cofix (mfix : mfixpoint term) (idx : nat) :=
   match List.nth_error mfix idx with
@@ -112,29 +113,23 @@ Section Wcbv.
       eval (mkApps f (repeat tBox n)) res ->
       eval (tCase (ind, pars) discr brs) res
 
-  (** Fix unfolding *)
-  | eval_fix f mfix idx args args' narg fn res :
-      eval f (tFix mfix idx) ->
+  (** Fix unfolding, with guard *)
+  | eval_fix f mfix idx argsv a av narg fn res :
+      eval f (mkApps (tFix mfix idx) argsv) ->
+      eval a av ->
       cunfold_fix mfix idx = Some (narg, fn) ->
-      (* There must be at least one argument for this to succeed *)
-      is_constructor_or_box narg args' ->
-      (** We unfold only a fix applied exactly to narg arguments,
-          avoiding overlap with [eval_beta] when there are more arguments. *)
-      S narg = #|args| ->
-      (* We reduce all arguments before unfolding *)
-      Forall2 eval args args' ->
-      eval (mkApps fn args') res ->
-      eval (mkApps f args) res
+      #|argsv| = narg ->
+      is_constructor_app_or_box av ->
+      eval (tApp (mkApps fn argsv) av) res ->
+      eval (tApp f a) res
 
-  (** Fix stuck *)
-  | eval_fix_value f mfix idx args args' :
-      eval f (tFix mfix idx) ->
-      (* We reduce all arguments to produce a suspended fix application value
-         Note that the stuck fixpoint can be applied to any number of arguments
-         here. *)
-      Forall2 eval args args' ->
-      isStuckFix (tFix mfix idx) args' ->
-      eval (mkApps f args) (mkApps (tFix mfix idx) args')
+  (** Fix stuck, with guard *)
+  | eval_fix_value f mfix idx argsv a av narg fn :
+      eval f (mkApps (tFix mfix idx) argsv) ->
+      eval a av ->
+      cunfold_fix mfix idx = Some (narg, fn) ->
+      (#|argsv| <> narg \/ (#|argsv| = narg /\ ~~is_constructor_app_or_box av)) ->
+      eval (tApp f a) (tApp (mkApps (tFix mfix idx) argsv) av)
 
   (** CoFix-case unfolding *)
   | red_cofix_case ip mfix idx args narg fn brs res :
@@ -183,87 +178,8 @@ Section Wcbv.
   | eval_atom t : atom t -> eval t t.
 
   Hint Constructors eval : core.
-
-  (* Scheme Minimality for eval Sort Type. *)
-  Definition eval_evals_ind :
-    forall P : term -> term -> Prop,
-      (forall a t t', eval a tBox -> P a tBox -> eval t t' -> P t t' -> eval (tApp a t) tBox -> P (tApp a t) tBox ) ->
-      (forall (f : term) (na : name) (b a a' res : term),
-          eval f (tLambda na b) ->
-          P f (tLambda na b) -> eval a a' -> P a a' -> eval (csubst a' 0 b) res -> P (csubst a' 0 b) res -> P (tApp f a) res) ->
-      (forall (na : name) (b0 b0' b1 res : term),
-          eval b0 b0' -> P b0 b0' -> eval (csubst b0' 0 b1) res -> P (csubst b0' 0 b1) res -> P (tLetIn na b0 b1) res) ->
-      (forall c (decl : constant_body) (body : term),
-          declared_constant Σ c decl ->
-          forall (res : term),
-            cst_body decl = Some body ->
-            eval body res -> P body res -> P (tConst c) res) ->
-      (forall (ind : inductive) (pars : nat) (discr : term) (c : nat)
-              (args : list term) (brs : list (nat × term)) (res : term),
-          eval discr (mkApps (tConstruct ind c) args) ->
-          P discr (mkApps (tConstruct ind c) args) ->
-          eval (iota_red pars c args brs) res -> P (iota_red pars c args brs) res -> P (tCase (ind, pars) discr brs) res) ->
-      (forall ind pars discr brs n f res,
-          eval discr tBox -> P discr tBox ->
-          brs = [(n, f)] ->
-          eval (mkApps f (repeat tBox n)) res -> P (mkApps f (repeat tBox n)) res ->
-          eval (tCase (ind, pars) discr brs) res -> P (tCase (ind, pars) discr brs) res
-      ) ->
-      (forall (i : inductive) (pars arg : nat) (discr : term) (args : list term) (k : nat)
-              (a res : term),
-          eval discr (mkApps (tConstruct i k) args) ->
-          P discr (mkApps (tConstruct i k) args) ->
-          eval (nth (pars + arg) args tDummy) res -> P (nth (pars + arg) args tDummy) res -> P (tProj (i, pars, arg) discr) res) ->
-      (forall i pars arg discr,
-          eval discr tBox -> P discr tBox ->
-          eval (tProj (i, pars, arg) discr) tBox -> P (tProj (i, pars, arg) discr) tBox
-      ) ->
-      (forall f (mfix : mfixpoint term) (idx : nat) (args args' : list term) (narg : nat) (fn res : term),
-          eval f (tFix mfix idx) ->
-          P f (tFix mfix idx) ->
-          cunfold_fix mfix idx = Some (narg, fn) ->
-          is_constructor_or_box narg args' ->
-          S narg = #|args| ->
-          Forall2 eval args args' ->
-          Forall2 P args args' ->
-          eval (mkApps fn args') res -> P (mkApps fn args') res -> P (mkApps f args) res) ->
-      (forall f (mfix : mfixpoint term) (idx : nat) (args args' : list term),
-          eval f (tFix mfix idx) ->
-          P f (tFix mfix idx) ->
-          Forall2 eval args args' ->
-          Forall2 P args args' ->
-          isStuckFix (tFix mfix idx) args' -> P (mkApps f args) (mkApps (tFix mfix idx) args')) ->
-      (forall (ip : inductive × nat) (mfix : mfixpoint term) (idx : nat) (args : list term)
-              (narg : nat) (fn : term) (brs : list (nat × term)) (res : term),
-          cunfold_cofix mfix idx = Some (narg, fn) ->
-          eval (tCase ip (mkApps fn args) brs) res ->
-          P (tCase ip (mkApps fn args) brs) res -> P (tCase ip (mkApps (tCoFix mfix idx) args) brs) res) ->
-      (forall (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn res : term),
-          cunfold_cofix mfix idx = Some (narg, fn) ->
-          eval (tProj p (mkApps fn args)) res ->
-          P (tProj p (mkApps fn args)) res -> P (tProj p (mkApps (tCoFix mfix idx) args)) res) ->
-      (forall f11 f' a a' : term,
-          eval f11 f' -> P f11 f' -> ~~ (isLambda f' || isFixApp f' || isBox f') -> eval a a' -> P a a' -> P (tApp f11 a) (tApp f' a')) ->
-      (forall t : term, atom t -> P t t) -> forall t t0 : term, eval t t0 -> P t t0.
-  Proof.
-    intros P Hbox Hbeta Hlet Hcst Hcase Hsing Hproj Hprojbox Hfix Hstuckfix Hcofixcase Hcofixproj Happcong Hatom.
-    fix eval_evals_ind 3. destruct 1;
-             try solve [match goal with [ H : _ |- _ ] =>
-                             match type of H with
-                               forall t t0, eval t t0 -> _ => fail 1
-                             | _ => eapply H
-                             end end; eauto].
-    - eapply Hbox; eauto.
-    - eapply Hcase; eauto.
-    - eapply Hfix; eauto.
-      clear -H3 eval_evals_ind.
-      revert args args' H3. fix aux 3. destruct 1. constructor; auto.
-      constructor. now apply eval_evals_ind. now apply aux.
-    - eapply Hstuckfix => //. eapply eval_evals_ind. auto.
-      clear -eval_evals_ind H0.
-      revert args args' H0. fix aux 3. destruct 1. constructor; auto.
-      constructor. now apply eval_evals_ind. now apply aux.
-  Qed.
+  Derive Signature for eval.
+  Derive NoConfusionHom for term.
 
   (** Characterization of values for this reduction relation.
       Only constructors and cofixpoints can accumulate arguments.
@@ -360,22 +276,46 @@ Section Wcbv.
 
   Lemma eval_to_value e e' : eval e e' -> value e'.
   Proof.
-    induction 1 using eval_evals_ind; simpl; auto using value.
-    (* eapply (value_app (tEvar n l') []). constructor. constructor. *)
-    - eapply value_stuck_fix => //.
-      now eapply Forall2_right in H1.
+    induction 1; simpl; auto using value.
+    - change (tApp ?h ?a) with (mkApps h [a]).
+      rewrite mkApps_nested.
+      apply value_mkApps_inv in IHeval1; [|easy].
+      destruct IHeval1 as [(-> & _)|[|(stuck & vals)]].
+      + cbn in *.
+        apply (value_stuck_fix _ [av]); [easy|].
+        cbn.
+        destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
+        noconf H1.
+        destruct H2 as [|(<- & ?)]; [|easy].
+        unfold is_nth_constructor_app_or_box.
+        now rewrite (proj2 (nth_error_None _ _));
+          cbn in *.
+      + easy.
+      + eapply value_stuck_fix; [now apply Forall_app_inv|].
+        unfold isStuckFix in *.
+        destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
+        noconf H1.
+        unfold is_nth_constructor_app_or_box in *.
+        destruct H2 as [|(<- & ?)]; [|now rewrite nth_error_snoc].
+        destruct (Nat.ltb_spec #|argsv| narg).
+        * rewrite (proj2 (nth_error_None _ _)); [|easy].
+          rewrite app_length.
+          cbn.
+          easy.
+        * now rewrite nth_error_app1.
+
     - destruct (mkApps_elim f' [a']).
       eapply value_mkApps_inv in IHeval1 => //.
       destruct IHeval1; intuition subst.
       * rewrite H3.
         simpl. rewrite H3 in H. simpl in *.
-        apply (value_app f [a']). rewrite H3 in H0. destruct f; simpl in * |- *; try congruence.
+        apply (value_app f0 [a']). rewrite H3 in H0. destruct f0; simpl in * |- *; try congruence.
         constructor; auto. constructor. constructor; auto.
       * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']).
         constructor 2; auto. eapply Forall_app_inv; auto.
       * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']).
         erewrite isFixApp_mkApps in H0 => //.
-        destruct f; simpl in *; try congruence.
+        destruct f0; simpl in *; try congruence.
         rewrite /isFixApp in H0. simpl in H0.
         rewrite orb_true_r orb_true_l in H0. easy.
   Qed.
@@ -430,247 +370,180 @@ Section Wcbv.
     f_equal. rewrite lift_closed // closed_subst //.
   Qed.
 
+Lemma eval_mkApps_tCoFix mfix idx args v :
+  eval (mkApps (tCoFix mfix idx) args) v ->
+  exists args', v = mkApps (tCoFix mfix idx) args'.
+Proof.
+  revert v.
+  induction args using List.rev_ind; intros v ev.
+  + exists [].
+    now depelim ev.
+  + rewrite mkApps_app in ev.
+    cbn in *.
+    depelim ev;
+      try (apply IHargs in ev1 as (? & ?); solve_discr).
+    * apply IHargs in ev1 as (argsv & ->).
+      exists (argsv ++ [a']).
+      now rewrite mkApps_app.
+    * easy.
+Qed.
 
-  (* Lemma eval_to_value e e' : eval e e' -> value e'. *)
-  (* Proof. *)
-  (*   induction 1 using eval_ind; simpl; auto using value. *)
-  (*   - eapply value_stuck_fix => //. *)
+Derive NoConfusionHom for EAst.global_decl.
 
-  (*     eapply Forall2_right. *)
-  (*     eauto. *)
-  (*     admit. *)
-  (*   - destruct (mkApps_elim f' [a']). *)
-  (*     eapply value_mkApps_inv in IHeval1 => //. *)
-  (*     destruct IHeval1; intuition subst. *)
-  (*     * rewrite H3. *)
-  (*       simpl. rewrite H3 in H. simpl in *. *)
-  (*       apply (value_app f0 [a']). destruct f0; simpl in * |- *; try congruence. *)
-
-  (*       constructor; auto. constructor. constructor; auto. *)
-  (*     * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']). *)
-  (*       constructor 2; auto. eapply All_app_inv; auto. *)
-  (*     * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']). *)
-  (*       rewrite isFixApp_mkApps in H => //. *)
-  (*       destruct f; simpl in *; try congruence. *)
-  (*       rewrite /isFixApp in H. simpl in H. *)
-  (*       rewrite orb_true_r orb_true_l in H. easy. *)
-  (* Qed. *)
-  (* Admitted. *)
-
-  (* Lemma value_final e : value e -> eval e e. *)
-  (* Proof. *)
-  (*   induction 1 using value_values_ind; simpl; auto using value. *)
-  (*   now constructor. *)
-  (*   assert (Forall2 eval l l). *)
-  (*   induction H1; constructor; auto. eapply IHForall. now depelim H0. *)
-  (*   rewrite value_head_spec in H. *)
-  (*   induction l using rev_ind. simpl. *)
-  (*   move/andP: H => [H H']. *)
-  (*   constructor; try easy. *)
-  (*   rewrite mkApps_app. *)
-  (*   eapply Forall_app in H0 as [Hl Hx]. depelim Hx. *)
-  (*   eapply Forall2_app_r in H2 as [Hl' Hx']. *)
-  (*   eapply eval_app_cong; auto. *)
-  (*   eapply IHl. auto. *)
-  (*   now eapply Forall2_Forall. auto. *)
-  (*   move/andP: H => [Ht Ht']. *)
-  (*   destruct l using rev_ind; auto. now rewrite mkApps_app; simpl. *)
-  (* Qed. *)
-
-  (* (** Evaluation preserves closedness: *) *)
-  (* Lemma eval_closed : forall n t u, closedn n t = true -> eval t u -> closedn n u = true. *)
-  (* Proof. *)
-  (*   induction 2 using eval_ind; simpl in *; auto. eapply IHeval3. *)
-  (*   admit. *)
-  (* Admitted. (* closedness of evaluates for Eterms, not needed for verification *) *)
-
-  (* Lemma eval_tApp_tFix_inv mfix idx a v : *)
-  (*   eval (tApp (tFix mfix idx) a) v -> *)
-  (*   (exists fn arg, *)
-  (*       (unfold_fix mfix idx = Some (arg, fn)) /\ *)
-  (*       (eval (tApp fn a) v)). *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr. *)
-  (*   - depelim H. *)
-  (*   - depelim H. *)
-  (*   - eexists _, _; firstorder eauto.  *)
-  (*   - now depelim H. *)
-  (*   - discriminate. *)
-  (* Qed. *)
-
-  (* Lemma eval_tBox t : eval tBox t -> t = tBox. *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr. auto. *)
-  (* Qed. *)
-
-  (* Lemma eval_tRel n t : eval (tRel n) t -> False. *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr; try now easy. *)
-  (* Qed. *)
-
-  (* Lemma eval_tVar i t : eval (tVar i) t -> False. *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr; try now easy. *)
-  (* Qed. *)
-
-  (* Lemma eval_tEvar n l t : eval (tEvar n l) t -> False. *)
-  (*                         (* exists l', Forall2 eval l l' /\ (t = tEvar n l'). *) *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr; try now easy. *)
-  (* Qed. *)
-
-  (* (* Lemma eval_atom_inj t t' : atom t -> eval t t' -> t = t'. *) *)
-  (* (* Proof. *) *)
-  (* (*   intros Ha H; depind H; try solve_discr; try now easy. *) *)
-  (* (* Qed. *) *)
-
-  (* Lemma eval_LetIn {n b t v} : *)
-  (*   eval (tLetIn n b t) v -> *)
-  (*   exists b', *)
-  (*     eval b b' /\ eval (t {0 := b'}) v. *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr; try now easy. *)
-  (* Qed. *)
-
-  (* Lemma eval_Const {c v} : *)
-  (*   eval (tConst c) v -> *)
-  (*   exists decl body, declared_constant Σ c decl /\ *)
-  (*                     cst_body decl = Some body /\ *)
-  (*                     eval body v. *)
-  (* Proof. *)
-  (*   intros H; depind H; try solve_discr; try now easy. *)
-  (*   exists decl, body. intuition auto. *)
-  (* Qed. *)
-
-  (* Lemma eval_mkApps_tCoFix mfix idx l v : *)
-  (*   eval (mkApps (tCoFix mfix idx) l) v -> *)
-  (*   (exists l', Forall2 eval l l' /\ (v = mkApps (tCoFix mfix idx) l')). *)
-  (* Proof. *)
-  (*   intros H. *)
-  (*   depind H; try solve_discr. *)
-  (*   destruct (mkApps_elim a [t]). *)
-  (*   rewrite -[tApp _ _](mkApps_app f (firstn n l0) [t]) in x. *)
-  (*   solve_discr. *)
-  (*   specialize (IHeval1 _ _ _ eq_refl). *)
-  (*   firstorder eauto. *)
-  (*   solve_discr. *)
-  (*   destruct (mkApps_elim f [a]). *)
-  (*   rewrite -[tApp _ _](mkApps_app f (firstn n l0) [a]) in x. solve_discr. *)
-  (*   specialize (IHeval1 _ _ _ eq_refl). *)
-  (*   firstorder eauto. solve_discr. *)
-  (*   destruct (mkApps_elim f [arg]). *)
-  (*   rewrite -[tApp _ _](mkApps_app f (firstn n l0) [arg]) in x. solve_discr. *)
-  (*   specialize (IHeval1 _ _ _ eq_refl). destruct IHeval1. *)
-  (*   destruct H2. solve_discr. *)
-  (*   change (tApp f a) with (mkApps f [a]) in x. *)
-  (*   assert (l <> []). *)
-  (*   destruct l; simpl in *; discriminate. *)
-  (*   rewrite (app_removelast_last a H2) in x |- *. *)
-  (*   rewrite mkApps_app in x. simpl in x. inv x. *)
-  (*   specialize (IHeval1 _ _ _ eq_refl). *)
-  (*   destruct IHeval1 as [l' [evl' eqf']]. *)
-  (*   exists (l' ++ [a']). *)
-  (*   split. eapply Forall2_app; auto. constructor. now rewrite - !H5. constructor. *)
-  (*   subst f'. *)
-  (*   now rewrite mkApps_app. *)
-  (*   eapply atom_mkApps in H; intuition try easy. *)
-  (*   subst. *)
-  (*   exists []. intuition auto. *)
-  (* Qed. *)
-
-  (* Lemma eval_deterministic {t v v'} : eval t v -> eval t v' -> v = v'. *)
-  (* Proof. *)
-  (*   intros tv. revert v'. *)
-  (*   revert t v tv. *)
-  (*   induction 1 using eval_ind; intros v' tv'. *)
-  (*   - depelim tv'; auto. specialize (IHtv1 _ tv'1); congruence. *)
-  (*     specialize (IHtv1 _ tv'1). now subst. *)
-  (*     specialize (IHtv1 _ tv'1). now subst. easy. *)
-  (*   - depelim tv'; auto; try specialize (IHtv1 _ tv'1) || solve [depelim tv1]; try congruence. *)
-  (*     inv IHtv1. specialize (IHtv2 _ tv'2). subst. *)
-  (*     now specialize (IHtv3 _ tv'3). *)
-  (*     now subst f'. easy. *)
-  (*   - eapply eval_LetIn in tv' as [b' [evb evt]]. *)
-  (*     rewrite -(IHtv1 _ evb) in evt. *)
-  (*     eapply (IHtv2 _ evt). *)
-  (*   - depelim tv'; try solve_discr. *)
-  (*     * specialize (IHtv1 _ tv'1). *)
-  (*       solve_discr. inv H. *)
-  (*       now specialize (IHtv2 _ tv'2). *)
-  (*     * specialize (IHtv1 _ tv'1); solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv1 as [l' [ev' eq]]. solve_discr. *)
-  (*     * easy. *)
-  (*   - subst. *)
-  (*     depelim tv'. *)
-  (*     * specialize (IHtv1 _ tv'1). *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv1 _ tv'1). *)
-  (*       now specialize (IHtv2 _ tv'2). *)
-  (*     * pose proof tv1. eapply eval_mkApps_tCoFix in H0. *)
-  (*       destruct H0 as [l' [evargs eq]]. solve_discr. *)
-  (*     * easy. *)
-  (*   - depelim tv' => //. *)
-  (*     * specialize (IHtv1 _ tv'1). discriminate. *)
-  (*     * specialize (IHtv1 _ tv'1). discriminate. *)
-  (*     * specialize (IHtv1 _ tv'1). inv IHtv1. *)
-  (*       rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv2 _ tv'2). *)
-  (*     * specialize (IHtv1 _ tv'1); subst. easy. *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * solve_discr. inv H1. rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv _ tv'). *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * solve_discr. inv H1. rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv _ tv'). *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv' as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-
-  (*   - eapply eval_Const in tv' as [decl' [body' [? ?]]]. *)
-  (*     intuition eauto. eapply IHtv. *)
-  (*     red in isdecl, H0. rewrite H0 in isdecl. inv isdecl. *)
-  (*     now rewrite H in H2; inv H2. *)
-
-  (*   - depelim tv'. *)
-  (*     * eapply eval_mkApps_tCoFix in tv1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv1 _ tv'1).  *)
-  (*       solve_discr. inv H. *)
-  (*       now specialize (IHtv2 _ tv'2). *)
-  (*     * specialize (IHtv1 _ tv'). solve_discr. *)
-  (*     * easy. *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * eapply eval_mkApps_tCoFix in tv as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv _ tv'1). solve_discr. *)
-
-  (*   - depelim tv'; try specialize (IHtv1 _ tv'1); subst; try easy. *)
-  (*     specialize (IHtv2 _ tv'2). subst. reflexivity. *)
-
-  (*   - depelim tv'; try easy. *)
-  (* Qed. *)
-
-  (* Lemma eval_mkApps_cong f f' l l' : *)
-  (*   eval f f' -> *)
-  (*   value_head f' -> *)
-  (*   Forall2 eval l l' -> *)
-  (*   eval (mkApps f l) (mkApps f' l'). *)
-  (* Proof. *)
-  (*   revert l'. induction l using rev_ind; intros l' evf vf' evl. *)
-  (*   depelim evl. eapply evf. *)
-  (*   eapply Forall2_app_inv_l in evl as [? [? [? ?]]]. *)
-  (*   intuition auto. subst. depelim H1. depelim H1. *)
-  (*   rewrite !mkApps_app /=. eapply eval_app_cong; auto. *)
-  (*   destruct x0 using rev_ind; simpl; [|rewrite !mkApps_app]; simpl in *; destruct f'; *)
-  (*     try discriminate; constructor. *)
-  (* Qed. *)
+Unset SsrRewrite.
+Lemma eval_deterministic {t v v'} :
+  eval t v ->
+  eval t v' ->
+  v = v'.
+Proof.
+  intros ev.
+  revert v'.
+  depind ev; intros v' ev'.
+  - depelim ev'.
+    + easy.
+    + now apply IHev1 in ev'1.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; subst; easy.
+    + easy.
+  - depelim ev'.
+    + now apply IHev1 in ev'1.
+    + apply IHev1 in ev'1; subst.
+      apply IHev2 in ev'2; subst.
+      noconf ev'1.
+      now apply IHev3 in ev'3.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; subst; easy.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; subst.
+      now apply IHev2 in ev'2.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; solve_discr.
+      noconf H.
+      now apply IHev2 in ev'2.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; solve_discr.
+    + subst.
+      noconf H0.
+      now apply IHev2 in ev'2.
+    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1.
+      apply mkApps_eq_inj in ev'1; try easy.
+      depelim ev'1.
+      noconf H2.
+      subst.
+      apply IHev2 in ev'2; subst.
+      rewrite H4 in H.
+      now noconf H.
+    + apply IHev1 in ev'1.
+      apply mkApps_eq_inj in ev'1; try easy.
+      depelim ev'1.
+      noconf H2.
+      noconf H3.
+      apply IHev2 in ev'2.
+      subst.
+      rewrite H4 in H.
+      noconf H.
+      destruct H5 as [|(_ & ?)]; [easy|].
+      now apply negb_true_iff in H.
+    + apply IHev1 in ev'1.
+      subst.
+      rewrite isFixApp_mkApps in H2 by easy.
+      cbn in *.
+      now rewrite orb_true_r in H2.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      apply mkApps_eq_inj in ev'1 as (ev'1 & <-); try easy.
+      noconf ev'1.
+      subst.
+      rewrite H1 in H.
+      noconf H.
+      destruct H0 as [|(? & ?)]; [easy|].
+      now apply negb_true_iff in H0.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      now apply mkApps_eq_inj in ev'1 as (ev'1 & <-).
+    + apply IHev1 in ev'1.
+      subst.
+      rewrite isFixApp_mkApps in H1 by easy.
+      cbn in H1.
+      now rewrite orb_true_r in H1.
+    + easy.
+  - depelim ev'.
+    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + apply mkApps_eq_inj in H1 as (H1 & <-); try easy.
+      noconf H1.
+      rewrite H0 in H.
+      noconf H.
+      now apply IHev in ev'.
+    + easy.
+  - depelim ev'.
+    + apply mkApps_eq_inj in H1 as (H1 & <-); try easy.
+      noconf H1.
+      rewrite H0 in H.
+      noconf H.
+      now apply IHev in ev'.
+    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + apply eval_mkApps_tCoFix in ev' as (? & ?); solve_discr.
+    + easy.
+  - depelim ev'.
+    + unfold ETyping.declared_constant in *.
+      rewrite isdecl0 in isdecl.
+      noconf isdecl.
+      rewrite H0 in H.
+      noconf H.
+      now apply IHev in ev'.
+    + easy.
+  - depelim ev'.
+    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
+    + apply IHev1 in ev'1.
+      now apply mkApps_eq_inj in ev'1 as (ev'1 & <-).
+    + apply IHev1 in ev'; solve_discr.
+    + easy.
+  - depelim ev'.
+    + apply eval_mkApps_tCoFix in ev as (? & ?); solve_discr.
+    + apply IHev in ev'1; solve_discr.
+    + easy.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      now subst.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      now subst.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      subst.
+      rewrite isFixApp_mkApps in H by easy.
+      cbn in H.
+      now rewrite orb_true_r in H.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      now subst.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      congruence.
+    + easy.
+  - now depelim ev'.
+Qed.
+Set SsrRewrite.
 
 End Wcbv.
+
+Arguments eval_deterministic {_ _ _ _}.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -381,15 +381,12 @@ Section Erase.
 
     Program Definition erase_mfix Γ (defs : mfixpoint term) : typing_result (EAst.mfixpoint E.term) :=
       let Γ' := (PCUICLiftSubst.fix_context defs ++ Γ)%list in
-      monad_map (fun d => H <- _ ;;
-                   dbody' <- erase Γ' d.(dbody) H;;
+      monad_map (fun d => dbody' <- erase Γ' d.(dbody) _;;
                           ret ({| E.dname := d.(dname); E.rarg := d.(rarg);
                                   E.dbody := dbody' |})) defs.
     Next Obligation.
-      clear erase.
-      destruct (wf_ext_is_graph HΣ) as [].
-      apply Checked. todo "well-typed fix body".
-    Defined.
+      todo "well-typed fix body".
+    Qed.
       (* epose proof ((fix check_types (mfix : mfixpoint term) acc (Hacc : ∥ wf_local_rel Σ Γ acc ∥) {struct mfix} *)
       (*         : typing_result (∥ wf_local_rel Σ (Γ ,,, acc) (fix_context_i #|acc| mfix) ∥) *)
       (*         := match mfix with *)

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -408,50 +408,6 @@ Proof.
       now eapply skipn_n_Sn.
 Qed.
 
-Lemma consistent_instance_ext_abstract_instance {cf:checker_flags} Σ ind mdecl :
-  wf Σ ->
-  declared_minductive Σ ind mdecl ->
-  let u := PCUICLookup.abstract_instance (ind_universes mdecl) in
-  consistent_instance_ext (Σ, ind_universes mdecl) (ind_universes mdecl) u.
-Proof.
-  intros wfΣ declm u.
-  unfold consistent_instance_ext, consistent_instance.
-  revert u. destruct (ind_universes mdecl) eqn:Heq; simpl; auto.
-  destruct cst. simpl.
-  split.
-  { unfold AUContext.repr. simpl.
-    apply All_forallb. apply All_mapi. simpl.
-    clear; generalize 0; induction l; constructor; eauto. }
-  split. apply All_forallb.
-  eapply All_mapi.
-  unfold global_ext_levels. simpl.
-  unfold AUContext.levels. simpl.
-  clear. unfold mapi. generalize 0; induction l; constructor; auto.
-  simpl. apply LevelSet.mem_spec. apply LevelSet.union_spec. left.
-  apply LevelSet.add_spec. left; reflexivity.
-  simpl. eapply (Alli_impl _ (IHl (S n))).
-  intros.
-  eapply LevelSet.mem_spec in H. eapply LevelSet.mem_spec.
-  apply LevelSet.union_spec in H. destruct H; apply LevelSet.union_spec; intuition auto.
-  left. apply LevelSet.add_spec. right; auto.
-  rewrite mapi_length. intuition auto.
-  simpl. red. destruct check_univs; auto.
-  unfold valid_constraints0. simpl.
-  intros v sv.
-  intro. intros hin.
-  specialize (sv x). apply sv. unfold global_ext_constraints in *.
-  eapply ConstraintSet.union_spec. simpl. left.
-  todounivs. (* Simon: this  subst_instance_cstrs is the identity *)
-  (* revert hin. unfold subst_instance_cstrs.
-  rewrite ConstraintSet.fold_spec.
-  intros. rewrite -(ConstraintSet.elements_spec1 t x).
-  apply ConstraintSet.elements_spec1 in hin.
-  induction (ConstraintSet.elements t). simpl in *. simpl in hin. inv hin.
-  simpl in hin.
-  depelim hin. subst. simpl in H0.
-  constructor. *)
-Qed.
-
 Lemma subslet_inds_gen {cf:checker_flags} Σ ind mdecl idecl :
   wf Σ ->
   declared_inductive Σ mdecl ind idecl ->
@@ -461,19 +417,20 @@ Lemma subslet_inds_gen {cf:checker_flags} Σ ind mdecl idecl :
 Proof.
   intros wfΣ isdecl u.
   unfold inds.
-  destruct isdecl as [declm _].
-  pose proof declm as declm'. 
+  pose proof (proj1 isdecl) as declm'. 
   apply PCUICWeakeningEnv.on_declared_minductive in declm' as [oind oc]; auto.
   clear oc.
   assert (Alli (fun i x =>
    (Σ, ind_universes mdecl) ;;; [] |- tInd {| inductive_mind := inductive_mind ind; inductive_ind := i |} u : (ind_type x)) 0 (ind_bodies mdecl)).
   { apply forall_nth_error_Alli. intros.
     eapply type_Cumul.
-    econstructor; eauto. split; eauto.
+    econstructor; eauto. split; eauto with pcuic.
     eapply consistent_instance_ext_abstract_instance; eauto.
+    eapply declared_inductive_wf_global_ext; eauto with pcuic.
     eapply Alli_nth_error in oind; eauto. simpl in oind.
     destruct oind. red in onArity. right. apply onArity.
-    todounivs. (* Same thing, the abstract universe instance is an identity *) }
+    rewrite (subst_instance_ind_type_id Σ _ {| inductive_mind := inductive_mind ind; inductive_ind := i |}); eauto.
+    destruct isdecl. split; eauto. reflexivity. }
   clear oind.
   revert X. clear onNpars onGuard.
   generalize (le_n #|ind_bodies mdecl|).

--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -12,9 +12,6 @@ Derive NoConfusion for term.
 Derive Signature for All.
 Derive Signature for All2.
 
-Axiom todounivs : forall {A}, A.
-Ltac todounivs := apply todounivs.
-
 Open Scope pcuic.
 Local Open Scope string_scope.
 Fixpoint string_of_term (t : term) :=

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -1219,7 +1219,7 @@ Proof.
       rewrite subst_instance_context_smash.
       eapply iparsubst0. simpl.
       rewrite subst_instance_constr_mkApps subst_mkApps /=.
-      rewrite subst_instance_instance_id subst_instance_to_extended_list.
+      rewrite (subst_instance_instance_id Σ) // subst_instance_to_extended_list.
       rewrite firstn_all2 in iparsubst0. lia.
       eapply spine_subst_smash in iparsubst0; auto.
       rewrite subst_instance_context_smash /=.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -273,7 +273,7 @@ Section Validity.
       constructor. constructor.
       simpl. rewrite subst_empty.
       rewrite subst_instance_constr_mkApps subst_mkApps /=.
-      rewrite subst_instance_instance_id.
+      rewrite (subst_instance_instance_id Σ); auto.
       rewrite subst_instance_to_extended_list.
       rewrite subst_instance_context_smash.
       rewrite (spine_subst_subst_to_extended_list_k sppar).

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license.   *)
 Set Warnings "-notation-overridden".
 
-From Coq Require Import Bool List Lia CRelationClasses.
+From Coq Require Import Arith Bool List Lia CRelationClasses.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst
      PCUICUnivSubst PCUICTyping PCUICReduction PCUICClosed PCUICCSubst.
@@ -124,7 +124,7 @@ Definition cunfold_cofix (mfix : mfixpoint term) (idx : nat) :=
 Definition isStuckFix t args :=
   match t with
   | tFix mfix idx =>
-    match unfold_fix mfix idx with
+    match cunfold_fix mfix idx with
     | Some (narg, fn) =>
       ~~ is_constructor narg args
     | None => false
@@ -194,28 +194,22 @@ Section Wcbv.
       eval (tProj (i, pars, arg) discr) res
 
   (** Fix unfolding, with guard *)
-  | eval_fix f mfix idx args args' narg fn res :
-      eval f (tFix mfix idx) ->
+  | eval_fix f mfix idx argsv a av narg fn res :
+      eval f (mkApps (tFix mfix idx) argsv) ->
+      eval a av ->
       cunfold_fix mfix idx = Some (narg, fn) ->
-      (* There must be at least one argument for this to succeed *)
-      is_constructor narg args' ->
-      (** We unfold only a fix applied exactly to narg arguments,
-          avoiding overlap with [eval_beta] when there are more arguments. *)
-      S narg = #|args| ->
-      (* We reduce all arguments before unfolding *)
-      All2 eval args args' ->
-      eval (mkApps fn args') res ->
-      eval (mkApps f args) res
+      #|argsv| = narg ->
+      isConstruct_app av ->
+      eval (tApp (mkApps fn argsv) av) res ->
+      eval (tApp f a) res
 
   (** Fix stuck, with guard *)
-  | eval_fix_value f mfix idx args args' :
-      eval f (tFix mfix idx) ->
-      (* We reduce all arguments to produce a suspended fix application value
-         Note that the stuck fixpoint can be applied to any number of arguments
-         here. *)
-      All2 eval args args' ->
-      isStuckFix (tFix mfix idx) args' ->
-      eval (mkApps f args) (mkApps (tFix mfix idx) args')
+  | eval_fix_value f mfix idx argsv a av narg fn :
+      eval f (mkApps (tFix mfix idx) argsv) ->
+      eval a av ->
+      cunfold_fix mfix idx = Some (narg, fn) ->
+      (#|argsv| <> narg \/ (#|argsv| = narg /\ ~~isConstruct_app av)) ->
+      eval (tApp f a) (tApp (mkApps (tFix mfix idx) argsv) av)
 
   (** CoFix-case unfolding *)
   | red_cofix_case ip mfix idx p args narg fn brs res :
@@ -246,83 +240,6 @@ Section Wcbv.
   (** Atoms are values (includes abstractions, cofixpoints and constructors
       along with type constructors) *)
   | eval_atom t : atom t -> eval t t.
-
-  (* Scheme Minimality for eval Sort Type. *)
-  Definition eval_evals_ind :
-    forall P : term -> term -> Type,
-      (forall (f : term) (na : name) (t b a a' res : term),
-          eval f (tLambda na t b) ->
-          P f (tLambda na t b) -> eval a a' -> P a a' -> eval (csubst a' 0 b) res -> P (csubst a' 0 b) res -> P (tApp f a) res) ->
-      (forall (na : name) (b0 b0' t b1 res : term),
-          eval b0 b0' -> P b0 b0' -> eval (csubst b0' 0 b1) res -> 
-          P (csubst b0' 0 b1) res -> P (tLetIn na b0 t b1) res) ->
-      (* (forall (i : nat) (body res : term),
-          option_map decl_body (nth_error Γ i) = Some (Some body) ->
-          eval ((lift0 (S i)) body) res -> P ((lift0 (S i)) body) res -> P (tRel i) res) -> *)
-      (* (forall i : nat, option_map decl_body (nth_error Γ i) = Some None -> P (tRel i) (tRel i)) -> *)
-      (forall c (decl : constant_body) (body : term),
-          declared_constant Σ c decl ->
-          forall (u : Instance.t) (res : term),
-            cst_body decl = Some body ->
-            eval (subst_instance_constr u body) res -> P (subst_instance_constr u body) res -> P (tConst c u) res) ->
-      (forall c (decl : constant_body),
-          declared_constant Σ c decl -> forall u : Instance.t, cst_body decl = None -> P (tConst c u) (tConst c u)) ->
-      (forall (ind : inductive) (pars : nat) (discr : term) (c : nat) (u : Instance.t)
-              (args : list term) (p : term) (brs : list (nat × term)) (res : term),
-          eval discr (mkApps (tConstruct ind c u) args) ->
-          P discr (mkApps (tConstruct ind c u) args) ->
-          eval (iota_red pars c args brs) res -> P (iota_red pars c args brs) res -> P (tCase (ind, pars) p discr brs) res) ->
-      (forall (i : inductive) (pars arg : nat) (discr : term) (args : list term) (k : nat) (u : Instance.t)
-              (a res : term),
-          eval discr (mkApps (tConstruct i k u) args) ->
-          P discr (mkApps (tConstruct i k u) args) ->
-          nth_error args (pars + arg) = Some a -> eval a res -> P a res -> P (tProj (i, pars, arg) discr) res) ->
-      (forall f (mfix : mfixpoint term) (idx : nat) (args args' : list term) (narg : nat) (fn res : term),
-          eval f (tFix mfix idx) ->
-          P f (tFix mfix idx) ->
-          cunfold_fix mfix idx = Some (narg, fn) ->
-          is_constructor narg args' ->
-          S narg = #|args| ->
-          All2 eval args args' ->
-          All2 P args args' ->
-          eval (mkApps fn args') res -> P (mkApps fn args') res -> P (mkApps f args) res) ->
-      (forall f (mfix : mfixpoint term) (idx : nat) (args args' : list term),
-          eval f (tFix mfix idx) ->
-          P f (tFix mfix idx) ->
-          All2 eval args args' ->
-          All2 P args args' ->
-          isStuckFix (tFix mfix idx) args' -> P (mkApps f args) (mkApps (tFix mfix idx) args')) ->
-      (forall (ip : inductive × nat) (mfix : mfixpoint term) (idx : nat) (p : term) (args : list term)
-              (narg : nat) (fn : term) (brs : list (nat × term)) (res : term),
-          cunfold_cofix mfix idx = Some (narg, fn) ->
-          eval (tCase ip p (mkApps fn args) brs) res ->
-          P (tCase ip p (mkApps fn args) brs) res -> P (tCase ip p (mkApps (tCoFix mfix idx) args) brs) res) ->
-      (forall (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn res : term),
-          cunfold_cofix mfix idx = Some (narg, fn) ->
-          eval (tProj p (mkApps fn args)) res ->
-          P (tProj p (mkApps fn args)) res -> P (tProj p (mkApps (tCoFix mfix idx) args)) res) ->
-      (forall f11 f' a a' : term,
-          eval f11 f' -> P f11 f' -> ~~ (isLambda f' || isFixApp f' || isArityHead f') -> eval a a' -> P a a' -> P (tApp f11 a) (tApp f' a')) ->
-      (forall t : term, atom t -> P t t) -> forall t t0 : term, eval t t0 -> P t t0.
-  Proof.
-    intros P Hbeta Hlet (*Hreldef Hrelvar*) Hcst Hax Hcase Hproj Hfix Hstuckfix Hcofixcase Hcofixproj Happcong Hatom.
-    fix eval_evals_ind 3. destruct 1;
-             try solve [match goal with [ H : _ |- _ ] =>
-                             match type of H with
-                               forall t t0, eval t t0 -> _ => fail 1
-                             | _ => eapply H
-                             end end; eauto].
-    (* - eapply Hrelvar, e. *)
-    - eapply Hax; [eapply isdecl|eapply e].
-    - eapply Hfix; eauto.
-      clear -a eval_evals_ind.
-      revert args args' a. fix aux 3. destruct 1. constructor; auto.
-      constructor. now apply eval_evals_ind. now apply aux.
-    - eapply Hstuckfix => //. eapply eval_evals_ind. auto.
-      clear -eval_evals_ind a.
-      revert args args' a. fix aux 3. destruct 1. constructor; auto.
-      constructor. now apply eval_evals_ind. now apply aux.
-  Defined.
 
   (** Characterization of values for this reduction relation.
       Only constructors and cofixpoints can accumulate arguments.
@@ -411,37 +328,89 @@ Section Wcbv.
 
   Lemma eval_to_value e e' : eval e e' -> value e'.
   Proof.
-    induction 1 using eval_evals_ind; simpl; auto using value.
-    (* eapply (value_app (tEvar n l') []). constructor. constructor. *)
-
-    (* - eapply (value_app (tRel i) []). now rewrite /value_head /= H. constructor. *)
+    induction 1; simpl; auto using value.
     - eapply (value_app (tConst c u) []).
-      red in H.
-      rewrite /value_head /= H.
+      red in isdecl.
+      rewrite /value_head /= isdecl.
       destruct decl as [? [b|] ?]; try discriminate.
       constructor. constructor.
-    - eapply value_stuck_fix => //.
-      now eapply All2_right in X1.
+    - change (tApp ?h ?a) with (mkApps h [a]).
+      rewrite mkApps_nested.
+      apply value_mkApps_inv in IHX1; [|easy].
+      destruct IHX1 as [[(-> & _)|]|(stuck & vals)].
+      + cbn in *.
+        apply (value_stuck_fix _ [av]); [easy|].
+        cbn.
+        destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
+        noconf e.
+        unfold is_constructor.
+        destruct o as [|(<- & ?)]; [|easy].
+        now rewrite (proj2 (nth_error_None _ _));
+          cbn in *.
+      + easy.
+      + eapply value_stuck_fix; [now apply All_app_inv|].
+        unfold isStuckFix in *.
+        destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
+        noconf e.
+        unfold is_constructor in *.
+        destruct o as [|(<- & ?)]; [|now rewrite nth_error_snoc].
+        destruct (Nat.ltb_spec #|argsv| narg).
+        * rewrite (proj2 (nth_error_None _ _)); [|easy].
+          rewrite app_length.
+          cbn.
+          easy.
+        * now rewrite nth_error_app1.
     - destruct (mkApps_elim f' [a']).
       eapply value_mkApps_inv in IHX1 => //.
       destruct IHX1; intuition subst.
       * rewrite a1.
-        simpl. rewrite a1 in H. simpl in *.
-        apply (value_app f [a']). destruct f; simpl in * |- *; try congruence;
+        simpl. rewrite a1 in i. simpl in *.
+        apply (value_app f0 [a']). destruct f0; simpl in * |- *; try congruence;
         constructor; auto. constructor. auto. constructor; auto.
       * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']).
         constructor 2; auto. eapply All_app_inv; auto.
       * rewrite [tApp _ _](mkApps_nested _ (firstn n l) [a']).
-        rewrite isFixApp_mkApps in H => //.
-        destruct f; simpl in *; try congruence.
-        rewrite /isFixApp in H. simpl in H.
-        rewrite orb_true_r orb_true_l in H. easy.
+        rewrite isFixApp_mkApps in i => //.
+        destruct f0; simpl in *; try congruence.
+        rewrite /isFixApp in i. simpl in i.
+        rewrite orb_true_r orb_true_l in i. easy.
   Qed.
 
   Lemma value_head_spec t :
     implb (value_head t) (~~ (isLambda t || isFixApp t || isArityHead t)).
   Proof.
     destruct t; simpl; intuition auto; eapply implybT.
+  Qed.
+
+  Lemma eval_stuck_fix args argsv mfix idx :
+    All2 eval args argsv ->
+    isStuckFix (tFix mfix idx) argsv ->
+    eval (mkApps (tFix mfix idx) args) (mkApps (tFix mfix idx) argsv).
+  Proof.
+    revert argsv.
+    induction args as [|a args IH] using MCList.rev_ind;
+      intros argsv all stuck.
+    - apply All2_length in all.
+      destruct argsv; [|easy].
+      now apply eval_atom.
+    - destruct argsv as [|? ? _] using MCList.rev_ind;
+        [apply All2_length in all; rewrite app_length in all; now cbn in *|].
+      apply All2_app_r in all as (all & ev_a).
+      rewrite <- !mkApps_nested.
+      cbn in *.
+      destruct (cunfold_fix mfix idx) as [(? & ?)|] eqn:cuf; [|easy].
+      eapply eval_fix_value.
+      + apply IH; [easy|].
+        destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
+        unfold is_constructor in *.
+        destruct (nth_error argsv _) eqn:nth; [|easy].
+        now erewrite nth_error_app_left in stuck.
+      + easy.
+      + easy.
+      + destruct (Nat.eqb_spec #|argsv| n) as [<-|].
+        * unfold is_constructor in *.
+          now rewrite nth_error_snoc in stuck.
+        * now left.
   Qed.
 
   Derive Signature for eval.
@@ -483,8 +452,7 @@ Section Wcbv.
         destruct t; auto.
     - destruct f; try discriminate.
       apply All_All2_refl in X0.
-      eapply eval_fix_value => //.
-      constructor; auto.
+      now apply eval_stuck_fix.
   Qed.
 
   Lemma closed_beta na t b u : closed (tLambda na t b) -> closed u -> closed (csubst u 0 b).
@@ -604,7 +572,7 @@ Section Wcbv.
   Lemma eval_closed `{checker_flags} {wfΣ : wf Σ} : forall t u, closed t -> eval t u -> closed u.
   Proof.
     move=> t u Hc ev. move: Hc.
-    induction ev using eval_evals_ind; simpl in *; auto;
+    induction ev; simpl in *; auto;
       (move/andP=> [/andP[Hc Hc'] Hc''] || move/andP=> [Hc Hc'] || move=>Hc); auto.
     - eapply IHev3. unshelve eapply closed_beta. 3:eauto. exact na. simpl. eauto.
     - eapply IHev2. now rewrite closed_csubst.
@@ -614,24 +582,27 @@ Section Wcbv.
       eapply closedn_mkApps_inv in IHev1.
       move/andP: IHev1 => [Hcons Hargs]. solve_all.
       eapply All_nth_error in Hargs; eauto.
-    - eapply IHev2.
-      eapply closedn_mkApps_inv in Hc. move/andP: Hc=> [cf cargs].
-      specialize (IHev1 cf).
-      rewrite -closed_unfold_fix_cunfold_eq in H0 => //.
-      eapply closed_unfold_fix in H0; eauto.
-      eapply closedn_mkApps; eauto.
-      solve_all.
-    - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs]. eapply closedn_mkApps; eauto.
+    - eapply IHev3.
+      apply Bool.andb_true_iff.
+      split; [|easy].
+      specialize (IHev1 Hc).
+      eapply closedn_mkApps_inv in IHev1.
+      apply Bool.andb_true_iff in IHev1.
+      eapply closedn_mkApps; [|easy].
+      eapply closed_unfold_fix; [easy|].
+      now rewrite closed_unfold_fix_cunfold_eq.
+    - apply Bool.andb_true_iff.
+      split; [|easy].
       solve_all.
     - eapply IHev. move/closedn_mkApps_inv/andP: Hc' => [Hfix Hargs].
       repeat (apply/andP; split; auto). eapply closedn_mkApps.
-      rewrite -closed_unfold_cofix_cunfold_eq in H0 => //.
-      eapply closed_unfold_cofix in H0; eauto.
+      rewrite -closed_unfold_cofix_cunfold_eq in e => //.
+      eapply closed_unfold_cofix in e; eauto.
       auto.
     - eapply IHev. move/closedn_mkApps_inv/andP: Hc => [Hfix Hargs].
       eapply closedn_mkApps; eauto.
-      rewrite -closed_unfold_cofix_cunfold_eq in H0 => //.
-      eapply closed_unfold_cofix in H0; eauto.
+      rewrite -closed_unfold_cofix_cunfold_eq in e => //.
+      eapply closed_unfold_cofix in e; eauto.
     - apply/andP; split; auto.
     Qed.
 
@@ -662,91 +633,151 @@ Section Wcbv.
 
   Lemma eval_tRel n t :
     eval (tRel n) t -> False.
-    Proof. intros H; depind H; solve_discr.
-    - destruct (mkApps_elim f args).
-      change (tRel n) with (mkApps (tRel n) []) in H1.
-      eapply mkApps_eq_inj in H1 => //. intuition subst.
-      rewrite firstn_nil in H, IHeval1.
-      specialize (IHeval1 _ _ eq_refl). rewrite skipn_nil in e0. discriminate.
-    - change (tRel n) with (mkApps (tRel n) []) in H0.
-    eapply mkApps_eq_inj in H0 => //.
-    + intuition subst.
-      now specialize (IHeval _ _ eq_refl).
-    + apply (f_equal nApp) in H0 as e. simpl in e.
-      rewrite nApp_mkApps in e. symmetry in e.
-      assert (nApp f = 0) as h by lia.
-      apply nApp_isApp_false in h. rewrite h. reflexivity.
-    - now simpl in i.
-  Qed.
-(*    (match option_map decl_body (nth_error Γ n) with
-     | Some (Some b) => eval (lift0 (S n) b) t
-     | _ => t = (tRel n)
-     end).
-  Proof.
-    intros H; depind H; try rewrite e; try solve_discr; try now easy.
-    - destruct (mkApps_elim f args).
-      change (tRel n) with (mkApps (tRel n) []) in H1.
-      eapply mkApps_eq_inj in H1 => //. intuition subst.
-      rewrite firstn_nil in H, IHeval1.
-      specialize (IHeval1 _ _ eq_refl). rewrite skipn_nil in e0. discriminate.
-    - change (tRel n) with (mkApps (tRel n) []) in H0.
-      eapply mkApps_eq_inj in H0 => //.
-      + intuition subst.
-        specialize (IHeval _ _ eq_refl).
-        destruct option_map as [[o|]|] => //. depelim a. simpl in i.
-        simpl. auto.
-      + apply (f_equal nApp) in H0 as e. simpl in e.
-        rewrite nApp_mkApps in e. symmetry in e.
-        assert (nApp f = 0) as h by lia.
-        apply nApp_isApp_false in h. rewrite h. reflexivity.
-  Qed. *)
+  Proof. now intros e; depelim e. Qed.
 
   Lemma eval_tVar i t : eval (tVar i) t -> False.
-  Proof.
-    intros H; depind H; try solve_discr; try now easy.
-    - apply (f_equal nApp) in H1 as h. simpl in h.
-      rewrite nApp_mkApps in h. lia.
-    - apply (f_equal nApp) in H0 as h. simpl in h.
-      rewrite nApp_mkApps in h. depelim a.
-      + simpl in *. subst.
-        eapply IHeval. reflexivity.
-      + simpl in h. lia.
-  Qed.
+  Proof. now intros e; depelim e. Qed.
 
   Lemma eval_tEvar n l t : eval (tEvar n l) t -> False.
-                          (* exists l', All2 eval l l' /\ (t = tEvar n l'). *)
-  Proof.
-    intros H; depind H; try solve_discr; try now easy.
-    - apply (f_equal nApp) in H1 as h. simpl in h.
-      rewrite nApp_mkApps in h. lia.
-    - apply (f_equal nApp) in H0 as h. simpl in h.
-      rewrite nApp_mkApps in h. depelim a.
-      + simpl in *. subst.
-        eapply IHeval. reflexivity.
-      + simpl in h. lia.
-  Qed.
+  Proof. now intros e; depelim e. Qed.
 
-  Lemma eval_atom_inj t t' : atom t -> eval t t' -> t = t'.
+  Lemma eval_mkApps_tCoFix mfix idx args v :
+    eval (mkApps (tCoFix mfix idx) args)  v ->
+    exists args', v = mkApps (tCoFix mfix idx) args'.
   Proof.
-    intros Ha H; depind H; try solve_discr; try now easy.
-    eapply atom_mkApps in Ha; intuition subst. discriminate.
-    eapply atom_mkApps in Ha; intuition subst. now depelim a.
+    revert v.
+    induction args using List.rev_ind; intros v ev.
+    + exists [].
+      now depelim ev.
+    + rewrite <- mkApps_nested in ev.
+      cbn in *.
+      depelim ev;
+        try solve [apply IHargs in ev1 as (? & ?); solve_discr].
+      * apply IHargs in ev1 as (argsv & ->).
+        exists (argsv ++ [a'])%list.
+        now rewrite <- mkApps_nested.
+      * easy.
   Qed.
+ 
+  Unset SsrRewrite.
+  Lemma eval_deterministic {t v v'} :
+    eval t v ->
+    eval t v' ->
+    v = v'.
+  Proof.
+  intros ev.
+  revert v'.
+  depind ev; intros v' ev'.
+  - depelim ev'.
+    + apply IHev1 in ev'1.
+      apply IHev2 in ev'2.
+      subst.
+      noconf ev'1.
+      now apply IHev3 in ev'3.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; subst; easy.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1.
+      subst.
+      now apply IHev2 in ev'2.
+    + easy.
+  - depelim ev'.
+    + rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
+      replace body0 with body in * by congruence.
+      now apply IHev in ev'.
+    + now rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
+    + easy.
+  - depelim ev'.
+    + now rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
+    + easy.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1.
+      apply mkApps_eq_inj in ev'1; try easy.
+      depelim ev'1.
+      noconf H.
+      noconf H0.
+      now apply IHev2 in ev'2.
+    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1.
+      apply mkApps_eq_inj in ev'1 as (ev'1 & <-); try easy.
+      noconf ev'1.
+      replace a0 with a in * by congruence.
+      now apply IHev2 in ev'2.
+    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1.
+      solve_discr.
+      rewrite e1 in e.
+      apply IHev2 in ev'2.
+      subst.
+      noconf e.
+      now apply IHev3 in ev'3.
+    + apply IHev1 in ev'1; solve_discr.
+      apply IHev2 in ev'2; subst.
+      destruct o as [|(? & ?)]; [easy|].
+      now apply Bool.negb_true_iff in H0.
+    + apply IHev1 in ev'1.
+      subst f'.
+      rewrite isFixApp_mkApps in i0 by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i0.
+    + easy.
+  - depelim ev'.
+    + apply IHev1 in ev'1; solve_discr.
+    + apply IHev1 in ev'1; solve_discr.
+      apply IHev2 in ev'2; subst.
+      destruct o as [|(? & ?)]; [easy|].
+      now apply Bool.negb_true_iff in H0.
+    + apply IHev1 in ev'1; solve_discr.
+      now apply IHev2 in ev'2; subst.
+    + apply IHev1 in ev'1; subst.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+    + easy.
+  - depelim ev'.
+    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + solve_discr.
+      rewrite e0 in e.
+      noconf e.
+      now apply IHev in ev'.
+    + easy.
+  - depelim ev'.
+    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + solve_discr.
+      rewrite e0 in e.
+      noconf e.
+      now apply IHev in ev'.
+    + easy.
+  - depelim ev'.
+    + now apply IHev1 in ev'1; subst.
+    + apply IHev1 in ev'1; subst.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+    + apply IHev1 in ev'1; subst.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+    + apply IHev1 in ev'1; subst.
+      now apply IHev2 in ev'2; subst.
+    + easy.
+  - now depelim ev'.
+  Qed.
+  Set SsrRewrite.
 
   Lemma eval_LetIn {n b ty t v} :
     eval (tLetIn n b ty t) v ->
     ∑ b',
       eval b b' * eval (csubst b' 0 t) v.
-  Proof.
-    intros H; depind H; try solve_discr; try now easy.
-    - apply (f_equal nApp) in H1 as h. simpl in h.
-      rewrite nApp_mkApps in h. exfalso. lia.
-    - apply (f_equal nApp) in H0 as h. simpl in h.
-      rewrite nApp_mkApps in h. depelim a.
-      + simpl in *. subst.
-        eapply IHeval. reflexivity.
-      + simpl in h. exfalso. lia.
-  Qed.
+  Proof. now intros H; depelim H. Qed.
 
   Lemma eval_Const {c u v} :
     eval (tConst c u) v ->
@@ -756,51 +787,14 @@ Section Wcbv.
                  | None => v = tConst c u
                  end.
   Proof.
-    intros H; depind H; try solve_discr; try now easy.
-    - exists decl. intuition auto. now rewrite e.
-    - exists decl. intuition auto. now rewrite e.
-    - apply (f_equal nApp) in H1 as h.
-      simpl in h. rewrite nApp_mkApps in h.
-      exfalso. lia.
-    - apply (f_equal nApp) in H0 as h.
-      simpl in h. rewrite nApp_mkApps in h.
-      destruct a.
-      + simpl in *. subst.
-        eapply IHeval. reflexivity.
-      + exfalso. simpl in h. lia.
-  Qed.
-
-  Lemma eval_mkApps_tCoFix mfix idx l v :
-    eval (mkApps (tCoFix mfix idx) l) v ->
-    ∑ l', All2 eval l l' * (v = mkApps (tCoFix mfix idx) l').
-  Proof.
-    intros H.
-    depind H; try solve_discr'.
-    - destruct (mkApps_elim f [a]).
-      rewrite [tApp _ _](mkApps_nested f (firstn n l0) [a]) in H2.
-      solve_discr'.
-      specialize (IHeval1 _ _ _ _ eq_refl).
-      firstorder eauto.
-      solve_discr'.
-    - destruct (mkApps_elim f args). solve_discr'.
-      specialize (IHeval1 _ _ _ _ eq_refl).
-      firstorder eauto. solve_discr.
-    - destruct (mkApps_elim f args). solve_discr'.
-      specialize (IHeval _ _ _ _ eq_refl).
-      firstorder eauto. solve_discr.
-    - destruct (mkApps_elim f [a]).
-      replace (tApp (mkApps f (firstn n l0)) a)
-        with (mkApps f (firstn n l0 ++ [a])) in H1.
-      2:now rewrite -mkApps_nested.
-      solve_discr'.
-      specialize (IHeval1 _ _ _ _ eq_refl).
-      firstorder eauto. subst.
-      exists (x ++ [a'])%list.
-      split. eapply All2_app; auto.
-      now rewrite -mkApps_nested.
-    - eapply atom_mkApps in i; intuition try easy.
-      subst.
-      exists []. intuition auto.
+    intros H; depelim H.
+    - exists decl.
+      split; [easy|].
+      now rewrite e.
+    - exists decl.
+      split; [easy|].
+      now rewrite e.
+    - easy.
   Qed.
 
   Lemma eval_mkApps_cong f f' l l' :
@@ -826,109 +820,9 @@ Section Wcbv.
     forward IHl. simpl; lia. cbn -[removelast] in *. simpl removelast. simpl. lia.
   Qed.
 
-  Lemma eval_deterministic {t v v'} : eval t v -> eval t v' -> v = v'.
-  Proof.
-    intros tv. revert v'.
-    revert t v tv.
-    induction 1 using eval_evals_ind; intros v' tv'.
-    - depelim tv'; auto.
-      * specialize (IHtv1 _ tv'1); try congruence. inv IHtv1.
-        specialize (IHtv2 _ tv'2). subst.
-        specialize (IHtv3 _ tv'3). now subst.
-      * rewrite [args](app_removelast_last a) in H.
-        destruct args; discriminate.
-        rewrite -mkApps_nested in H. simpl in H. injection H. intros. clear H.
-        subst.
-        assert (eval (mkApps f0 (removelast args)) (mkApps (tFix mfix idx) (removelast args'))).
-        eapply eval_fix_value. auto. admit.
-        simpl. admit.
-(*        rewrite e /is_constructor. rewrite /is_constructor in i.
-        destruct (nth_error (removelast args') narg) eqn:Heq.
-        eapply nth_error_Some_length in Heq.
-        have H':= (removelast_length args').
-        forward H'. rewrite -(All2_length _ _ a0). lia.
-        elimtype False. rewrite -(All2_length _ _ a0) in H'. lia. 
-        constructor.*)
-        specialize (IHtv1 _ X).
-        solve_discr'.
-      * destruct (mkApps_elim f [a]).
-        destruct (mkApps_elim f0 args).
-(*
-    - depelim tv'; auto; try specialize (IHtv1 _ tv'1) || solve [depelim tv1]; try congruence.
-      inv IHtv1. specialize (IHtv2 _ tv'2). subst.
-      now specialize (IHtv3 _ tv'3).
-      now subst f'. easy.
-    - eapply eval_LetIn in tv' as [b' [evb evt]].
-      rewrite -(IHtv1 _ evb) in evt.
-      eapply (IHtv2 _ evt).
-    - depelim tv'; try solve_discr.
-      * specialize (IHtv1 _ tv'1).
-        solve_discr. inv H.
-        now specialize (IHtv2 _ tv'2).
-      * specialize (IHtv1 _ tv'1); solve_discr.
-      * eapply eval_mkApps_tCoFix in tv1 as [l' [ev' eq]]. solve_discr.
-      * easy.
-    - subst.
-      depelim tv'.
-      * specialize (IHtv1 _ tv'1).
-        solve_discr.
-      * specialize (IHtv1 _ tv'1).
-        now specialize (IHtv2 _ tv'2).
-      * pose proof tv1. eapply eval_mkApps_tCoFix in H0.
-        destruct H0 as [l' [evargs eq]]. solve_discr.
-      * easy.
-    - depelim tv' => //.
-      * depelim tv'1.
-      * depelim tv'1.
-      * rewrite H in H0. inv H0.
-        now specialize (IHtv _ tv').
-      * now depelim tv'1.
-*)
-  (*   - depelim tv'; try easy. *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * solve_discr. inv H1. rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv _ tv'). *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * solve_discr. inv H1. rewrite H in H0. inv H0. *)
-  (*       now specialize (IHtv _ tv'). *)
-  (*     * eapply eval_mkApps_tCoFix in tv'1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * eapply eval_mkApps_tCoFix in tv' as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-
-  (*   - eapply eval_Const in tv' as [decl' [body' [? ?]]]. *)
-  (*     intuition eauto. eapply IHtv. *)
-  (*     red in isdecl, H0. rewrite H0 in isdecl. inv isdecl. *)
-  (*     now rewrite H in H2; inv H2. *)
-
-  (*   - depelim tv'. *)
-  (*     * eapply eval_mkApps_tCoFix in tv1 as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv1 _ tv'1). *)
-  (*       solve_discr. inv H. *)
-  (*       now specialize (IHtv2 _ tv'2). *)
-  (*     * specialize (IHtv1 _ tv'). solve_discr. *)
-  (*     * easy. *)
-
-  (*   - depelim tv'; try easy. *)
-  (*     * eapply eval_mkApps_tCoFix in tv as [l' [evargs eq]]. *)
-  (*       solve_discr. *)
-  (*     * specialize (IHtv _ tv'1). solve_discr. *)
-
-  (*   - depelim tv'; try specialize (IHtv1 _ tv'1); subst; try easy. *)
-  (*     depelim tv1. easy. *)
-  (*     specialize (IHtv2 _ tv'2). congruence. *)
-
-  (*   - depelim tv'; try easy. *)
-  (* Qed. *)
-  Admitted.
-
 End Wcbv.
 
+Arguments eval_deterministic {_ _ _ _}.
 
 (** Well-typed closed programs can't go wrong: they always evaluate to a value. *)
 
@@ -943,7 +837,7 @@ Lemma wcbeval_red `{checker_flags} : forall (Σ : global_env_ext) t u, wf Σ -> 
     eval Σ t u -> red Σ [] t u.
 Proof.
   intros Σ t u wfΣ Hc He. revert Hc.
-  induction He using eval_evals_ind; simpl; 
+  induction He; simpl; 
   (move/andP => [/andP[Hc Hc'] Hc''] || move/andP => [Hc Hc'] || move => Hc);
     try solve[econstructor; eauto].
 
@@ -981,36 +875,45 @@ Proof.
     apply red1_red. econstructor; eauto.
     eapply eval_closed in He1; eauto. eapply closed_arg in He1; eauto.
 
-  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs]. 
-    redt (mkApps (tFix mfix idx) args'); eauto.
-    eapply red_mkApps; eauto. solve_all.
-    rewrite -closed_unfold_fix_cunfold_eq in H0; auto.
-    eapply eval_closed in He1; eauto.
-    redt (mkApps fn args'); eauto.
-    eapply red1_red. eapply red_fix; eauto.
-    eapply IHHe2. eapply eval_closed in He1; eauto.
-    eapply closedn_mkApps; eauto using closed_unfold_fix.
-    clear -wfΣ X Hargs. solve_all. now eapply eval_closed.
+  - redt (tApp (mkApps (tFix mfix idx) argsv) av);
+      [eapply red_app; eauto|].
+    assert (closed_fix: closed (mkApps (tFix mfix idx) argsv)).
+    { eapply eval_closed; [easy| |easy].
+      easy. }
+    eapply closedn_mkApps_inv in closed_fix.
+    apply andb_true_iff in closed_fix.
+    rewrite -closed_unfold_fix_cunfold_eq in e; [easy|].
+    redt (tApp (mkApps fn argsv) av).
+    + repeat change (tApp ?h ?a) with (mkApps h [a]).
+      rewrite !mkApps_nested.
+      apply red1_red.
+      eapply red_fix; [easy|].
+      unfold is_constructor.
+      now rewrite nth_error_snoc.
+    + eapply IHHe3.
+      cbn.
+      apply andb_true_iff.
+      split.
+      * apply closedn_mkApps; [|easy].
+        now eapply closed_unfold_fix.
+      * now eapply eval_closed; [| |easy].
 
-  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
-    eapply red_mkApps; eauto.
-    eauto using eval_closed.
-    solve_all.
+  - now apply red_app.
 
   - move/closedn_mkApps_inv/andP: Hc' => [Hf Hargs].
-    rewrite -closed_unfold_cofix_cunfold_eq in H0; auto.
+    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
     redt _. eapply red1_red.
     eapply PCUICTyping.red_cofix_case; eauto.
     eapply IHHe.
-    eapply closed_unfold_cofix in H0; eauto.
+    eapply closed_unfold_cofix in e; eauto.
     simpl. rewrite Hc closedn_mkApps; eauto.
 
   - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
-    rewrite -closed_unfold_cofix_cunfold_eq in H0; auto.
+    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
     redt _. 2:eapply IHHe.
     redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
     apply red1_red. econstructor; eauto.
-    simpl. eapply closed_unfold_cofix in H0; eauto.
+    simpl. eapply closed_unfold_cofix in e; eauto.
     rewrite closedn_mkApps; eauto.
 
   - eapply (red_mkApps _ _ [a] [a']); auto.

--- a/safechecker/src/g_metacoq_safechecker.mlg
+++ b/safechecker/src/g_metacoq_safechecker.mlg
@@ -20,7 +20,7 @@ let time prefix f x =
 
 let check env evm (c, ustate) =
   Feedback.msg_debug (str"Quoting");
-  let term = time (str"Quoting") (Ast_quoter.quote_term_rec env) (EConstr.to_constr evm c) in
+  let term = time (str"Quoting") (Ast_quoter.quote_term_rec true env) (EConstr.to_constr evm c) in
   let uctx = UState.context_set ustate in
   Feedback.msg_debug (str"Universes added: " ++ Printer.pr_universe_ctx_set evm uctx);
   let uctx = Universes0.Monomorphic_ctx (Ast_quoter.quote_univ_contextset uctx) in

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -100,16 +100,12 @@ Proof.
   now rewrite IHt1.
 Qed.
 
+Derive NoConfusion for sort_family.
+Derive EqDec for sort_family.
+
 Definition mkApps_decompose_app t :
   t = mkApps  (fst (decompose_app t)) (snd (decompose_app t))
   := mkApps_decompose_app_rec t [].
-
-
-Derive EqDec for sort_family.
-Next Obligation.
-  unfold Classes.dec_eq. decide equality.
-Defined.
-
 
 Inductive type_error :=
 | UnboundRel (n : nat)

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -374,7 +374,7 @@ struct
     Ind of Names.inductive
   | Const of KerName.t
 
-  let quote_term_rec env trm =
+  let quote_term_rec bypass env trm =
     let visited_terms = ref Names.KNset.empty in
     let visited_types = ref Mindset.empty in
     let constants = ref [] in
@@ -405,13 +405,15 @@ struct
         | Undef _ -> None
         | Primitive _ -> CErrors.user_err Pp.(str "Primitives are unsupported by TemplateCoq")
 	      | Def cs -> Some (Mod_subst.force_constr cs)
-	      | OpaqueDef lc -> 
+	      | OpaqueDef lc ->
+          if bypass then
           let c, univs = Opaqueproof.force_proof Library.indirect_accessor (Environ.opaque_tables env) lc in
           let () = match univs with
           | Opaqueproof.PrivateMonomorphic () -> ()
           | Opaqueproof.PrivatePolymorphic (n, csts) -> if not (Univ.ContextSet.is_empty csts && Int.equal n 0) then 
             CErrors.user_err Pp.(str "Private polymorphic universes not supported by TemplateCoq")
           in Some c
+          else None
         in
         let tm, acc =
           match body with

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -359,12 +359,13 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
           k (env, evm, EConstr.to_constr evm t)) in  (* todo better *)
     ignore (Obligations.add_definition ~name:ident ~term:c cty ~uctx ~poly ~kind ~hook obls)
 
-  | TmQuote (false, trm) ->
+  | TmQuote trm ->
     (* user should do the reduction (using tmEval) if they want *)
     let qt = quote_term env trm
     in k (env, evm, qt)
-  | TmQuote (true, trm) ->
-    let qt = quote_term_rec env trm in
+  | TmQuoteRecTransp  (bypass, trm) ->
+    let bypass = unquote_bool (reduce_all env evm bypass) in
+    let qt = quote_term_rec bypass env trm in
     k (env, evm, qt)
   | TmQuoteInd (name, strict) ->
        let kn = unquote_kn (reduce_all env evm name) in

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -32,7 +32,7 @@ let (ptmReturn,
      ptmCurrentModPath,
 
      ptmQuote,
-     ptmQuoteRec,
+     ptmQuoteRecTransp,
      ptmQuoteInductive,
      ptmQuoteConstant,
      ptmQuoteUniverses,
@@ -70,7 +70,7 @@ let (ptmReturn,
    r_template_monad_prop_p "tmCurrentModPath",
 
    r_template_monad_prop_p "tmQuote",
-   r_template_monad_prop_p "tmQuoteRec",
+   r_template_monad_prop_p "tmQuoteRecTransp",
    r_template_monad_prop_p "tmQuoteInductive",
    r_template_monad_prop_p "tmQuoteConstant",
    r_template_monad_prop_p "tmQuoteUniverses",
@@ -165,7 +165,8 @@ type template_monad =
   | TmCurrentModPath
 
     (* quoting *)
-  | TmQuote of bool * Constr.t  (* only Prop *)
+  | TmQuote of Constr.t (* only Prop *)
+  | TmQuoteRecTransp of Constr.t * Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
@@ -300,13 +301,14 @@ let next_action env evd (pgm : constr) : template_monad * _ =
   else if eq_gr ptmQuote then
     match args with
     | _::trm::[] ->
-       (TmQuote (false,trm), universes)
-    | _ -> monad_failure "tmQuote" 2
-  else if eq_gr ptmQuoteRec then
+       (TmQuote trm, universes)
+    | _ -> monad_failure "tmQuote" 3
+  else if eq_gr ptmQuoteRecTransp then
     match args with
-    | _::trm::[] ->
-       (TmQuote (true,trm), universes)
-    | _ -> monad_failure "tmQuoteRec" 2
+    | _::trm::bypass::[] ->
+       (TmQuoteRecTransp (bypass,trm), universes)
+    | _ -> monad_failure "tmQuoteRec" 3
+
 
   else if eq_gr ptmQuoteInductive then
     match args with

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -37,7 +37,8 @@ type template_monad =
   | TmCurrentModPath
 
     (* quoting *)
-  | TmQuote of bool * Constr.t  (* only Prop *)
+  | TmQuote of Constr.t (* arguments: recursive * bypass opacity * term  *)  (* only Prop *)
+  | TmQuoteRecTransp of Constr.t * Constr.t
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -209,6 +209,7 @@ Register MetaCoq.Template.TemplateMonad.Core.tmCurrentModPath as metacoq.templat
 
 Register MetaCoq.Template.TemplateMonad.Core.tmQuote as metacoq.templatemonad.prop.tmQuote.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteRec as metacoq.templatemonad.prop.tmQuoteRec.
+Register MetaCoq.Template.TemplateMonad.Core.tmQuoteRecTransp as metacoq.templatemonad.prop.tmQuoteRecTransp.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteInductive as metacoq.templatemonad.prop.tmQuoteInductive.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteConstant as metacoq.templatemonad.prop.tmQuoteConstant.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteUniverses as metacoq.templatemonad.prop.tmQuoteUniverses.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -45,8 +45,10 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 (* Quoting and unquoting commands *)
 (* Similar to MetaCoq Quote Definition ... := ... *)
 | tmQuote : forall {A:Type@{t}}, A  -> TemplateMonad Ast.term
-(* Similar to MetaCoq Quote Recursively Definition ... := ...*)
-| tmQuoteRec : forall {A:Type@{t}}, A  -> TemplateMonad program
+(* Similar to MetaCoq Quote Recursively Definition but takes a boolean "bypass opacity" flag.
+  ([true] - quote bodies of all dependencies (transparent and opaque);
+   [false] -quote bodies of transparent definitions only) *)
+| tmQuoteRecTransp : forall {A:Type@{t}}, A -> bool(* bypass opacity? *) -> TemplateMonad program
 (* Quote the body of a definition or inductive. Its name need not be fully qualified *)
 | tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
 | tmQuoteUniverses : TemplateMonad ConstraintSet.t
@@ -90,6 +92,9 @@ Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
 
 Definition tmAxiom id := tmAxiomRed id None.
 Definition tmDefinition id {A} t := @tmDefinitionRed_ false id None A t.
+
+(** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
+Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
 
 Definition tmLocate1 (q : qualid) : TemplateMonad global_reference :=
   l <- tmLocate q ;;

--- a/template-coq/theories/utils/MCList.v
+++ b/template-coq/theories/utils/MCList.v
@@ -744,6 +744,15 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma nth_error_snoc {A} (l : list A) (a : A) i :
+  i = #|l| ->
+  nth_error (l ++ [a]) i = Some a.
+Proof.
+  intros ->.
+  rewrite nth_error_app_ge; [easy|].
+  now rewrite Nat.sub_diag.
+Qed.
+
 Lemma map_inj :
   forall A B (f : A -> B) l l',
     (forall x y, f x = f y -> x = y) ->

--- a/test-suite/opaque.v
+++ b/test-suite/opaque.v
@@ -1,10 +1,34 @@
-Require Import MetaCoq.Template.Loader.
+From Coq Require Import String List Nat.
+From MetaCoq.Template Require Import All.
+
+Import MonadNotation String ListNotations.
 
 Definition foo : nat. exact 0. Qed.
 
 Local Open Scope string_scope.
 MetaCoq Quote Recursively Definition foo_syn := foo.
+MetaCoq Quote Recursively Definition comm_syn := PeanoNat.Nat.add_comm.
 
 Axiom really_opaque : nat.
 
 MetaCoq Quote Recursively Definition really_opaque_syn := really_opaque.
+
+MetaCoq Run (foo_t <- tmQuoteRecTransp foo false ;; (* quote respecting transparency *)
+             foo_o <- tmQuoteRec foo ;; (* quote ignoring transparency settings  *)
+             tmDefinition "foo_t" foo_t ;;
+             tmDefinition "foo_o" foo_o).
+
+Example foo_quoted_correctly :
+  (exists c v, lookup_env (fst foo_t) (MPfile ["opaque"; "TestSuite"; "MetaCoq"], "foo") = Some v /\
+    v = ConstantDecl c /\ c.(cst_body) = None) /\
+    (exists c v, lookup_env (fst foo_o) (MPfile ["opaque"; "TestSuite"; "MetaCoq"], "foo") = Some v /\
+    v = ConstantDecl c /\ c.(cst_body) <> None ).
+Proof.
+  split;eexists;eexists;cbn; now intuition.
+Qed.
+
+Time MetaCoq Run (t <- tmQuoteRecTransp Plus.le_plus_r false ;;
+                  tmDefinition "add_comm_syn" t). (* quote respecting transparency *)
+
+Time MetaCoq Run (t <- tmQuoteRec Plus.le_plus_r ;;
+                  tmDefinition "add_comm_syn'" t). (* quote ignoring transparency settings  *)


### PR DESCRIPTION
I just merged from `coq-8.11`. Merging worked, there was only one compilation problem in `PCUICSafeChecker.v` regarding Equations which was easy to resolve.

I tested compilation under `ocaml 4.09.1`, `Coq 8.12.0`, and `Equations 1.2.3.+8.12`. If CI (using `ocaml 4.07.1` agrees) this should be ready to take as base for an opam release. 

I feel a little bit unconfident because of our limited test-suite, so I'm now porting the undecidability library containing the L-extraction plugin, if there are problems I'll report here.