### PR TITLE
Only allow projection out of first constructor

### DIFF
--- a/checker/theories/WcbvEval.v
+++ b/checker/theories/WcbvEval.v
@@ -158,8 +158,8 @@ Section Wcbv.
       eval (tCase (ind, pars) p discr brs) res
 
   (** Proj *)
-  | eval_proj i pars arg discr args k u a res :
-      eval discr (mkApps (tConstruct i k u) args) ->
+  | eval_proj i pars arg discr args u a res :
+      eval discr (mkApps (tConstruct i 0 u) args) ->
       nth_error args (pars + arg) = Some a ->
       eval a res ->
       eval (tProj (i, pars, arg) discr) res
@@ -238,10 +238,10 @@ Section Wcbv.
           eval discr (mkApps (tConstruct ind c u) args) ->
           P discr (mkApps (tConstruct ind c u) args) ->
           eval (iota_red pars c args brs) res -> P (iota_red pars c args brs) res -> P (tCase (ind, pars) p discr brs) res) ->
-      (forall (i : inductive) (pars arg : nat) (discr : term) (args : list term) (k : nat) (u : Instance.t)
+      (forall (i : inductive) (pars arg : nat) (discr : term) (args : list term) (u : Instance.t)
               (a res : term),
-          eval discr (mkApps (tConstruct i k u) args) ->
-          P discr (mkApps (tConstruct i k u) args) ->
+          eval discr (mkApps (tConstruct i 0 u) args) ->
+          P discr (mkApps (tConstruct i 0 u) args) ->
           nth_error args (pars + arg) = Some a -> eval a res -> P a res -> P (tProj (i, pars, arg) discr) res) ->
       (forall (f : term) (mfix : mfixpoint term) (idx : nat) (fixargsv args argsv : list term)
              (narg : nat) (fn res : term),

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -150,8 +150,8 @@ Section Wcbv.
       eval (tConst c) res
 
   (** Proj *)
-  | eval_proj i pars arg discr args k res :
-      eval discr (mkApps (tConstruct i k) args) ->
+  | eval_proj i pars arg discr args res :
+      eval discr (mkApps (tConstruct i 0) args) ->
       eval (List.nth (pars + arg) args tDummy) res ->
       eval (tProj (i, pars, arg) discr) res
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -889,7 +889,7 @@ Proof.
         eapply value_app_inv in H1. subst. eassumption.
       * rename H3 into Hinf.
         eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
-        assert (Σ ;;; [] |- mkApps (tConstruct i k u) args : mkApps (tInd i x) x2).
+        assert (Σ ;;; [] |- mkApps (tConstruct i 0 u) args : mkApps (tInd i x) x2).
         eapply subject_reduction_eval; eauto.
         eapply PCUICValidity.inversion_mkApps in X as (? & ? & ?); eauto.
         eapply typing_spine_inv in t2 as []; eauto.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -1449,7 +1449,7 @@ Section PredRed.
 
     - eapply red1_red. econstructor; eauto.
 
-    - transitivity (tProj (i, pars, narg) (mkApps (tConstruct i k u) args1)).
+    - transitivity (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args1)).
       eapply red_proj_c; eauto.
       eapply red_mkApps; [|solve_all]. auto.
       eapply red1_red. econstructor; eauto.

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -465,11 +465,11 @@ Section ParallelReduction.
       pred1 Γ Γ' (tConst c u) (tConst c u)
 
   (** Proj *)
-  | pred_proj i pars narg k u args0 args1 arg1 :
+  | pred_proj i pars narg u args0 args1 arg1 :
       All2_local_env (on_decl pred1) Γ Γ' ->
       All2 (pred1 Γ Γ') args0 args1 ->
       nth_error args1 (pars + narg) = Some arg1 ->
-      pred1 Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i k u) args0)) arg1
+      pred1 Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args0)) arg1
 
   (** Congruences *)
   | pred_abs na M M' N N' : pred1 Γ Γ' M M' -> pred1 (Γ ,, vass na M) (Γ' ,, vass na M') N N' ->
@@ -788,14 +788,14 @@ Section ParallelReduction.
           All2_local_env (on_decl pred1) Γ Γ' ->
           Pctx Γ Γ' ->
           P Γ Γ' (tConst c u) (tConst c u)) ->
