### PR TITLE
Update to equations 1.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - NJOBS=2
   - COMPILER="4.07.1"
   - FINDLIB_VER="1.8.0"
-  - EQUATIONS_VER="1.2.1+8.11"
+  - EQUATIONS_VER="1.2.3+8.11"
   - COQ_VER="8.11.0"
 
 install:

--- a/checker/theories/Substitution.v
+++ b/checker/theories/Substitution.v
@@ -1646,7 +1646,7 @@ Proof.
   intros wfΣ wfΓ.
   induction Δ; simpl; intros Hwf.
   intros _. clear Hwf. simpl in wfΓ. now eapply All_local_env_app in wfΓ.
-  depelim Hwf; unfold snoc in H; noconf H;
+  depelim Hwf;
   rewrite subst_context_snoc; simpl; constructor.
   eapply IHΔ; eauto. red. exists (tu.π1). simpl.
   rewrite Nat.add_0_r. eapply t0; eauto.
@@ -1887,8 +1887,7 @@ Proof.
       apply All_local_env_app_inv; intuition auto.
       clear -sub a.
       induction ctx; try constructor; depelim a.
-      -- inversion H0. subst. noconf H4.
-         rewrite subst_context_snoc.
+      -- rewrite subst_context_snoc.
          unfold snoc.
          econstructor; auto.
          eapply IHctx. eapply a.
@@ -1896,8 +1895,7 @@ Proof.
          specialize (t0 _ _ (Δ ,,, ctx) _ sub). forward t0.
          now rewrite app_context_assoc. simpl in t0.
          now rewrite subst_context_app Nat.add_0_r app_context_assoc app_length in t0.
-      -- inversion H0. subst. noconf H4.
-         rewrite subst_context_snoc.
+      -- rewrite subst_context_snoc.
          constructor; auto.
          ++ eapply IHctx. eapply a.
          ++ simpl.

--- a/checker/theories/Weakening.v
+++ b/checker/theories/Weakening.v
@@ -891,7 +891,7 @@ Proof.
   intros wfΣ wfΓ.
   induction Γ'; simpl; intros wf Hwf.
   induction Hwf; simpl; auto.
-  depelim Hwf;unfold snoc in H; noconf H;
+  depelim Hwf;
   rewrite lift_context_snoc; simpl; constructor.
   eapply IHΓ'; eauto. red. exists (tu.π1). simpl.
   rewrite Nat.add_0_r. apply t0; auto.
@@ -1079,9 +1079,7 @@ Proof.
       apply All_local_env_app_inv; intuition auto.
       clear -wf a.
       induction ctx; try constructor; depelim a.
-      -- rewrite lift_context_snoc.
-         inversion H. subst. simpl in H3; noconf H3.
-         simpl in H0; noconf H0.
+      -- rewrite lift_context_snoc.         
          constructor; auto.
          eapply IHctx. eapply a.
          simpl. destruct tu as [u tu]. exists u.
@@ -1090,7 +1088,6 @@ Proof.
          specialize (t0 eq_refl). simpl in t0.
          rewrite app_context_length lift_context_app app_context_assoc Nat.add_0_r in t0. apply t0.
       -- rewrite lift_context_snoc.
-         inversion H. subst. noconf H3.
          constructor; auto.
          ++ eapply IHctx. eapply a.
          ++ simpl.

--- a/coq-metacoq-checker.opam
+++ b/coq-metacoq-checker.opam
@@ -24,7 +24,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.11" & < "8.12~"}
-  "coq-equations" { >= "1.2" }
+  "coq-equations" { >= "1.2.3" }
   "coq-metacoq-template" {= version}
 ]
 synopsis: "Specification of Coq's type theory and reference checker implementation"

--- a/coq-metacoq-pcuic.opam
+++ b/coq-metacoq-pcuic.opam
@@ -24,7 +24,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.11" & < "8.12~"}
-  "coq-equations" {>= "1.2"}
+  "coq-equations" {>= "1.2.3"}
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}
 ]

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -276,14 +276,13 @@ Lemma type_mkProd_or_LetIn {cf:checker_flags} Σ Γ d u t s :
 Proof.
   intros wfΣ. destruct d as [na [b|] dty] => [Hd Ht|Hd Ht]; rewrite /mkProd_or_LetIn /=.
   - have wf := typing_wf_local Ht.
-    depelim wf; simpl in H; noconf H. clear l.
+    depelim wf. clear l.
     eapply type_Cumul. econstructor; eauto.
     left. red. exists [], s; intuition auto.
     transitivity (tSort s).
     eapply red_cumul. eapply red1_red. constructor. reflexivity.
   - have wf := typing_wf_local Ht.
-    depelim wf; simpl in H; noconf H.
-    clear l.
+    depelim wf; clear l.
     eapply type_Cumul. eapply type_Prod; eauto.
     left. red. exists [], (Universe.sort_of_product u s); intuition auto.
     reflexivity.
@@ -551,8 +550,7 @@ Proof.
     eapply substitution_let in t1; auto.
     eapply invert_cumul_letin_l in c; auto.
     pose proof (subslet_app_inv _ _ _ _ _ sub) as [subl subr].
