### PR TITLE
Finish proving lemmas about cumulative inductives

### DIFF
--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -397,7 +397,7 @@ Proof.
       simpl.
       intros v indv. specialize (on_ctype_variance v indv).
       simpl in *. move: on_ctype_variance.
-      unfold respects_variance. destruct variance_universes as [[univs u] u'].
+      unfold respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
       intros [args idxs]. split.
       eapply (All2_local_env_impl args); intros.
       eapply weakening_env_cumul; eauto.

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -172,6 +172,27 @@ Proof.
     exists s'. eapply (substitution _ _ Δ s [] _ _ HΣ' sub Hs).
 Qed.
 
+Lemma isWAT_subst_gen {cf:checker_flags} {Σ : global_env_ext} (HΣ' : wf Σ) {Γ Δ Δ'} {A} s :
+  subslet Σ Γ s Δ ->
+  isWfArity_or_Type Σ (Γ ,,, Δ ,,, Δ') A -> 
+  isWfArity_or_Type Σ (Γ ,,, subst_context s 0 Δ') (subst s #|Δ'| A).
+Proof.
+  intros sub WAT.
+  destruct WAT.
+  - left.
+    destruct i as [ctx [s' [wfa wfl]]].
+    exists (subst_context s #|Δ'|ctx), s'.
+    generalize (subst_destArity [] A s #|Δ'|).
+    rewrite wfa /=.
+    split; auto.
+    epose proof (subst_context_app _ 0 _ _).
+    rewrite Nat.add_0_r in H0. rewrite <- app_context_assoc, <- H0.
+    eapply substitution_wf_local; eauto.
+    now rewrite app_context_assoc.
+  - right.
+    destruct i as [s' Hs].
+    exists s'. eapply (substitution _ _ Δ s _ _ _ HΣ' sub Hs).
+Qed.
 
 Lemma typing_spine_letin_inv {cf:checker_flags} {Σ Γ na b B T args S} : 
   wf Σ.1 ->

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -2773,6 +2773,25 @@ Section ConfluenceFacts.
       intros ? ? ?; eapply red_trans.
   Qed.
 
+  Lemma red_mkApps_tRel (Γ : context) k b (args : list term) c :
+    nth_error Γ k = Some b -> decl_body b = None ->
+    red Σ Γ (mkApps (tRel k) args) c ->
+    ∑ args' : list term,
+    (c = mkApps (tRel k) args') * (All2 (red Σ Γ) args args').
+  Proof.
+    move => Hnth Hb Hred. apply red_alt in Hred.
+    eapply red_pred in Hred; tas.
+    generalize_eq x (mkApps (tRel k) args).
+    induction Hred in k, b, Hnth, Hb, args |- * ; simplify *.
+    - eapply pred1_mkApps_tRel in r as [r' [eq redargs]]; eauto.
+      subst y. exists r'. intuition auto. solve_all. now apply pred1_red in X.
+    - exists args; split; eauto. apply All2_same; auto.
+    - specialize IHHred1 as [? [? ?]]; eauto. subst.
+      specialize (IHHred2 _ _ _ Hnth Hb eq_refl) as [? [? ?]]. subst z.
+      exists x0. intuition auto. eapply All2_trans; eauto.
+      intros ? ? ?; eapply red_trans.
+  Qed.
+
   Lemma red_mkApps_tConst_axiom (Γ : context)
         cst u (args : list term) cb c :
     declared_constant Σ cst cb -> cst_body cb = None ->

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -2466,6 +2466,20 @@ Proof.
   rewrite !lift_closed in X => //.
 Qed.
 
+Lemma weaken_cumul {cf:checker_flags} {Σ Γ t u} Δ : 
+  wf Σ.1 -> closedn_ctx 0 Γ ->
+  closedn #|Γ| t -> closedn #|Γ| u ->
+  Σ ;;; Γ |- t <= u ->
+  Σ ;;; Δ ,,, Γ |- t <= u.
+Proof.
+  intros wfΣ clΓ clt clu ty.
+  epose proof (weakening_cumul Σ [] Γ Δ t u wfΣ).
+  rewrite !app_context_nil_l in X.
+  forward X by eauto.
+  rewrite closed_ctx_lift in X; auto.
+  rewrite !lift_closed in X => //.
+Qed.
+
 Lemma conv_subst_instance {cf:checker_flags} (Σ : global_env_ext) Γ u A B univs :
   forallb (fun x => negb (Level.is_prop x)) u ->
   valid_constraints (global_ext_constraints (Σ.1, univs))
@@ -2752,14 +2766,14 @@ Proof.
   eapply subst_conv; eauto.
 Qed.
 
-Lemma cumul_ctx_subst {cf:checker_flags} Σ Γ Γ' Δ Δ' s s' : 
+Lemma cumul_ctx_subst {cf:checker_flags} Σ Γ Γ' Γ'0 Γ'' Δ Δ' s s' : 
   wf Σ.1 ->
-  wf_local Σ (Γ ,,, Γ' ,,, Δ) ->
-  cumul_ctx_rel Σ (Γ ,,, Γ') Δ Δ' ->
-  All2 (conv Σ []) s s' ->
-  subslet Σ [] s Γ ->
-  subslet Σ [] s' Γ ->
-  cumul_ctx_rel Σ (subst_context s 0 Γ') (subst_context s #|Γ'| Δ) (subst_context s' #|Γ'| Δ').
+  wf_local Σ (Γ ,,, Γ' ,,, Γ'' ,,, Δ) ->
+  cumul_ctx_rel Σ (Γ ,,, Γ' ,,, Γ'') Δ Δ' ->
+  All2 (conv Σ Γ) s s' ->
+  untyped_subslet Γ s Γ' ->
+  untyped_subslet Γ s' Γ'0 ->
+  cumul_ctx_rel Σ (Γ ,,, subst_context s 0 Γ'') (subst_context s #|Γ''| Δ) (subst_context s' #|Γ''| Δ').
 Proof.
   intros wfΣ wf. induction 1.
   - simpl. constructor.
@@ -2769,11 +2783,10 @@ Proof.
     specialize (IHX wf Hs subs subs').
     constructor; auto. 
     red. red in p. simpl.
-    epose proof (subst_cumul [] Γ Γ (Γ' ,,, Γ0) _ _ _ _ wfΣ subs subs' Hs).
-    rewrite app_context_nil_l app_context_assoc in X0.
+    epose proof (untyped_subst_cumul Γ Γ' Γ'0 (Γ'' ,,, Γ0) _ _ _ _ wfΣ subs subs' Hs).
+    rewrite app_context_assoc in X0.
     specialize (X0 wf p).
-    rewrite subst_context_app in X0; autorewrite with len in X0.
-    rewrite app_context_nil_l in X0.
+    rewrite !subst_context_app app_context_assoc in X0; autorewrite with len in X0.
     now rewrite -(All2_local_env_length X).
   - rewrite !subst_context_snoc /=.
     intros Hs subs subs'.
@@ -2782,13 +2795,13 @@ Proof.
     constructor; auto.
     red. red in p. simpl.
     destruct p as [pb pt].
-    epose proof (subst_cumul [] Γ Γ (Γ' ,,, Γ0) _ _ _ _ wfΣ subs subs' Hs) as X0.
-    rewrite app_context_nil_l app_context_assoc in X0.
+    epose proof (untyped_subst_cumul Γ Γ' Γ'0 (Γ'' ,,, Γ0) _ _ _ _ wfΣ subs subs' Hs) as X0.
+    rewrite app_context_assoc in X0.
     specialize (X0 wf pb).
-    epose proof (subst_cumul [] Γ Γ (Γ' ,,, Γ0) _ _ _ _ wfΣ subs subs' Hs) as X1.
-    rewrite app_context_nil_l app_context_assoc in X1.
+    epose proof (untyped_subst_cumul Γ Γ' Γ'0 (Γ'' ,,, Γ0) _ _ _ _ wfΣ subs subs' Hs) as X1.
+    rewrite !app_context_assoc in X1.
     specialize (X1 wf pt).
-    rewrite !subst_context_app !app_context_nil_l in X0, X1; autorewrite with len in X0, X1.
+    rewrite !subst_context_app !app_context_assoc in X0, X1; autorewrite with len in X0, X1.
     now rewrite -(All2_local_env_length X).
 Qed.
 
@@ -2810,4 +2823,55 @@ Proof.
       destruct (IHX _ _ Hnth) as [decl' [Hnth' cum]].
       eexists; intuition eauto.
   - move=> H; elimtype False; depelim H; simpl in H0; noconf H0.
+Qed.
+
+Require Import ssrbool.
+
+Lemma closed_ctx_decl k d Γ : closedn_ctx k (d :: Γ) =
+  closed_decl (k + #|Γ|) d && closedn_ctx k Γ.
+Proof.
+  unfold closedn_ctx at 1.
+  rewrite mapi_rev /= forallb_app {2}/id /= andb_true_r.
+  replace (#|Γ| - 0) with #|Γ| by lia.
+  rewrite andb_comm. f_equal.
+  unfold closedn_ctx.
+  rewrite mapi_rev (mapi_rec_add _ _ 1 0) /=.
+  f_equal.
+Qed.
+
+Lemma weaken_cumul_ctx {cf:checker_flags} Σ Γ Γ' Δ Δ' :
+  wf Σ.1 ->
+  closed_ctx (Γ' ,,, Δ) ->
+  closed_ctx (Γ' ,,, Δ') ->
+  wf_local Σ Γ ->
+  cumul_ctx_rel Σ Γ' Δ Δ' ->
+  cumul_ctx_rel Σ (Γ ,,, Γ') Δ Δ'.
+Proof.
+  intros wfΣ wf wf' wf''. induction 1.
+  - simpl. constructor.
+  - rewrite /= closed_ctx_decl in wf.
+    rewrite /= closed_ctx_decl in wf'.
+    move/andP: wf => [wfd wf].
+    move/andP: wf' => [wfd' wf'].
+    constructor; auto.
+    + now eapply IHX.
+    + red. red in p. 
+      rewrite -app_context_assoc.
+      eapply weaken_cumul; eauto.
+      autorewrite with len; simpl; rewrite (All2_local_env_length X).
+      now autorewrite with len in wfd'.
+  - rewrite /= closed_ctx_decl in wf.
+    rewrite /= closed_ctx_decl in wf'.
+    move/andP: wf => [wfd wf].
+    move/andP: wf' => [wfd' wf'].
+    constructor; auto.
+    + now eapply IHX.
+    + red. red in p. 
+      rewrite -app_context_assoc.
+      autorewrite with len in *.
+      destruct p.
+      move/andP: wfd => /= [wfb wft].
+      move/andP: wfd' => /= [wfb' wft'].
+      rewrite <- (All2_local_env_length X) in *.
+      split; eapply weaken_cumul; autorewrite with len; eauto.
 Qed.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -2843,9 +2843,7 @@ Proof.
 Qed.
 
 Lemma All2_local_env_nth_error {cf:checker_flags} Σ Γ Δ Δ' : 
-  All2_local_env (fun (Γ' _ : PCUICEnvironment.context) 
-  (_ : option (term × term)) (x y : term) =>
-  Σ;;; Γ ,,, Γ' |- x <= y) Δ Δ' ->
+  cumul_ctx_rel Σ Γ Δ Δ' ->
   assumption_context Δ ->
   forall n decl, nth_error Δ n = Some decl ->
   ∑ decl', (nth_error Δ' n = Some decl') * (Σ ;;; Γ ,,, skipn (S n) Δ |- decl_type decl <= decl_type decl').

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -14,15 +14,6 @@ Require Equations.Prop.DepElim.
 From Equations Require Import Equations.
 Require Import ssreflect.
 
-Lemma consistent_instance_ext_noprop {cf:checker_flags} {Σ univs u} : 
-  consistent_instance_ext Σ univs u ->
-  forallb (fun x1 : Level.t => negb (Level.is_prop x1)) u.
-Proof.
-  unfold consistent_instance_ext, consistent_instance.
-  destruct univs. destruct u; simpl; try discriminate; auto.
-  firstorder.
-Qed.
-
 Lemma not_prop_not_leq_prop sf : sf <> InProp -> ~ leb_sort_family sf InProp.
 Proof.
   destruct sf; simpl; try congruence.

--- a/pcuic/theories/PCUICLiftSubst.v
+++ b/pcuic/theories/PCUICLiftSubst.v
@@ -161,6 +161,15 @@ Fixpoint extended_subst (Γ : context) (n : nat)
     end
   end.
 
+Definition expand_lets_k Γ k t := 
+  (subst (extended_subst Γ 0) k (lift (context_assumptions Γ) (k + #|Γ|) t)).
+
+Definition expand_lets Γ t := expand_lets_k Γ 0 t.
+
+Definition expand_lets_k_ctx Γ k Δ := 
+  (subst_context (extended_subst Γ 0) k (lift_context (context_assumptions Γ) (k + #|Γ|) Δ)).
+
+Definition expand_lets_ctx Γ Δ := expand_lets_k_ctx Γ 0 Δ.
 
 Fixpoint closedn k (t : term) : bool :=
   match t with

--- a/pcuic/theories/PCUICLiftSubst.v
+++ b/pcuic/theories/PCUICLiftSubst.v
@@ -139,6 +139,29 @@ Fixpoint smash_context (Γ Γ' : context) : context :=
   | [] => Γ
   end.
 
+(* Smashing a context Γ with Δ depending on it is the same as smashing Γ
+    and substituting all references to Γ in Δ by the expansions of let bindings. *)
+
+Fixpoint extended_subst (Γ : context) (n : nat)
+  (* Δ, smash_context Γ, n |- extended_subst Γ n : Γ *) :=
+  match Γ with
+  | nil => nil
+  | cons d vs =>
+    match decl_body d with
+    | Some b =>
+      (* Δ , vs |- b *)
+      let s := extended_subst vs n in
+      (* Δ , smash_context vs , n |- s : vs *)
+      let b' := lift (context_assumptions vs + n) #|s| b in
+      (* Δ, smash_context vs, n , vs |- b' *)
+      let b' := subst0 s b' in
+      (* Δ, smash_context vs , n |- b' *)
+      b' :: s
+    | None => tRel n :: extended_subst vs (S n)
+    end
+  end.
+
+
 Fixpoint closedn k (t : term) : bool :=
   match t with
   | tRel i => Nat.ltb i k

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -445,6 +445,27 @@ Section Pred1_inversion.
     eapply All2_app; auto.
   Qed.
 
+  Lemma pred1_mkApps_tRel (Σ : global_env) (Γ Δ : context) k b (args : list term) c :
+    nth_error Γ k = Some b -> decl_body b = None ->
+    pred1 Σ Γ Δ (mkApps (tRel k) args) c ->
+    {args' : list term & (c = mkApps (tRel k) args') * (All2 (pred1 Σ Γ Δ) args args') }%type.
+  Proof with solve_discr.
+    revert c. induction args using rev_ind; intros; simpl in *.
+    - depelim X...
+      * exists []. intuition auto.
+        eapply nth_error_pred1_ctx in a; eauto.
+        destruct a as [body' [eqopt _]]. rewrite H /= H0 in eqopt. discriminate.
+      * exists []; intuition auto.
+    - rewrite -mkApps_nested /= in X.
+      depelim X; try (simpl in H1; noconf H1); solve_discr.
+      * prepare_discr. apply mkApps_eq_decompose_app in H1.
+        rewrite !decompose_app_rec_mkApps in H1. noconf H1.
+      * destruct (IHargs _ H H0 X1) as [args' [-> Hargs']].
+        exists (args' ++ [N1])%list.
+        rewrite <- mkApps_nested. intuition auto.
+        eapply All2_app; auto.
+  Qed.
+
   Lemma pred1_mkApps_tConst_axiom (Σ : global_env) (Γ Δ : context)
         cst u (args : list term) cb c :
     declared_constant Σ cst cb -> cst_body cb = None ->

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -2230,7 +2230,7 @@ Lemma subslet_cumul {cf:checker_flags} Σ Δ args Γ Γ' :
   assumption_context Γ -> assumption_context Γ' -> 
   wf_local Σ (Δ ,,, Γ) ->
   wf_local Σ (Δ ,,, Γ') ->
-  All2_local_env (fun Γ Γ' _ ty ty' => Σ ;;; Δ ,,, Γ |- ty <= ty') Γ Γ' ->
+  cumul_ctx_rel Σ Δ Γ Γ' ->
   subslet Σ Δ args Γ -> subslet Σ Δ args Γ'.
 Proof.
   intros wfΣ ass ass' wf wf' a2. induction a2 in wf, wf', args, ass, ass' |- *.
@@ -2256,7 +2256,7 @@ Lemma spine_subst_cumul {cf:checker_flags} Σ Δ args Γ Γ' :
   assumption_context Γ -> assumption_context Γ' -> 
   wf_local Σ (Δ ,,, Γ) ->
   wf_local Σ (Δ ,,, Γ') ->
-  All2_local_env (fun Γ Γ' _ ty ty' => Σ ;;; Δ ,,, Γ |- ty <= ty') Γ Γ' ->
+  cumul_ctx_rel Σ Δ Γ Γ' ->
   spine_subst Σ Δ args (List.rev args) Γ -> 
   spine_subst Σ Δ args (List.rev args) Γ'.
 Proof.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -1110,9 +1110,6 @@ Fixpoint all_rels (Γ : context) (n : nat) (k : nat) :=
     end
   end.
 
-Definition expand_lets Γ :=
-  all_rels Γ 0 #|Γ|.
-
 Lemma all_rels_length Γ n k : #|all_rels Γ n k| = #|Γ|.
 Proof.
   induction Γ in n, k |- *; simpl; auto.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1162,6 +1162,37 @@ Proof.
     now rewrite Nat.add_1_r.
 Qed.
 
+Lemma lift_extended_subst' Γ k k' : extended_subst Γ (k + k') = map (lift0 k) (extended_subst Γ k').
+Proof.
+  induction Γ as [|[? [] ?] ?] in k |- *; simpl; auto.
+  - rewrite IHΓ. f_equal.
+    autorewrite with len.
+    rewrite distr_lift_subst. f_equal.
+    autorewrite with len. rewrite simpl_lift; lia_f_equal.
+  - f_equal.
+    rewrite (IHΓ (S k)) (IHΓ 1).
+    rewrite map_map_compose. apply map_ext => x.
+    rewrite simpl_lift; lia_f_equal.
+Qed.
+
+Lemma subst_extended_subst_k s Γ k k' : extended_subst (subst_context s k Γ) k' = 
+  map (subst s (k + context_assumptions Γ + k')) (extended_subst Γ k').
+Proof.
+  induction Γ as [|[na [b|] ty] Γ]; simpl; auto; rewrite subst_context_snoc /=;
+    autorewrite with len; f_equal; auto.
+  - rewrite IHΓ.
+    rewrite commut_lift_subst_rec; try lia.
+    rewrite distr_subst. autorewrite with len. f_equal.
+    now rewrite context_assumptions_fold.
+  - elim: Nat.leb_spec => //. lia.
+  - rewrite (lift_extended_subst' _ 1 k') IHΓ. 
+    rewrite (lift_extended_subst' _ 1 k'). 
+    rewrite !map_map_compose.
+    apply map_ext.
+    intros x. 
+    erewrite (commut_lift_subst_rec); lia_f_equal.
+Qed.
+
 Lemma extended_subst_subst_instance_constr u Γ n :
   map (subst_instance_constr u) (extended_subst Γ n) =
   extended_subst (subst_instance_context u Γ) n.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1120,31 +1120,7 @@ Proof.
   revert Δ; induction Γ as [|[na [b|] ty]]; intros Δ; simpl; auto.
 Qed.
 
-
-(* Smashing a context Γ with Δ depending on it is the same as smashing Γ
-     and substituting all references to Γ in Δ by the expansions of let bindings.
-  *)
-
 Arguments Nat.sub : simpl nomatch.
-
-Fixpoint extended_subst (Γ : context) (n : nat) 
-  (* Δ, smash_context Γ, n |- extended_subst Γ n : Γ *) :=
-  match Γ with
-  | nil => nil
-  | cons d vs =>
-    match decl_body d with
-    | Some b =>
-      (* Δ , vs |- b *)
-      let s := extended_subst vs n in
-      (* Δ , smash_context vs , n |- s : vs *)
-      let b' := lift (context_assumptions vs + n) #|s| b in
-      (* Δ, smash_context vs, n , vs |- b' *)
-      let b' := subst0 s b' in
-      (* Δ, smash_context vs , n |- b' *)
-      b' :: s
-    | None => tRel n :: extended_subst vs (S n)
-    end
-  end.
 
 Lemma extended_subst_length Γ n : #|extended_subst Γ n| = #|Γ|.
 Proof.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -816,10 +816,11 @@ Module PCUICTypingDef <: Typing PCUICTerm PCUICEnvironment PCUICEnvTyping.
   Definition conv := @conv.
   Definition cumul := @cumul.
   Definition smash_context := smash_context.
+  Definition expand_lets := expand_lets.
   Definition extended_subst := extended_subst.
   Definition expand_lets_ctx := expand_lets_ctx.
   Definition lift_context := lift_context.
-  Definition subst_context := subst_context.  
+  Definition subst_context := subst_context.
   Definition subst_telescope := subst_telescope.
   Definition subst_instance_context := subst_instance_context.
   Definition subst_instance_constr := subst_instance_constr.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -817,6 +817,7 @@ Module PCUICTypingDef <: Typing PCUICTerm PCUICEnvironment PCUICEnvTyping.
   Definition cumul := @cumul.
   Definition smash_context := smash_context.
   Definition extended_subst := extended_subst.
+  Definition expand_lets_ctx := expand_lets_ctx.
   Definition lift_context := lift_context.
   Definition subst_context := subst_context.  
   Definition subst_telescope := subst_telescope.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -829,6 +829,7 @@ Module PCUICTypingDef <: Typing PCUICTerm PCUICEnvironment PCUICEnvTyping.
   Definition inds := inds. 
   Definition noccur_between := noccur_between. 
   Definition closedn := closedn.
+  Definition destArity := destArity [].
 End PCUICTypingDef.
 
 Module PCUICDeclarationTyping :=

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -816,7 +816,9 @@ Module PCUICTypingDef <: Typing PCUICTerm PCUICEnvironment PCUICEnvTyping.
   Definition conv := @conv.
   Definition cumul := @cumul.
   Definition smash_context := smash_context.
+  Definition extended_subst := extended_subst.
   Definition lift_context := lift_context.
+  Definition subst_context := subst_context.  
   Definition subst_telescope := subst_telescope.
   Definition subst_instance_context := subst_instance_context.
   Definition subst_instance_constr := subst_instance_constr.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -485,7 +485,7 @@ Proof.
       * simpl.
         intros v indv. specialize (on_ctype_variance v indv).
         simpl in *. move: on_ctype_variance.
-        unfold respects_variance. destruct variance_universes as [[univs u] u'].
+        unfold respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
         intros [args idxs]. split.
         ** eapply (All2_local_env_impl args); intros.
            eapply weakening_env_cumul; eauto.

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -292,6 +292,7 @@ Module Type Typing (T : Term) (E : EnvironmentSig T) (ET : EnvTypingSig T E).
   Parameter Inline smash_context : context -> context -> context.
   Parameter Inline lift_context : nat -> nat -> context -> context.
   Parameter Inline subst_context : list term -> nat ->  context -> context.
+  Parameter Inline expand_lets : context -> term -> term.
   Parameter Inline expand_lets_ctx : context -> context -> context.
   Parameter Inline subst_telescope : list term -> nat -> context -> context.
   Parameter Inline subst_instance_context : Instance.t -> context -> context.
@@ -529,8 +530,8 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
           (subst_instance_context u' (expand_lets_ctx (ind_params mdecl) (smash_context [] (cshape_args cs)))) *
         All2 
           (conv (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl ,,, cshape_args cs))))
-          (map (subst_instance_constr u) (cshape_indices cs))
-          (map (subst_instance_constr u') (cshape_indices cs))
+          (map (subst_instance_constr u ∘ expand_lets (ind_params mdecl ,,, cshape_args cs)) (cshape_indices cs))
+          (map (subst_instance_constr u' ∘ expand_lets (ind_params mdecl ,,, cshape_args cs)) (cshape_indices cs))
       | None => False (* Monomorphic inductives have no variance attached *)
       end.
 

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -520,11 +520,12 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
       match variance_universes univs v with
       | Some (univs, u, u') =>
       All2_local_env 
-        (on_decl (fun Γ Γ' t t' => cumul (Σ, univs) (ind_arities mdecl ,,, smash_context [] (ind_params mdecl) ,,, Γ) t t'))
+        (on_decl (fun Γ Γ' t t' => 
+          cumul (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl)) ,,, Γ) t t'))
         (subst_instance_context u (smash_context [] (cshape_args cs)))
         (subst_instance_context u' (smash_context [] (cshape_args cs))) *
       All2 
-        (conv (Σ, univs) (ind_arities mdecl ,,, smash_context [] (ind_params mdecl ,,, cshape_args cs)))
+        (conv (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl ,,, cshape_args cs))))
         (map (subst_instance_constr u) (cshape_indices cs))
         (map (subst_instance_constr u') (cshape_indices cs))
       | None => False (* Monomorphic inductives have no variance attached *)

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -292,6 +292,7 @@ Module Type Typing (T : Term) (E : EnvironmentSig T) (ET : EnvTypingSig T E).
   Parameter Inline smash_context : context -> context -> context.
   Parameter Inline lift_context : nat -> nat -> context -> context.
   Parameter Inline subst_context : list term -> nat ->  context -> context.
+  Parameter Inline expand_lets_ctx : context -> context -> context.
   Parameter Inline subst_telescope : list term -> nat -> context -> context.
   Parameter Inline subst_instance_context : Instance.t -> context -> context.
   Parameter Inline subst_instance_constr : Instance.t -> term  -> term.
@@ -524,8 +525,8 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
         All2_local_env 
           (on_decl (fun Γ Γ' t t' => 
             cumul (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl)) ,,, Γ) t t'))
-          (subst_instance_context u (subst_context (extended_subst (ind_params mdecl) 0) 0 (smash_context [] (cshape_args cs))))
-          (subst_instance_context u' (subst_context (extended_subst (ind_params mdecl) 0) 0 (smash_context [] (cshape_args cs)))) *
+          (subst_instance_context u (expand_lets_ctx (ind_params mdecl) (smash_context [] (cshape_args cs))))
+          (subst_instance_context u' (expand_lets_ctx (ind_params mdecl) (smash_context [] (cshape_args cs)))) *
         All2 
           (conv (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl ,,, cshape_args cs))))
           (map (subst_instance_constr u) (cshape_indices cs))

--- a/template-coq/theories/LiftSubst.v
+++ b/template-coq/theories/LiftSubst.v
@@ -163,6 +163,16 @@ Fixpoint extended_subst (Γ : context) (n : nat)
     end
   end.
 
+Definition expand_lets_k Γ k t := 
+  (subst (extended_subst Γ 0) k (lift (context_assumptions Γ) (k + #|Γ|) t)).
+
+Definition expand_lets Γ t := expand_lets_k Γ 0 t.
+
+Definition expand_lets_k_ctx Γ k Δ := 
+  (subst_context (extended_subst Γ 0) k (lift_context (context_assumptions Γ) (k + #|Γ|) Δ)).
+
+Definition expand_lets_ctx Γ Δ := expand_lets_k_ctx Γ 0 Δ.
+
 Create HintDb terms.
 
 Ltac arith_congr := repeat (try lia; progress f_equal).

--- a/template-coq/theories/LiftSubst.v
+++ b/template-coq/theories/LiftSubst.v
@@ -144,6 +144,25 @@ Fixpoint noccur_between k n (t : term) : bool :=
   | x => true
   end.
 
+Fixpoint extended_subst (Γ : context) (n : nat) 
+  (* Δ, smash_context Γ, n |- extended_subst Γ n : Γ *) :=
+  match Γ with
+  | nil => nil
+  | cons d vs =>
+    match decl_body d with
+    | Some b =>
+      (* Δ , vs |- b *)
+      let s := extended_subst vs n in
+      (* Δ , smash_context vs , n |- s : vs *)
+      let b' := lift (context_assumptions vs + n) #|s| b in
+      (* Δ, smash_context vs, n , vs |- b' *)
+      let b' := subst0 s b' in
+      (* Δ, smash_context vs , n |- b' *)
+      b' :: s
+    | None => tRel n :: extended_subst vs (S n)
+    end
+  end.
+
 Create HintDb terms.
 
 Ltac arith_congr := repeat (try lia; progress f_equal).

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -893,6 +893,8 @@ Module TemplateTyping <: Typing TemplateTerm TemplateEnvironment TemplateEnvTypi
   Definition lift := lift.
   Definition subst := subst.
   Definition lift_context := lift_context.
+  Definition subst_context := subst_context.
+  Definition extended_subst := extended_subst.
   Definition subst_instance_constr := subst_instance_constr.
   Definition subst_instance_context := subst_instance_context.
   Definition subst_telescope := subst_telescope.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -903,6 +903,7 @@ Module TemplateTyping <: Typing TemplateTerm TemplateEnvironment TemplateEnvTypi
   Definition inds := inds.
   Definition noccur_between := noccur_between.
   Definition closedn := closedn.
+  Definition destArity := destArity [].
 End TemplateTyping.
 
 Module TemplateDeclarationTyping :=

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -890,6 +890,7 @@ Module TemplateTyping <: Typing TemplateTerm TemplateEnvironment TemplateEnvTypi
   Definition conv := @conv.
   Definition cumul := @cumul.
   Definition smash_context := smash_context.
+  Definition expand_lets := expand_lets.
   Definition expand_lets_ctx := expand_lets_ctx.
   Definition lift := lift.
   Definition subst := subst.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -890,6 +890,7 @@ Module TemplateTyping <: Typing TemplateTerm TemplateEnvironment TemplateEnvTypi
   Definition conv := @conv.
   Definition cumul := @cumul.
   Definition smash_context := smash_context.
+  Definition expand_lets_ctx := expand_lets_ctx.
   Definition lift := lift.
   Definition subst := subst.
   Definition lift_context := lift_context.


### PR DESCRIPTION
This closes the development of cumulative inductives. This uses a positivity criterion on constructors ensuring that any recursive inductive occurrence appears only on the right of constructor argument arrow types, and is always fully applied. Positivity is checked up-to unfolding of lets in parameters and arguments. Note: nested types are not allowed by this definition yet, but mutual ones are.