### PR TITLE
Optimizing the fixpoint evaluation rule

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -518,14 +518,12 @@ Qed.
 
 Lemma Is_type_eval (Σ : global_env_ext) t v:
   wf Σ ->
+  axiom_free Σ ->
   eval Σ t v ->
   isErasable Σ [] t ->
   isErasable Σ [] v.
 Proof.
   intros; eapply Is_type_red. eauto.
-  eapply wcbeval_red; eauto.
   red in X1. destruct X1 as [T [HT _]].
-  eapply typecheck_closed in HT as [_ HT]; auto. 
-  apply andP in HT. now destruct HT.
-  eauto.
+  eapply wcbeval_red; eauto. assumption.
 Qed.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -113,11 +113,10 @@ Section Wcbv.
       eval (tCase (ind, pars) discr brs) res
 
   (** Fix unfolding, with guard *)
-  | eval_fix f mfix idx argsv a av narg fn res :
+  | eval_fix f mfix idx argsv a av fn res :
       eval f (mkApps (tFix mfix idx) argsv) ->
       eval a av ->
-      cunfold_fix mfix idx = Some (narg, fn) ->
-      narg <= #|argsv| ->
+      cunfold_fix mfix idx = Some (#|argsv|, fn) ->
       eval (tApp (mkApps fn argsv) av) res ->
       eval (tApp f a) res
 
@@ -540,7 +539,8 @@ Proof.
       noconf H1; noconf H2.
       subst.
       apply IHev2 in ev'2; subst.
-      rewrite H3 in H.
+      noconf H0.
+      rewrite H2 in H.
       now noconf H.
     + apply IHev1 in ev'1.
       apply mkApps_eq_inj in ev'1; try easy.
@@ -548,14 +548,14 @@ Proof.
       noconf H1.
       noconf H2.
       apply IHev2 in ev'2.
-      subst.
-      rewrite H3 in H.
+      subst. noconf H0.
+      rewrite H2 in H.
       noconf H. lia.
     + apply IHev1 in ev'1.
       subst.
-      rewrite isFixApp_mkApps in H1 by easy.
+      rewrite isFixApp_mkApps in H0 by easy.
       cbn in *.
-      now rewrite orb_true_r in H1.
+      now rewrite orb_true_r in H0.
     + easy.
   - depelim ev'.
     + apply IHev1 in ev'1; solve_discr.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -934,7 +934,7 @@ Proof.
       econstructor.
       eapply Is_type_eval. 4:eapply X. eauto. eauto.
       eapply eval_fix; eauto.
-      rewrite /cunfold_fix e0 //.
+      rewrite /cunfold_fix e0 //. congruence.
     + eapply IHeval1 in He1 as IH1; eauto.
       destruct IH1 as (er_stuck_v & er_stuck & ev_stuck).
       eapply IHeval2 in He2 as IH2; eauto.
@@ -959,7 +959,8 @@ Proof.
           rewrite mkApps_nested. eapply value_final.
           eapply eval_to_value; eauto.
           eapply value_final, eval_to_value; eauto.
-          rewrite  /cunfold_fix e0 //. auto. auto. }
+          rewrite  /cunfold_fix e0 //. auto. auto.
+          rewrite H3; eauto. auto. }
 
       inv H2.
       * assert (Hmfix' := X).
@@ -976,7 +977,7 @@ Proof.
         -- cbn in e3. rename x5 into L.
            eapply (erases_mkApps _ _ _ _ (argsv ++ [av])) in H2; first last.
            { eapply Forall2_app.
-             - exact H3.
+             - exact H4.
              - eauto. }
            rewrite <- mkApps_nested in H2.
            rewrite EAstUtils.mkApps_app in H2.
@@ -996,7 +997,7 @@ Proof.
              pose proof (eval_to_value _ _ _ e3) as vfix.
              eapply PCUICWcbvEval.stuck_fix_value_args in vfix; eauto.
              2:{ rewrite /cunfold_fix e0 //. }
-             simpl in vfix. assert (rarg = #|argsv|) by lia.
+             simpl in vfix. 
              subst. unfold is_constructor.
              rewrite nth_error_snoc. lia.
              assert(Σ ;;; [] |- mkApps (tFix mfix idx) (argsv ++ [av]) : PCUICLiftSubst.subst [av] 0 x1).
@@ -1014,7 +1015,8 @@ Proof.
            ++ eauto.
            ++ eauto.
            ++ rewrite <- Ee.closed_unfold_fix_cunfold_eq.
-              { unfold ETyping.unfold_fix. now rewrite e. }
+              { unfold ETyping.unfold_fix. rewrite e -e2.
+                now rewrite (Forall2_length H4). }
               eapply eval_closed in e3; eauto.
               clear -e3 Hmfix'.
               pose proof (All2_length _ _ Hmfix').
@@ -1034,8 +1036,7 @@ Proof.
               now rewrite Nat.add_0_r in Hbod.
               eauto with pcuic.
               now eapply PCUICClosed.subject_closed in Ht.
-           ++ apply Forall2_length in H3. rewrite <- e2. lia.
-           ++ auto.
+          ++ auto.
            
         -- cbn. destruct p. destruct p.
            eapply (erases_subst Σ [] (PCUICLiftSubst.fix_context mfix) [] dbody (fix_subst mfix)) in e3; cbn; eauto.
@@ -1045,10 +1046,10 @@ Proof.
            ++ eapply All2_from_nth_error.
               erewrite fix_subst_length, ETyping.fix_subst_length, All2_length; eauto.
               intros.
-              rewrite fix_subst_nth in H4. now rewrite fix_subst_length in H2.
+              rewrite fix_subst_nth in H3. now rewrite fix_subst_length in H2.
               rewrite efix_subst_nth in H5. rewrite fix_subst_length in H2.
-                                                erewrite <- All2_length; eauto.
-              inv H5; inv H4.
+              erewrite <- All2_length; eauto.
+              inv H5; inv H3.
               erewrite All2_length; eauto.
       * eapply (Is_type_app _ _ _ (argsv ++ [av])) in X as []; tas.
         -- exists EAst.tBox.
@@ -1058,7 +1059,7 @@ Proof.
               rewrite -mkApps_nested.
               eapply eval_fix; eauto. 
               1-2:eapply value_final, eval_to_value; eauto.
-              rewrite /cunfold_fix e0 //.
+              rewrite /cunfold_fix e0 //. congruence.
            ++ eapply Ee.eval_box; [|eauto].
               apply eval_to_mkApps_tBox_inv in ev_stuck as ?; subst.
               eauto.
@@ -1206,7 +1207,7 @@ Proof.
     + inv He.
       * eexists. split; eauto. now econstructor.
       * eexists. split. 2: now econstructor.
-        econstructor; eauto.
+        econstructor; eauto.      
 Qed.
 
 Print Assumptions erases_correct.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -11,7 +11,7 @@ From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils
   PCUICUnivSubst PCUICWeakeningEnv PCUICCumulativity.
 
 Require Import Equations.Prop.DepElim.
-
+Require Import ssreflect.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
 Local Set Keyed Unification.
@@ -292,7 +292,7 @@ Proof.
     destruct p. destruct p. repeat split; eauto.
     eapply e2 in e1.
     unfold PCUICUnivSubst.subst_instance_context in *.
-    unfold map_context in *. rewrite map_app in *. subst types. 2:eauto.
+    unfold map_context in *. rewrite  ->map_app in *. subst types. 2:eauto.
     eapply erases_ctx_ext. eassumption. unfold app_context.
     f_equal.
     eapply fix_context_subst_instance. all: eauto.
@@ -326,11 +326,10 @@ Proof.
   destruct p. repeat split; eauto.
   eapply e2 in e1.
   unfold PCUICUnivSubst.subst_instance_context in *.
-  unfold map_context in *. rewrite map_app in *. subst types. 2:eauto.
+  unfold map_context in *. rewrite -> map_app in *. subst types. 2:eauto.
   eapply erases_ctx_ext. eassumption. unfold app_context.
   f_equal.
   eapply fix_context_subst_instance. all: eauto.
-
 Qed.
 
 Lemma erases_subst_instance_constr :
@@ -565,12 +564,12 @@ Proof.
     solve_all. destruct y ;  simpl in *; subst.
     unfold EAst.test_def; simpl; eauto.
     rewrite <-H. rewrite fix_context_length in b0.
-    eapply b0. eauto. now rewrite app_length, fix_context_length.
+    eapply b0. eauto. now rewrite app_length fix_context_length.
   - epose proof (All2_length _ _ X0).
     solve_all. destruct y ;  simpl in *; subst.
     unfold EAst.test_def; simpl; eauto.
     rewrite <-H. rewrite fix_context_length in b0.
-    eapply b0. eauto. now rewrite app_length, fix_context_length.
+    eapply b0. eauto. now rewrite app_length fix_context_length.
 Qed.
 
 Lemma eval_to_mkApps_tBox_inv Σ t argsv :
@@ -594,7 +593,7 @@ Lemma erases_correct Σ t T t' v Σ' :
 Proof.
   intros pre Hty He Heg H.
   revert T Hty t' He.
-  induction H; intros T Hty t' He; inv pre.
+  induction H; intros T Hty t' He; destruct pre as [axfree wfΣ].
   - assert (Hty' := Hty).
     assert (eval Σ (PCUICAst.tApp f a) res) by eauto.
     eapply inversion_App in Hty as (? & ? & ? & ? & ? & ?).
@@ -602,14 +601,14 @@ Proof.
 
     + eapply IHeval1 in H4 as (vf' & Hvf' & He_vf'); eauto.
       eapply IHeval2 in H6 as (vu' & Hvu' & He_vu'); eauto.
-      pose proof (subject_reduction_eval Σ _ _ _ (wf_ext_wf _ extr_env_wf'0) t0 H).
-        eapply inversion_Lambda in X0 as (? & ? & ? & ? & ?).
-        assert (Σ ;;; [] |- a' : t). {
+      pose proof (subject_reduction_eval t0 H).
+      eapply inversion_Lambda in X0 as (? & ? & ? & ? & ?).
+      assert (Σ ;;; [] |- a' : t). {
           eapply subject_reduction_eval; eauto.
           eapply PCUICConversion.cumul_Prod_inv in c0 as [].
           econstructor. eassumption. eauto. eapply conv_sym in c0; eauto.
           now eapply conv_cumul. auto. auto. }
-      assert (eqs := type_closed_subst b extr_env_wf'0  X0).
+      assert (eqs := type_closed_subst b wfΣ X0).
       inv Hvf'.
       * assert (Σ;;; [] |- PCUICLiftSubst.subst1 a' 0 b ⇝ℇ subst1 vu' 0 t').
         eapply (erases_subst Σ [] [PCUICAst.vass na t] [] b [a'] t'); eauto.
@@ -626,7 +625,7 @@ Proof.
         eapply Is_type_lambda in X1; eauto. destruct X1. econstructor.
         eapply (is_type_subst Σ [] [PCUICAst.vass na _] [] _ [a']) in X1 ; auto.
         cbn in X1.
-        eapply Is_type_eval.
+        eapply Is_type_eval; try assumption.
         eauto. eapply H1. rewrite <-eqs. eassumption.
         all: eauto. econstructor. econstructor. rewrite parsubst_empty.
         eauto. econstructor. eauto. eauto.
@@ -643,7 +642,8 @@ Proof.
       assert (Hc : PCUICContextConversion.conv_context Σ ([],, vdef na b0 t) [vdef na b0' t]). {
         econstructor. econstructor. econstructor.
         eapply PCUICCumulativity.red_conv.
-        eapply wcbeval_red; eauto. now eapply PCUICClosed.subject_closed in t1. reflexivity.
+        now eapply wcbeval_red; eauto.
+        reflexivity.
       }
       assert (Σ;;; [vdef na b0' t] |- b1 : x0). {
         cbn in *. eapply PCUICContextConversion.context_conversion. 3:eauto. all:cbn; eauto.
@@ -661,8 +661,8 @@ Proof.
         econstructor. all: cbn; eauto.
         eapply subject_reduction_eval; eauto.
       }
-      unshelve epose proof (subject_reduction_eval _ _ _ _ _ t1 H); eauto.
-      assert (eqs := type_closed_subst b1 extr_env_wf'0 X1).
+      pose proof (subject_reduction_eval t1 H).
+      assert (eqs := type_closed_subst b1 _ X1).
       rewrite eqs in H1.
       eapply IHeval2 in H1 as (vres & Hvres & Hty_vres).
       2:{ rewrite <-eqs. eapply substitution_let; eauto. }
@@ -673,38 +673,38 @@ Proof.
     + exists EAst.tBox. split. 2:econstructor; eauto.
       econstructor. eapply Is_type_eval; eauto.
 
-  - destruct Σ as (Σ, univs).
-    unfold erases_global in Heg.
+  - unfold erases_global in Heg.
     assert (Σ |-p tConst c u ▷ res) by eauto.
     eapply inversion_Const in Hty as (? & ? & ? & ? & ?); [|easy].
     inv He.
     + assert (isdecl' := isdecl).
       eapply lookup_env_erases in isdecl; eauto.
       destruct isdecl as (decl' & ? & ?).
-      unfold erases_constant_body in *. rewrite e in *.
+      unfold erases_constant_body in *. rewrite -> e in *.
       destruct ?; try tauto. cbn in *.
       eapply declared_constant_inj in d; eauto; subst.
       edestruct IHeval.
-      * cbn in *. pose proof (wf_ext_wf _ extr_env_wf'0). cbn in X0.
+      * cbn in *.
         assert (isdecl'' := isdecl').
         eapply PCUICWeakeningEnv.declared_constant_inv in isdecl'; eauto.
         2:eapply PCUICWeakeningEnv.weaken_env_prop_typing.
         unfold on_constant_decl in isdecl'. rewrite e in isdecl'. red in isdecl'.
         unfold declared_constant in isdecl''.
-        eapply typing_subst_instance_decl with (Σ0 := (Σ, univs)) (Γ := []); eauto.
-      * pose proof (wf_ext_wf _ extr_env_wf'0). cbn in X0.
-        assert (isdecl'' := isdecl').
+        eapply typing_subst_instance_decl with (Σ0 := Σ) (Γ := []); eauto.
+        apply wfΣ.
+      * assert (isdecl'' := isdecl').
         eapply PCUICWeakeningEnv.declared_constant_inv in isdecl'; eauto.
         unfold on_constant_decl in isdecl'. rewrite e in isdecl'. cbn in *.
         2:eapply PCUICWeakeningEnv.weaken_env_prop_typing.
-        eapply erases_subst_instance_decl with (Σ := (Σ, univs)) (Γ := []); eauto.
+        eapply erases_subst_instance_decl with (Σ := Σ) (Γ := []); eauto.
+        apply wfΣ.
       * destruct H2. exists x0. split; eauto. econstructor; eauto.
     + exists EAst.tBox. split. econstructor.
-      eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
+      eapply Is_type_eval. 3: eassumption. eauto. eauto. eauto. econstructor. eauto.
 
   - destruct Σ as (Σ, univs).
     cbn in *.
-    eapply extr_env_axiom_free'0 in isdecl. congruence.
+    eapply axfree in isdecl. congruence.
 
   - assert (Hty' := Hty).
     assert (Σ |-p tCase (ind, pars) p discr brs ▷ res) by eauto.
@@ -747,9 +747,7 @@ Proof.
         edestruct (IHeval2) as (? & ? & ?).
         eapply subject_reduction. eauto. exact Hty.
         etransitivity.
-        eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
-        now eapply PCUICClosed.subject_closed in t0.
-        eauto.
+        eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto.
         econstructor. econstructor. econstructor.
 
         all:unfold iota_red in *. all:cbn in *.
@@ -769,23 +767,22 @@ Proof.
         pose proof (Ee.eval_to_value _ _ _ He_v').
         eapply value_app_inv in H4. subst. eassumption.
 
-        eapply wf_ext_wf in extr_env_wf'0.
-        eapply tCase_length_branch_inv in extr_env_wf'0.
+        eapply wf_ext_wf in wfΣ.
+        eapply tCase_length_branch_inv in wfΣ.
         2:{ eapply subject_reduction. eauto.
             exact Hty.
-            eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto.
-            now eapply PCUICClosed.subject_closed in t0. }
+            eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto. }
         2: reflexivity.
 
         enough (#|skipn (ind_npars mdecl') (x0 ++ x1)| = narg) as <- by eauto.
-        rewrite skipn_length. rewrite extr_env_wf'0. lia.
-        rewrite extr_env_wf'0. lia.
+        rewrite skipn_length; lia.
+        
       * subst. unfold iota_red in *.
         destruct (nth_error brs c) eqn:Hnth.
         2:{ eapply nth_error_None in Hnth. erewrite All2_length in Hnth. 2:exact a.
             eapply nth_error_Some_length in H2. cbn in H2. lia. }
         rewrite <- nth_default_eq in *. unfold nth_default in *.
-        rewrite Hnth in *.
+        rewrite -> Hnth in *.
 
         destruct (All2_nth_error_Some _ _ X0 Hnth) as (? & ? & ? & ?).
         destruct (All2_nth_error_Some _ _ a Hnth) as (? & ? & ? & ?).
@@ -794,7 +791,7 @@ Proof.
         eapply subject_reduction. eauto. exact Hty.
         etransitivity.
         eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
-        now eapply PCUICClosed.subject_closed in t0. eauto.
+        now eapply PCUICClosed.subject_closed in t0. eauto. eauto.
 
         etransitivity. eapply trans_red. econstructor.
         econstructor. unfold iota_red. rewrite <- nth_default_eq. unfold nth_default.
@@ -807,7 +804,7 @@ Proof.
            econstructor. eauto. unfold ETyping.iota_red.
            rewrite <- nth_default_eq. unfold nth_default. rewrite e1. cbn. eauto.
         -- eapply Is_type_app in X1 as []; auto.
-           2:{ eapply subject_reduction_eval. 3:eassumption. all: eauto. }
+           2:{ eapply subject_reduction_eval. 2:eassumption. eauto. }
 
            eapply tConstruct_no_Type in X1; auto.
            eapply H10 in X1 as []; eauto. 2: exists []; now destruct Σ.
@@ -825,7 +822,7 @@ Proof.
            eapply subject_reduction. eauto. exact Hty.
            etransitivity.
            eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
-           now eapply PCUICClosed.subject_closed in t0; eauto. eauto.
+           now eapply PCUICClosed.subject_closed in t0; eauto. eauto. eauto.
            econstructor. econstructor. 
            econstructor.
 
@@ -848,17 +845,15 @@ Proof.
            apply He_v'.
            enough (#|skipn (ind_npars mdecl') args| = n) as <- by eauto.
 
-           eapply wf_ext_wf in extr_env_wf'0.
-           eapply tCase_length_branch_inv in extr_env_wf'0.
+           eapply wf_ext_wf in wfΣ.
+           eapply tCase_length_branch_inv in wfΣ.
            2:{ eapply subject_reduction. eauto.
                exact Hty.
-               eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
-               now eapply PCUICClosed.subject_closed in t0. eauto. }
+               eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto. }
            2: reflexivity.
 
            enough (#|skipn (ind_npars mdecl') args| = n) as <- by eauto.
-           rewrite skipn_length. rewrite extr_env_wf'0. lia.
-           rewrite extr_env_wf'0. lia. 
+           rewrite skipn_length; lia.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval; eauto. econstructor; eauto.
 
@@ -879,7 +874,7 @@ Proof.
         2: now destruct d. 2: now exists []; destruct Σ.
 
         econstructor.
-        eapply Is_type_eval. eauto. eauto.
+        eapply Is_type_eval; eauto.
         eapply nth_error_all.
         erewrite nth_error_skipn. reflexivity. eassumption.
         eapply All_impl. assert (pars = ind_npars x0). destruct d as (? & ? & ?). now rewrite H7. subst.
@@ -902,13 +897,13 @@ Proof.
         -- exists EAst.tBox. split.
 
 
-           eapply Is_type_app in X as []; eauto. 2:{ eapply subject_reduction_eval. 3: eauto. eauto. eauto. }
+           eapply Is_type_app in X as []; eauto. 2:{ eapply subject_reduction_eval; [|eauto]; eauto. }
 
            eapply tConstruct_no_Type in X. eapply Hinf in X as [? []]; eauto.
            2: now destruct d. 2: now exists []; destruct Σ.
 
            econstructor.
-           eapply Is_type_eval. eauto. eauto.
+           eapply Is_type_eval; eauto.
            eapply nth_error_all.
            erewrite nth_error_skipn. reflexivity. eassumption.
            eapply All_impl. assert (pars = ind_npars x0). destruct d as (? & ? & ?). now rewrite H7. subst.
@@ -919,42 +914,27 @@ Proof.
            pose proof (Ee.eval_to_value _ _ _ Hty_vc').
            eapply value_app_inv in H2. subst. eassumption.
     + exists EAst.tBox. split. econstructor.
-      eapply Is_type_eval. 3: eassumption. eauto. eauto. econstructor. eauto.
+      eapply Is_type_eval. 4: eassumption. all:eauto. econstructor. eauto.
 
   - assert (Hty' := Hty).
     assert (Hunf := H).
     assert (Hcon := H1).
     eapply inversion_App in Hty' as (? & ? & ? & ? & ? & ?); eauto.
     assert (Ht := t).
-    eapply subject_reduction in t. 2:eauto. 2:eapply wcbeval_red; eauto.
-    2:now eapply PCUICClosed.subject_closed in Ht.
+    eapply subject_reduction in t. 2:auto. 2:eapply wcbeval_red; eauto.
     assert (HT := t).
     apply PCUICValidity.inversion_mkApps in HT as (? & ? & ?); auto.
     assert (Ht1 := t1).
     apply inversion_Fix in t1 as Hfix; auto.
     destruct Hfix as (? & ? & ? & ? & ? & ? & ?).
-    rewrite <- closed_unfold_fix_cunfold_eq in e; first last.
-    eapply (PCUICClosed.subject_closed (Γ := [])); eauto.
-    assert (uf := e).
-    unfold unfold_fix in e. rewrite e0 in e. inv e.
+    unfold cunfold_fix in e. rewrite e0 in e. inv e.
     depelim He; first last.
     
     + exists EAst.tBox. split; [|now constructor].
       econstructor.
-      eapply Is_type_eval. eauto. eassumption.
-      eapply Is_type_red. eauto. 2: exact X.
-      cbn.
-      etransitivity.
-      eapply PCUICReduction.red_app.
-      eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in Ht.
-      eauto. eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in t0.
-      eauto.
-      rewrite <- !mkApps_snoc.
-      eapply PCUICReduction.red1_red.
-      eapply red_fix.
-      eauto.
-      unfold is_constructor.
-      rewrite nth_error_snoc; eauto.
+      eapply Is_type_eval. 4:eapply X. eauto. eauto.
+      eapply eval_fix; eauto.
+      rewrite /cunfold_fix e0 //.
     + eapply IHeval1 in He1 as IH1; eauto.
       destruct IH1 as (er_stuck_v & er_stuck & ev_stuck).
       eapply IHeval2 in He2 as IH2; eauto.
@@ -968,25 +948,23 @@ Proof.
         split; [|eauto using Ee.eval].
         destruct H2.
         eapply (Is_type_app _ _ _ (x5 ++ [av])) in X as []; eauto; first last.
-        - rewrite mkApps_nested, app_assoc, mkApps_snoc.
+        - rewrite mkApps_nested app_assoc mkApps_snoc.
           eapply type_App; eauto.
           eapply subject_reduction; eauto.
           eapply wcbeval_red; eauto.
-          eapply PCUICClosed.subject_closed in t0; eauto.
         - eapply erases_box.
-          eapply Is_type_eval; eauto.
-          eapply Is_type_red; [eauto| |].
-          + rewrite <- mkApps_snoc.
-            eapply PCUICReduction.red1_red.
-            eapply red_fix; [eauto|].
-            unfold is_constructor.
-            now rewrite nth_error_snoc.
-          + rewrite <- app_assoc.
-            now rewrite <- mkApps_nested. }
-      
+          eapply Is_type_eval; auto. 2:eauto.
+          rewrite -mkApps_nested /=.
+          eapply eval_fix.
+          rewrite mkApps_nested. eapply value_final.
+          eapply eval_to_value; eauto.
+          eapply value_final, eval_to_value; eauto.
+          rewrite  /cunfold_fix e0 //. auto. auto. }
+
       inv H2.
       * assert (Hmfix' := X).
         eapply All2_nth_error_Some in X as (? & ? & ?); eauto.
+        pose proof (closed_fix_substl_subst_eq (PCUICClosed.subject_closed _ t1) e0) as cls.
         destruct x3. cbn in *. subst.
 
         enough (Σ;;; [] ,,, PCUICLiftSubst.subst_context (fix_subst mfix) 0 []
@@ -998,25 +976,39 @@ Proof.
         -- cbn in e3. rename x5 into L.
            eapply (erases_mkApps _ _ _ _ (argsv ++ [av])) in H2; first last.
            { eapply Forall2_app.
-             - exact H4.
+             - exact H3.
              - eauto. }
            rewrite <- mkApps_nested in H2.
            rewrite EAstUtils.mkApps_app in H2.
-           cbn in *.
+           cbn in *. simpl in H2.
+          rewrite cls in H2.
            eapply IHeval3 in H2 as (? & ? & ?); cbn; eauto; first last.
            { eapply subject_reduction. eauto. exact Hty.
              etransitivity.
-             eapply PCUICReduction.red_app. eapply wcbeval_red; eauto.
-             now eapply PCUICClosed.subject_closed in Ht.
-             eapply wcbeval_red. eauto. now eapply PCUICClosed.subject_closed in t0.
-             eauto.
+             eapply PCUICReduction.red_app. eapply wcbeval_red; eauto. 
+             eapply wcbeval_red; eauto.
              rewrite <- !mkApps_snoc.
              eapply PCUICReduction.red1_red.
              eapply red_fix.
-             eauto.
-             unfold is_constructor.
-             rewrite nth_error_snoc; eauto. }
-           
+             rewrite closed_unfold_fix_cunfold_eq.
+             now eapply PCUICClosed.subject_closed in t1.
+             rewrite /cunfold_fix e0 /= //.
+             pose proof (eval_to_value _ _ _ e3) as vfix.
+             eapply PCUICWcbvEval.stuck_fix_value_args in vfix; eauto.
+             2:{ rewrite /cunfold_fix e0 //. }
+             simpl in vfix. assert (rarg = #|argsv|) by lia.
+             subst. unfold is_constructor.
+             rewrite nth_error_snoc. lia.
+             assert(Σ ;;; [] |- mkApps (tFix mfix idx) (argsv ++ [av]) : PCUICLiftSubst.subst [av] 0 x1).
+             { rewrite -mkApps_nested. eapply type_App; eauto. eapply subject_reduction_eval;eauto. }
+             epose proof (fix_app_is_constructor Σ (args:=argsv ++ [av])%list axfree X).
+             rewrite /unfold_fix e0 in X0.
+             specialize (X0 eq_refl). simpl in X0.
+             rewrite nth_error_snoc in X0. auto. apply X0.
+             eapply value_whnf; eauto.
+             eapply eval_closed; eauto. now eapply PCUICClosed.subject_closed in t0.
+             eapply eval_to_value; eauto. }
+
            exists x3. split. eauto.
            eapply Ee.eval_fix.
            ++ eauto.
@@ -1042,29 +1034,9 @@ Proof.
               now rewrite Nat.add_0_r in Hbod.
               eauto with pcuic.
               now eapply PCUICClosed.subject_closed in Ht.
-           ++ apply Forall2_length in H4. rewrite <- e2. lia.
-           ++ unfold isConstruct_app in *.
-              destruct (decompose_app av) eqn:EE.
-              assert (E2 : fst (decompose_app av) = t3) by now rewrite EE.
-              destruct t3.
-              all:inv i.
-
-              pose proof (decompose_app_rec_inv EE).
-              cbn in H3. subst.
-
-              eapply erases_mkApps_inv in er_arg
-                as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-              ** subst.
-                 now apply eval_to_mkApps_tBox_inv in ev_arg as ->.
-              ** subst. apply H2.
-              ** eauto.
-              ** eapply subject_reduction; last first.
-                 eapply wcbeval_red; last first.
-                 eauto.
-                 now eapply PCUICClosed.subject_closed in t0.
-                 eauto.
-                 eauto.
-                 eauto.
+           ++ apply Forall2_length in H3. rewrite <- e2. lia.
+           ++ auto.
+           
         -- cbn. destruct p. destruct p.
            eapply (erases_subst Σ [] (PCUICLiftSubst.fix_context mfix) [] dbody (fix_subst mfix)) in e3; cbn; eauto.
            ++ eapply subslet_fix_subst. now eapply wf_ext_wf. all: eassumption.
@@ -1073,23 +1045,20 @@ Proof.
            ++ eapply All2_from_nth_error.
               erewrite fix_subst_length, ETyping.fix_subst_length, All2_length; eauto.
               intros.
-              rewrite fix_subst_nth in H3. 2:{ now rewrite fix_subst_length in H2. }
-              rewrite efix_subst_nth in H5. 2:{ rewrite fix_subst_length in H2.
-                                                erewrite <- All2_length; eauto. }
-              inv H5; inv H3.
+              rewrite fix_subst_nth in H4. now rewrite fix_subst_length in H2.
+              rewrite efix_subst_nth in H5. rewrite fix_subst_length in H2.
+                                                erewrite <- All2_length; eauto.
+              inv H5; inv H4.
               erewrite All2_length; eauto.
-      * eapply Is_type_app in X as []; tas.
+      * eapply (Is_type_app _ _ _ (argsv ++ [av])) in X as []; tas.
         -- exists EAst.tBox.
            split.
            ++ econstructor.
-              eapply Is_type_eval; eauto.
-              eapply Is_type_red; [eauto| |].
-              ** eapply PCUICReduction.red1_red.
-                 rewrite <- mkApps_snoc.
-                 eapply red_fix; [eauto|].
-                 unfold is_constructor.
-                 now rewrite nth_error_snoc.
-              ** eauto.
+              eapply Is_type_eval. 4:eauto. all:eauto.
+              rewrite -mkApps_nested.
+              eapply eval_fix; eauto. 
+              1-2:eapply value_final, eval_to_value; eauto.
+              rewrite /cunfold_fix e0 //.
            ++ eapply Ee.eval_box; [|eauto].
               apply eval_to_mkApps_tBox_inv in ev_stuck as ?; subst.
               eauto.
@@ -1098,15 +1067,13 @@ Proof.
            eapply type_App; eauto.
            eapply subject_reduction; eauto.
            eapply wcbeval_red; eauto.
-           eapply PCUICClosed.subject_closed in t0; eauto.
 
   - apply inversion_App in Hty as Hty'; [|eauto].
     destruct Hty' as (? & ? & ? & ? & ? & ?).
 
     eapply subject_reduction in t as typ_stuck_fix; [|eauto|]; first last.
-    { eapply wcbeval_red; [eauto| |eauto].
-      eapply PCUICClosed.subject_closed in t; eauto. }
-    
+    { eapply wcbeval_red. 4:eauto. all:eauto. }
+
     eapply erases_App in He as He'; [|eauto].
     destruct He' as [(-> & [])|(? & ? & -> & ? & ?)].
     + exists E.tBox.
@@ -1115,14 +1082,11 @@ Proof.
       eapply Is_type_red.
       * eauto.
       * eapply PCUICReduction.red_app.
-        -- eapply wcbeval_red; [eauto| |eauto].
-           eapply PCUICClosed.subject_closed in t; eauto.
-        -- eapply wcbeval_red; [eauto| |eauto].
-           eapply PCUICClosed.subject_closed in t0; eauto.
+        -- eapply wcbeval_red; [eauto|eauto| |eauto]. eauto.
+        -- eapply wcbeval_red; [eauto|eauto| |eauto]. eauto.
       * eauto.
     + eapply subject_reduction in t0 as typ_arg; [|eauto|]; first last.
-      { eapply wcbeval_red; [eauto| |eauto].
-        eapply PCUICClosed.subject_closed in t0; eauto. }
+      { eapply wcbeval_red; [eauto|eauto| |eauto]. eauto. }
 
       eapply IHeval1 in H1 as (? & ? & ?); [|eauto].
       eapply IHeval2 in H2 as (? & ? & ?); [|eauto].
@@ -1130,7 +1094,7 @@ Proof.
       destruct H1 as [(? & ? & ? & -> & [] & ? & ? & ->)|(? & ? & -> & ? & ?)].
       * apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
         depelim H5.
-        rewrite !app_nil_r in *.
+        rewrite -> !app_nil_r in *.
         cbn in *.
         exists E.tBox.
         split; [|eauto using Ee.eval].
@@ -1153,38 +1117,7 @@ Proof.
            ++ unfold Ee.cunfold_fix.
               rewrite e0.
               reflexivity.
-           ++ eapply Forall2_length in H5.
-              destruct o as [|(<- & ?)]. noconf e.
-              rewrite <-H5, <- e2. revert H1.
-              assert(#|argsv| < rargd || #|argsv| > rarg d).
-              
-              congruence. lia.
-              [left; congruence|right].
-              split; [congruence|].
-              eapply subject_reduction_eval in t; eauto.
-              injection e. intros <- eq.
-              assert (Σ ;;; [] |- mkApps (tFix mfix idx) (argsv ++ [a]) : PCUICLiftSubst.subst1 a 0 x1).
-              { rewrite <-mkApps_nested; simpl. eapply type_App; eauto. }
-              eapply PCUICValidity.inversion_mkApps in X as (fixty & tyfix & sp); auto.
-              eapply inversion_Fix in tyfix as (? & ? & ? & ? & ? & ? & ?); auto.
-              rewrite e4 in nth. injection nth; intros ->.
-              eapply PCUICSpine.typing_spine_strengthen in sp; eauto.
-              eapply wf_fixpoint_spine in sp; eauto.
-              2:{ eapply nth_error_all in a0; eauto. eapply a0. }
-              rewrite eq in sp. rewrite nth_error_app_ge in sp; try lia.
-              rewrite Nat.sub_diag in sp. simpl in sp.
-              destruct sp as [ind [u [indargs [tya ck]]]].
-              eapply wf_ext_wf in extr_env_wf'0.
-              pose proof (eval_ind_canonical Σ _ _ _ _ extr_env_axiom_free'0 tya _ H0).
-              revert H1 H6.
-              unfold negb, isConstruct_app, PCUICParallelReductionConfluence.construct_cofix_discr, PCUICInductives.head.
-              destruct (decompose_app av) as [hd tl] eqn:da. simpl.
-              destruct hd; try congruence. intros _ _.
-              eapply subject_reduction_eval in tya; eauto.
-              eapply decompose_app_inv in da. subst av.
-              eapply typing_cofix_coind in tya; auto.
-              pose proof (check_recursivity_kind_inj Σ ck tya).
-              now discriminate.
+           ++ eapply Forall2_length in H5. noconf e. lia.
               
         -- exists E.tBox.
            apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
@@ -1223,10 +1156,8 @@ Proof.
         inversion H1.
         edestruct H7; eauto. cbn. eapply subject_reduction. eauto.
         exact Hty. eapply PCUICReduction.red_app.
-        eapply PCUICClosed.subject_closed in t'; auto.
         eapply wcbeval_red; eauto.
-        eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; auto.
-        eapply PCUICClosed.subject_closed in Ha; auto.
+        eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; eauto.
         eapply wcbeval_red; eauto.
       * exists (E.tApp x2 x3).
         split. 2:{ eapply Ee.eval_app_cong; eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1042,8 +1042,7 @@ Proof.
               now rewrite Nat.add_0_r in Hbod.
               eauto with pcuic.
               now eapply PCUICClosed.subject_closed in Ht.
-           ++ apply Forall2_length in H4.
-              congruence.
+           ++ apply Forall2_length in H4. rewrite <- e2. lia.
            ++ unfold isConstruct_app in *.
               destruct (decompose_app av) eqn:EE.
               assert (E2 : fst (decompose_app av) = t3) by now rewrite EE.
@@ -1057,12 +1056,7 @@ Proof.
                 as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?) ].
               ** subst.
                  now apply eval_to_mkApps_tBox_inv in ev_arg as ->.
-              ** subst. inv H5.
-                 +++ destruct x6 using rev_ind; cbn - [EAstUtils.decompose_app]. reflexivity.
-                     unfold is_constructor_app_or_box.
-                     rewrite emkApps_snoc at 1.
-                     now rewrite EAstUtils.decompose_app_mkApps.
-                 +++ now apply eval_to_mkApps_tBox_inv in ev_arg as ->.
+              ** subst. apply H2.
               ** eauto.
               ** eapply subject_reduction; last first.
                  eapply wcbeval_red; last first.
@@ -1071,7 +1065,6 @@ Proof.
                  eauto.
                  eauto.
                  eauto.
-           ++ eauto.
         -- cbn. destruct p. destruct p.
            eapply (erases_subst Σ [] (PCUICLiftSubst.fix_context mfix) [] dbody (fix_subst mfix)) in e3; cbn; eauto.
            ++ eapply subslet_fix_subst. now eapply wf_ext_wf. all: eassumption.
@@ -1161,7 +1154,12 @@ Proof.
               rewrite e0.
               reflexivity.
            ++ eapply Forall2_length in H5.
-              destruct o as [|(<- & ?)]; [left; congruence|right].
+              destruct o as [|(<- & ?)]. noconf e.
+              rewrite <-H5, <- e2. revert H1.
+              assert(#|argsv| < rargd || #|argsv| > rarg d).
+              
+              congruence. lia.
+              [left; congruence|right].
               split; [congruence|].
               eapply subject_reduction_eval in t; eauto.
               injection e. intros <- eq.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -10,9 +10,8 @@ From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils
   PCUICInduction PCUICLiftSubst PCUICContexts PCUICGeneration PCUICSpine PCUICConversion
   PCUICValidity PCUICInductives  PCUICConversion
   PCUICInductiveInversion PCUICNormal PCUICSafeLemmata PCUICParallelReductionConfluence PCUICSN
-  PCUICWcbvEval.
+  PCUICWcbvEval PCUICClosed PCUICReduction PCUICCSubst.
   
-Local Open Scope string_scope.
 Set Asymmetric Patterns.
 Local Set Keyed Unification.
 
@@ -65,6 +64,21 @@ Proof.
     now eapply isArity_subst.
 Qed.
 
+Ltac destruct_sigma H := 
+  repeat match type of H with
+  | @sigT _ (fun x => _) => let v := fresh x in
+    destruct H as (v & H); simpl in H
+  | (_ × _)%type => destruct H as (? & H); simpl in H
+  end.
+  
+Lemma closedn_mkApps k f args : closedn k (mkApps f args) = closedn k f && forallb (closedn k) args.
+Proof.
+  induction args using rev_ind; simpl => //.
+  - now rewrite andb_true_r.
+  - now rewrite -mkApps_nested /= IHargs forallb_app andb_assoc /= andb_true_r.
+Qed. 
+
+
 Section Arities.
   Context {cf:checker_flags} {Σ : global_env_ext}.
   Context {wfΣ : wf Σ}.
@@ -101,7 +115,6 @@ Section Arities.
 
 End Arities.
 
-Require Import PCUICValidity ssreflect.
 Lemma All2_map_left' {A B  C} (P : A -> B -> Type) l l' (f : C -> A) :
   All2 P (map f l) l' -> All2 (fun x y => P (f x) y) l l'.
 Proof. intros. rewrite - (map_id l') in X. eapply All2_map_inv; eauto. Qed.
@@ -271,7 +284,7 @@ Section Spines.
       intros wf sp; depelim sp. rewrite nth_error_nil //.
       pose proof (All_local_env_app _ _ _ wf) as [_ wfty].
       eapply All_local_env_app in wfty as [wfty _]. depelim wfty.
-      eapply cumul_Prod_inv in c as [dom codom]; pcuic.
+      eapply cumul_Prod_inv in c as [dom codom]. 2-3:pcuic.
       assert (Σ ;;; Γ |- hd : ty).
       { eapply type_Cumul; pcuic. eapply conv_cumul. now symmetry. }
       eapply (substitution_cumul0 _ _ _ _ _ _ hd) in codom; eauto.
@@ -322,7 +335,7 @@ Section Spines.
         simpl; len => hargs. simpl in hargs.
         rewrite Nat.add_1_r in hargs. destruct args => //.
         depelim sp. noconf hargs.
-        eapply cumul_Prod_inv in c as [dom codom]; pcuic.
+        eapply cumul_Prod_inv in c as [dom codom]. 2-3:pcuic.
         rewrite expand_lets_vass. simpl.
         eapply (substitution_cumul0 _ _ _ _ _ _ t) in codom; eauto.
         eapply typing_spine_strengthen in sp; eauto.
@@ -378,10 +391,10 @@ Section Spines.
       eapply All_local_env_app in wfty as [wfty _]. depelim wfty.
       intros Hargs.
       depelim sp. 
-      + eapply invert_cumul_prod_l in c as [na' [dom [codom [[red eqdom] cum]]]]; pcuic.
+      + eapply invert_cumul_prod_l in c as [na' [dom [codom [[red eqdom] cum]]]]; auto.
         move=> _. exists na', dom, codom.
         now eapply conv_cumul, conv_sym, red_conv.
-      + eapply cumul_Prod_inv in c as [dom codom]; pcuic.
+      + eapply cumul_Prod_inv in c as [dom codom]. 2-3:pcuic.
         assert (Σ ;;; Γ |- hd : ty).
         { eapply type_Cumul; pcuic. eapply conv_cumul. now symmetry. }
         eapply (substitution_cumul0 _ _ _ _ _ _ hd) in codom; eauto.
@@ -711,6 +724,95 @@ Section Normalization.
 End Normalization.
 *)
 
+(** Evaluation is a subrelation of reduction: *)
+
+Tactic Notation "redt" uconstr(y) := eapply (CRelationClasses.transitivity (R:=red _ _) (y:=y)).
+(*
+Lemma wcbeval_red `{checker_flags} : env_prop (fun Σ Γ t ty =>
+    forall u, Γ = [] ->
+    eval Σ t u -> red Σ [] t u) (fun Σ Γ wf => wf_local Σ Γ).
+Proof.
+  eapply typing_ind_env => Σ wfΣ Γ wf //.
+  - move=> n decl hnth _ u eqΓ ev; subst Γ.
+    depelim ev. constructor.
+  - move=> l _ inl u eqΓ ev; subst Γ; depelim ev.
+    constructor.
+  - move=> n t b s1 s2 _ hty IH Hb IH' u eqΓ; subst Γ.
+    intros sp; depelim sp; constructor.
+  - intros. subst Γ. depelim X4; constructor.
+  - intros * _ Hbty IH Hb IHb Hb' IHb' u eqΓ; subst Γ.
+    intros sp; depelim sp; auto.
+    rewrite (closed_subst b0' 0 b') in sp2.
+    eapply eval_closed; eauto.
+    eapply subject_closed in Hb; eauto.
+    redt (tLetIn n b0' b_ty b'); eauto.
+    eapply red_letin; eauto.
+    redt (b' {0 := b0'}); auto.
+    do 2 econstructor.
+    
+    specialize (IHHe1 _ t1).
+    rewrite /subst1.
+    rewrite -(closed_subst b0' 0 b1); eauto using eval_closed.
+    eapply subject_reduction in t1; eauto. eapply subject_closed in t1; eauto.
+    eapply IHHe2.
+    rewrite closed_subst.
+*)
+
+    (*eapply All2_same. intros. split; auto.
+    redt (iota_red _ _ _ _); eauto. 2:eapply IHHe2.
+    eapply red1_red. econstructor.
+    eapply closed_iota; eauto. now eapply eval_closed in He1.
+
+  - redt _. 2:eapply IHHe2; eauto using eval_closed.
+    redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
+    apply red1_red. econstructor; eauto.
+    eapply eval_closed in He1; eauto. eapply closed_arg in He1; eauto.
+
+  - redt (tApp (mkApps (tFix mfix idx) argsv) av);
+      [eapply red_app; eauto|].
+    assert (closed_fix: closed (mkApps (tFix mfix idx) argsv)).
+    { eapply eval_closed; [easy| |easy].
+      easy. }
+    eapply closedn_mkApps_inv in closed_fix.
+    apply andb_true_iff in closed_fix.
+    rewrite -closed_unfold_fix_cunfold_eq in e; [easy|].
+    redt (tApp (mkApps fn argsv) av).
+    + repeat change (tApp ?h ?a) with (mkApps h [a]).
+      rewrite !mkApps_nested.
+      apply red1_red.
+      eapply red_fix; [easy|].
+      unfold is_constructor.
+      rewrite nth_error_app_ge //.
+    + eapply IHHe3.
+      cbn.
+      apply andb_true_iff.
+      split.
+      * apply closedn_mkApps; [|easy].
+        now eapply closed_unfold_fix.
+      * now eapply eval_closed; [| |easy].
+
+  - now apply red_app.
+
+  - move/closedn_mkApps_inv/andP: Hc' => [Hf Hargs].
+    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
+    redt _. eapply red1_red.
+    eapply PCUICTyping.red_cofix_case; eauto.
+    eapply IHHe.
+    eapply closed_unfold_cofix in e; eauto.
+    simpl. rewrite Hc closedn_mkApps; eauto.
+
+  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
+    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
+    redt _. 2:eapply IHHe.
+    redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
+    apply red1_red. econstructor; eauto.
+    simpl. eapply closed_unfold_cofix in e; eauto.
+    rewrite closedn_mkApps; eauto.
+
+  - eapply (red_mkApps _ _ [a] [a']); auto.
+Qed.*)
+
+
 Section WeakNormalization.
   Context {cf:checker_flags} (Σ : global_env_ext).
   Context {wfΣ : wf Σ}.
@@ -718,14 +820,7 @@ Section WeakNormalization.
   Section reducible.
   Notation wh_neutral := (whne RedFlags.default).
   Notation wh_normal := (whnf RedFlags.default).
-  Require Import PCUICClosed.
 
-  Lemma closedn_mkApps k f args : closedn k (mkApps f args) = closedn k f && forallb (closedn k) args.
-  Proof.
-    induction args using rev_ind; simpl => //.
-    - now rewrite andb_true_r.
-    - now rewrite -mkApps_nested /= IHargs forallb_app andb_assoc /= andb_true_r.
-  Qed. 
   Transparent construct_cofix_discr.
 
   Lemma value_whnf t : closed t -> value Σ t -> wh_normal Σ [] t.
@@ -749,16 +844,13 @@ Section WeakNormalization.
       eapply whnf_cofixapp.
     - destruct f => //. cbn in H.
       destruct cunfold_fix as [[rarg body]|] eqn:unf => //.
-      rewrite /is_constructor in H.
       pose proof cl as cl'.
       rewrite closedn_mkApps in cl'. move/andP: cl' => [clfix _].
       rewrite -P.closed_unfold_fix_cunfold_eq in unf => //.
-      destruct nth_error eqn:nth => //.
-      * have clarg := closed_arg  _ _ _ _ cl nth.
-        eapply whnf_ne; eapply whne_fixapp; eauto.
-        eapply nth_error_all in X0; eauto.
-        destruct isConstruct_app => //.
-      * eapply whnf_fixapp. rewrite unf //.
+      rewrite /unfold_fix in unf.
+      destruct nth_error eqn:nth => //. noconf unf.
+      eapply whnf_fixapp. rewrite /unfold_fix nth.
+      eapply Nat.leb_le in H. now eapply nth_error_None.
   Qed.
 
   Lemma eval_whne t t' : closed t -> eval Σ t t' -> wh_normal Σ [] t'.
@@ -899,7 +991,7 @@ Section WeakNormalization.
       wh_normal Σ Γ t -> Γ = [] -> construct_cofix_discr (head t).
   Proof.
     all:intros axfree typed ne;
-    pose proof (PCUICClosed.subject_closed wfΣ typed) as cl;
+    pose proof (subject_closed wfΣ typed) as cl;
     destruct ne; intros eqΓ;  simpl in *; try discriminate.
     - rewrite eqΓ in cl => //.
     - now eapply typing_var in typed.
@@ -973,24 +1065,215 @@ Section WeakNormalization.
     False.
   Proof. intros; now eapply wh_neutral_empty_gen. Qed.
 
-  Lemma wh_normal_empty t i u args : axiom_free Σ -> 
+  Lemma wh_normal_ind_discr t i u args : axiom_free Σ -> 
       Σ ;;; [] |- t : mkApps (tInd i u) args -> 
       wh_normal Σ [] t -> 
       construct_cofix_discr (head t).
   Proof. intros; now eapply wh_normal_empty_gen. Qed. 
 
+  Lemma whnf_ind_finite t ind u indargs : 
+    axiom_free Σ ->
+    Σ ;;; [] |- t : mkApps (tInd ind u) indargs ->
+    wh_normal Σ [] t ->
+    check_recursivity_kind Σ (inductive_mind ind) Finite ->
+    isConstruct_app t.
+  Proof.
+    intros axfree typed whnf ck.
+    rewrite /isConstruct_app.
+    eapply wh_normal_ind_discr in whnf; eauto.
+    rewrite /head in whnf.
+    destruct (decompose_app t) as [hd tl] eqn:da; simpl in *.
+    destruct hd eqn:eqh => //. subst hd.
+    eapply decompose_app_inv in da. subst.
+    eapply typing_cofix_coind in typed.
+    now move: (check_recursivity_kind_inj typed ck).
+  Qed.
+
+  Lemma fix_app_is_constructor mfix idx args ty narg fn : 
+    axiom_free Σ ->
+    All (wh_normal Σ []) args ->
+    Σ;;; [] |- mkApps (tFix mfix idx) args : ty ->
+    unfold_fix mfix idx = Some (narg, fn) ->
+    match nth_error args narg return Type with
+    | Some a => isConstruct_app a
+    | None => ∑ na dom codom, Σ ;;; [] |- tProd na dom codom <= ty
+    end.
+  Proof.
+    intros axfree allnorm typed unf.
+    eapply inversion_mkApps in typed as (? & ? & ?); eauto.
+    eapply inversion_Fix in t as (? & ? & ? & ? & ? & ? & ?); auto.
+    eapply typing_spine_strengthen in t0; eauto.
+    eapply nth_error_all in a; eauto. simpl in a.
+    rewrite /unfold_fix in unf. rewrite e in unf.
+    noconf unf.
+    eapply (wf_fixpoint_spine wfΣ) in t0; eauto.
+    rewrite /is_constructor. destruct (nth_error args (rarg x0)) eqn:hnth.
+    destruct_sigma t0. destruct t0.
+    eapply nth_error_all in allnorm; eauto.
+    eapply whnf_ind_finite in t0; eauto.
+    assumption.
+  Qed.
+
+  (** Evaluation on well-typed terms corresponds to reduction. 
+      It differs in two ways from standard reduction: 
+      - using closed substitution operations applicable only on closed terms
+      - it does not check that fixpoints that are applied to enough arguments 
+        have a constructor at their recursive argument as it is ensured by typing. *)
+
+  Lemma wcbeval_red t ty u :
+    axiom_free Σ ->
+    Σ ;;; [] |- t : ty ->
+    eval Σ t u -> red Σ [] t u.
+  Proof.
+  intros axfree Hc He.
+  revert ty Hc.
+  induction He; simpl; move=> ty Ht;
+    try solve[econstructor; eauto].
+
+  - eapply inversion_App in Ht as (? & ? & ? & ? & ? & ?); auto.
+    redt (tApp (tLambda na t b) a); eauto.
+    eapply red_app; eauto.
+    redt (tApp (tLambda na t b) a'). eapply red_app; eauto.
+    specialize (IHHe1 _ t0). specialize (IHHe2 _ t1).
+    redt (csubst a' 0 b).
+    rewrite (closed_subst a' 0 b).
+    eapply eval_closed; eauto. now eapply subject_closed in t1.
+    eapply red1_red. constructor.
+    pose proof (subject_closed wfΣ t1); auto.
+    eapply eval_closed in H; eauto.
+    eapply subject_reduction in IHHe1. 2-3:eauto.
+    eapply inversion_Lambda in IHHe1 as (? & ? & ? & ? & ?); eauto.
+    eapply (substitution0 _ []) in t3; eauto.
+    eapply IHHe3.
+    rewrite (closed_subst a' 0 b); auto.
+    rewrite /subst1 in t3. eapply t3.
+    eapply type_Cumul; eauto.
+    eapply subject_reduction in IHHe2; eauto.
+    eapply cumul_Prod_inv in c0 as [dom codom]; eauto.
+    eapply conv_cumul; now symmetry.
+
+  - eapply inversion_LetIn in Ht as (? & ? & ? & ? & ? & ?); auto.
+    redt (tLetIn na b0' t b1); eauto.
+    eapply red_letin; eauto.
+    redt (b1 {0 := b0'}); auto.
+    do 2 econstructor.
+    specialize (IHHe1 _ t1).
+    rewrite /subst1.
+    rewrite -(closed_subst b0' 0 b1).
+    eapply subject_reduction in t1; eauto. eapply subject_closed in t1; eauto.
+    eapply IHHe2.
+    rewrite closed_subst.
+    eapply subject_reduction in t1; eauto. eapply subject_closed in t1; eauto.
+    eapply substitution_let in t2; eauto.
+    eapply subject_reduction in t2.
+    3:{ eapply (red_red _ _ [vass na t] []); eauto. repeat constructor. }    
+    eapply t2. auto.
+    
+
+  - redt (subst_instance_constr u body); auto.
+    eapply red1_red. econstructor; eauto.
+    eapply IHHe. eapply subject_reduction; eauto.
+    eapply red1_red. econstructor; eauto.
+
+  - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
+    apply inversion_Case in Ht; auto; destruct_sigma Ht.
+    specialize (IHHe1 _ t0).
+    assert (red Σ [] (tCase (ind, pars) p discr brs) (iota_red pars c args brs)).
+    { redt _.
+      eapply red_case; eauto. eapply All2_refl; intros; eauto.
+      eapply red1_red; constructor. }
+    specialize (X X0).
+    redt _; eauto.
+
+  - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
+    apply inversion_Proj in Ht; auto; destruct_sigma Ht.
+    specialize (IHHe1 _ t).
+    assert (red Σ [] (tProj (i, pars, arg) discr) a).
+    { redt _.
+      eapply red_proj_c; eauto.
+      eapply red1_red; constructor; auto. }
+    specialize (X X0).
+    redt _; eauto.
+
+  - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
+    apply inversion_App in Ht; auto; destruct_sigma Ht.
+    specialize (IHHe1 _ t).
+    specialize (IHHe2 _ t0).
+    epose proof (subject_reduction Σ [] _ _ _ wfΣ t IHHe1) as Ht2.
+    epose proof (subject_reduction Σ [] _ _ _ wfΣ t0 IHHe2) as Ha2.
+    assert (red Σ [] (tApp f a) (tApp (mkApps fn argsv) av)).
+    { redt _.
+      eapply red_app; eauto.
+      rewrite ![tApp _ _](mkApps_nested _ _ [_]).
+      eapply red1_red. 
+      rewrite -closed_unfold_fix_cunfold_eq in e.
+      eapply subject_closed in Ht2; auto.
+      rewrite closedn_mkApps in Ht2. now move/andP: Ht2 => [clf _].
+      eapply red_fix; eauto.
+      assert (Σ ;;; [] |- mkApps (tFix mfix idx) (argsv ++ [av]) : B {0 := av}).
+      { rewrite -mkApps_nested /=. eapply type_App; eauto. }
+      eapply fix_app_is_constructor in X0; eauto.
+      rewrite /is_constructor.
+      destruct nth_error eqn:hnth => //.
+      eapply nth_error_None in hnth; len in hnth; simpl in *. lia.
+      assert (All (closedn 0) (argsv ++ [av])%list).
+      { eapply subject_closed in X0; eauto.
+        rewrite closedn_mkApps in X0.
+        move/andP: X0 => [clfix clargs].
+        now eapply forallb_All in clargs. }
+      assert (All (value Σ) (argsv ++ [av])).
+      { eapply All_app_inv; [|constructor; [|constructor]].
+        eapply eval_to_value in He1.
+        eapply value_mkApps_inv in He1 as [[[-> Hat]|[vh vargs]]|[hstuck vargs]] => //.
+        now eapply eval_to_value in He2. }        
+      solve_all.
+      now eapply value_whnf. }
+    redt _; eauto.
+
+  - apply inversion_App in Ht; auto; destruct_sigma Ht.
+    specialize (IHHe1 _ t).
+    specialize (IHHe2 _ t0).
+    now eapply red_app.
+
+  - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
+    apply inversion_Case in Ht; auto; destruct_sigma Ht.
+    pose proof (subject_closed wfΣ t0) as H.
+    rewrite closedn_mkApps in H. move/andP: H => [clcofix clargs].
+    assert (red Σ [] (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)).
+    { eapply red1_red. eapply PCUICTyping.red_cofix_case.
+      rewrite -closed_unfold_cofix_cunfold_eq in e; eauto. }
+    specialize (X X0).
+    specialize (IHHe _ X).
+    redt _; eauto.
+    
+  - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
+    apply inversion_Proj in Ht; auto; destruct_sigma Ht.
+    pose proof (subject_closed wfΣ t) as H.
+    rewrite closedn_mkApps in H. move/andP: H => [clcofix clargs].
+    assert (red Σ [] (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))).
+    { eapply red1_red. eapply PCUICTyping.red_cofix_proj.
+      rewrite -closed_unfold_cofix_cunfold_eq in e; eauto. }
+    specialize (X X0).
+    specialize (IHHe _ X).
+    redt _; eauto.
+
+  - eapply inversion_App in Ht as (? & ? & ? & Hf & Ha & Ht); auto.
+    specialize (IHHe1 _ Hf).
+    specialize (IHHe2 _ Ha).
+    now eapply red_app.
+  Qed.
+
   Lemma eval_ind_canonical t i u args : 
     axiom_free Σ ->
     Σ ;;; [] |- t : mkApps (tInd i u) args -> 
-    forall t', 
-    eval Σ t t' ->
+    forall t', eval Σ t t' ->
     construct_cofix_discr (head t').
   Proof.
     intros axfree Ht t' eval.
     pose proof (subject_closed wfΣ Ht).
     eapply subject_reduction in Ht. 3:eapply wcbeval_red; eauto. 2:auto.
     eapply eval_whne in eval; auto.
-    eapply wh_normal_empty; eauto.
+    eapply wh_normal_ind_discr; eauto.
   Qed.
 
   End reducible.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -208,11 +208,10 @@ Section Wcbv.
       eval (tProj (i, pars, arg) discr) res
 
   (** Fix unfolding, with guard *)
-  | eval_fix f mfix idx argsv a av narg fn res :
+  | eval_fix f mfix idx argsv a av fn res :
       eval f (mkApps (tFix mfix idx) argsv) ->
       eval a av ->
-      cunfold_fix mfix idx = Some (narg, fn) ->
-      narg <= #|argsv| ->      
+      cunfold_fix mfix idx = Some (#|argsv|, fn) ->
       eval (tApp (mkApps fn argsv) av) res ->
       eval (tApp f a) res
 

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -4,7 +4,8 @@ Set Warnings "-notation-overridden".
 From Coq Require Import Arith Bool List Lia CRelationClasses.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst
-     PCUICUnivSubst PCUICTyping PCUICReduction PCUICClosed PCUICCSubst.
+     PCUICUnivSubst PCUICTyping PCUICReduction PCUICClosed PCUICCSubst 
+     PCUICSubstitution PCUICInversion PCUICSR.
 Require Import String.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -121,12 +122,11 @@ Definition cunfold_cofix (mfix : mfixpoint term) (idx : nat) :=
   | None => None
   end.
 
-Definition isStuckFix t args :=
+Definition isStuckFix t (args : list term) :=
   match t with
   | tFix mfix idx =>
     match cunfold_fix mfix idx with
-    | Some (narg, fn) =>
-      ~~ is_constructor narg args
+    | Some (narg, fn) => #|args| <=? narg
     | None => false
     end
   | _ => false
@@ -198,8 +198,7 @@ Section Wcbv.
       eval f (mkApps (tFix mfix idx) argsv) ->
       eval a av ->
       cunfold_fix mfix idx = Some (narg, fn) ->
-      #|argsv| = narg ->
-      isConstruct_app av ->
+      narg <= #|argsv| ->      
       eval (tApp (mkApps fn argsv) av) res ->
       eval (tApp f a) res
 
@@ -208,7 +207,7 @@ Section Wcbv.
       eval f (mkApps (tFix mfix idx) argsv) ->
       eval a av ->
       cunfold_fix mfix idx = Some (narg, fn) ->
-      (#|argsv| <> narg \/ (#|argsv| = narg /\ ~~isConstruct_app av)) ->
+      (#|argsv| < narg) ->
       eval (tApp f a) (tApp (mkApps (tFix mfix idx) argsv) av)
 
   (** CoFix-case unfolding *)
@@ -342,24 +341,13 @@ Section Wcbv.
         apply (value_stuck_fix _ [av]); [easy|].
         cbn.
         destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
-        noconf e.
-        unfold is_constructor.
-        destruct o as [|(<- & ?)]; [|easy].
-        now rewrite (proj2 (nth_error_None _ _));
-          cbn in *.
+        noconf e. eapply Nat.leb_le. lia.
       + easy.
       + eapply value_stuck_fix; [now apply All_app_inv|].
         unfold isStuckFix in *.
         destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
-        noconf e.
-        unfold is_constructor in *.
-        destruct o as [|(<- & ?)]; [|now rewrite nth_error_snoc].
-        destruct (Nat.ltb_spec #|argsv| narg).
-        * rewrite (proj2 (nth_error_None _ _)); [|easy].
-          rewrite app_length.
-          cbn.
-          easy.
-        * now rewrite nth_error_app1.
+        noconf e. rewrite app_length /=.
+        eapply Nat.leb_le; lia.
     - destruct (mkApps_elim f' [a']).
       eapply value_mkApps_inv in IHX1 => //.
       destruct IHX1; intuition subst.
@@ -402,15 +390,12 @@ Section Wcbv.
       eapply eval_fix_value.
       + apply IH; [easy|].
         destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
-        unfold is_constructor in *.
-        destruct (nth_error argsv _) eqn:nth; [|easy].
-        now erewrite nth_error_app_left in stuck.
+        rewrite app_length /= in stuck.
+        eapply Nat.leb_le in stuck. eapply Nat.leb_le. lia.
       + easy.
       + easy.
-      + destruct (Nat.eqb_spec #|argsv| n) as [<-|].
-        * unfold is_constructor in *.
-          now rewrite nth_error_snoc in stuck.
-        * now left.
+      + rewrite app_length /= in stuck.
+        eapply Nat.leb_le in stuck; lia.
   Qed.
 
   Derive Signature for eval.
@@ -714,27 +699,23 @@ Section Wcbv.
     + apply IHev1 in ev'1; solve_discr.
     + apply IHev1 in ev'1.
       solve_discr.
-      rewrite e1 in e.
-      apply IHev2 in ev'2.
-      subst.
-      noconf e.
+      rewrite e0 in e. noconf e.
+      apply IHev2 in ev'2. subst.
       now apply IHev3 in ev'3.
     + apply IHev1 in ev'1; solve_discr.
       apply IHev2 in ev'2; subst.
-      destruct o as [|(? & ?)]; [easy|].
-      now apply Bool.negb_true_iff in H0.
+      rewrite e0 in e. noconf e. lia.
     + apply IHev1 in ev'1.
       subst f'.
-      rewrite isFixApp_mkApps in i0 by easy.
+      rewrite isFixApp_mkApps in i by easy.
       cbn in *.
-      now rewrite Bool.orb_true_r in i0.
+      now rewrite Bool.orb_true_r in i.
     + easy.
   - depelim ev'.
     + apply IHev1 in ev'1; solve_discr.
     + apply IHev1 in ev'1; solve_discr.
       apply IHev2 in ev'2; subst.
-      destruct o as [|(? & ?)]; [easy|].
-      now apply Bool.negb_true_iff in H0.
+      rewrite e0 in e; noconf e. lia.
     + apply IHev1 in ev'1; solve_discr.
       now apply IHev2 in ev'2; subst.
     + apply IHev1 in ev'1; subst.
@@ -829,92 +810,3 @@ Arguments eval_deterministic {_ _ _ _}.
 Conjecture closed_typed_wcbeval : forall {cf : checker_flags} (Σ : global_env_ext) t T,
     Σ ;;; [] |- t : T -> ∑ u, eval (fst Σ) t u.
 
-(** Evaluation is a subrelation of reduction: *)
-
-Tactic Notation "redt" uconstr(y) := eapply (transitivity (R:=red _ _) (y:=y)).
-
-Lemma wcbeval_red `{checker_flags} : forall (Σ : global_env_ext) t u, wf Σ -> closed t ->
-    eval Σ t u -> red Σ [] t u.
-Proof.
-  intros Σ t u wfΣ Hc He. revert Hc.
-  induction He; simpl; 
-  (move/andP => [/andP[Hc Hc'] Hc''] || move/andP => [Hc Hc'] || move => Hc);
-    try solve[econstructor; eauto].
-
-  - redt (tApp (tLambda na t b) a); eauto.
-    eapply red_app; eauto.
-    redt (tApp (tLambda na t b) a'). eapply red_app; eauto.
-    redt (csubst a' 0 b).
-    rewrite (closed_subst a' 0 b).
-    eapply eval_closed; eauto. eapply red1_red. constructor.
-    eapply IHHe3. eapply closed_csubst. eauto using eval_closed.
-    eapply eval_closed in He1; eauto. 
-    simpl in He1. now move/andP: He1.
-
-  - redt (tLetIn na b0' t b1); eauto.
-    eapply red_letin; auto.
-    redt (b1 {0 := b0'}); auto.
-    do 2 econstructor.
-    forward IHHe2.
-    eapply closed_csubst; eauto using eval_closed. unfold subst1.
-    rewrite -(closed_subst b0' 0 b1); eauto using eval_closed.
-
-  - redt (subst_instance_constr u body); auto.
-    eapply red1_red. econstructor; eauto.
-    apply IHHe. now eapply closed_def.
-
-  - redt (tCase (ind, pars) p _ brs).
-    eapply red_case. eauto. eapply IHHe1; eauto.
-    eapply All2_same. intros. split; auto.
-    redt (iota_red _ _ _ _); eauto. 2:eapply IHHe2.
-    eapply red1_red. econstructor.
-    eapply closed_iota; eauto. now eapply eval_closed in He1.
-
-  - redt _. 2:eapply IHHe2; eauto using eval_closed.
-    redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
-    apply red1_red. econstructor; eauto.
-    eapply eval_closed in He1; eauto. eapply closed_arg in He1; eauto.
-
-  - redt (tApp (mkApps (tFix mfix idx) argsv) av);
-      [eapply red_app; eauto|].
-    assert (closed_fix: closed (mkApps (tFix mfix idx) argsv)).
-    { eapply eval_closed; [easy| |easy].
-      easy. }
-    eapply closedn_mkApps_inv in closed_fix.
-    apply andb_true_iff in closed_fix.
-    rewrite -closed_unfold_fix_cunfold_eq in e; [easy|].
-    redt (tApp (mkApps fn argsv) av).
-    + repeat change (tApp ?h ?a) with (mkApps h [a]).
-      rewrite !mkApps_nested.
-      apply red1_red.
-      eapply red_fix; [easy|].
-      unfold is_constructor.
-      now rewrite nth_error_snoc.
-    + eapply IHHe3.
-      cbn.
-      apply andb_true_iff.
-      split.
-      * apply closedn_mkApps; [|easy].
-        now eapply closed_unfold_fix.
-      * now eapply eval_closed; [| |easy].
-
-  - now apply red_app.
-
-  - move/closedn_mkApps_inv/andP: Hc' => [Hf Hargs].
-    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
-    redt _. eapply red1_red.
-    eapply PCUICTyping.red_cofix_case; eauto.
-    eapply IHHe.
-    eapply closed_unfold_cofix in e; eauto.
-    simpl. rewrite Hc closedn_mkApps; eauto.
-
-  - move/closedn_mkApps_inv/andP: Hc => [Hf Hargs].
-    rewrite -closed_unfold_cofix_cunfold_eq in e; auto.
-    redt _. 2:eapply IHHe.
-    redt (tProj _ (mkApps _ _)). eapply red_proj_c. eauto.
-    apply red1_red. econstructor; eauto.
-    simpl. eapply closed_unfold_cofix in e; eauto.
-    rewrite closedn_mkApps; eauto.
-
-  - eapply (red_mkApps _ _ [a] [a']); auto.
-Qed.


### PR DESCRIPTION
This commit simplifies evaluation of fixpoints in weak-call-by-value, thanks to canonicity of inductive values.

Now a fixpoint appearing during evaluation can be in only two shapes:
- It does not have enough arguments and is stuck
- It has enough arguments and unfolds (the recursive argument has to be a constructor by typing).

This is done already at the level of PCUIC, so that erasure does not have to deal with it too much (the correctness of erasure still needs a bit of the same reasoning).

I guess this is the most we can do to simplify evaluation, which should now stay quite stable.

There remains todo's in the erasure correctness proof for cofixpoints only.