-    depelim subl; simpl in H1; noconf H1.
-    depelim subl. rewrite subst_empty in H0. rewrite H0 in subr.
+    depelim subl. depelim subl. rewrite subst_empty in H0. rewrite H0 in subr.
     specialize (IHn (subst_context [b] 0 l) (subst [b] #|l| T) ltac:(rewrite subst_context_length; lia)).
     specialize (IHn _ _ subr).
     rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in t1.
@@ -565,8 +563,7 @@ Proof.
     intros Hs.
     eapply inversion_Prod in Hs as [? [? [? [? ?]]]]; auto.
     pose proof (subslet_app_inv _ _ _ _ _ sub) as [subl subr].
-    depelim subl; simpl in H1; noconf H1.
-    depelim subl. rewrite subst_empty in t2. rewrite H0 in subr.
+    depelim subl; depelim subl. rewrite subst_empty in t2. rewrite H0 in subr.
     epose proof (substitution0 _ _ na _ _ _ _ wfΣ t0 t2).
     specialize (IHn (subst_context [t1] 0 l) (subst [t1] #|l| T)).
     forward IHn. rewrite subst_context_length; lia.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -17,7 +17,6 @@ Ltac tc := try typeclasses eauto 10.
 
 Set Asymmetric Patterns.
 
-
 Lemma red1_eq_context_upto_l Σ Re Γ Δ u v :
   RelationClasses.Reflexive Re ->
   SubstUnivPreserving Re ->
@@ -2590,12 +2589,12 @@ Section RedConfluence.
     induction X in X0, Δ, Δ', X1 |- *. depelim X1. depelim X0. constructor.
     destruct x as [na b ty], y as [na' b' ty']; simpl in *.
     subst.
-    depelim X1. depelim X0. hnf in H. noconf H.
+    depelim X1. depelim X0. 
     red in o. simpl in *. subst.
     destruct y as [? [b'|] ?]; noconf e.
     constructor; auto. eapply IHX; eauto.
     red. eapply red_eq_context_upto_names; eauto.
-    hnf in H. noconf H. destruct o. depelim X0. simpl in *.
+    destruct o. depelim X0. simpl in *.
     destruct y as [? [b'|] ?]; noconf e. subst; simpl in *.
     constructor. eapply IHX; eauto.
     red.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -156,7 +156,7 @@ Section ContextReduction.
     red1_red_ctxP (Γ ,,, Δ) (Γ' ,,, Δ).
   Proof.
     induction Δ as [|[na [b|] ty] Δ]; intros; auto.
-    - elimtype False. depelim H. hnf in H0. noconf H0.
+    - elimtype False. depelim H. 
     - case; move => n b b' //. eapply IHΔ. now depelim H. apply X.
   Qed.
 
@@ -881,22 +881,16 @@ Proof.
       clear -a X4 X5.
       induction ctx; auto.
       destruct a0 as [na [b|] ty]; simpl.
-      depelim Hwf; simpl in H; noconf H.
-      unfold snoc in H. noconf H. simpl in H. noconf H.
-      unfold snoc in H. noconf H. simpl in H; noconf H.
-      simpl in H0. subst.
+      depelim Hwf.
       depelim a. specialize (IHctx _ a).
       red in l, l0. destruct l as [s Hs].
       constructor; auto; red.
       exists s; eapply t1. now eapply conv_context_app_same. auto.
       eapply t0. now eapply conv_context_app_same. auto.
-      depelim Hwf; simpl in H; noconf H.
-      unfold snoc in H. noconf H. simpl in H. noconf H.
-      simpl in H0. subst. depelim a.
+      depelim Hwf; depelim a.
       specialize (IHctx _ a).
       constructor; auto. eexists; eapply t0.
       now eapply conv_context_app_same. auto.
-      unfold snoc in H; simpl in H; noconf H. simpl in H; noconf H.
      * right. destruct s as [s [ty ?]]. exists s. eauto.
     * eapply cumul_conv_ctx; eauto.
 Qed.

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -61,9 +61,7 @@ Lemma conv_context_smash {cf:checker_flags} Σ Γ Δ Δ' :
 Proof.
   intros Hass Hconv.
   induction Hass in Δ', Hconv |- *. depelim Hconv. constructor.
-  depelim Hconv;
-  simpl in H; noconf H.
-  constructor; auto.
+  depelim Hconv; constructor; auto.
 Qed.
 
 Lemma smash_context_assumption_context {Γ Δ} : 
@@ -84,13 +82,7 @@ Qed.
 
 Lemma assumption_context_length ctx : assumption_context ctx ->
   context_assumptions ctx = #|ctx|.
-Proof.
-  induction ctx; simpl; auto.
-  destruct a as [na [b|] ty]; simpl.
-  intros. depelim H; simpl in H0; noconf H0.
-  depelim H; simpl in H0; noconf H0.
-  rewrite IHctx; auto.
-Qed.
+Proof. induction 1; simpl; auto. Qed.
 
 Lemma context_subst_length2 {ctx args s} : context_subst ctx args s -> #|args| = context_assumptions ctx.
 Proof.
@@ -100,15 +92,15 @@ Qed.
 
 Lemma context_subst_fun {ctx args s s'} : context_subst ctx args s -> context_subst ctx args s' -> s = s'.
 Proof.
-  induction 1 in s' |- *; intros H'; depelim H'; try simpl in H; try noconf H; auto.
-  eapply app_inj_tail in H0. intuition subst.
+  induction 1 in s' |- *; intros H'; depelim H'; auto.
+  eapply app_inj_tail in H. intuition subst.
   now specialize (IHX _ H').
   now specialize (IHX _ H').
 Qed.
 
 Lemma context_subst_fun' {ctx args args' s s'} : context_subst ctx args s -> context_subst ctx args' s' -> #|args| = #|args'|.
 Proof.
-  induction 1 as [ | ? ? ? ? ? ? ? IHX | ? ? ? ? ? ? ? IHX ] in args', s' |- *; intros H'; depelim H'; try simpl in H; try noconf H; auto.
+  induction 1 as [ | ? ? ? ? ? ? ? IHX | ? ? ? ? ? ? ? IHX ] in args', s' |- *; intros H'; depelim H'; auto.
   now rewrite !app_length; specialize (IHX _ _ H').
   now specialize (IHX _ _ H').
 Qed.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -21,10 +21,10 @@ Ltac pcuic := intuition eauto 5 with pcuic ||
 
 Hint Resolve eq_universe_leq_universe' : pcuic.
 
-Derive Signature for cumul assumption_context.
+Derive Signature for conv cumul assumption_context.
  
 (* Bug in Equations ... *)
-(* Derive Signature for clos_refl_trans_1n. *)
+Derive Signature for clos_refl_trans_1n. 
 
 (* So that we can use [conv_trans]... *)
 Existing Class wf.
@@ -2349,7 +2349,7 @@ Proof.
   move=> wfΣ eqsub subs subs'.
   assert(∑ s0 s'0, All2 (red Σ Γ) s s0 * All2 (red Σ Γ) s' s'0 * All2 (eq_term Σ Σ) s0 s'0)
     as [s0 [s'0 [[redl redr] eqs]]].
-  { induction eqsub in Δ, subs |- *.
+  { clear subs'; induction eqsub in Δ, subs |- *.
     * depelim subs. exists [], []; split; auto.
     * depelim subs.
     - specialize (IHeqsub _ subs) as [s0 [s'0 [[redl redr] eqs0]]].
@@ -2438,11 +2438,10 @@ Proof.
   induction Δ as [|d Δ]; intros * wfl ctxr len0; destruct Δ' as [|d' Δ']; simpl in len0; try lia.
   - constructor.
   - rewrite !subst_context_snoc. specialize (IHΔ Δ'). depelim wfl; specialize (IHΔ wfl);
-    depelim ctxr; simpl in H; noconf H; noconf len0; simpl in H; noconf H;
-    depelim c; simpl.
+    depelim ctxr; depelim c; noconf len0; simpl.
     * constructor; auto. constructor. simpl.
-      ** rewrite !Nat.add_0_r. rewrite -H.
-      eapply subst_conv; eauto. now rewrite -app_context_assoc.
+      ** rewrite !Nat.add_0_r -H.
+        eapply subst_conv; eauto. now rewrite -app_context_assoc.
     * constructor; auto. constructor; simpl;
       rewrite !Nat.add_0_r -H;
       eapply subst_conv; eauto; now rewrite -app_context_assoc.
@@ -2517,7 +2516,7 @@ Proof.
     rewrite closedn_ctx_cons in cl. apply andP in cl as [clctx cld].
     simpl in wf0.
     destruct d as [na [b|] ty] => /=.
-    * depelim wf0; simpl in H; noconf H; simpl in *.
+    * depelim wf0; simpl in *.
       simpl in cld. unfold closed_decl in cld. simpl in cld. simpl.
       apply andP in cld as [clb clty].
       constructor; auto. constructor.
@@ -2527,7 +2526,7 @@ Proof.
         apply eq_term_upto_univ_subst_instance_constr; try typeclasses eauto. auto.
       ** constructor. red.
         apply eq_term_upto_univ_subst_instance_constr; try typeclasses eauto. auto.
-    * depelim wf0; simpl in H; noconf H; simpl in *.
+    * depelim wf0; simpl in *.
       simpl in cld. unfold closed_decl in cld. simpl in cld. simpl.
       constructor; auto. constructor. apply weaken_conv; auto.
       1-2:autorewrite with len; now rewrite closedn_subst_instance_constr.
@@ -2747,7 +2746,7 @@ Proof.
   - simpl. constructor.
   - rewrite !subst_context_snoc /=.
     intros Hs subs subs'.
-    depelim wf; simpl in H; noconf H.
+    depelim wf.
     specialize (IHX wf Hs subs subs').
     constructor; auto.
     red. red in p. simpl.
@@ -2759,7 +2758,7 @@ Proof.
     now rewrite -(All2_local_env_length X).
   - rewrite !subst_context_snoc /=.
     intros Hs subs subs'.
-    depelim wf; simpl in H; noconf H.
+    depelim wf.
     specialize (IHX wf Hs subs subs').
     constructor; auto.
     red. red in p. simpl.
@@ -2816,7 +2815,7 @@ Proof.
   - simpl. constructor.
   - rewrite !subst_context_snoc /=.
     intros Hs subs subs'.
-    depelim wf; simpl in H; noconf H.
+    depelim wf.
     specialize (IHX wf Hs subs subs').
     constructor; auto. 
     red. red in p. simpl.
@@ -2826,8 +2825,7 @@ Proof.
     rewrite !subst_context_app app_context_assoc in X0; autorewrite with len in X0.
     now rewrite -(All2_local_env_length X).
   - rewrite !subst_context_snoc /=.
-    intros Hs subs subs'.
-    depelim wf; simpl in H; noconf H.
+    intros Hs subs subs'. depelim wf.
     specialize (IHX wf Hs subs subs').
     constructor; auto.
     red. red in p. simpl.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -277,20 +277,20 @@ Proof.
       specialize (H _ _ _ _ Ht sp).
       split.
       * intros prs;eapply All_local_assum_app in prs as [prd prs].
-      depelim prd; simpl in H0; noconf H0.
-      apply H.
-      clear -wfΣ prs.
-      eapply All_local_assum_subst; eauto.
-      simpl. intros.
-      destruct X as [s [Ht2 isp]].
-      exists s; firstorder.
-      rewrite Nat.add_0_r. eapply (substitution _ Γ [vdef na b ty] [b] Γ1 _ (tSort s)); auto.
-      rewrite -{1}(subst_empty 0 b).
-      repeat (constructor; auto). rewrite !subst_empty.
-      eapply typing_wf_local in Ht2.
-      rewrite app_context_assoc in Ht2. eapply All_local_env_app in Ht2 as [Ht2 _].
-      depelim Ht2; simpl in H3; noconf H3. apply l0.
-      now rewrite app_context_assoc in Ht2.
+        depelim prd.
+        apply H.
+        clear -wfΣ prs.
+        eapply All_local_assum_subst; eauto.
+        simpl. intros.
+        destruct X as [s [Ht2 isp]].
+        exists s; firstorder.
+        rewrite Nat.add_0_r. eapply (substitution _ Γ [vdef na b ty] [b] Γ1 _ (tSort s)); auto.
+        rewrite -{1}(subst_empty 0 b).
+        repeat (constructor; auto). rewrite !subst_empty.
+        eapply typing_wf_local in Ht2.
+        rewrite app_context_assoc in Ht2. eapply All_local_env_app in Ht2 as [Ht2 _].
+        depelim Ht2. apply l0.
+        now rewrite app_context_assoc in Ht2.
       * intros mdecl idec decli oib.
         now apply H.
     + rewrite it_mkProd_or_LetIn_app in sp.
@@ -321,7 +321,7 @@ Proof.
         specialize (H _ _ _ _ Ht sp).
         split.
         intros prs;eapply All_local_assum_app in prs as [prd prs].
-        depelim prd; simpl in H0; noconf H0.
+        depelim prd.
         eapply (type_Cumul _ _ _ _ ty) in t0.
         2:{ right. destruct s0 as [s' [Hs' _]]. exists s'; auto. }
         2:{ eapply conv_cumul. now symmetry. }

--- a/pcuic/theories/PCUICGeneration.v
+++ b/pcuic/theories/PCUICGeneration.v
@@ -59,11 +59,11 @@ Section Generation.
     - assumption.
     - simpl. cbn. eapply ih.
       simpl in h. pose proof (typing_wf_local h) as hc.
-      dependent induction hc; inversion H; subst.
+      dependent induction hc.
       econstructor; try eassumption. exact t0.π2.
     - simpl. cbn. eapply ih.
       pose proof (typing_wf_local h) as hc. cbn in hc.
-      dependent induction hc; inversion H; subst.
+      dependent induction hc;
       econstructor; try eassumption. exact t0.π2.
   Qed.
 

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -1027,7 +1027,7 @@ Proof.
   intros cl; revert n' t cl k Heqn'.
   eapply (term_closedn_list_ind (fun n' t => forall k, n' = #|s| + k -> 
   subst (map (lift0  n) s) k t = subst s (n + k) (lift n k t)));
-  intros; simpl; solve_all; eauto.
+  intros; simpl; f_equal; eauto.
   - subst k.
     simpl.
     destruct (Nat.leb_spec k0 n0).
@@ -1042,24 +1042,18 @@ Proof.
     destruct (Nat.leb_spec (n + k0) n0); try lia.
     reflexivity.
 
-  - simpl. f_equal. rewrite map_map_compose. solve_all.
-  - simpl; f_equal; eauto.
-    rewrite (H0 (S k0)). lia. lia_f_equal.
-  - simpl. f_equal; eauto.
-    rewrite (H0 (S k0)). lia. lia_f_equal.
-  - simpl. f_equal; eauto.
-    rewrite (H1 (S k0)). lia. lia_f_equal.
-  - simpl. f_equal; eauto.
-    rewrite map_map_compose. solve_all.
-  - simpl. f_equal; eauto.
-    rewrite map_map_compose. len.
+  - rewrite map_map_compose. solve_all.
+  - rewrite (H0 (S k0)). lia. lia_f_equal.
+  - rewrite (H0 (S k0)). lia. lia_f_equal.
+  - rewrite (H1 (S k0)). lia. lia_f_equal.
+  - rewrite map_map_compose. solve_all.
+  - rewrite map_map_compose. len.
     solve_all. rewrite map_def_map_def.
     specialize (a _ H). specialize (b (#|fix_context m| + k0)).
     forward b by lia. eapply map_def_eq_spec; auto.
     autorewrite with len in b.
     rewrite  b. lia_f_equal.
-  - simpl. f_equal; eauto.
-    rewrite map_map_compose. len.
+  - rewrite map_map_compose. len.
     solve_all. rewrite map_def_map_def.
     specialize (a _ H). specialize (b (#|fix_context m| + k0)).
     forward b by lia. eapply map_def_eq_spec; auto.

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -14,12 +14,13 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      
 Close Scope string_scope.
 
-Require Import ssreflect. 
+Require Import ssreflect.
 
 Set Asymmetric Patterns.
 Set SimplIsCbn.
 
 From Equations Require Import Equations.
+Require Import Equations.Type.Relation_Properties.
 
 Ltac len := autorewrite with len.
 Hint Rewrite reln_length : len.
@@ -1808,12 +1809,9 @@ Proof.
   have subsrel := expand_lets_cstr_head (#|ind_bodies mdecl| - S i) (cshape_args cs  ++ ind_params mdecl).
   rewrite app_length (Nat.add_comm #|(cshape_args cs)|) Nat.add_assoc in subsrel. rewrite {}subsrel in hpos.
   rewrite context_assumptions_app in hpos. depelim hpos; solve_discr.
-  simpl in H; noconf H.
   eapply All_map_inv in a.
   eapply All_app in a as [ _ a].
-  eapply All_map; eapply (All_impl a).
-  clear. intros.
-  autorewrite with len in H; simpl in H.
+  eapply All_map; eapply (All_impl a); clear; intros x H; len in H; simpl in H.
   now rewrite context_assumptions_app.
 Qed.
 
@@ -1833,7 +1831,6 @@ Proof.
   rewrite -smash_context_lift -smash_context_subst /=; len.
   lia_f_equal.
 Qed.
-
 
 Lemma expand_lets_k_ctx_length Γ k Δ : #|expand_lets_k_ctx Γ k Δ| = #|Δ|.
 Proof. now rewrite /expand_lets_k_ctx; len. Qed.
@@ -2122,7 +2119,7 @@ Lemma wt_cumul_ctx_rel_cons {cf:checker_flags} Σ Γ Δ Δ' na ty na' ty' :
   wt_cumul_ctx_rel Σ Γ (vass na ty :: Δ) (vass na' ty' :: Δ').
 Proof.
   intros []; split; simpl; try constructor; auto.
-  now depelim X0; simpl in H; noconf H.
+  now depelim X0.
 Qed.
 
 Lemma positive_cstr_closed_args_subst_arities {cf:checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ.1} {u u' Γ}
@@ -2162,8 +2159,7 @@ Proof.
       now len in wf. } 
   revert cum.
   induction cpos; simpl; rewrite ?subst_context_nil ?subst_context_snoc; try solve [constructor; auto].
-  all:len; intros cv; depelim cv; simpl in H; noconf H; simpl in H0; noconf H0.
-  depelim wf; simpl in H; noconf H.
+  all:len; intros cv; depelim cv; depelim wf.
   assert (isWfArity_or_Type Σ
   (subst_instance_context u (ind_arities mdecl) ,,,
    subst_instance_context u (smash_context [] (ind_params mdecl) ,,, Γ))
@@ -2173,10 +2169,9 @@ Proof.
   all:constructor.
   - eapply IHcpos. auto. now depelim ass. eapply cv.
   - red in o. simpl in *.
-    rewrite app_context_nil_l in t1.
-    simpl in wf.
-    eapply positive_cstr_arg_subst in t1; eauto.
-    move: t1; len; simpl.
+    rewrite app_context_nil_l in t0.
+    eapply positive_cstr_arg_subst in t0; eauto.
+    move: t0; len; simpl.
     * rewrite subst_instance_context_smash /=.
       rewrite subst_instance_context_app subst_instance_context_smash subst_context_app.
       rewrite closed_ctx_subst ?closedn_subst_instance_context // ?closedn_smash_context; eauto.
@@ -2248,7 +2243,6 @@ Proof.
   - now rewrite !(subst_instance_context_smash _ (expand_lets_ctx _ _)).
 Qed.
 
-Require Import Equations.Type.Relation_Properties.
 Lemma red_subst_instance {cf:checker_flags} (Σ : global_env) (Γ : context) (u : Instance.t) (s t : term) :
   red Σ Γ s t ->
   red Σ (subst_instance_context u Γ) (subst_instance_constr u s)
@@ -2258,8 +2252,7 @@ Proof.
   apply red_alt, clos_rt1n_rt.
   induction H. constructor.
   eapply red1_subst_instance in r.
-  econstructor 2. eapply r.
-  auto.
+  econstructor 2. eapply r. auto.
 Qed.
 
 Lemma nth_error_decl_body_ass_ctx {Γ Δ i body} : 
@@ -2868,18 +2861,14 @@ Proof.
   unfold cumul_ctx_rel.
   intros wfΣ onu onv cu cu' vari Ru.
   induction Γ as [|[na [b|] ty] tl]; simpl.
-  constructor.
-  intros H; depelim H; simpl in H0; noconf H0; simpl in H1; noconf H1.
-  econstructor; auto. red.
-  destruct o.
+  constructor. intros H; depelim H.
+  econstructor; auto. red. destruct o.
   rewrite -subst_instance_context_app in c, c0. simpl in c0 |- *.
   rewrite -subst_instance_context_app.
   split; eapply cumul_inst_variance; eauto.
 
-  intros H; depelim H; simpl in H0; noconf H0; simpl in H1; noconf H1.
-  simpl in *.
-  constructor; auto.
-  red. simpl.
+  intros H; depelim H; simpl in *.
+  constructor; auto. red. simpl.
   rewrite -subst_instance_context_app in o.
   rewrite -subst_instance_context_app.
   eapply cumul_inst_variance; eauto.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -956,7 +956,7 @@ Proof.
   move=> wfΣ wfΔ.
   generalize 0 at 1 4.
   induction Δ as [|[na [d|] ?] ?] in wfΔ |- *; simpl; auto;
-  depelim wfΔ; simpl in H; noconf H.
+  depelim wfΔ.
   * intros n. rewrite extended_subst_length. rewrite lift_closed.
     red in l0. autorewrite with len. now eapply subject_closed in l0.
     rewrite (reln_lift 1 0).
@@ -978,8 +978,7 @@ Lemma subslet_extended_subst {cf:checker_flags} Σ Δ :
   subslet Σ (smash_context [] Δ) (extended_subst Δ 0) Δ.
 Proof.
   move=> wfΣ wfΔ.
-  induction Δ as [|[na [d|] ?] ?] in wfΔ |- *; simpl; auto;
-  depelim wfΔ; simpl in H; noconf H.
+  induction Δ as [|[na [d|] ?] ?] in wfΔ |- *; simpl; auto; depelim wfΔ.
   * rewrite extended_subst_length. rewrite lift_closed.
     red in l0. autorewrite with len. now eapply subject_closed in l0.
     constructor. auto. specialize (IHΔ wfΔ).
@@ -1253,7 +1252,7 @@ Proof.
 Qed.
 
 Lemma head_tapp t1 t2 : head (tApp t1 t2) = head t1.
-Proof.  rewrite /head /decompose_app /= fst_decompose_app_rec //. Qed.
+Proof. rewrite /head /decompose_app /= fst_decompose_app_rec //. Qed.
 
 Lemma destInd_head_subst s k t f : destInd (head (subst s k t)) = Some f ->
   (destInd (head t) = Some f) +  

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -16,6 +16,11 @@ Derive NoConfusion for term.
 Derive Subterm for term.
 Derive Signature NoConfusion for All All2.
 
+Ltac simplify_IH_hyps := 
+  repeat match goal with 
+      [ H : _ |- _ ] => eqns_specialize_eqs H
+  end.
+
 Lemma size_lift n k t : size (lift n k t) = size t.
 Proof.
   revert n k t.
@@ -535,187 +540,11 @@ Section ParallelReduction.
     intros. split. apply X. apply aux. apply X.
   Defined.
 
-  (* Lemma pred1_ind_all : *)
-  (*   forall P : forall (Γ Γ' : context) (t t0 : term), Type, *)
-  (*     let P' Γ Γ' x y := ((pred1 Γ Γ' x y) * P Γ Γ' x y)%type in *)
-  (*     (forall (Γ Γ' : context) (na : name) (t0 t1 b0 b1 a0 a1 : term), *)
-  (*         pred1 (Γ ,, vass na t0) (Γ' ,, vass na t1) b0 b1 -> P (Γ ,, vass na t0) (Γ' ,, vass na t1) b0 b1 -> *)
-  (*         pred1 Γ Γ' t0 t1 -> P Γ Γ' t0 t1 -> *)
-  (*         pred1 Γ Γ' a0 a1 -> P Γ Γ' a0 a1 -> P Γ Γ' (tApp (tLambda na t0 b0) a0) (b1 {0 := a1})) -> *)
-  (*     (forall (Γ Γ' : context) (na : name) (d0 d1 t0 t1 b0 b1 : term), *)
-  (*         pred1 Γ Γ' t0 t1 -> P Γ Γ' t0 t1 -> *)
-  (*         pred1 Γ Γ' d0 d1 -> P Γ Γ' d0 d1 -> *)
-  (*         pred1 (Γ ,, vdef na d0 t0) (Γ' ,, vdef na d1 t1) b0 b1 -> *)
-  (*         P (Γ ,, vdef na d0 t0) (Γ' ,, vdef na d1 t1) b0 b1 -> P Γ Γ' (tLetIn na d0 t0 b0) (b1 {0 := d1})) -> *)
-  (*     (forall (Γ Γ' : context) (i : nat) (body : term), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         option_map decl_body (nth_error Γ' i) = Some (Some body) -> *)
-  (*         P Γ Γ' (tRel i) (lift0 (S i) body)) -> *)
-  (*     (forall (Γ Γ' : context) (i : nat), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         P Γ Γ' (tRel i) (tRel i)) -> *)
-  (*     (forall (Γ Γ' : context) (ind : inductive) (pars c : nat) (u : Instance.t) (args0 args1 : list term) *)
-  (*             (p : term) (brs0 brs1 : list (nat * term)), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         All2 (P' Γ Γ') args0 args1 -> *)
-  (*         All2_prop_eq Γ Γ' snd fst P' brs0 brs1 -> *)
-  (*         P Γ Γ' (tCase (ind, pars) p (mkApps (tConstruct ind c u) args0) brs0) (iota_red pars c args1 brs1)) -> *)
-  (*     (forall (Γ Γ' : context) (mfix : mfixpoint term) (idx : nat) (args0 args1 : list term) (narg : nat) (fn0 fn1 : term), *)
-  (*         unfold_fix mfix idx = Some (narg, fn0) -> *)
-  (*         is_constructor narg args1 = true -> *)
-  (*         All2 (P' Γ Γ') args0 args1 -> *)
-  (*         pred1 Γ Γ' fn0 fn1 -> P Γ Γ' fn0 fn1 -> P Γ Γ' (mkApps (tFix mfix idx) args0) (mkApps fn1 args1)) -> *)
-  (*     (forall (Γ Γ' : context) (ip : inductive * nat) (p0 p1 : term) (mfix : mfixpoint term) (idx : nat) *)
-  (*             (args0 args1 : list term) (narg : nat) (fn0 fn1 : term) (brs0 brs1 : list (nat * term)), *)
-  (*         unfold_cofix mfix idx = Some (narg, fn0) -> *)
-  (*         All2 (P' Γ Γ') args0 args1 -> *)
-  (*         pred1 Γ Γ' fn0 fn1 -> *)
-  (*         P Γ Γ' fn0 fn1 -> *)
-  (*         pred1 Γ Γ' p0 p1 -> *)
-  (*         P Γ Γ' p0 p1 -> *)
-  (*         All2_prop_eq Γ Γ' snd fst P' brs0 brs1 -> *)
-  (*         P Γ Γ' (tCase ip p0 (mkApps (tCoFix mfix idx) args0) brs0) (tCase ip p1 (mkApps fn1 args1) brs1)) -> *)
-  (*     (forall (Γ Γ' : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args0 args1 : list term) *)
-  (*             (narg : nat) (fn0 fn1 : term), *)
-  (*         unfold_cofix mfix idx = Some (narg, fn0) -> *)
-  (*         All2 (P' Γ Γ') args0 args1 -> *)
-  (*         pred1 Γ Γ' fn0 fn1 -> P Γ Γ' fn0 fn1 -> *)
-  (*         P Γ Γ' (tProj p (mkApps (tCoFix mfix idx) args0)) (tProj p (mkApps fn1 args1))) -> *)
-  (*     (forall (Γ Γ' : context) (c : ident) (decl : constant_body) (body : term), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         declared_constant Σ c decl -> *)
-  (*         forall u : Instance.t, cst_body decl = Some body -> *)
-  (*                                       P Γ Γ' (tConst c u) (subst_instance_constr u body)) -> *)
-  (*     (forall (Γ Γ' : context) (c : ident) (u : Instance.t), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         P Γ Γ' (tConst c u) (tConst c u)) -> *)
-  (*     (forall (Γ Γ' : context) (i : inductive) (pars narg : nat) (k : nat) (u : Instance.t) *)
-  (*             (args0 args1 : list term) (arg1 : term), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         All2 (pred1 Γ Γ') args0 args1 -> *)
-  (*         All2 (P Γ Γ') args0 args1 -> *)
-  (*         nth_error args1 (pars + narg) = Some arg1 -> *)
-  (*         P Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i k u) args0)) arg1) -> *)
-  (*     (forall (Γ Γ' : context) (na : name) (M M' N N' : term), *)
-  (*         pred1 Γ Γ' M M' -> *)
-  (*         P Γ Γ' M M' -> pred1 (Γ,, vass na M) (Γ' ,, vass na M') N N' -> *)
-  (*         P (Γ,, vass na M) (Γ' ,, vass na M') N N' -> P Γ Γ' (tLambda na M N) (tLambda na M' N')) -> *)
-  (*     (forall (Γ Γ' : context) (M0 M1 N0 N1 : term), *)
-  (*         pred1 Γ Γ' M0 M1 -> P Γ Γ' M0 M1 -> pred1 Γ Γ' N0 N1 -> P Γ Γ' N0 N1 -> P Γ Γ' (tApp M0 N0) (tApp M1 N1)) -> *)
-  (*     (forall (Γ Γ' : context) (na : name) (d0 d1 t0 t1 b0 b1 : term), *)
-  (*         pred1 Γ Γ' d0 d1 -> *)
-  (*         P Γ Γ' d0 d1 -> *)
-  (*         pred1 Γ Γ' t0 t1 -> *)
-  (*         P Γ Γ' t0 t1 -> *)
-  (*         pred1 (Γ,, vdef na d0 t0) (Γ',,vdef na d1 t1) b0 b1 -> *)
-  (*         P (Γ,, vdef na d0 t0) (Γ',,vdef na d1 t1) b0 b1 -> P Γ Γ' (tLetIn na d0 t0 b0) (tLetIn na d1 t1 b1)) -> *)
-  (*     (forall (Γ Γ' : context) (ind : inductive * nat) (p0 p1 c0 c1 : term) (brs0 brs1 : list (nat * term)), *)
-  (*         pred1 Γ Γ' p0 p1 -> *)
-  (*         P Γ Γ' p0 p1 -> *)
-  (*         pred1 Γ Γ' c0 c1 -> *)
-  (*         P Γ Γ' c0 c1 -> All2_prop_eq Γ Γ' snd fst P' brs0 brs1 -> *)
-  (*         P Γ Γ' (tCase ind p0 c0 brs0) (tCase ind p1 c1 brs1)) -> *)
-  (*     (forall (Γ Γ' : context) (p : projection) (c c' : term), *)
-  (*         pred1 Γ Γ' c c' -> P Γ Γ' c c' -> P Γ Γ' (tProj p c) (tProj p c')) -> *)
-
-  (*     (forall (Γ Γ' : context) (mfix0 : mfixpoint term) (mfix1 : list (def term)) (idx : nat), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         All2_local_env (on_decl (on_decl_over pred1 Γ Γ')) (fix_context mfix0) (fix_context mfix1) -> *)
-  (*         All2_local_env (on_decl (on_decl_over P Γ Γ')) (fix_context mfix0) (fix_context mfix1) -> *)
-  (*         All2_prop2_eq Γ Γ' (Γ ,,, fix_context mfix0) (Γ' ,,, fix_context mfix1) *)
-  (*                       dtype dbody (fun x => (dname x, rarg x)) P' mfix0 mfix1 -> *)
-  (*         P Γ Γ' (tFix mfix0 idx) (tFix mfix1 idx)) -> *)
-
-  (*     (forall (Γ Γ' : context) (mfix0 : mfixpoint term) (mfix1 : list (def term)) (idx : nat), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         All2_local_env (on_decl (on_decl_over pred1 Γ Γ')) (fix_context mfix0) (fix_context mfix1) -> *)
-  (*         All2_local_env (on_decl (on_decl_over P Γ Γ')) (fix_context mfix0) (fix_context mfix1) -> *)
-  (*         All2_prop2_eq Γ Γ' (Γ ,,, fix_context mfix0) (Γ' ,,, fix_context mfix1) dtype dbody (fun x => (dname x, rarg x)) P' mfix0 mfix1 -> *)
-  (*         P Γ Γ' (tCoFix mfix0 idx) (tCoFix mfix1 idx)) -> *)
-  (*     (forall (Γ Γ' : context) (na : name) (M0 M1 N0 N1 : term), *)
-  (*         pred1 Γ Γ' M0 M1 -> *)
-  (*         P Γ Γ' M0 M1 -> pred1 (Γ,, vass na M0) (Γ' ,, vass na M1) N0 N1 -> *)
-  (*         P (Γ,, vass na M0) (Γ' ,, vass na M1) N0 N1 -> P Γ Γ' (tProd na M0 N0) (tProd na M1 N1)) -> *)
-  (*     (forall (Γ Γ' : context) (ev : nat) (l l' : list term), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         All2 (P' Γ Γ') l l' -> P Γ Γ' (tEvar ev l) (tEvar ev l')) -> *)
-  (*     (forall (Γ Γ' : context) (t : term), *)
-  (*         All2_local_env (on_decl pred1) Γ Γ' -> *)
-  (*         All2_local_env (on_decl P) Γ Γ' -> *)
-  (*         pred_atom t -> P Γ Γ' t t) -> *)
-  (*     forall (Γ Γ' : context) (t t0 : term), pred1 Γ Γ' t t0 -> P Γ Γ' t t0. *)
-  (* Proof. *)
-  (*   intros. revert Γ Γ' t t0 X20. *)
-  (*   fix aux 5. intros Γ Γ' t t'. *)
-  (*   move aux at top. *)
-  (*   destruct 1; match goal with *)
-  (*               | |- P _ _ (tFix _ _) (tFix _ _) => idtac *)
-  (*               | |- P _ _ (tCoFix _ _) (tCoFix _ _) => idtac *)
-  (*               | |- P _ _ (mkApps (tFix _ _) _) _ => idtac *)
-  (*               | |- P _ _ (tCase _ _ (mkApps (tCoFix _ _) _) _) _ => idtac *)
-  (*               | |- P _ _ (tProj _ (mkApps (tCoFix _ _) _)) _ => idtac *)
-  (*               | |- P _ _ (tRel _) _ => idtac *)
-  (*               | |- P _ _ (tConst _ _) _ => idtac *)
-  (*               | H : _ |- _ => eapply H; eauto *)
-  (*               end. *)
-  (*   - simpl. apply X1; auto. *)
-  (*     apply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - simpl. apply X2; auto. *)
-  (*     apply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - apply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - eapply (All2_All2_prop (P:=pred1) (Q:=P') a0 ((extendP aux) Γ Γ')). *)
-  (*   - eapply (All2_All2_prop_eq (P:=pred1) (Q:=P') (f:=snd) (g:=fst) a1 (extendP aux Γ Γ')). *)
-  (*   - eapply X4; eauto. *)
-  (*     eapply (All2_All2_prop (P:=pred1) (Q:=P') a (extendP aux Γ Γ')). *)
-  (*   - eapply X5; eauto. *)
-  (*     eapply (All2_All2_prop (P:=pred1) (Q:=P') a (extendP aux Γ Γ')). *)
-  (*     eapply (All2_All2_prop_eq (P:=pred1) (Q:=P') (f:=snd) a0 (extendP aux Γ Γ')). *)
-  (*   - eapply X6; eauto. *)
-  (*     eapply (All2_All2_prop (P:=pred1) (Q:=P') a (extendP aux Γ Γ')). *)
-  (*   - eapply X7; eauto. *)
-  (*     apply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - eapply X8; eauto. *)
-  (*     apply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - apply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - eapply (All2_All2_prop (P:=pred1) (Q:=P) a0). intros. apply (aux _ _ _ _ X20). *)
-  (*   - eapply (All2_All2_prop_eq (P:=pred1) (Q:=P') (f:=snd) a (extendP aux Γ Γ')). *)
-  (*   - eapply X15. *)
-  (*     eapply (All2_local_env_impl a). intros. apply X20. *)
-  (*     eapply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*     eapply (All2_local_env_impl a0). intros. red. exact X20. *)
-  (*     eapply (All2_local_env_impl a0). intros. red. apply (aux _ _ _ _ X20). *)
-  (*     eapply (All2_All2_prop2_eq (Q:=P') (f:=dtype) (g:=dbody) a1 (extendP aux)). *)
-  (*   - eapply X16. *)
-  (*     eapply (All2_local_env_impl a). intros. apply X20. *)
-  (*     eapply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*     eapply (All2_local_env_impl a0). intros. red. exact X20. *)
-  (*     eapply (All2_local_env_impl a0). intros. red. apply (aux _ _ _ _ X20). *)
-  (*     eapply (All2_All2_prop2_eq (Q:=P') (f:=dtype) (g:=dbody) a1 (extendP aux)). *)
-  (*   - eapply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (*   - eapply (All2_All2_prop (P:=pred1) (Q:=P') a0 (extendP aux Γ Γ')). *)
-  (*   - eapply (All2_local_env_impl a). intros. apply (aux _ _ _ _ X20). *)
-  (* Defined. *)
-
   Lemma pred1_ind_all_ctx :
     forall (P : forall (Γ Γ' : context) (t t0 : term), Type)
            (Pctx : forall (Γ Γ' : context), Type),
-           (* (Plist : forall {A} (f : A -> term), context -> context -> list A -> list A -> Type), *)
       let P' Γ Γ' x y := ((pred1 Γ Γ' x y) * P Γ Γ' x y)%type in
       (forall Γ Γ', All2_local_env (on_decl pred1) Γ Γ' -> All2_local_env (on_decl P) Γ Γ' -> Pctx Γ Γ') ->
-      (* (forall (f : A -> term) (l l' : list A) (g : A -> B), *)
-      (*     All2 (on_Trel pred1 f) l l' -> *)
-      (*     All2 (on_Trel P f) l l' -> *)
-      (*     All2 (on_Trel eq g) l l' -> *)
-      (*     Plist f Γ Γ' l l') -> *)
       (forall (Γ Γ' : context) (na : name) (t0 t1 b0 b1 a0 a1 : term),
           pred1 (Γ ,, vass na t0) (Γ' ,, vass na t1) b0 b1 -> P (Γ ,, vass na t0) (Γ' ,, vass na t1) b0 b1 ->
           pred1 Γ Γ' t0 t1 -> P Γ Γ' t0 t1 ->
@@ -1146,7 +975,7 @@ Section ParallelWeakening.
     rewrite map_length. generalize (#|mfix|) at 2 3. induction n. simpl. reflexivity.
     simpl. rewrite - IHn. f_equal. apply H.
   Qed.
-
+    
   Lemma weakening_pred1 Σ Γ Γ' Γ'' Δ Δ' Δ'' M N : wf Σ ->
     pred1 Σ (Γ ,,, Γ') (Δ ,,, Δ') M N ->
     #|Γ| = #|Δ| ->
@@ -1197,17 +1026,16 @@ Section ParallelWeakening.
         induction a0; rewrite ?lift_context_snoc0; cbn; constructor; pcuic.
         * apply IHa0.
           -- depelim predΓ'.
-             ++ hnf in H, H0. noconf H. noconf H0. assumption.
-             ++ hnf in H, H0. noconf H.
+             ++ assumption.
           -- unfold ",,,". lia.
         * now rewrite !Nat.add_0_r.
         * apply IHa0; auto. depelim predΓ'.
-          all: hnf in H, H0. all: noconf H. noconf H0. assumption.
+          assumption.
         * split; red; now rewrite !Nat.add_0_r.
 
     - (* Beta *)
       specialize (forall_Γ _ (Γ'0,, vass na t0) eq_refl _ (Δ' ,, vass na t1) eq_refl heq_length _ _ X5).
-      specialize (forall_Γ1 _ _ eq_refl heq_length _ _ X5).
+      specialize (forall_Γ1 heq_length _ _ X5).
       econstructor; now rewrite !lift_context_snoc0 !Nat.add_0_r in forall_Γ.
 
     - (* Zeta *)
@@ -1946,14 +1774,10 @@ Section ParallelSubstitution.
     - constructor; auto with pcuic.
       forward H by pcuic.
       + constructor; pcuic. apply pred1_pred1_ctx in redN.
-        depelim redN. all: hnf in H, H0. all: noconf H.
-        noconf H0. pcuic.
+        depelim redN. pcuic.
       + simpl in H |- *. apply pred1_pred1_ctx in redN; pcuic.
-        depelim redN. all: hnf in H, H0. all: noconf H.
-        noconf H0. pcuic.
+        depelim redN; pcuic.
     - pose proof (pred1_pred1_ctx _ redN). depelim X.
-      all: hnf in H0, H1. all: noconf H0.
-      noconf H1.
       apply H; pcuic. auto. constructor; pcuic.
   Qed.
 
@@ -1965,8 +1789,6 @@ Section ParallelSubstitution.
     intros wfΣ redM redN.
     pose proof (substitution_let_pred1 Σ Γ [vdef na M A] [] Δ [vdef na' M' A'] [] [M] [M'] N N' wfΣ) as H.
     pose proof (pred1_pred1_ctx _ redN). depelim X.
-    all: hnf in H0, H1. all: noconf H0.
-    noconf H1.
     simpl in o.
     forward H.
     - pose proof (psubst_vdef Σ Γ Δ [] [] [] [] na na' M M' A A').

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -43,7 +43,7 @@ Lemma map_In_spec {A B : Type} (f : A → B) (l : list A) :
   map_In l (fun (x : A) (_ : In x l) => f x) = List.map f l.
 Proof.
   remember (fun (x : A) (_ : In x l) => f x) as g.
-  funelim (map_In l g); rewrite ?H; trivial.
+  funelim (map_In l g) => //; simpl; rewrite (H f0); trivial.
 Qed.
 
 Section list_size.
@@ -479,7 +479,6 @@ Section Pred1_inversion.
     - exists []. intuition auto.
     - rewrite <- mkApps_nested in X.
       depelim X...
-      * simpl in H1; noconf H1. solve_discr.
       * prepare_discr. apply mkApps_eq_decompose_app in H1.
         rewrite !decompose_app_rec_mkApps in H1. noconf H1.
       * destruct (IHargs _ H H0 X1) as [args' [-> Hargs']].
@@ -2111,7 +2110,7 @@ Section Rho.
     assert ((Nat.pred #|mfix0| - (#|mfix0| - S #|l|)) = #|l|) by lia.
     assert ((Nat.pred #|mfix0| - (#|mfix0| - S #|l'|)) = #|l'|) by lia.
     rewrite H0 H1.
-    intros. depelim Hctxs. red in o. simpl in H2, H3. noconf H2; noconf H3.
+    intros. depelim Hctxs. red in o. 
     red in o. noconf Heqlen. simpl in H.
     rewrite -H.
     econstructor. unfold mapi in IHAll2.
@@ -2147,7 +2146,6 @@ Section Rho.
       rewrite rho_ctx_app in a2. unfold on_Trel.
       eapply All2_map_left. simpl. eapply a2.
       eapply All2_map_left. simpl. solve_all. }
-    simpl in H2. noconf H2.
   Qed.
 
 (* TODO generalize fix/cofix subst by tFix/tCofix constructor! *)
@@ -2192,8 +2190,6 @@ Section Rho.
     assert ((Nat.pred #|mfix0| - (#|mfix0| - S #|l'|)) = #|l'|) by lia.
     rewrite H0 H1.
     intros. depelim Hctxs. red in o.
-    simpl in H2. noconf H2.
-    simpl in H3. noconf H3.
     constructor. unfold mapi in IHAll2.
     forward IHAll2 by lia.
     forward IHAll2 by lia.
@@ -2224,7 +2220,6 @@ Section Rho.
       rewrite rho_ctx_app in a2. unfold on_Trel.
       eapply All2_map_left. simpl. eapply a2.
       eapply All2_map_left. simpl. solve_all. }
-    hnf in H2. noconf H2.
   Qed.
 
   Definition pred1_subst Γ Δ Δ' σ τ :=
@@ -2526,14 +2521,12 @@ Section Rho.
     cbn in H. destruct c as [? [?|] ?]; noconf H.
     depelim X0.
     - destruct Δ'. noconf H. destruct c as [? [?|] ?]; noconf H.
-      simpl in H. noconf H. simpl in H. noconf H.
       constructor. eapply IHΔ. auto. red. red in o. intros.
       red in o. rewrite !rho_ctx_app. eapply o.
     - destruct Δ'. noconf H. destruct c as [? [?|] ?]; noconf H.
-      simpl in H. noconf H. red in o. destruct o.
+      destruct o.
       constructor. eapply IHΔ. auto. red. red in o, o0. intros.
       rewrite !rho_ctx_app. split; eauto.
-      simpl in H. noconf H.
   Qed.
 
   Lemma pred1_rho_fix_context_2 (Γ Γ' : context) (m m' : mfixpoint term) :

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -1453,17 +1453,17 @@ Section SRContext.
     specialize (X r).
     assert(wf_local Σ Γ').
     apply typing_wf_local in H.
-    induction H in Γ', r, X |-  *; depelim r; simpl in H; noconf H.
+    induction H in Γ', r, X |-  *; depelim r.
     - constructor; auto. red in o.
-      destruct t2 as [s Hs]. exists s.
+      destruct t1 as [s Hs]. exists s.
       eapply subject_reduction1 in Hs; eauto.
-    - depelim X; simpl in H; noconf H; simpl in H0; noconf H0.
+    - depelim X.
       constructor; auto. 
       destruct t1 as [s Hs]. exists s.
       eapply context_conversion; eauto.
-    - depelim X; simpl in H; noconf H; simpl in H0; noconf H0.
-      red in o. destruct t2 as [s Hs].
-      simpl in t3.
+    - depelim X.
+      red in o. destruct t1 as [s Hs].
+      simpl in t2.
       destruct o as [[r ->]|[r <-]].
 
       constructor; auto. exists s; auto.
@@ -1472,10 +1472,8 @@ Section SRContext.
       eapply type_Cumul; eauto. right. exists s.
       eapply subject_reduction1; eauto.
       now apply red_cumul, red1_red.
-    - depelim X; simpl in H; noconf H; simpl in H0; noconf H0.
-      destruct t2 as [s Hs].
-      simpl in t3.
-
+    - depelim X. destruct t1 as [s Hs].
+      simpl in t2.
       constructor; auto. exists s; auto.
       eapply context_conversion; eauto.
       red; eapply context_conversion; eauto.
@@ -1514,7 +1512,6 @@ Section SRContext.
     all: constructor; cbnr; eauto.
   Qed.
 
-
   Lemma wf_local_red {Σ Γ Γ'} :
     wf Σ.1 ->
     red_ctx Σ.1 Γ Γ' -> wf_local Σ Γ -> wf_local Σ Γ'.
@@ -1524,7 +1521,6 @@ Section SRContext.
     apply eq_context_upto_names_upto_names in e.
     eauto using wf_local_alpha.
   Qed.
-
 
   Lemma wf_local_subst1 Σ (wfΣ : wf Σ.1) Γ na b t Γ' :
       wf_local Σ (Γ ,,, [],, vdef na b t ,,, Γ') ->

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -55,13 +55,12 @@ induction Δ in s, s', Δ' |- *; simpl; auto; move=> sub'.
   move:(subslet_length sub') => /=.
   rewrite /snoc /= subst_context_length /= => Hlen.
   destruct a as [na [b|] ty].
-  * depelim sub'; simpl in H; noconf H.
-    simpl in t0, Hlen.
+  * depelim sub'; simpl in t0, Hlen.
     rewrite -subst_app_simpl' /=. lia.
     constructor. eauto.
     now rewrite - !subst_app_simpl' in t0; try lia.
   * rewrite /subst_decl /map_decl /snoc /= in sub'.
-    depelim sub'; simpl in H; noconf H. simpl in Hlen.
+    depelim sub'; simpl in Hlen.
     rewrite - !subst_app_simpl' in t0; try lia.
     simpl; constructor; eauto.
 Qed.
@@ -133,10 +132,10 @@ Proof.
       rewrite H [firstn _ [u]]firstn_0 // app_nil_r in Hr |- *.
       specialize (IHctx Hr). rewrite app_assoc.
       now econstructor.
-    * destruct a as [na' [b'|] ty']; simpl in *; simpl in H; noconf H. simpl in H.
-      rewrite skipn_S in Hl, Hr, H. rewrite -H.
-      pose proof (context_subst_length _ _ _ Hl). rewrite subst_context_length in H0.
-      rewrite {3}H0 -subst_app_simpl [firstn #|ctx| _ ++ _]firstn_skipn. constructor.
+    * destruct a as [na' [b'|] ty']; simpl in *; noconf H.
+      rewrite skipn_S in Hl, Hr, H. subst b.
+      pose proof (context_subst_length _ _ _ Hl). rewrite subst_context_length in H.
+      rewrite {3}H -subst_app_simpl [firstn #|ctx| _ ++ _]firstn_skipn. constructor.
       apply IHctx => //.
 Qed.
 
@@ -214,8 +213,8 @@ Lemma spine_subst_inj_subst {cf:checker_flags} {Σ Γ inst s s' Δ} :
   s = s'.
 Proof.
   intros [_ _ c _] [_ _ c' _].
-  induction c in s', c' |- *; depelim c'; simpl; auto;
-  simpl in H; noconf H. eapply app_inj_tail in H0 as [-> ->].
+  induction c in s', c' |- *; depelim c'; simpl; auto. 
+  apply app_inj_tail in H as [-> ->].
   f_equal; eauto.
   specialize (IHc _ c'). now subst. 
 Qed.
@@ -299,7 +298,7 @@ Proof.
         forward IHn. {
           rewrite app_context_assoc in wfΓ'.
           apply All_local_env_app in wfΓ' as [wfb wfa].
-          depelim wfb. simpl in H; noconf H. simpl in H. noconf H.
+          depelim wfb.
           eapply substitution_wf_local. eauto. 
           epose proof (cons_let_def Σ Γ [] [] na b ty ltac:(constructor)).
           rewrite !subst_empty in X. eapply X. auto.
@@ -322,8 +321,7 @@ Proof.
         * apply subslet_app. now rewrite subst_empty.
           repeat constructor.
           rewrite app_context_assoc in wfΓ'. simpl in wfΓ'.
-          apply wf_local_app in wfΓ'. depelim wfΓ'; simpl in H; noconf H.
-          now rewrite !subst_empty.
+          apply wf_local_app in wfΓ'. depelim wfΓ'; now rewrite !subst_empty.
       + rewrite PCUICCtxShape.context_assumptions_app /=.
         depelim Hsp. 
         now eapply cumul_Prod_Sort_inv in c.
@@ -334,16 +332,14 @@ Proof.
         forward IHn. {
           rewrite app_context_assoc in wfΓ'.
           apply All_local_env_app in wfΓ' as [wfb wfa]; eauto.
-          depelim wfb. simpl in H; noconf H.
+          depelim wfb. 
           eapply substitution_wf_local. auto. 
           constructor. constructor. rewrite subst_empty.
           eapply type_Cumul. eapply t.
           right; eapply l0.
           eapply conv_cumul; auto. now symmetry. 
           eapply All_local_env_app_inv; eauto; split.
-          constructor; eauto. eapply isWAT_tProd in i; intuition eauto.
-          simpl in H; noconf H.
-        }
+          constructor; eauto. eapply isWAT_tProd in i; intuition eauto. }
         forward IHn by rewrite subst_context_length; lia.
         specialize (IHn s tl s'). 
         rewrite context_assumptions_subst in IHn.
@@ -364,7 +360,7 @@ Proof.
         * apply subslet_app => //.
           repeat constructor.
           rewrite app_context_assoc in wfΓ'. simpl in wfΓ'.
-          apply wf_local_app in wfΓ'. depelim wfΓ'; simpl in H; noconf H.
+          apply wf_local_app in wfΓ'. depelim wfΓ'.
           rewrite !subst_empty. red in l0.
           eapply type_Cumul; eauto. eapply conv_cumul. now symmetry.
 Qed.
@@ -408,13 +404,13 @@ Proof.
   * rewrite it_mkProd_or_LetIn_app /= /mkProd_or_LetIn /=.
     rewrite rev_app_distr in Hsub. 
     simpl in Hsub. destruct args; try discriminate.
-    simpl in Hargs. rewrite Nat.add_1_r in Hargs. noconf Hargs. simpl in H; noconf H.
+    simpl in Hargs. rewrite Nat.add_1_r in Hargs. noconf Hargs.
     intros subs. rewrite app_context_assoc in subs.    
     specialize (IHn Δ _ T args s _ ltac:(lia) Hsub Hsp H subs).
     intros Har.
     forward IHn. now rewrite it_mkProd_or_LetIn_app.
     eapply subslet_app_inv in subs as [subsl subsr].
-    depelim subsl; simpl in H1; noconf H1.
+    depelim subsl.
     have Hskip := make_context_subst_skipn Hsub. 
     rewrite List.rev_length in Hskip. rewrite Hskip in H0; noconf H0.
     simpl; eapply typing_spine_prod; auto; first
@@ -503,7 +499,7 @@ induction Γ in inst, s' |- *.
 + intros H' Hsub. 
   rewrite subst_context_snoc0 in Hsub.
   destruct a as [na [b|] ty];
-  depelim Hsub; simpl in H; noconf H.
+  depelim Hsub.
   - specialize (IHΓ _ _ H' Hsub).
     assert(#|Γ| = #|s0|) as ->.
     { apply context_subst_length in Hsub.
@@ -526,19 +522,14 @@ Lemma spine_subst_conv {cf:checker_flags} Σ Γ inst insts Δ inst' insts' Δ' :
 Proof.
 move=> wfΣ [_ wf cs sl] [_ _ cs' sl'] cv.
 move: inst insts cs wf sl inst' insts' cs' sl'.
-induction cv; intros; depelim cs ; depelim cs';
-  try (simpl in H; noconf H); try (simpl in H0; noconf H0).
+induction cv; intros; depelim cs ; depelim cs'.  
 - constructor; auto.    
 - eapply All2_app_inv in X as [[l1 l2] [[? ?] ?]].
   depelim a2. depelim a2. apply app_inj_tail in e as [? ?]; subst.
-  depelim sl; depelim sl'; simpl in H; noconf H; simpl in H0; noconf H0;
-    try (simpl in H1; noconf H1).
-  depelim wf; simpl in H; noconf H.
+  depelim sl; depelim sl'; depelim wf.
   specialize (IHcv _ _ cs wf sl _ _ cs' sl' a1).
   constructor; auto.
-- depelim sl; depelim sl'; simpl in H; noconf H; simpl in H0; noconf H0;
-    try (simpl in H1; noconf H1); try (simpl in H2; noconf H2).
-  depelim wf; simpl in H; noconf H.
+- depelim sl; depelim sl'; depelim wf.
   specialize (IHcv _ _ cs wf sl _ _ cs' sl' X).
   constructor; auto.
   eapply (subst_conv _ _ _ []); eauto.
@@ -839,7 +830,7 @@ Proof.
     * constructor. rewrite /subst1 subst_it_mkProd_or_LetIn.
       rewrite Nat.add_0_r.
       apply subslet_app_inv in subsl as [subsl subsl'].
-      depelim subsl; simpl in H0; noconf H0. depelim subsl.
+      depelim subsl; depelim subsl.
       apply context_subst_app in cs as [cs cs'].
       simpl in *. rewrite skipn_0 in cs.
       specialize (X (subst_context (skipn #|Γ0| s) 0 Γ0) ltac:(now autorewrite with len) _ _ 
@@ -851,15 +842,15 @@ Proof.
       now autorewrite with len in subsl'.
       rewrite -H.  now rewrite firstn_skipn.
     * apply subslet_app_inv in subsl as [subsl subsl'].
-      depelim subsl; simpl in H0; noconf H0. depelim subsl.
+      depelim subsl; depelim subsl.
       apply context_subst_app in cs as [cs cs'].
       simpl in *.
-      destruct args. depelim cs'; simpl in H; noconf H.
+      destruct args. depelim cs'.
       depelim cs'. discriminate.
       simpl in *. rewrite skipn_S skipn_0 in cs.
       rewrite subst_empty in t0.
-      depelim cs'; simpl in H; noconf H. depelim cs'. noconf H0.
-      rewrite H1 in H2. noconf H2.
+      depelim cs'; depelim cs'. simpl in H; noconf H.
+      rewrite H1 in H0. noconf H0.
       constructor; auto.
       rewrite /subst1 subst_it_mkProd_or_LetIn.
       rewrite Nat.add_0_r.
@@ -924,17 +915,13 @@ Lemma ctx_inst_sub_eq {cf:checker_flags} {Σ Γ} {Δ : context} {Δ' args args'}
   args' = args ->
   Δ = Δ' -> ctx_inst_sub c = ctx_inst_sub d.
 Proof.
-  intros -> ->.
-  induction c; depelim d; auto; simpl in H; noconf H.
-  simpl in *. subst d0. simpl. now rewrite (IHc d).
-  simpl in *. subst d0; simpl. now rewrite (IHc d).
+  intros -> ->. induction c; depelim d; auto; simpl in *; now rewrite (IHc d).
 Qed.
 
 Lemma ctx_inst_subst_length {cf:checker_flags} {Σ Γ} {Δ : context} {args} (c : ctx_inst Σ Γ args Δ) :
   #|ctx_inst_sub c| = #|Δ|.
 Proof.
-  induction c; simpl; auto; try lia.
-  rewrite app_length IHc subst_telescope_length /=; lia.
+  induction c; simpl; auto; try lia;
   rewrite app_length IHc subst_telescope_length /=; lia.
 Qed.
 
@@ -947,11 +934,9 @@ Proof.
   rewrite app_nil_r; apply ctx_inst_sub_eq. now rewrite skipn_0.
   now rewrite subst_telescope_empty.
   simpl in *. destruct d as [na [b|] ty]; simpl in *.
-  depelim c; simpl in H0; noconf H0; simpl in *. subst c0; simpl.
-  depelim x; simpl in H; noconf H; simpl in *.
+  depelim c; simpl in *. 
+  depelim x; simpl in *.
   injection H0. discriminate. injection H0. discriminate.
-  noconf H0. simpl in *.
-  subst x0. simpl.
   specialize (H (subst_telescope [b] 0 Γ0) ltac:(now rewrite /subst_telescope mapi_length)).
   revert c. rewrite subst_telescope_app.
   intros c.
@@ -959,25 +944,22 @@ Proof.
   revert H. rewrite context_assumptions_subst_telescope.
   intros.
   specialize (H x).
-  revert c1. rewrite subst_app_telescope.
+  revert c0. rewrite subst_app_telescope.
   rewrite (ctx_inst_subst_length x) subst_telescope_length.
   intros c1.
   now rewrite (H c1) app_assoc.
-  
-  depelim c; simpl in H0; noconf H0; simpl in *. subst c0; simpl.
-  depelim x; simpl in H; noconf H; simpl in *. noconf H0; simpl in *.
-  subst x0. simpl.
+
+  depelim c; depelim x; simpl in *.
   specialize (H (subst_telescope [i] 0 Γ0) ltac:(now rewrite /subst_telescope mapi_length)).
   revert c. rewrite subst_telescope_app. intros c.
   specialize (H _ _ c). simpl in *.
   revert H. rewrite context_assumptions_subst_telescope.
   intros. 
   specialize (H x).
-  revert c1. rewrite subst_app_telescope.
+  revert c0. rewrite subst_app_telescope.
   rewrite (ctx_inst_subst_length x) subst_telescope_length.
   intros c1.
   now rewrite (H c1) app_assoc.
-  noconf H0.
 Qed.
 
 Lemma context_assumptions_rev Γ : context_assumptions (List.rev Γ) = context_assumptions Γ.
@@ -989,14 +971,13 @@ Qed.
 Lemma ctx_inst_def {cf:checker_flags} {Σ Γ args na b t} (c : ctx_inst Σ Γ args [vdef na b t]) :
   ((args = []) * (ctx_inst_sub c = [b]))%type.
 Proof.
-  depelim c; simpl in H; noconf H.
-  simpl in c. depelim c; simpl in *. subst c0. constructor; simpl in *; auto.
+  depelim c; simpl in c. depelim c; simpl in *. constructor; simpl in *; auto.
 Qed.
 
 Lemma ctx_inst_ass {cf:checker_flags} {Σ Γ args na t} (c : ctx_inst Σ Γ args [vass na t]) : 
   ∑ i, ((args = [i]) * (lift_typing typing Σ Γ i (Some t)) * (ctx_inst_sub c = [i]))%type.
 Proof.
-  depelim c; simpl in H; noconf H; simpl in *. subst c0.
+  depelim c; simpl in *. 
   depelim c. exists i; constructor; auto.
 Qed.
 
@@ -1028,7 +1009,7 @@ Proof.
     rewrite skipn_S skipn_0 in subr.
     generalize dependent x. rewrite context_assumptions_rev.
     intros.
-    depelim wfΔ; simpl in H; noconf H.
+    depelim wfΔ.
     specialize (IHΔ _ wfΔ _ subr). constructor; auto.
     red in l0. eapply (substitution _ _ _ _ []); eauto.
   - pose proof (ctx_inst_ass c) as [i [[Hargs Hty] Hinst]].
@@ -1037,7 +1018,7 @@ Proof.
     rewrite skipn_S skipn_0 in subr subl.
     generalize dependent x. rewrite context_assumptions_rev.
     intros.
-    depelim wfΔ; simpl in H; noconf H.
+    depelim wfΔ.
     specialize (IHΔ _ wfΔ _ subr). constructor; auto.
 Qed.
 
@@ -1409,7 +1390,7 @@ Proof.
       pose proof wf as wf'.
       rewrite -eql in wf'.
       rewrite app_context_assoc in wf'.
-      apply wf_local_app in wf'. depelim wf'; simpl in H0; noconf H0.
+      apply wf_local_app in wf'. depelim wf'.
       eapply (weakening_typing); auto.
     * rewrite app_length /= Nat.add_1_r in IHc.
       constructor; auto.
@@ -1417,7 +1398,7 @@ Proof.
       pose proof wf as wf'.
       rewrite -eql in wf'.
       rewrite app_context_assoc in wf'.
-      apply wf_local_app in wf'. depelim wf'; simpl in H; noconf H.
+      apply wf_local_app in wf'. depelim wf'.
       rewrite Nat.add_0_r.
 
       eapply type_Cumul.
@@ -1717,7 +1698,7 @@ Proof.
         repeat constructor. rewrite !subst_empty.
         eapply All_local_env_app in wfΓΔ as [_ wf].
         eapply All_local_env_app in wf as [wfd _].
-        depelim wfd; simpl in H; noconf H. apply l0.
+        depelim wfd. apply l0.
       * rewrite subst_app_simpl.
         move: (context_subst_length _ _ _ sps).
         now  autorewrite with len => <-.
@@ -1768,113 +1749,6 @@ Proof.
         now autorewrite with len => <-.
       * apply conv_cumul. now symmetry.
 Qed.
-
-(*
-Lemma wf_arity_spine_inv {cf : checker_flags} {Σ : global_env × universes_decl}
-  {Γ Δ Δ' : context} {T args args' T'} :
-  wf Σ.1 ->
-  #|args| = context_assumptions Δ ->
-  wf_local Σ Γ ->
-  wf_arity_spine Σ Γ (it_mkProd_or_LetIn Δ T) (args ++ args') T' ->
-  ∑ args_sub,
-     spine_subst Σ Γ args args_sub Δ *
-     wf_arity_spine Σ Γ (subst0 args_sub T) args' T'.
-Proof.
-  intros wfΣ len wfΓ.
-  revert args len T.
-  induction Δ as [|d Δ] using ctx_length_rev_ind; intros args. simpl.
-  destruct args; simpl; try discriminate.
-  - intros _ T sp; exists []; split; [constructor|]; auto.
-    now rewrite subst_empty.
-  - rewrite context_assumptions_app => eq T sp.
-    destruct sp as [wat sp].
-    assert (wfΓΔ := isWAT_it_mkProd_or_LetIn_wf_local _ _ (Δ ++ [d]) _ _ wat).
-    rewrite it_mkProd_or_LetIn_app in sp, wat.
-    destruct d as [? [b|] ?]; simpl in *.
-    + rewrite Nat.add_0_r in eq.
-      eapply arity_spine_letin_inv in sp => //.
-      rewrite /subst1 subst_it_mkProd_or_LetIn in sp.
-      specialize (X (subst_context [b] 0 Δ) ltac:(now autorewrite with len)).
-      specialize (X args ltac:(now rewrite context_assumptions_subst)).
-      rewrite Nat.add_0_r in sp.
-      eapply isWAT_tLetIn_red in wat as wat' => //.
-      rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in wat'; auto.
-      destruct (X _ (Build_wf_arity_spine _ _ _ _ _ _ wat' sp)) as [args_sub [sps sp']].
-      clear wat'.
-      exists (args_sub ++ [b]); split; [constructor|]; auto.
-      * eapply context_subst_app_inv.
-        simpl. rewrite skipn_0.
-        move: (context_subst_length _ _ _ sps).
-        autorewrite with len.
-        move=> eq'. rewrite eq'.
-        rewrite skipn_all_app (firstn_app_left _ 0) //.
-        rewrite firstn_0 // app_nil_r.
-        split; auto. apply sps. rewrite -{2}(subst_empty 0 b).
-        constructor. constructor.
-      * eapply subslet_app => //. eapply sps.
-        rewrite -{1}(subst_empty 0 b).
-        repeat constructor. rewrite !subst_empty.
-        eapply All_local_env_app in wfΓΔ as [_ wf].
-        eapply All_local_env_app in wf as [wfd _].
-        depelim wfd; simpl in H; noconf H. apply l0.
-      * rewrite subst_app_simpl.
-        move: (context_subst_length _ _ _ sps).
-        now  autorewrite with len => <-.
-    + rewrite /mkProd_or_LetIn /= in sp, wat.
-      destruct args as [|a args]; simpl in eq; try lia.
-      specialize (X (subst_context [a] 0 Δ) ltac:(now autorewrite with len)).
-      specialize (X args ltac:(now rewrite context_assumptions_subst)).
-      eapply isWAT_tProd in wat as wat' => //.
-      destruct wat' as [wat' wat''] => //.
-      specialize (X (subst [a] #|Δ| T)).
-      depelim sp.
-      rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in sp.
-      forward X. { split.
-        pose proof wfΓΔ as wfΓΔ'.
-        rewrite app_context_assoc in wfΓΔ'. eapply All_local_env_app in wfΓΔ' as [wfΓΔ' _].
-        eapply (isWAT_subst wfΣ wfΓΔ') in wat''; eauto.
-        2:{ repeat constructor. rewrite subst_empty. eapply t. }
-        now rewrite subst_it_mkProd_or_LetIn Nat.add_0_r in wat''.
-        apply sp. }
-      destruct X as [args_sub [sps sp']].
-      exists (args_sub ++ [a]); split; [constructor|]; auto.
-      * eapply context_subst_app_inv.
-        simpl. rewrite skipn_S skipn_0.
-        move: (context_subst_length _ _ _ sps).
-        autorewrite with len.
-        move=> eq'. rewrite eq'.
-        rewrite skipn_all_app (firstn_app_left _ 0) //.
-        rewrite firstn_0 // app_nil_r.
-        split; auto. apply sps.
-        eapply (context_subst_ass _ []). constructor.
-      * eapply subslet_app => //. eapply sps.
-        rewrite -{1}(subst_empty 0 a).
-        repeat constructor. now rewrite !subst_empty.
-      * rewrite subst_app_simpl.
-        move: (context_subst_length _ _ _ sps).
-        now autorewrite with len => <-.  
-Qed.
-
-Lemma typing_spine_arity_spine {cf:checker_flags} Σ Γ T args T' ctx concl :
-  wf Σ.1 ->
-  typing_spine Σ Γ T args T' ->
-  isWfArity_or_Type Σ Γ T ->
-  decompose_prod_assum [] T = (ctx, concl) ->
-  context_assumptions ctx >= #|args| ->
-  arity_spine Σ Γ T args T'.
-Proof.
-  intros wfΣ.
-  induction 1 in ctx, concl |- *.
-  - econstructor; eauto.
-  - intros wat; destruct T; simpl; (intros [= <- <-] || intros decomp); simpl; intros le; try lia.
-    constructor.
-    pose proof (typing_wf_local t).
-    eapply cumul_Prod_inv in c as [conv cum]; auto.
-    eapply isWAT_tProd in wat as [wfT1 wfT2]; auto.
-    eapply type_Cumul with A; eauto. eapply conv_cumul. now symmetry.
-    eapply 
-
-*)
 
 Lemma typing_spine_app {cf:checker_flags} Σ Γ ty args na A B arg :
   wf Σ.1 ->
@@ -1995,10 +1869,10 @@ Proof.
   - induction inst_subslet0 in inst, inst_ctx_subst0, spine_codom_wf0 |- *.
     depelim inst_ctx_subst0.
     + constructor.
-    + depelim inst_ctx_subst0; simpl in H; noconf H.
+    + depelim inst_ctx_subst0.
       simpl. rewrite smash_context_acc.
       simpl. rewrite List.rev_app_distr.
-      depelim spine_codom_wf0; simpl in H; noconf H.
+      depelim spine_codom_wf0.
       constructor. now apply IHinst_subslet0.
       eapply meta_conv. eauto.
       simpl.
@@ -2020,25 +1894,9 @@ Proof.
       rewrite map_inst_idsn. now autorewrite with len.
       now apply context_subst_extended_subst.
     + simpl. rewrite smash_context_acc.
-      simpl. depelim spine_codom_wf0; simpl in H; noconf H.
-      depelim inst_ctx_subst0; simpl in H; noconf H; simpl in H0; noconf H0.
-      apply IHinst_subslet0; auto.
+      simpl. depelim spine_codom_wf0.
+      depelim inst_ctx_subst0; apply IHinst_subslet0; auto.
 Qed.
-(* 
-Lemma lift_extended_subst (Γ : context) k : 
-  extended_subst Γ k = map (lift0 k) (extended_subst Γ 0).
-Proof.
-  induction Γ as [|[? [] ?] ?] in k |- *; simpl; auto.
-  - rewrite IHΓ. f_equal.
-    autorewrite with len.
-    rewrite distr_lift_subst. f_equal.
-    autorewrite with len. rewrite simpl_lift; lia_f_equal.
-  - rewrite Nat.add_0_r; f_equal.
-    rewrite IHΓ (IHΓ 1).
-    rewrite map_map_compose. apply map_ext => x.
-    rewrite simpl_lift; try lia.
-    now rewrite Nat.add_1_r.
-Qed. *)
 
 Lemma extended_subst_app Γ Γ' : 
   extended_subst (Γ ++ Γ') 0 = 
@@ -2190,11 +2048,11 @@ Proof.
       rewrite subst_context_lift_id in subsl.
       eapply subslet_app_inv in subsl as [subsl subsr].
       destruct args; simpl in * => //. 
-      noconf len; simpl in H; noconf H.
+      noconf len.
       autorewrite with len in subsl, subsr. simpl in *.
       rewrite -H in subsl subsr. rewrite skipn_all_app_eq ?List.rev_length in subsl subsr => //.
       rewrite (firstn_app_left _ 0) ?firstn_0 ?app_nil_r ?List.rev_length in subsr => //.
-      depelim subsl; simpl in H0; noconf H0.
+      depelim subsl.
       constructor. now rewrite subst_empty in t1.
       rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r.
       rewrite -(smash_context_subst []) /= in subsr.
@@ -2235,12 +2093,12 @@ Lemma subslet_cumul {cf:checker_flags} Σ Δ args Γ Γ' :
 Proof.
   intros wfΣ ass ass' wf wf' a2. induction a2 in wf, wf', args, ass, ass' |- *.
   - inversion 1; constructor.
-  - intros subsl; depelim subsl; simpl in H; noconf H.
+  - intros subsl; depelim subsl.
     specialize (IHa2 s).
-    forward IHa2 by now depelim ass; simpl in H; noconf H.
-    forward IHa2 by now depelim ass'; simpl in H; noconf H.
-    depelim wf; simpl in H; noconf H.
-    depelim wf'; simpl in H; noconf H.
+    forward IHa2 by now depelim ass.
+    forward IHa2 by now depelim ass'.
+    depelim wf.
+    depelim wf'.
     specialize (IHa2 wf wf' subsl).
     constructor; auto.
     eapply type_Cumul; eauto.
@@ -2268,6 +2126,6 @@ Proof.
     induction ctxs in ass, Γ', ass', a2 |- *; depelim a2; try (simpl in H; noconf H); try constructor; auto.
     * eapply IHctxs. now depelim ass.
       now depelim ass'. auto.
-    * elimtype False; depelim ass. simpl in H; noconf H.
+    * elimtype False; depelim ass.
   - eapply subslet_cumul. 6:eauto. all:eauto.
 Qed.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1714,13 +1714,13 @@ Proof.
     apply red_letin; auto.
     now rewrite subst_context_snoc0 in IHred1.
 
-  - simplify_IH_hyps. eapply red_case; auto.
+  - eqns_specialize_eqs IHred1. eapply red_case; auto.
     apply All2_map, All2_same. intros. split; auto.
 
-  - simplify_IH_hyps. eapply red_case; auto.
+  - eqns_specialize_eqs IHred1. eapply red_case; auto.
     apply All2_map, All2_same. intros. split; auto.
 
-  - simplify_IH_hyps. apply red_case; auto.
+  - apply red_case; auto.
     apply All2_map.
     eapply OnOne2_All2; eauto. simpl. intuition eauto.
 
@@ -1880,13 +1880,13 @@ Proof.
     apply red_letin; auto.
     now rewrite subst_context_snoc0 in IHred1.
 
-  - simplify_IH_hyps. eapply red_case; auto.
+  - eqns_specialize_eqs IHred1. eapply red_case; auto.
     apply All2_map, All2_same. intros. split; auto.
 
-  - simplify_IH_hyps. eapply red_case; auto.
+  - eqns_specialize_eqs IHred1. eapply red_case; auto.
     apply All2_map, All2_same. intros. split; auto.
 
-  - simplify_IH_hyps. apply red_case; auto.
+  - apply red_case; auto.
     eapply All2_map.
     eapply OnOne2_All2; eauto. simpl. intuition eauto.
 
@@ -2488,7 +2488,7 @@ Proof.
   - induction Δ.
     + clear X. simpl in *.  now apply All_local_env_app in wfΓ0.
     + rewrite subst_context_snoc.
-      depelim X; unfold snoc in H; noconf H; simpl;
+      depelim X; simpl;
       econstructor; eauto.
       * exists (tu.π1). rewrite Nat.add_0_r; now eapply t0.
       * exists (tu.π1). rewrite Nat.add_0_r; now eapply t1.
@@ -2692,7 +2692,7 @@ Proof.
         clear -sub a.
         induction ctx; try constructor; depelim a.
         -- rewrite subst_context_snoc.
-           unfold snoc. unfold vass, snoc in H. noconf H.
+           unfold snoc. 
            econstructor; auto.
            ++ eapply IHctx. eapply a.
            ++ simpl. destruct tu as [u tu]. exists u.
@@ -2701,7 +2701,6 @@ Proof.
               simpl in t0.
               now rewrite subst_context_app Nat.add_0_r app_context_assoc app_length in t0.
       -- rewrite subst_context_snoc.
-         unfold vdef, snoc in H |- *. noconf H.
          constructor; auto.
          ++ eapply IHctx. eapply a.
          ++ simpl.
@@ -2760,7 +2759,7 @@ Proof.
   intros HΣ Ht.
   assert ((wf_local Σ Γ) * (Σ ;;; Γ |- u : U)%type) as [wfΓ tyu].
   { apply typing_wf_local in Ht; eauto with wf.
-    now depelim Ht; simpl in *; unfold vdef, vass in H; noconf H.
+    now depelim Ht; simpl in *.
   }
   epose proof (substitution Σ Γ [vdef n u U] _ [] t T HΣ) as thm.
   forward thm.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -974,8 +974,8 @@ Lemma size_wf_local_app `{checker_flags} {Σ} (Γ Γ' : context) (Hwf : wf_local
 Proof.
   induction Γ' in Γ, Hwf |- *; try lia. simpl. lia.
   depelim Hwf.
-  - inversion H0. subst. noconf H4. simpl. unfold eq_rect_r. simpl. specialize (IHΓ' _ Hwf). lia.
-  - inversion H0. subst. noconf H4. specialize (IHΓ' _ Hwf). simpl. unfold eq_rect_r. simpl. lia.
+  - specialize (IHΓ' _ Hwf). simpl. unfold eq_rect_r; simpl. lia.
+  - specialize (IHΓ' _ Hwf). simpl. unfold eq_rect_r. simpl. lia.
 Qed.
 
 Lemma typing_wf_local_size `{checker_flags} {Σ} {Γ t T}

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -956,8 +956,7 @@ Proof.
         try specialize (forall_Γ  _ _ _ eq_refl wf).
     
   - induction Γ'; simpl; auto.
-    depelim X; unfold snoc in H; noconf H;
-    rewrite lift_context_snoc; simpl; constructor.
+    depelim X; rewrite lift_context_snoc; simpl; constructor.
     + eapply IHΓ'; eauto.
     + red. exists (tu.π1). simpl.
       rewrite Nat.add_0_r. apply t0; auto.
@@ -1111,8 +1110,6 @@ Proof.
       clear -wf a.
       induction ctx; try constructor; depelim a.
       -- rewrite lift_context_snoc.
-          inversion H. subst. simpl in H3; noconf H3.
-          simpl in H0; noconf H0.
           constructor; auto.
           * eapply IHctx. eapply a.
           * simpl. destruct tu as [u tu]. exists u.
@@ -1121,7 +1118,6 @@ Proof.
             specialize (t0 eq_refl). simpl in t0.
             rewrite app_context_length lift_context_app app_context_assoc Nat.add_0_r in t0. apply t0.
       -- rewrite lift_context_snoc.
-          inversion H. subst. noconf H3.
           constructor; auto.
           ++ eapply IHctx. eapply a.
           ++ simpl.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -105,11 +105,7 @@ Definition mkApps_decompose_app t :
   := mkApps_decompose_app_rec t [].
 
 
-Derive EqDec for sort_family.
-Next Obligation.
-  unfold Classes.dec_eq. decide equality.
-Defined.
-
+Derive NoConfusion EqDec for sort_family.
 
 Inductive type_error :=
 | UnboundRel (n : nat)


### PR DESCRIPTION
This moves the 8.11 branch to equations-1.2.3 as well, cleaning the proofs of the [simpl in H; noconf H] pattern.