-      (forall (Γ Γ' : context) (i : inductive) (pars narg : nat) (k : nat) (u : Instance.t)
+      (forall (Γ Γ' : context) (i : inductive) (pars narg : nat) (u : Instance.t)
               (args0 args1 : list term) (arg1 : term),
           All2_local_env (on_decl pred1) Γ Γ' ->
           Pctx Γ Γ' ->
           All2 (pred1 Γ Γ') args0 args1 ->
           All2 (P Γ Γ') args0 args1 ->
           nth_error args1 (pars + narg) = Some arg1 ->
-          P Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i k u) args0)) arg1) ->
+          P Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args0)) arg1) ->
       (forall (Γ Γ' : context) (na : name) (M M' N N' : term),
           pred1 Γ Γ' M M' ->
           P Γ Γ' M M' -> pred1 (Γ,, vass na M) (Γ' ,, vass na M') N N' ->

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -1340,9 +1340,9 @@ Inductive tred1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
     tred1 Σ Γ (tConst c u) (subst_instance_constr u body)
 
 (** Proj *)
-| tred_proj i pars narg args k u arg:
+| tred_proj i pars narg args u arg:
     nth_error args (pars + narg) = Some arg ->
-    tred1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg.
+    tred1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg.
 
 Definition ctred1 Σ :=
   context_env_clos (tred1 Σ).

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -851,8 +851,7 @@ Proof.
     destruct ci as ((([cparsubst0 iparsubst0] & idxsubst0) & subsidx) & [s [typectx [Hpars Hargs]]]).
     destruct ind_cshapes as [|? []]; try contradiction.
     destruct X2 as [projty projeq].
-    destruct k; simpl in *; try discriminate. noconf Hnth.
-    2:{ rewrite nth_error_nil in Hnth. discriminate. }
+    noconf Hnth.
     specialize (projsubsl onProjs).
     destruct onProjs.
     pose proof (on_declared_minductive wf isdecl.p1.p1) as onmind.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -182,9 +182,9 @@ Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
     red1 Σ Γ (tConst c u) (subst_instance_constr u body)
 
 (** Proj *)
-| red_proj i pars narg args k u arg:
+| red_proj i pars narg args u arg:
     nth_error args (pars + narg) = Some arg ->
-    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg
+    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg
 
 
 | abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
@@ -260,10 +260,10 @@ Lemma red1_ind_all :
         declared_constant Σ c decl ->
         forall u : Instance.t, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
 
-       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (k : nat) (u : Instance.t)
+       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
          (arg : term),
            nth_error args (pars + narg) = Some arg ->
-           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg) ->
+           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
 
        (forall (Γ : context) (na : name) (M M' N : term),
         red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -187,8 +187,8 @@ Section Wcbv.
       eval (tCase (ind, pars) p discr brs) res
 
   (** Proj *)
-  | eval_proj i pars arg discr args k u a res :
-      eval discr (mkApps (tConstruct i k u) args) ->
+  | eval_proj i pars arg discr args u a res :
+      eval discr (mkApps (tConstruct i 0 u) args) ->
       nth_error args (pars + arg) = Some a ->
       eval a res ->
       eval (tProj (i, pars, arg) discr) res

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -3273,21 +3273,21 @@ Section Conversion.
 
     unfold_one_proj Γ p c h with p := {
     | (i, pars, narg) with inspect (reduce_stack RedFlags.default Σ hΣ Γ c ε _) := {
-      | @exist (cred, ρ) eq with cc_viewc cred := {
-        | ccview_construct ind' n ui with inspect (decompose_stack ρ) := {
+      | @exist (cred, ρ) eq with cc0_viewc cred := {
+        | cc0view_construct ind' ui with inspect (decompose_stack ρ) := {
           | @exist (args, ξ) eq' with inspect (nth_error args (pars + narg)) := {
             | @exist (Some arg) eq2 := Some arg ;
             | @exist None _ := None
             }
           } ;
-        | ccview_cofix mfix idx with inspect (decompose_stack ρ) := {
+        | cc0view_cofix mfix idx with inspect (decompose_stack ρ) := {
           | @exist (args, ξ) eq' with inspect (unfold_cofix mfix idx) := {
             | @exist (Some (narg, fn)) eq2 :=
               Some (tProj (i, pars, narg) (mkApps fn args)) ;
             | @exist None eq2 := None
             }
           } ;
-        | ccview_other t _ := None
+        | cc0view_other t _ := None
         }
       }
     }.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -201,9 +201,9 @@ Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
     red1 Σ Γ (tConst c u) (subst_instance_constr u body)
 
 (** Proj *)
-| red_proj i pars narg args k u arg:
+| red_proj i pars narg args u arg:
     nth_error args (pars + narg) = Some arg ->
-    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg
+    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg
 
 
 | abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
@@ -280,10 +280,10 @@ Lemma red1_ind_all :
         declared_constant Σ c decl ->
         forall u : Instance.t, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
 
-       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (k : nat) (u : Instance.t)
+       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
          (arg : term),
            nth_error args (pars + narg) = Some arg ->
-           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i k u) args)) arg) ->
+           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
 
        (forall (Γ : context) (na : name) (M M' N : term),
         red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->


### PR DESCRIPTION
Change reduction/evaluation to allow projecting only out of the first constructor. This is already enforced by typing so the change is not that large, but allowing this in reductions makes it harder to reason about it in untyped settings (eg. in erasure).