### PR TITLE
Cleaning in reduction/conversion/cumulativity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,6 +348,8 @@ pcuic/src/pCUICReflect.ml
 pcuic/src/pCUICReflect.mli
 pcuic/src/pCUICUtils.ml
 pcuic/src/pCUICUtils.mli
+erasure/src/pCUICReduction.ml
+erasure/src/pCUICReduction.mli
 
 /pcuic/src/ssreflect.mli
 /_opam

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -41,6 +41,8 @@ src/pCUICReflect.mli
 src/pCUICReflect.ml
 src/pCUICEquality.mli
 src/pCUICEquality.ml
+src/pCUICReduction.ml
+src/pCUICReduction.mli
 src/pCUICTyping.ml
 src/pCUICTyping.mli
 src/pCUICUnivSubst.ml

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -154,12 +154,13 @@ Proof.
 Qed.
 
 Lemma invert_it_Ind_red Σ L i u l t Γ : wf Σ ->
-  red Σ Γ (it_mkProd_or_LetIn L (mkApps (tInd i u) l)) t -> exists L' l', t = it_mkProd_or_LetIn L' (mkApps (tInd i u) l').
+  red Σ Γ (it_mkProd_or_LetIn L (mkApps (tInd i u) l)) t
+  -> exists L' l', t = it_mkProd_or_LetIn L' (mkApps (tInd i u) l').
 Proof.
-  intros. induction X0.
+  intros. induction X0 using red_rect'.
   - eauto.
   - destruct IHX0 as (? & ? & ->).
-    eapply invert_it_Ind_red1 in r as (? & ? & ?); eauto.
+    eapply invert_it_Ind_red1 in X1 as (? & ? & ?); eauto.
 Qed.
 
 Lemma it_mkProd_red_Arity Σ  c0 i u l : wf Σ ->
@@ -287,14 +288,12 @@ Proof.
   constructor; auto.
 Qed.
 
-Hint Constructors red red1 : core.
-
 Lemma context_conversion_red1 (Σ : global_env_ext) Γ Γ' s t : wf Σ -> (* Σ ;;; Γ' |- t : T -> *)
    context_relation (@conv_decls Σ) Γ Γ' -> red1 Σ Γ s t -> red Σ Γ' s t.
 Proof.
   intros HΣ HT X0. induction X0 using red1_ind_all in Γ', HΣ, HT |- *; eauto.
-  all:eauto.
-  - econstructor. econstructor. econstructor.
+  all:pcuic.
+  - econstructor. econstructor.
     rewrite <- H.
     induction HT in i |- *; destruct i; eauto.
     now inv p.
@@ -316,15 +315,15 @@ Proof.
     eapply All_All2_refl. induction brs; eauto.
   -     eapply PCUICReduction.red_case; eauto. clear.
     eapply All_All2_refl. induction brs; eauto.
-  - destruct ind.
-    eapply PCUICReduction.red_case; eauto.
+  - destruct a.
+    eapply red_case; eauto.
     clear - HΣ X HT.
     induction X.
     + econstructor. destruct p. destruct p.
       split; eauto.
       eapply All_All2_refl.
       induction tl; eauto.
-    + econstructor.  repeat econstructor.
+    + econstructor. now split.
       eassumption.
   -
     eapply PCUICReduction.red_proj_c. eauto.
@@ -381,7 +380,7 @@ Qed.
 Lemma context_conversion_red (Σ : global_env_ext) Γ Γ' s t : wf Σ ->
   context_relation (@conv_decls Σ) Γ Γ' -> red Σ Γ s t -> red Σ Γ' s t.
 Proof.
-  intros. induction X1; eauto.
+  intros. induction X1 using red_rect'; eauto.
   etransitivity. eapply IHX1.
   eapply context_conversion_red1; eauto.
 Qed.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -748,7 +748,7 @@ Proof.
         eapply subject_reduction. eauto. exact Hty.
         etransitivity.
         eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto.
-        econstructor. econstructor. econstructor.
+        econstructor. econstructor.
 
         all:unfold iota_red in *. all:cbn in *.
         eapply erases_mkApps. eauto.
@@ -793,9 +793,9 @@ Proof.
         eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
         now eapply PCUICClosed.subject_closed in t0. eauto. eauto.
 
-        etransitivity. eapply trans_red. econstructor.
-        econstructor. unfold iota_red. rewrite <- nth_default_eq. unfold nth_default.
-        rewrite Hnth. econstructor.
+        etransitivity. constructor. constructor.
+        unfold iota_red. rewrite <- nth_default_eq. unfold nth_default.
+        rewrite Hnth. reflexivity.
 
         eapply erases_mkApps. eauto.
         eapply Forall2_skipn. eauto.
@@ -823,8 +823,8 @@ Proof.
            etransitivity.
            eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
            now eapply PCUICClosed.subject_closed in t0; eauto. eauto. eauto.
-           econstructor. econstructor. 
-           econstructor.
+           etransitivity. constructor. constructor.
+           unfold iota_red. rewrite <- nth_default_eq. reflexivity.
 
            eapply erases_mkApps. eauto.
            instantiate (1 := repeat EAst.tBox _).

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -54,7 +54,7 @@ Proof.
   induction (wf_cod' s) as [s _ IH_sub] in Γ, H, IH |- *.
   econstructor.
   intros (Γ' & B & ?) [(na & A & ? & ?)]. subst.
-    inversion r.
+  eapply Relation_Properties.clos_rt_rtn1 in r. inversion r.
     + subst. eapply IH_sub. econstructor. cbn. reflexivity.
       intros. eapply IH.
       inversion H0.
@@ -62,15 +62,19 @@ Proof.
       * subst. eapply cored_red in H2 as [].
         eapply cored_red_trans. 2: eapply prod_red_r. 2:eassumption.
         eapply PCUICReduction.red_prod_r. eauto.
-      * repeat econstructor.
+      * constructor. do 2 eexists. now split.
     + subst. eapply IH.
-      * eapply red_neq_cored. exact r. intros ?. subst.
-        eapply cored_red_trans in X0; eauto.
+      * eapply red_neq_cored.
+        eapply Relation_Properties.clos_rtn1_rt. exact r.
+        intros ?. subst.
+        eapply Relation_Properties.clos_rtn1_rt in X1.
+        eapply cored_red_trans in X0; [| exact X1 ].
         eapply Acc_no_loop in X0. eauto.
         eapply @normalisation'; eauto.
-      * repeat econstructor.
+      * constructor. do 2 eexists. now split.
 Grab Existential Variables.
-- eapply red_wellformed; sq. 3:eauto. all:eauto.
+- eapply red_wellformed; sq.
+  3:eapply Relation_Properties.clos_rtn1_rt in r; eassumption. all:eauto.
 - destruct H as [[] |[]].
   -- eapply inversion_Prod in X0 as (? & ? & ? & ? & ?) ; auto.
      eapply cored_red in H0 as [].
@@ -221,7 +225,7 @@ Qed.
 
 Lemma red_red' Γ t t' : red Σ Γ t t' -> red' Σ Γ t t'.
 Proof.
-  induction 1.
+  induction 1 using red_rect'.
   - econstructor.
   - etransitivity. eassumption. econstructor. eauto. econstructor.
 Qed.
@@ -325,7 +329,7 @@ Qed.
 Next Obligation.
   clear He.
   destruct H as (? & ? & ?). eexists (tProd _ _ _). split; sq.
-  etransitivity. eassumption. eapply PCUICReduction.red_prod. econstructor.
+  etransitivity. eassumption. eapply PCUICReduction.red_prod. reflexivity.
   eassumption. now cbn.
 Qed.
 Next Obligation.

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -321,7 +321,7 @@ Lemma subslet_fix_subst `{cf : checker_flags} Σ mfix1 T n :
   wf Σ.1 ->
   Σ ;;; [] |- tFix mfix1 n : T ->
   (* wf_local Σ (PCUICLiftSubst.fix_context mfix1) -> *)
-  subslet Σ [] (PCUICTyping.fix_subst mfix1) (PCUICLiftSubst.fix_context mfix1).
+  subslet Σ [] (fix_subst mfix1) (PCUICLiftSubst.fix_context mfix1).
 Proof.
   intro hΣ.
   unfold fix_subst, PCUICLiftSubst.fix_context.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -57,7 +57,7 @@ Proof.
   induction (wf_cod' s) as [s _ IH_sub] in Γ, H, IH |- *.
   econstructor.
   intros (Γ' & B & ?) [(na & A & ? & ?)]. subst.
-    inversion r.
+  eapply Relation_Properties.clos_rt_rtn1 in r. inversion r.
     + subst. eapply IH_sub. econstructor. cbn. reflexivity.
       intros. eapply IH.
       inversion H0.
@@ -65,15 +65,19 @@ Proof.
       * subst. eapply cored_red in H2 as [].
         eapply cored_red_trans. 2: eapply prod_red_r. 2:eassumption.
         eapply PCUICReduction.red_prod_r. eauto.
-      * repeat econstructor.
+      * constructor. do 2 eexists. now split.
     + subst. eapply IH.
-      * eapply red_neq_cored. exact r. intros ?. subst.
-        eapply cored_red_trans in X0; eauto.
+      * eapply red_neq_cored.
+        eapply Relation_Properties.clos_rtn1_rt. exact r.
+        intros ?. subst.
+        eapply Relation_Properties.clos_rtn1_rt in X1.
+        eapply cored_red_trans in X0; [| exact X1 ].
         eapply Acc_no_loop in X0. eauto.
         eapply @normalisation'; eauto.
-      * repeat econstructor.
+      * constructor. do 2 eexists. now split.
 Grab Existential Variables.
-- eapply red_wellformed; sq. 3:eauto. all:eauto.
+- eapply red_wellformed; sq.
+  3:eapply Relation_Properties.clos_rtn1_rt in r; eassumption. all:eauto.
 - destruct H as [[] |[]].
   -- eapply inversion_Prod in X0 as (? & ? & ? & ? & ?) ; auto.
      eapply cored_red in H0 as [].
@@ -147,7 +151,7 @@ Next Obligation.
 Qed.
 Next Obligation.
   destruct H as (? & ? & ?). eexists (tProd _ _ _). split; sq.
-  etransitivity. eassumption. eapply PCUICReduction.red_prod. econstructor.
+  etransitivity. eassumption. eapply PCUICReduction.red_prod. reflexivity.
   eassumption. now cbn.
 Qed.
 Next Obligation.

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -1,6 +1,7 @@
 -R theories MetaCoq.PCUIC
 
 theories/PCUICUtils.v
+theories/PCUICRelations.v
 theories/PCUICAst.v
 theories/PCUICSize.v
 theories/PCUICAstUtils.v

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -6,7 +6,6 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICLiftSubst PCUICTyping PCUICWeakening
      PCUICCumulativity PCUICEquality
      PCUICContextConversion PCUICValidity.
-Derive Signature for red.
 Import MonadNotation.
 
 Local Set Keyed Unification.

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -2,7 +2,8 @@
 
 
 Require Import List. Import ListNotations.
-From MetaCoq.Template Require Export Universes BasicAst Environment.
+From MetaCoq.Template Require Export Universes BasicAst
+     Environment EnvironmentTyping.
 
 Declare Scope pcuic.
 Delimit Scope pcuic with pcuic.
@@ -140,3 +141,6 @@ Record mutual_inductive_entry := {
 
   Module PCUICEnvironment := Environment PCUICTerm.
   Include PCUICEnvironment.
+
+  Module PCUICLookup := Lookup PCUICTerm PCUICEnvironment.
+  Include PCUICLookup.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -1240,7 +1240,7 @@ Section WeakNormalization.
     pose proof (subject_closed wfΣ t0) as H.
     rewrite closedn_mkApps in H. move/andP: H => [clcofix clargs].
     assert (red Σ [] (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)).
-    { eapply red1_red. eapply PCUICTyping.red_cofix_case.
+    { eapply red1_red. eapply red_cofix_case.
       rewrite -closed_unfold_cofix_cunfold_eq in e; eauto. }
     specialize (X X0).
     specialize (IHHe _ X).
@@ -1251,7 +1251,7 @@ Section WeakNormalization.
     pose proof (subject_closed wfΣ t) as H.
     rewrite closedn_mkApps in H. move/andP: H => [clcofix clargs].
     assert (red Σ [] (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))).
-    { eapply red1_red. eapply PCUICTyping.red_cofix_proj.
+    { eapply red1_red. eapply red_cofix_proj.
       rewrite -closed_unfold_cofix_cunfold_eq in e; eauto. }
     specialize (X X0).
     specialize (IHHe _ X).

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -999,41 +999,9 @@ End RedEq.
 
 
 
-(* Using Derive makes Qed break?? *)
-(** FIXME Equations Derive Bug *)
-(* Polymorphic Derive Signature for Relation.clos_refl_trans. *)
-Set Universe Polymorphism.
-Definition clos_refl_trans_sig@{i j} (A : Type@{i}) (R : Relation.relation A)
-           (index : sigma (fun _ : A => A)) : Type@{j} :=
-    Relation.clos_refl_trans@{i j} R (pr1 index) (pr2 index).
-
-Definition clos_refl_trans_sig_pack@{i j} (A : Type@{i}) (R : Relation.relation A) (x H : A)
-           (clos_refl_trans_var : Relation.clos_refl_trans R x H) :
-  sigma@{i} (fun index : sigma (fun _ : A => A) => Relation.clos_refl_trans@{i j} R (pr1 index) (pr2 index)) :=
-    ({| pr1 := {| pr1 := x; pr2 := H |}; pr2 := clos_refl_trans_var |}).
-
-Instance clos_refl_trans_Signature (A : Type) (R : Relation.relation A) (x H : A)
-  : Signature (Relation.clos_refl_trans R x H) (sigma (fun _ : A => A)) (clos_refl_trans_sig A R) :=
-  clos_refl_trans_sig_pack A R x H.
-Unset Universe Polymorphism.
+Polymorphic Derive Signature for Relation.clos_refl_trans.
 
 Derive Signature for red1.
-
-(* Definition red1_sig@{} (Σ : global_env) (index : sigma (fun _ : context => sigma (fun _ : term => term))) := *)
-(*   let Γ := pr1 index in let H := pr1 (pr2 index) in let H0 := pr2 (pr2 index) in red1 Σ Γ H H0. *)
-
-(* Universe red1u. *)
-
-(* Definition red1_sig_pack@{} (Σ : global_env) (Γ : context) (H H0 : term) (red1_var : red1 Σ Γ H H0) *)
-(*   : sigma@{red1u} (fun index : sigma (fun _ : context => sigma (fun _ : term => term)) => *)
-(*         red1 Σ (pr1 index) (pr1 (pr2 index)) (pr2 (pr2 index))) *)
-(*   := *)
-(*      {| pr1 := {| pr1 := Γ; pr2 := {| pr1 := H; pr2 := H0 |} |}; pr2 := red1_var |}. *)
-
-(* Instance red1_Signature@{} (Σ : global_env) (Γ : context) (H H0 : term) *)
-(*      : Signature@{red1u} (red1 Σ Γ H H0) (sigma (fun _ : context => sigma (fun _ : term => term))) (red1_sig Σ) := *)
-(*   red1_sig_pack Σ Γ H H0. *)
-(* (** FIXME Equations *)  ==> seems fixed now that term is not in Set anymore *)
 
 Lemma local_env_telescope P Γ Γ' Δ Δ' :
   All2_telescope (on_decl P) Γ Γ' Δ Δ' ->

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -1977,7 +1977,7 @@ Section RedConfluence.
     red Σ Γ t u ->
     trans_clos pred1_rel (Γ, t) (Γ, u).
   Proof.
-    move/(equiv _ _ (red_alt _ _ _ _)) => tu.
+    move/(fst (red_alt _ _ _ _)) => tu.
     induction tu.
     constructor. now eapply red1_pred1 in r.
     constructor. pcuic.
@@ -2602,7 +2602,7 @@ Section RedConfluence.
   Qed.
 
   Instance proper_red_ctx :
-    Proper (eq_context_upto_names ==> eq_context_upto_names ==> isEquiv) red_ctx.
+    Proper (eq_context_upto_names ==> eq_context_upto_names ==> iffT) red_ctx.
   Proof.
     reduce_goal.
     split.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -283,9 +283,7 @@ Section ContextReduction.
     red1_red_ctxP Γ Γ' ->
     ∑ t, red Σ Γ' T t * red Σ Γ' U t.
   Proof.
-    intros r rc rP.
-    eapply red_alt in r.
-    induction r.
+    intros r rc rP. induction r.
     - eapply red1_red_ctx_aux; eauto.
     - exists x; split; auto.
     - destruct IHr1 as [xl [redl redr]].
@@ -451,9 +449,7 @@ Section ContextConversion.
     red Σ Δ u v' *
     eq_term_upto_univ Σ Re Re v v'.
   Proof.
-    intros r HΓ.
-    eapply red_alt in r.
-    induction r.
+    intros r HΓ. induction r.
     - eapply red1_eq_context_upto_l in r; eauto.
       destruct r as [v [? ?]]. exists v. intuition pcuic.
     - exists x. split; auto. reflexivity.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -107,34 +107,72 @@ Proof.
     apply conv_context_sym => //.
 Qed.
 
-(* Properties about η
-   Maybe they should be moved somewhere else.
-*)
-Section Eta.
 
-  Context `{cf : checker_flags}.
-  Context {Σ : global_env_ext}.
-  Context {hΣ : wf Σ}.
+Section EquivalenceConvCumulDefs.
 
-  (* TODO MOVE *)
-  Fixpoint isFixApp t : bool :=
-    match t with
-    | tApp f u => isFixApp f
-    | tFix mfix idx => true
-    | _ => false
-    end.
+  Context {cf:checker_flags} (Σ : global_env_ext) (wfΣ : wf Σ) (Γ : context).
 
-  (* TODO MOVE *)
-  Lemma isFixApp_mkApps :
-    forall t l,
-      isFixApp (mkApps t l) = isFixApp t.
+  Proposition conv_conv1 M N : 
+    conv1 Σ Γ M N <~> conv Σ Γ M N.
   Proof.
-    intros t l. induction l in t |- *.
-    - cbn. reflexivity.
-    - cbn. rewrite IHl. reflexivity.
+    split; intro H.
+    - induction H.
+      + destruct r as [[r|r]|r].
+        * eapply red_conv; eauto.
+        * now econstructor 3; tea.
+        * now constructor.
+      + reflexivity.
+      + etransitivity; tea.
+    - induction H.
+      + constructor. now right.
+      + etransitivity; tea.
+        constructor. left. now left.
+      + etransitivity; tea.
+        constructor. left. now right.
   Qed.
 
-End Eta.
+
+  Proposition cumul_cumul1 M N : 
+    cumul1 Σ Γ M N <~> cumul Σ Γ M N.
+  Proof.
+    split; intro H.
+    - induction H.
+      + destruct r as [[r|r]|r].
+        * eapply red_cumul; eauto.
+        * now econstructor 3; tea.
+        * now constructor.
+      + reflexivity.
+      + etransitivity; tea.
+    - induction H.
+      + constructor. now right.
+      + etransitivity; tea.
+        constructor. left. now left.
+      + etransitivity; tea.
+        constructor. left. now right.
+  Qed.
+
+End EquivalenceConvCumulDefs.
+
+
+
+(* TODO MOVE *)
+Fixpoint isFixApp t : bool :=
+  match t with
+  | tApp f u => isFixApp f
+  | tFix mfix idx => true
+  | _ => false
+  end.
+
+(* TODO MOVE *)
+Lemma isFixApp_mkApps :
+  forall t l,
+    isFixApp (mkApps t l) = isFixApp t.
+Proof.
+  intros t l. induction l in t |- *.
+  - cbn. reflexivity.
+  - cbn. rewrite IHl. reflexivity.
+Qed.
+
 
 Lemma congr_cumul_prod_l : forall `{checker_flags} Σ Γ na na' M1 M2 N1,
   wf Σ.1 ->
@@ -465,8 +503,8 @@ Section Inversions.
   Proof.
     intros Γ T a.
     induction T in Γ, a |- *. all: try contradiction.
-    - right. eexists. constructor. constructor.
-    - left. eexists _,_,_. constructor. constructor.
+    - right. eexists. constructor. reflexivity.
+    - left. eexists _,_,_. constructor. reflexivity.
     - simpl in a. eapply IHT3 in a as [[na' [A [B [r]]]] | [u [r]]].
       + left. eexists _,_,_. constructor.
         eapply red_trans.
@@ -515,8 +553,7 @@ Section Inversions.
   Lemma invert_red_sort Γ u v :
     red Σ Γ (tSort u) v -> v = tSort u.
   Proof.
-    intros H; apply red_alt in H.
-    generalize_eq x (tSort u).
+    intros H. generalize_eq x (tSort u).
     induction H; simplify *.
     - depind r. solve_discr.
     - reflexivity.
@@ -549,8 +586,7 @@ Section Inversions.
              (red Σ Γ A A') *
              (red Σ (vass na A :: Γ) B B').
   Proof.
-    intros H. apply red_alt in H.
-    generalize_eq x (tProd na A B). revert na A B.
+    intros H. generalize_eq x (tProd na A B). revert na A B.
     induction H; simplify_dep_elim.
     - depelim r.
       + solve_discr.
@@ -599,7 +635,7 @@ Section Inversions.
     induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
     all: dependent destruction e.
     - eexists. split.
-      + constructor. constructor.
+      + constructor. reflexivity.
       + reflexivity.
     - simpl in a.
       eapply IHu2 in e2. 2: assumption.
@@ -627,7 +663,7 @@ Section Inversions.
     induction u in Γ, a, v, Rle, e |- *. all: try contradiction.
     all: dependent destruction e.
     - eexists. split.
-      + constructor. constructor.
+      + constructor. reflexivity.
       + reflexivity.
     - simpl in a.
       eapply IHu2 in e2. 2: assumption.
@@ -701,7 +737,7 @@ Section Inversions.
       exists v'. split.
       + constructor. eapply red_trans.
         * eapply trans_red.
-          -- constructor.
+          -- reflexivity.
           -- eassumption.
         * assumption.
       + assumption.
@@ -724,7 +760,7 @@ Section Inversions.
       exists v'. split.
       + constructor. eapply red_trans.
         * eapply trans_red.
-          -- constructor.
+          -- reflexivity.
           -- eassumption.
         * assumption.
       + assumption.
@@ -760,14 +796,13 @@ Section Inversions.
     (red Σ.1 Γ (subst10 d b) C)%type.
   Proof.
     generalize_eq x (tLetIn na d ty b).
-    intros e H. apply red_alt in H.
-    revert na d ty b e.
+    intros e H. revert na d ty b e.
     eapply clos_rt_rt1n_iff in H.
     induction H; simplify_dep_elim.
     + left; do 4 eexists. repeat split; eauto with pcuic.
     + depelim r; try specialize (IHclos_refl_trans_1n _ _ _ _ eq_refl) as
       [(? & ? & ? & ? & ((? & ?) & ?) & ?)|?].
-      - right. now apply red_alt, clos_rt_rt1n_iff.
+      - right. now apply clos_rt_rt1n_iff.
       - solve_discr.
       - left. do 4 eexists. repeat split; eauto with pcuic.
         * now transitivity r.
@@ -1209,31 +1244,20 @@ Section Inversions.
   Lemma red_conv_cum_l {leq Γ u v} :
     red (fst Σ) Γ u v -> conv_cum leq Σ Γ u v.
   Proof.
-    induction 1.
-    - reflexivity.
-    - etransitivity; tea.
-      destruct leq.
-      + simpl. destruct IHX. constructor.
-        eapply conv_red_l; eauto.
-      + simpl. constructor.
-        eapply cumul_red_l.
-        * eassumption.
-        * eapply cumul_refl'.
+    destruct leq; constructor.
+    + now eapply red_conv.
+    + now eapply red_cumul.
   Qed.
 
   Lemma red_conv_cum_r {leq Γ u v} :
     red (fst Σ) Γ u v -> conv_cum leq Σ Γ v u.
   Proof.
-    induction 1.
-    - reflexivity.
-    - etransitivity; tea.
-      destruct leq.
-      + simpl. destruct IHX. constructor.
-        eapply conv_red_r; eauto.
-      + simpl. constructor.
-        eapply cumul_red_r.
-        * eapply cumul_refl'.
-        * assumption.
+   induction 1.
+   - destruct leq; constructor.
+     + now eapply conv_red_r.
+     + now eapply cumul_red_r.
+   - reflexivity.
+   - etransitivity; tea.
   Qed.
 
   Lemma conv_cum_Prod leq Γ na1 na2 A1 A2 B1 B2 :
@@ -1883,9 +1907,7 @@ Section Inversions.
     ∑ A2 b2, (T = tLambda na A2 b2) *
              red Σ Γ A1 A2 * red Σ (Γ ,, vass na A1) b1 b2.
   Proof.
-    intros.
-    eapply red_alt in X. eapply clos_rt_rt1n_iff in X.
-    depind X.
+    intros. eapply clos_rt_rt1n_iff in X. depind X.
     - eexists _, _; intuition eauto.
     - depelim r; solve_discr; specialize (IHX _ _ _ _ eq_refl);
       destruct IHX as [A2 [B2 [[-> ?] ?]]].

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -191,7 +191,6 @@ Proof.
     exists nf, nf'; intuition pcuic.
     now transitivity v.
   - intros [nf [nf' [[redv redv'] eq]]].
-    apply red_alt in redv. apply red_alt in redv'.
     apply clos_rt_rt1n in redv.
     apply clos_rt_rt1n in redv'.
     induction redv.
@@ -466,8 +465,7 @@ Lemma red_upto_conv_ctx_prop Σ Γ Γ' t t' :
   conv_ctx_prop Σ Γ Γ' ->
   red Σ.1 Γ' t t'.
 Proof.
-  intros Hred. eapply red_alt in Hred.
-  intros convctx. eapply red_alt.
+  intros Hred. intros convctx.
   induction Hred; eauto.
   constructor. now eapply red1_upto_conv_ctx_prop.
   eapply rt_trans; eauto.

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -8,6 +8,17 @@ Set Asymmetric Patterns.
 
 Set Default Goal Selector "!".
 
+(** *************************************************************************************
+The "natural" definition of conversion is given by [conv0]. It is the reflexive
+symmetric transitive closure of beta redution + equality modulo universes.
+It turns out to be equivalent to [conv1]: only beta reduction needs to be symmetrized.
+Cumulativity is defined in the same style ([cumul1]), not symmetrizing [leq_term] because
+it is oriented.
+
+Those definitions are NOT used in the definition of typing. Instead we use [cumul] and
+[conv] which are defined as "reducing to a common term". It tunrs out to be equivalent
+to [conv1] and [cumul1] by confluence. It will be shown afterward, in PCUICConversion.v .
+**************************************************************************************** *)
 
 Section ConvCumulDefs.
   Context {cf:checker_flags} (Σ : global_env_ext) (Γ : context).

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -1,17 +1,73 @@
 (* Distributed under the terms of the MIT license.   *)
-
-From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst
-     PCUICEquality PCUICTyping
-     PCUICReduction PCUICPosition.
+From Coq Require Import Bool List Arith Lia ssreflect.
+From MetaCoq.Template Require Import config utils EnvironmentTyping.
+From MetaCoq.PCUIC Require Import PCUICRelations PCUICAst PCUICAstUtils
+     PCUICLiftSubst PCUICEquality PCUICUnivSubst PCUICReduction.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
-Require Import CRelationClasses.
-Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
 
 Set Default Goal Selector "!".
 
-Reserved Notation " Σ ;;; Γ |- t == u " (at level 50, Γ, t, u at next level).
+
+Section ConvCumulDefs.
+  Context {cf:checker_flags} (Σ : global_env_ext) (Γ : context).
+
+  Definition conv0 : relation term
+    := clos_refl_sym_trans (relation_disjunction (red1 Σ Γ) (eq_term Σ Σ)).
+
+  Definition conv1 : relation term
+    := clos_refl_trans (relation_disjunction (clos_sym (red1 Σ Γ)) (eq_term Σ Σ)).
+
+
+  Lemma conv0_conv1 M N :
+    conv0 M N <~> conv1 M N.
+  Proof.
+    split; intro H.
+    - induction H.
+      + constructor. now destruct r; [left; left|right].
+      + reflexivity.
+      + now apply clos_rt_trans_Symmetric.
+      + etransitivity; eassumption.
+    - induction H.
+      + destruct r as [[]|].
+        * now constructor; left.
+        * now symmetry; constructor; left.
+        * now constructor; right.
+      + reflexivity.
+      + etransitivity; eassumption.
+  Defined.
+
+
+  Definition cumul1 : relation term
+    := clos_refl_trans (relation_disjunction (clos_sym (red1 Σ Γ)) (leq_term Σ Σ)).
+
+End ConvCumulDefs.
+
+Reserved Notation " Σ ;;; Γ |- t : T " (at level 50, Γ, t, T at next level).
+Reserved Notation " Σ ;;; Γ |- t <= u " (at level 50, Γ, t, u at next level).
+Reserved Notation " Σ ;;; Γ |- t = u " (at level 50, Γ, t, u at next level).
+
+(** ** Cumulativity *)
+
+Inductive cumul `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| cumul_refl t u : leq_term Σ.1 (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t <= u
+| cumul_red_l t u v : red1 Σ.1 Γ t v -> Σ ;;; Γ |- v <= u -> Σ ;;; Γ |- t <= u
+| cumul_red_r t u v : Σ ;;; Γ |- t <= v -> red1 Σ.1 Γ u v -> Σ ;;; Γ |- t <= u
+
+where " Σ ;;; Γ |- t <= u " := (cumul Σ Γ t u) : type_scope.
+
+(** *** Conversion   
+ *)
+
+Inductive conv `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| conv_refl t u : eq_term Σ.1 (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t = u
+| conv_red_l t u v : red1 Σ Γ t v -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- t = u
+| conv_red_r t u v : Σ ;;; Γ |- t = v -> red1 (fst Σ) Γ u v -> Σ ;;; Γ |- t = u
+
+where " Σ ;;; Γ |- t = u " := (@conv _ Σ Γ t u) : type_scope.
+
+Hint Resolve cumul_refl conv_refl : pcuic.
+
 
 Lemma cumul_alt `{cf : checker_flags} Σ Γ t u :
   Σ ;;; Γ |- t <= u <~> { v & { v' & (red Σ Γ t v * red Σ Γ u v' * 
@@ -24,7 +80,7 @@ Proof.
       exists v', v''. intuition auto. now eapply red_step.
     + destruct IHX as (v' & v'' & (redv & redv') & leqv).
       exists v', v''. intuition auto. now eapply red_step.
-  - intros [v [v' [[redv redv'] Hleq]]]. apply red_alt in redv. apply red_alt in redv'.
+  - intros [v [v' [[redv redv'] Hleq]]].
     apply clos_rt_rt1n in redv.
     apply clos_rt_rt1n in redv'.
     induction redv.
@@ -48,9 +104,9 @@ Lemma red_cumul `{cf : checker_flags} {Σ : global_env_ext} {Γ t u} :
   red Σ Γ t u ->
   Σ ;;; Γ |- t <= u.
 Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n in X.
+  intros. apply clos_rt_rt1n in X.
   induction X.
-  - apply cumul_refl'.
+  - reflexivity.
   - econstructor 2. all: eauto.
 Qed.
 
@@ -58,16 +114,16 @@ Lemma red_cumul_inv `{cf : checker_flags} {Σ : global_env_ext} {Γ t u} :
   red Σ Γ t u ->
   Σ ;;; Γ |- u <= t.
 Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n in X.
+  intros. apply clos_rt_rt1n in X.
   induction X.
-  - apply cumul_refl'.
+  - reflexivity.
   - econstructor 3. all: eauto.
 Qed.
 
 Lemma red_cumul_cumul `{cf : checker_flags} {Σ : global_env_ext} {Γ t u v} :
   red Σ Γ t u -> Σ ;;; Γ |- u <= v -> Σ ;;; Γ |- t <= v.
 Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n in X.
+  intros. apply clos_rt_rt1n in X.
   induction X. 1: auto.
   econstructor 2; eauto.
 Qed.
@@ -75,7 +131,7 @@ Qed.
 Lemma red_cumul_cumul_inv `{cf : checker_flags} {Σ : global_env_ext} {Γ t u v} :
   red Σ Γ t v -> Σ ;;; Γ |- u <= v -> Σ ;;; Γ |- u <= t.
 Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n in X.
+  intros. apply clos_rt_rt1n in X.
   induction X. 1: auto.
   econstructor 3.
   - eapply IHX. eauto.
@@ -110,7 +166,7 @@ Qed.
 Lemma red_conv {cf:checker_flags} (Σ : global_env_ext) Γ t u
   : red Σ Γ t u -> Σ ;;; Γ |- t = u.
 Proof.
-  intros H%red_alt%clos_rt_rt1n_iff.
+  intros H%clos_rt_rt1n_iff.
   induction H.
   - reflexivity.
   - econstructor 2; eauto. 
@@ -178,7 +234,7 @@ Hint Resolve leq_term_refl cumul_refl' : core.
 Lemma red_conv_conv `{cf : checker_flags} Σ Γ t u v :
   red (fst Σ) Γ t u -> Σ ;;; Γ |- u = v -> Σ ;;; Γ |- t = v.
 Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
+  intros. apply clos_rt_rt1n_iff in X.
   induction X; auto.
   econstructor 2; eauto.
 Qed.
@@ -186,7 +242,7 @@ Qed.
 Lemma red_conv_conv_inv `{cf : checker_flags} Σ Γ t u v :
   red (fst Σ) Γ t u -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- v = t.
 Proof.
-  intros. apply red_alt in X. apply clos_rt_rt1n_iff in X.
+  intros X%clos_rt_rt1n_iff.
   induction X; auto.
   now econstructor 3; [eapply IHX|]; eauto.
 Qed.
@@ -231,7 +287,7 @@ Definition conv_cum `{cf : checker_flags} leq Σ Γ u v :=
   end.
 
 Lemma conv_conv_cum_l `{cf : checker_flags} :
-  forall (Σ : global_env_ext) leq Γ u v, wf Σ ->
+  forall (Σ : global_env_ext) leq Γ u v,
       Σ ;;; Γ |- u = v ->
       conv_cum leq Σ Γ u v.
 Proof.
@@ -241,11 +297,11 @@ Proof.
 Qed.
 
 Lemma conv_conv_cum_r `{cf : checker_flags} :
-  forall (Σ : global_env_ext) leq Γ u v, wf Σ ->
+  forall (Σ : global_env_ext) leq Γ u v,
       Σ ;;; Γ |- u = v ->
       conv_cum leq Σ Γ v u.
 Proof.
-  intros Σ [] Γ u v wfΣ h.
+  intros Σ [] Γ u v h.
   - cbn. constructor. apply conv_sym; auto.
   - cbn. constructor. apply conv_cumul.
     now apply conv_sym.

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -9,30 +9,8 @@ Require Import ssreflect.
 From Equations.Prop Require Import DepElim.
 Set Equations With UIP.
 
-
 Local Open Scope type_scope.
 
-Section CRelationLemmas.
-  Local Set Universe Polymorphism.
-  Context {A : Type} (R : crelation A).
-
-  Lemma flip_Reflexive : Reflexive R -> Reflexive (flip R).
-  Proof.
-    intros HR x. unfold flip. apply reflexivity.
-  Qed.
-
-  Lemma flip_Symmetric : Symmetric R -> Symmetric (flip R).
-  Proof.
-    intros HR x y. unfold flip. apply symmetry.
-  Qed.
-
-  Lemma flip_Transitive : Transitive R -> Transitive (flip R).
-  Proof.
-    intros HR x y z xy yz.
-    unfold flip in *. now transitivity y.
-  Qed.
-
-End CRelationLemmas.
 
 Definition R_universe_instance R :=
   fun u u' => Forall2 R (List.map Universe.make u) (List.map Universe.make u').

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -1006,21 +1006,6 @@ Proof.
     intro. rtoProp. split; tas. split; eapply X0; tea.
 Qed.
 
-Lemma equiv_reflectT P (b : bool) : (P -> b) -> (b -> P) -> reflectT P b.
-Proof.
-  intros. destruct b; constructor; auto.
-Qed.
-
-Lemma reflectT_subrelation {A} {R} {r : A -> A -> bool} : (forall x y, reflectT (R x y) (r x y)) -> subrelation R r.
-Proof.
-  intros. intros x y h. destruct (X x y); auto.
-Qed.
-
-Lemma reflectT_subrelation' {A} {R} {r : A -> A -> bool} : (forall x y, reflectT (R x y) (r x y)) -> subrelation r R.
-Proof.
-  intros. intros x y h. destruct (X x y); auto. discriminate.
-Qed.
-
 Lemma reflect_eq_term_upto_univ Σ equ lequ (Re Rle : Universe.t -> Universe.t -> Prop) napp :
   (forall u u', reflectT (Re u u') (equ u u')) ->
   (forall u u', reflectT (Rle u u') (lequ u u')) ->
@@ -1795,14 +1780,6 @@ Proof.
     dependent destruction h1. reflexivity.
   - eapply decompose_app_notApp. eassumption.
   - reflexivity.
-Qed.
-
-(* TODO MOVE *)
-Instance subrelation_same :
-  forall A (R : A -> A -> Prop),
-    RelationClasses.subrelation R R.
-Proof.
-  intros A R x y h. assumption.
 Qed.
 
 Lemma R_global_instance_flip Σ gr napp

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -2245,8 +2245,8 @@ Lemma red_subst_instance {cf:checker_flags} (Σ : global_env) (Γ : context) (u 
   red Σ (subst_instance_context u Γ) (subst_instance_constr u s)
             (subst_instance_constr u t).
 Proof.
-  intros H; apply red_alt, clos_rt_rt1n in H.
-  apply red_alt, clos_rt1n_rt.
+  intros H; apply clos_rt_rt1n in H.
+  apply clos_rt1n_rt.
   induction H. constructor.
   eapply red1_subst_instance in r.
   econstructor 2. eapply r. auto.
@@ -2299,8 +2299,8 @@ Lemma red_assumption_context_app_irrelevant Σ Γ Δ Γ' t t' :
   red Σ (Γ' ,,, Δ) t t'. 
 Proof.
   intros r ass eqc.
-  eapply red_alt, clos_rt_rt1n in r.
-  eapply red_alt. eapply clos_rt1n_rt.
+  eapply clos_rt_rt1n in r.
+  eapply clos_rt1n_rt.
   induction r; [constructor|econstructor 2].
   eapply red1_assumption_context_irrelevant; eauto. apply IHr.
 Qed.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -1316,8 +1316,7 @@ Lemma red_destInd (Σ : global_env_ext) Γ t t' ind u :
   red Σ.1 Γ t t' -> destInd (head t) = Some (ind, u) -> 
   destInd (head t') = Some (ind, u).
 Proof.
-  intros r%red_alt.
-  apply Relation_Properties.clos_rt_rt1n_iff in r.
+  intros r%Relation_Properties.clos_rt_rt1n_iff.
   induction r.
   auto.
   intros.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -483,7 +483,7 @@ Proof.
   destruct X as [_ _ _ on_projs_all on_projs].
   eapply forall_nth_error_Alli.
   intros.
-  pose proof (equiv_inv _ _ (nth_error_Some' (ind_projs idecl) (context_assumptions (cshape_args cs) - S i))).
+  pose proof (snd (nth_error_Some' (ind_projs idecl) (context_assumptions (cshape_args cs) - S i))).
   apply X. eapply nth_error_Some_length in H. 
     autorewrite with len in H. simpl in H; lia.
 Qed.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -3,7 +3,7 @@
 From Coq Require Import Bool List.
 From MetaCoq.Template
 Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICTyping.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICReduction.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
 

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -518,7 +518,7 @@ Section Pred1_inversion.
     intros hnth isc pred. remember (mkApps _ _) as fixt.
     revert mfix0 idx args0 Heqfixt hnth isc.
     induction pred; intros; solve_discr.
-    - unfold PCUICTyping.unfold_fix in e.
+    - unfold unfold_fix in e.
       red in a1.
       eapply All2_nth_error_Some in a1; eauto.
       destruct a1 as [t' [ht' [hds [hr [= eqna eqrarg]]]]].
@@ -3117,7 +3117,7 @@ Section Rho.
       rewrite - {1} (map_id args1). eapply All2_map, All2_impl; eauto. simpl. intuition.
 
     - (* Fix reduction *)
-      unfold PCUICTyping.unfold_fix in heq_unfold_fix |- *.
+      unfold unfold_fix in heq_unfold_fix |- *.
       rewrite rho_app_fix.
       destruct nth_error eqn:Heq; noconf heq_unfold_fix.
       eapply All2_nth_error_Some_right in Heq; eauto.
@@ -3266,7 +3266,7 @@ Section Rho.
             red in redo.
             solve_all.
             unfold on_Trel in *. intuition auto. now noconf b0.
-            unfold PCUICTyping.unfold_fix. rewrite nth_error_map e /=.
+            unfold unfold_fix. rewrite nth_error_map e /=.
             rewrite map_fix_subst /= //.
             intros n.  simp rho; simpl; now simp rho.
             move: i1.

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -1305,7 +1305,7 @@ Section Rho.
   Lemma refine_pred Γ Δ t u u' : u = u' -> pred1 Σ Γ Δ t u' -> pred1 Σ Γ Δ t u.
   Proof. now intros ->. Qed.
 
-  Lemma ctxmap_ext Γ Δ : CMorphisms.Proper (CMorphisms.respectful (pointwise_relation _ eq) isEquiv) (ctxmap Γ Δ).
+  Lemma ctxmap_ext Γ Δ : CMorphisms.Proper (CMorphisms.respectful (pointwise_relation _ eq) iffT) (ctxmap Γ Δ).
   Proof.
     red. red. intros.
     split; intros X.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -59,9 +59,6 @@ Section Principality.
       destruct ih as [? ?]
     end.
 
-  Arguments equiv {A B}.
-  Arguments equiv_inv {A B}.
-
   Lemma cumul_sort_confluence {Γ A u v} :
     Σ ;;; Γ |- A <= tSort u ->
     Σ ;;; Γ |- A <= tSort v ->

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -1,24 +1,367 @@
-(* Distributed under the terms of the MIT license.   *)
-Require Import ssreflect.
-From Coq Require Import Bool List Utf8
-  ZArith Lia.
-From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
-     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICPosition.
-
-Require Import Equations.Prop.DepElim.
-
-(* Type-valued relations. *)
-Require Import CRelationClasses.
-Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
-From Equations Require Import Equations.
-
+From Coq Require Import Bool List Utf8 ZArith Lia ssreflect.
+From MetaCoq.Template Require Import config utils EnvironmentTyping.
+From MetaCoq.PCUIC Require Import PCUICRelations PCUICAst PCUICAstUtils
+     PCUICLiftSubst PCUICEquality PCUICUnivSubst PCUICInduction.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
 
+Require Import Equations.Prop.DepElim.
+From Equations Require Import Equations.
+
 Set Default Goal Selector "!".
 
-(** * Parallel reduction and confluence *)
+
+Definition tDummy := tVar String.EmptyString.
+
+Definition iota_red npar c args brs :=
+  (mkApps (snd (List.nth c brs (0, tDummy))) (List.skipn npar args)).
+
+
+(** ** Reduction *)
+
+(** *** Helper functions for reduction *)
+
+Definition fix_subst (l : mfixpoint term) :=
+  let fix aux n :=
+      match n with
+      | 0 => []
+      | S n => tFix l n :: aux n
+      end
+  in aux (List.length l).
+
+Definition unfold_fix (mfix : mfixpoint term) (idx : nat) :=
+  match List.nth_error mfix idx with
+  | Some d => Some (d.(rarg), subst0 (fix_subst mfix) d.(dbody))
+  | None => None
+  end.
+
+Definition cofix_subst (l : mfixpoint term) :=
+  let fix aux n :=
+      match n with
+      | 0 => []
+      | S n => tCoFix l n :: aux n
+      end
+  in aux (List.length l).
+
+Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
+  match List.nth_error mfix idx with
+  | Some d => Some (d.(rarg), subst0 (cofix_subst mfix) d.(dbody))
+  | None => None
+  end.
+
+Definition is_constructor n ts :=
+  match List.nth_error ts n with
+  | Some a => isConstruct_app a
+  | None => false
+  end.
+
+Lemma fix_subst_length mfix : #|fix_subst mfix| = #|mfix|.
+Proof.
+  unfold fix_subst. generalize (tFix mfix). intros.
+  induction mfix; simpl; auto.
+Qed.
+
+Lemma cofix_subst_length mfix : #|cofix_subst mfix| = #|mfix|.
+Proof.
+  unfold cofix_subst. generalize (tCoFix mfix). intros.
+  induction mfix; simpl; auto.
+Qed.
+
+Lemma fix_context_length mfix : #|fix_context mfix| = #|mfix|.
+Proof. unfold fix_context. now rewrite List.rev_length mapi_length. Qed.
+
+
+(** *** One step strong beta-zeta-iota-fix-delta reduction
+
+  Inspired by the reduction relation from Coq in Coq [Barras'99].
+*)
+
+Local Open Scope type_scope.
+Arguments OnOne2 {A} P%type l l'.
+
+Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
+(** Reductions *)
+(** Beta *)
+| red_beta na t b a :
+    red1 Σ Γ (tApp (tLambda na t b) a) (subst10 a b)
+
+(** Let *)
+| red_zeta na b t b' :
+    red1 Σ Γ (tLetIn na b t b') (subst10 b b')
+
+| red_rel i body :
+    option_map decl_body (nth_error Γ i) = Some (Some body) ->
+    red1 Σ Γ (tRel i) (lift0 (S i) body)
+
+(** Case *)
+| red_iota ind pars c u args p brs :
+    red1 Σ Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs)
+         (iota_red pars c args brs)
+
+(** Fix unfolding, with guard *)
+| red_fix mfix idx args narg fn :
+    unfold_fix mfix idx = Some (narg, fn) ->
+    is_constructor narg args = true ->
+    red1 Σ Γ (mkApps (tFix mfix idx) args) (mkApps fn args)
+
+(** CoFix-case unfolding *)
+| red_cofix_case ip p mfix idx args narg fn brs :
+    unfold_cofix mfix idx = Some (narg, fn) ->
+    red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
+         (tCase ip p (mkApps fn args) brs)
+
+(** CoFix-proj unfolding *)
+| red_cofix_proj p mfix idx args narg fn :
+    unfold_cofix mfix idx = Some (narg, fn) ->
+    red1 Σ Γ (tProj p (mkApps (tCoFix mfix idx) args))
+         (tProj p (mkApps fn args))
+
+(** Constant unfolding *)
+| red_delta c decl body (isdecl : declared_constant Σ c decl) u :
+    decl.(cst_body) = Some body ->
+    red1 Σ Γ (tConst c u) (subst_instance_constr u body)
+
+(** Proj *)
+| red_proj i pars narg args u arg:
+    nth_error args (pars + narg) = Some arg ->
+    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg
+
+
+| abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
+| abs_red_r na M M' N : red1 Σ (Γ ,, vass na N) M M' -> red1 Σ Γ (tLambda na N M) (tLambda na N M')
+
+| letin_red_def na b t b' r : red1 Σ Γ b r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na r t b')
+| letin_red_ty na b t b' r : red1 Σ Γ t r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b r b')
+| letin_red_body na b t b' r : red1 Σ (Γ ,, vdef na b t) b' r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b t r)
+
+| case_red_pred ind p p' c brs : red1 Σ Γ p p' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p' c brs)
+| case_red_discr ind p c c' brs : red1 Σ Γ c c' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c' brs)
+| case_red_brs ind p c brs brs' :
+    OnOne2 (on_Trel_eq (red1 Σ Γ) snd fst) brs brs' ->
+    red1 Σ Γ (tCase ind p c brs) (tCase ind p c brs')
+
+| proj_red p c c' : red1 Σ Γ c c' -> red1 Σ Γ (tProj p c) (tProj p c')
+
+| app_red_l M1 N1 M2 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tApp M1 M2) (tApp N1 M2)
+| app_red_r M2 N2 M1 : red1 Σ Γ M2 N2 -> red1 Σ Γ (tApp M1 M2) (tApp M1 N2)
+
+| prod_red_l na M1 M2 N1 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tProd na M1 M2) (tProd na N1 M2)
+| prod_red_r na M2 N2 M1 : red1 Σ (Γ ,, vass na M1) M2 N2 ->
+                               red1 Σ Γ (tProd na M1 M2) (tProd na M1 N2)
+
+| evar_red ev l l' : OnOne2 (red1 Σ Γ) l l' -> red1 Σ Γ (tEvar ev l) (tEvar ev l')
+
+| fix_red_ty mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
+
+| fix_red_body mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x)))
+           mfix0 mfix1 ->
+    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
+
+| cofix_red_ty mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)
+
+| cofix_red_body mfix0 mfix1 idx :
+    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
+    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx).
+
+Lemma red1_ind_all :
+  forall (Σ : global_env) (P : context -> term -> term -> Type),
+
+       (forall (Γ : context) (na : name) (t b a : term),
+        P Γ (tApp (tLambda na t b) a) (b {0 := a})) ->
+
+       (forall (Γ : context) (na : name) (b t b' : term), P Γ (tLetIn na b t b') (b' {0 := b})) ->
+
+       (forall (Γ : context) (i : nat) (body : term),
+        option_map decl_body (nth_error Γ i) = Some (Some body) -> P Γ (tRel i) ((lift0 (S i)) body)) ->
+
+       (forall (Γ : context) (ind : inductive) (pars c : nat) (u : Instance.t) (args : list term)
+          (p : term) (brs : list (nat * term)),
+        P Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs) (iota_red pars c args brs)) ->
+
+       (forall (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
+        unfold_fix mfix idx = Some (narg, fn) ->
+        is_constructor narg args = true -> P Γ (mkApps (tFix mfix idx) args) (mkApps fn args)) ->
+
+       (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
+          (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
+        unfold_cofix mfix idx = Some (narg, fn) ->
+        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
+
+       (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
+          (narg : nat) (fn : term),
+        unfold_cofix mfix idx = Some (narg, fn) -> P Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
+
+       (forall (Γ : context) c (decl : constant_body) (body : term),
+        declared_constant Σ c decl ->
+        forall u : Instance.t, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
+
+       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
+         (arg : term),
+           nth_error args (pars + narg) = Some arg ->
+           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
+
+       (forall (Γ : context) (na : name) (M M' N : term),
+        red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->
+
+       (forall (Γ : context) (na : name) (M M' N : term),
+        red1 Σ (Γ,, vass na N) M M' -> P (Γ,, vass na N) M M' -> P Γ (tLambda na N M) (tLambda na N M')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ Γ b r -> P Γ b r -> P Γ (tLetIn na b t b') (tLetIn na r t b')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ Γ t r -> P Γ t r -> P Γ (tLetIn na b t b') (tLetIn na b r b')) ->
+
+       (forall (Γ : context) (na : name) (b t b' r : term),
+        red1 Σ (Γ,, vdef na b t) b' r -> P (Γ,, vdef na b t) b' r -> P Γ (tLetIn na b t b') (tLetIn na b t r)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p p' c : term) (brs : list (nat * term)),
+        red1 Σ Γ p p' -> P Γ p p' -> P Γ (tCase ind p c brs) (tCase ind p' c brs)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p c c' : term) (brs : list (nat * term)),
+        red1 Σ Γ c c' -> P Γ c c' -> P Γ (tCase ind p c brs) (tCase ind p c' brs)) ->
+
+       (forall (Γ : context) (ind : inductive * nat) (p c : term) (brs brs' : list (nat * term)),
+           OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) snd fst) brs brs' ->
+           P Γ (tCase ind p c brs) (tCase ind p c brs')) ->
+
+       (forall (Γ : context) (p : projection) (c c' : term), red1 Σ Γ c c' -> P Γ c c' ->
+                                                             P Γ (tProj p c) (tProj p c')) ->
+
+       (forall (Γ : context) (M1 N1 : term) (M2 : term), red1 Σ Γ M1 N1 -> P Γ M1 N1 ->
+                                                         P Γ (tApp M1 M2) (tApp N1 M2)) ->
+
+       (forall (Γ : context) (M2 N2 : term) (M1 : term), red1 Σ Γ M2 N2 -> P Γ M2 N2 ->
+                                                         P Γ (tApp M1 M2) (tApp M1 N2)) ->
+
+       (forall (Γ : context) (na : name) (M1 M2 N1 : term),
+        red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tProd na M1 M2) (tProd na N1 M2)) ->
+
+       (forall (Γ : context) (na : name) (M2 N2 M1 : term),
+        red1 Σ (Γ,, vass na M1) M2 N2 -> P (Γ,, vass na M1) M2 N2 -> P Γ (tProd na M1 M2) (tProd na M1 N2)) ->
+
+       (forall (Γ : context) (ev : nat) (l l' : list term),
+           OnOne2 (Trel_conj (red1 Σ Γ) (P Γ)) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
+                                      (P (Γ ,,, fix_context mfix0))) dbody
+                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
+        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
+        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
+
+       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
+        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
+                                      (P (Γ ,,, fix_context mfix0))) dbody
+                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
+        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
+
+       forall (Γ : context) (t t0 : term), red1 Σ Γ t t0 -> P Γ t t0.
+Proof.
+  intros. rename X26 into Xlast. revert Γ t t0 Xlast.
+  fix aux 4. intros Γ t T.
+  move aux at top.
+  destruct 1; match goal with
+              | |- P _ (tFix _ _) (tFix _ _) => idtac
+              | |- P _ (tCoFix _ _) (tCoFix _ _) => idtac
+              | |- P _ (mkApps (tFix _ _) _) _ => idtac
+              | |- P _ (tCase _ _ (mkApps (tCoFix _ _) _) _) _ => idtac
+              | |- P _ (tProj _ (mkApps (tCoFix _ _) _)) _ => idtac
+              | H : _ |- _ => eapply H; eauto
+              end.
+  - eapply X3; eauto.
+  - eapply X4; eauto.
+  - eapply X5; eauto.
+
+  - revert brs brs' o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    + constructor. intuition auto.
+    + constructor. intuition auto.
+
+  - revert l l' o.
+    fix auxl 3.
+    intros l l' Hl. destruct Hl.
+    + constructor. split; auto.
+    + constructor. auto.
+
+  - eapply X22.
+    revert mfix0 mfix1 o; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+
+  - eapply X23.
+    revert o. generalize (fix_context mfix0). intros c Xnew.
+    revert mfix0 mfix1 Xnew; fix auxl 3; intros l l' Hl;
+    destruct Hl; constructor; try split; auto; intuition.
+
+  - eapply X24.
+    revert mfix0 mfix1 o.
+    fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+
+  - eapply X25.
+    revert o. generalize (fix_context mfix0). intros c new.
+    revert mfix0 mfix1 new; fix auxl 3; intros l l' Hl; destruct Hl;
+      constructor; try split; auto; intuition.
+Defined.
+
+Hint Constructors red1 : pcuic.
+
+Definition red Σ Γ := clos_refl_trans (red1 Σ Γ).
+
+
+Lemma refl_red Σ Γ t : red Σ Γ t t.
+Proof.
+  reflexivity.
+Defined.
+
+Lemma trans_red Σ Γ M P N : red Σ Γ M P -> red1 Σ Γ P N -> red Σ Γ M N.
+Proof.
+  etransitivity; tea. now constructor.
+Defined.
+
+Definition red_rect' Σ Γ M (P : term -> Type) :
+  P M ->
+  (forall P0 N, red Σ Γ M P0 -> P P0 -> red1 Σ Γ P0 N -> P N) ->
+  forall (t : term) (r : red Σ Γ M t), P t.
+Proof.
+  intros X X0 t r. apply clos_rt_rtn1_iff in r.
+  induction r; eauto.
+  eapply X0; tea. now apply clos_rt_rtn1_iff.
+Defined.
+
+
+(** Simple lemmas about reduction *)
+
+Lemma red1_red Σ Γ t u : red1 Σ Γ t u -> red Σ Γ t u.
+Proof.
+  econstructor; eauto.
+Qed.
+
+Hint Resolve red1_red refl_red : core pcuic.
+
+Lemma red_step Σ Γ t u v : red1 Σ Γ t u -> red Σ Γ u v -> red Σ Γ t v.
+Proof.
+  etransitivity; tea. now constructor.
+Qed.
+
+Lemma red_trans Σ Γ t u v : red Σ Γ t u -> red Σ Γ u v -> red Σ Γ t v.
+Proof.
+  etransitivity; tea.
+Defined.
+
 
 (** For this notion of reductions, theses are the atoms that reduce to themselves:
 
@@ -35,41 +378,9 @@ Definition atom t :=
   | _ => false
   end.
 
-(** Simple lemmas about reduction *)
-
-Lemma red1_red (Σ : global_env) Γ t u : red1 Σ Γ t u -> red Σ Γ t u.
-Proof. econstructor; eauto. constructor. Qed.
-Hint Resolve red1_red refl_red : core pcuic.
-
-Lemma red_step Σ Γ t u v : red1 Σ Γ t u -> red Σ Γ u v -> red Σ Γ t v.
-Proof.
-  induction 2.
-  - econstructor; auto.
-  - econstructor 2; eauto.
-Qed.
-
-Lemma red_alt@{i j +} Σ Γ t u : red Σ Γ t u <~> clos_refl_trans@{i j} (red1 Σ Γ) t u.
-Proof.
-  split.
-  - intros H. apply clos_rt_rtn1_iff.
-    induction H; econstructor; eauto.
-  - intros H. apply clos_rt_rtn1_iff in H.
-    induction H; econstructor; eauto.
-Qed.
-
-Lemma red_trans Σ Γ t u v : red Σ Γ t u -> red Σ Γ u v -> red Σ Γ t v.
-Proof.
-  intros. apply red_alt. apply red_alt in X. apply red_alt in X0. now econstructor 3.
-Defined.
-
-Instance red_Transitive Σ Γ : Transitive (red Σ Γ).
-Proof. refine (red_trans _ _). Qed.
-
-Instance red_Reflexive Σ Γ : Reflexive (red Σ Γ)
-  := refl_red _ _.
-
 (** Generic method to show that a relation is closed by congruence using
     a notion of one-hole context. *)
+
 
 Section ReductionCongruence.
   Context {Σ : global_env}.
@@ -203,11 +514,11 @@ Section ReductionCongruence.
 
   Lemma contextual_closure_red Γ t u : contextual_closure (red Σ) Γ t u -> red Σ Γ t u.
   Proof.
-    induction 1. 1: constructor.
-    apply red_alt in r. apply clos_rt_rt1n in r.
-    induction r. 1: constructor.
-    apply clos_rt_rt1n_iff in r0. apply red_alt in r0.
-    eapply red_step; eauto. clear r0 IHr z.
+    induction 1; trea.
+    apply clos_rt_rt1n in r. induction r; trea.
+    apply clos_rt_rt1n_iff in r0.
+    etransitivity; tea. constructor.
+    clear -r.
     set (P := fun ctx t => forall Γ y, red1 Σ (hole_context ctx Γ) x y ->
                                      red1 Σ Γ t (fill_context y ctx)).
     set (P' := fun l fill_l =>
@@ -255,6 +566,7 @@ Section ReductionCongruence.
           OnOne2 (Trel_conj (on_Trel (red1 Σ Γ) fst) (on_Trel eq snd)) l1 l2 ->
           redl Γ l l2.
 
+    
     Lemma OnOne2_red_redl :
       forall Γ A (l l' : list (term × A)),
         OnOne2 (Trel_conj (on_Trel (red Σ Γ) fst) (on_Trel eq snd)) l l' ->
@@ -265,7 +577,7 @@ Section ReductionCongruence.
       - destruct p as [p1 p2].
         unfold on_Trel in p1, p2.
         destruct hd as [t a], hd' as [t' a']. simpl in *. subst.
-        induction p1.
+        induction p1 using red_rect'.
         + constructor.
         + econstructor.
           * eapply IHp1.
@@ -386,8 +698,9 @@ Section ReductionCongruence.
 
     Context {Γ : context}.
 
-    Lemma red_abs na M M' N N' : red Σ Γ M M' -> red Σ (Γ ,, vass na M') N N' ->
-                                               red Σ Γ (tLambda na M N) (tLambda na M' N').
+    Lemma red_abs na M M' N N' :
+      red Σ Γ M M' -> red Σ (Γ ,, vass na M') N N'
+      -> red Σ Γ (tLambda na M N) (tLambda na M' N').
     Proof.
       intros. eapply (transitivity (y := tLambda na M' N)).
       - now apply (red_ctx (tCtxLambda_l _ tCtxHole _)).
@@ -398,11 +711,7 @@ Section ReductionCongruence.
         red Σ Γ v1 v2 ->
         red Σ Γ (tApp u v1) (tApp u v2).
     Proof.
-      intro h. revert u. induction h ; intros u.
-      - constructor.
-      - econstructor.
-        + eapply IHh.
-        + constructor. assumption.
+      intro h. rst_induction h; eauto with pcuic.
     Qed.
 
     Lemma red_app M0 M1 N0 N1 :
@@ -448,11 +757,8 @@ Section ReductionCongruence.
         red Σ Γ t u ->
         red Σ Γ (mkApps t l) (mkApps u l).
     Proof.
-      intros t u π h. induction h.
-      - constructor.
-      - econstructor.
-        + eapply IHh.
-        + eapply red1_mkApps_f. assumption.
+      intros t u π h. rst_induction h; eauto with pcuic.
+      eapply red1_mkApps_f. assumption.
     Qed.
 
     Lemma red_mkApps M0 M1 N0 N1 :
@@ -482,10 +788,7 @@ Section ReductionCongruence.
         red Σ Γ (tCase indn p c brs) (tCase indn p' c brs).
     Proof.
       intros indn p c brs p' h.
-      induction h.
-      - constructor.
-      - econstructor ; try eassumption.
-        constructor. assumption.
+      rst_induction h; eauto with pcuic.
     Qed.
 
     Lemma red_case_c :
@@ -494,10 +797,7 @@ Section ReductionCongruence.
         red Σ Γ (tCase indn p c brs) (tCase indn p c' brs).
     Proof.
       intros indn p c brs c' h.
-      induction h.
-      - constructor.
-      - econstructor ; try eassumption.
-        constructor. assumption.
+      rst_induction h; eauto with pcuic.
     Qed.
 
     Derive Signature for redl.
@@ -510,10 +810,10 @@ Section ReductionCongruence.
       intros indn p c brs brs' h.
       apply OnOne2_on_Trel_eq_red_redl in h.
       dependent induction h.
-      - apply list_map_swap_eq in H. subst. constructor.
-      - econstructor.
+      - apply list_map_swap_eq in H. now subst.
+      - etransitivity.
         + eapply IHh. rewrite <- map_swap_invol. reflexivity.
-        + constructor. rewrite (map_swap_invol _ _ brs').
+        + constructor. constructor. rewrite (map_swap_invol _ _ brs').
           eapply OnOne2_map.
           eapply OnOne2_impl ; eauto.
     Qed.
@@ -551,11 +851,10 @@ Section ReductionCongruence.
     Proof.
       intros indn p c brs brs' h.
       apply All2_many_OnOne2 in h.
-      induction h.
-      - constructor.
-      - eapply red_trans.
-        + eapply IHh.
-        + eapply red_case_one_brs. assumption.
+      induction h; trea.
+      eapply red_trans.
+      + eapply IHh.
+      + eapply red_case_one_brs. assumption.
     Qed.
 
     (* Fixpoint brs_n_context l := *)
@@ -631,11 +930,8 @@ Section ReductionCongruence.
             (it_mkLambda_or_LetIn Δ v).
     Proof.
       intros Δ u v h.
-      induction h.
-      - constructor.
-      - econstructor.
-        + eassumption.
-        + eapply red1_it_mkLambda_or_LetIn. assumption.
+      rst_induction h; eauto with pcuic.
+      eapply red1_it_mkLambda_or_LetIn. assumption.
     Qed.
 
     Lemma red_it_mkProd_or_LetIn :
@@ -645,11 +941,8 @@ Section ReductionCongruence.
             (it_mkProd_or_LetIn Δ v).
     Proof.
       intros Δ u v h.
-      induction h.
-      - constructor.
-      - econstructor.
-        + eassumption.
-        + eapply red1_it_mkProd_or_LetIn. assumption.
+      rst_induction h; eauto with pcuic.
+      eapply red1_it_mkProd_or_LetIn. assumption.
     Qed.
 
     Lemma red_proj_c :
@@ -658,11 +951,7 @@ Section ReductionCongruence.
         red Σ Γ (tProj p c) (tProj p c').
     Proof.
       intros p c c' h.
-      induction h in p |- *.
-      - constructor.
-      - econstructor.
-        + eapply IHh.
-        + econstructor. assumption.
+      rst_induction h; eauto with pcuic.
     Qed.
 
     Lemma red_fix_one_ty :
@@ -675,9 +964,8 @@ Section ReductionCongruence.
       dependent induction h.
       - assert (mfix = mfix').
         { eapply map_inj ; eauto.
-          intros y z e. cbn in e. destruct y, z. inversion e. eauto.
-        } subst.
-        constructor.
+          intros y z e. destruct y, z. inversion e. now subst.
+        } now subst.
       - set (f := fun x : def term => (dtype x, (dname x, dbody x, rarg x))) in *.
         set (g := fun '(ty, (na, bo, ra)) => mkdef term na ty bo ra).
         assert (el :  forall l, l = map f (map g l)).
@@ -690,7 +978,7 @@ Section ReductionCongruence.
           - reflexivity.
           - cbn. destruct a. cbn. f_equal. assumption.
         }
-        econstructor.
+        eapply trans_red.
         + eapply IHh. symmetry. apply el.
         + constructor. rewrite (el' mfix').
           eapply OnOne2_map.
@@ -708,7 +996,7 @@ Section ReductionCongruence.
       intros mfix idx mfix' h.
       apply All2_many_OnOne2 in h.
       induction h.
-      - constructor.
+      - reflexivity.
       - eapply red_trans.
         + eapply IHh.
         + eapply red_fix_one_ty. assumption.
@@ -728,7 +1016,7 @@ Section ReductionCongruence.
         { eapply map_inj ; eauto.
           intros y z e. cbn in e. destruct y, z. inversion e. eauto.
         } subst.
-        constructor.
+        reflexivity.
       - set (f := fun x : def term => (dbody x, (dname x, dtype x, rarg x))) in *.
         set (g := fun '(bo, (na, ty, ra)) => mkdef term na ty bo ra).
         assert (el :  forall l, l = map f (map g l)).
@@ -741,7 +1029,7 @@ Section ReductionCongruence.
           - reflexivity.
           - cbn. destruct a. cbn. f_equal. assumption.
         }
-        econstructor.
+        eapply trans_red.
         + eapply IHh. symmetry. apply el.
         + eapply fix_red_body. rewrite (el' mfix').
           eapply OnOne2_map.
@@ -785,7 +1073,7 @@ Section ReductionCongruence.
       intros mfix idx mfix' h.
       apply All2_many_OnOne2 in h.
       induction h.
-      - constructor.
+      - reflexivity.
       - eapply red_trans.
         + eapply IHh.
         + eapply red_fix_one_body.
@@ -862,7 +1150,7 @@ Section ReductionCongruence.
         { eapply map_inj ; eauto.
           intros y z e. cbn in e. destruct y, z. inversion e. eauto.
         } subst.
-        constructor.
+        reflexivity.
       - set (f := fun x : def term => (dtype x, (dname x, dbody x, rarg x))) in *.
         set (g := fun '(ty, (na, bo, ra)) => mkdef term na ty bo ra).
         assert (el :  forall l, l = map f (map g l)).
@@ -875,7 +1163,7 @@ Section ReductionCongruence.
           - reflexivity.
           - cbn. destruct a. cbn. f_equal. assumption.
         }
-        econstructor.
+        eapply trans_red.
         + eapply IHh. symmetry. apply el.
         + constructor. rewrite (el' mfix').
           eapply OnOne2_map.
@@ -893,7 +1181,7 @@ Section ReductionCongruence.
       intros mfix idx mfix' h.
       apply All2_many_OnOne2 in h.
       induction h.
-      - constructor.
+      - reflexivity.
       - eapply red_trans.
         + eapply IHh.
         + eapply red_cofix_one_ty. assumption.
@@ -913,7 +1201,7 @@ Section ReductionCongruence.
         { eapply map_inj ; eauto.
           intros y z e. cbn in e. destruct y, z. inversion e. eauto.
         } subst.
-        constructor.
+        reflexivity.
       - set (f := fun x : def term => (dbody x, (dname x, dtype x, rarg x))) in *.
         set (g := fun '(bo, (na, ty, ra)) => mkdef term na ty bo ra).
         assert (el :  forall l, l = map f (map g l)).
@@ -926,7 +1214,7 @@ Section ReductionCongruence.
           - reflexivity.
           - cbn. destruct a. cbn. f_equal. assumption.
         }
-        econstructor.
+        eapply trans_red.
         + eapply IHh. symmetry. apply el.
         + eapply cofix_red_body. rewrite (el' mfix').
           eapply OnOne2_map.
@@ -970,7 +1258,7 @@ Section ReductionCongruence.
       intros mfix idx mfix' h.
       apply All2_many_OnOne2 in h.
       induction h.
-      - constructor.
+      - reflexivity.
       - eapply red_trans.
         + eapply IHh.
         + eapply red_cofix_one_body.
@@ -1041,10 +1329,7 @@ Section ReductionCongruence.
         red Σ Γ (tProd na A B) (tProd na A' B).
     Proof.
       intros na A B A' h.
-      induction h.
-      - constructor.
-      - econstructor ; try eassumption.
-        constructor. assumption.
+      rst_induction h; eauto with pcuic.
     Qed.
 
     Lemma red_prod_r :
@@ -1053,10 +1338,7 @@ Section ReductionCongruence.
         red Σ Γ (tProd na A B) (tProd na A B').
     Proof.
       intros na A B B' h.
-      induction h.
-      - constructor.
-      - econstructor ; try eassumption.
-        constructor. assumption.
+      rst_induction h; eauto with pcuic.
     Qed.
 
     Lemma red_prod :
@@ -1093,7 +1375,7 @@ Section ReductionCongruence.
         { eapply map_inj ; eauto.
           intros y z e. cbn in e. inversion e. eauto.
         } subst.
-        constructor.
+        reflexivity.
       - set (f := fun x : term => (x, tt)) in *.
         set (g := (fun '(x, _) => x) : term × unit -> term).
         assert (el :  forall l, l = map f (map g l)).
@@ -1106,7 +1388,7 @@ Section ReductionCongruence.
           - reflexivity.
           - cbn. f_equal. assumption.
         }
-        econstructor.
+        eapply trans_red.
         + eapply IHh. symmetry. apply el.
         + constructor. rewrite (el' l').
           eapply OnOne2_map.
@@ -1124,7 +1406,7 @@ Section ReductionCongruence.
       intros ev l l' h.
       apply All2_many_OnOne2 in h.
       induction h.
-      - constructor.
+      - reflexivity.
       - eapply red_trans.
         + eapply IHh.
         + eapply red_one_evar. assumption.
@@ -1132,12 +1414,11 @@ Section ReductionCongruence.
 
     Lemma red_atom t : atom t -> red Σ Γ t t.
     Proof.
-      intros. constructor.
+      intros. reflexivity.
     Qed.
 
   End Congruences.
 End ReductionCongruence.
-
 
 
 Lemma red_rel_all Σ Γ i body t :
@@ -1199,6 +1480,7 @@ Ltac OnOne2_All2 :=
 Hint Extern 0 (All2 _ _ _) => OnOne2_All2; intuition auto with pred : pred.
 
 (* TODO Find a better place for this. *)
+Require Import PCUICPosition.
 Section Stacks.
 
   Context (Σ : global_env_ext).
@@ -1234,11 +1516,9 @@ Section Stacks.
       red Σ (Γ ,,, stack_context π) t u ->
       red Σ Γ (zip (t, π)) (zip (u, π)).
   Proof.
-    intros Γ t u π h. induction h.
-    - constructor.
-    - econstructor.
-      + eapply IHh.
-      + eapply red1_context. assumption.
+    intros Γ t u π h.
+      rst_induction h; eauto with pcuic.
+      eapply red1_context. assumption.
   Qed.
 
   Lemma red1_zipp :
@@ -1258,11 +1538,9 @@ Section Stacks.
       red Σ Γ t u ->
       red Σ Γ (zipp t π) (zipp u π).
   Proof.
-    intros Γ t u π h. induction h.
-    - constructor.
-    - econstructor.
-      + eapply IHh.
-      + eapply red1_zipp. assumption.
+    intros Γ t u π h.
+    rst_induction h; eauto with pcuic.
+    eapply red1_zipp. assumption.
   Qed.
 
   Lemma red1_zippx :
@@ -1285,11 +1563,9 @@ Section Stacks.
       red Σ (Γ ,,, stack_context π) t u ->
       red Σ Γ (zippx t π) (zippx u π).
   Proof.
-    intros Γ t u π h. induction h.
-    - constructor.
-    - econstructor.
-      + eapply IHh.
-      + eapply red1_zippx. assumption.
+    intros Γ t u π h.
+    rst_induction h; eauto with pcuic.
+    eapply red1_zippx. assumption.
   Qed.
 
 End Stacks.

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -26,6 +26,21 @@ Proof.
   destruct 1; now constructor.
 Qed.
 
+Lemma equiv_reflectT P (b : bool) : (P -> b) -> (b -> P) -> reflectT P b.
+Proof.
+  intros. destruct b; constructor; auto. intro. now discriminate H.
+Qed.
+
+Lemma reflectT_subrelation {A} {R} {r : A -> A -> bool} : (forall x y, reflectT (R x y) (r x y)) -> CRelationClasses.subrelation R r.
+Proof.
+  intros. intros x y h. destruct (X x y); auto.
+Qed.
+
+Lemma reflectT_subrelation' {A} {R} {r : A -> A -> bool} : (forall x y, reflectT (R x y) (r x y)) -> CRelationClasses.subrelation r R.
+Proof.
+  intros. intros x y h. destruct (X x y); auto. discriminate.
+Qed.
+
 (* Some reflection / EqDec lemmata *)
 
 Class ReflectEq A := {

--- a/pcuic/theories/PCUICRelations.v
+++ b/pcuic/theories/PCUICRelations.v
@@ -1,0 +1,128 @@
+Require Import ssreflect.
+Require Export CRelationClasses.
+Require Export Equations.Type.Relation Equations.Type.Relation_Properties.
+
+
+Section Flip.
+  Local Set Universe Polymorphism.
+  Context {A : Type} (R : crelation A).
+
+  Lemma flip_Reflexive : Reflexive R -> Reflexive (flip R).
+  Proof.
+    intros HR x. unfold flip. apply reflexivity.
+  Qed.
+
+  Lemma flip_Symmetric : Symmetric R -> Symmetric (flip R).
+  Proof.
+    intros HR x y. unfold flip. apply symmetry.
+  Qed.
+
+  Lemma flip_Transitive : Transitive R -> Transitive (flip R).
+  Proof.
+    intros HR x y z xy yz.
+    unfold flip in *. eapply HR; eassumption.
+  Qed.
+
+End Flip.
+
+
+
+
+Definition commutes {A} (R S : relation A) :=
+  forall x y z, R x y -> S x z -> { w & S y w * R z w}%type.
+
+
+Lemma clos_t_rt {A} {R : A -> A -> Type} x y : trans_clos R x y -> clos_refl_trans R x y.
+Proof.
+  induction 1; try solve [econstructor; eauto].
+Qed.
+
+
+Arguments rt_step {A} {R} {x y}.
+Polymorphic Hint Resolve rt_refl rt_step : core.
+
+
+Definition clos_rt_monotone {A} (R S : relation A) :
+  inclusion R S -> inclusion (clos_refl_trans R) (clos_refl_trans S).
+Proof.
+  move => incls x y.
+  induction 1; solve [econstructor; eauto].
+Qed.
+
+Lemma relation_equivalence_inclusion {A} (R S : relation A) :
+  inclusion R S -> inclusion S R -> relation_equivalence R S.
+Proof. firstorder. Qed.
+
+Lemma clos_rt_disjunction_left {A} (R S : relation A) :
+  inclusion (clos_refl_trans R)
+            (clos_refl_trans (relation_disjunction R S)).
+Proof.
+  apply clos_rt_monotone.
+  intros x y H; left; exact H.
+Qed.
+
+Lemma clos_rt_disjunction_right {A} (R S : relation A) :
+  inclusion (clos_refl_trans S)
+            (clos_refl_trans (relation_disjunction R S)).
+Proof.
+  apply clos_rt_monotone.
+  intros x y H; right; exact H.
+Qed.
+
+Global Instance clos_rt_trans A R : Transitive (@clos_refl_trans A R).
+Proof.
+  intros x y z H H'. econstructor 3; eauto.
+Qed.
+
+Global Instance clos_rt_refl A R : Reflexive (@clos_refl_trans A R).
+Proof. intros x. constructor 2. Qed.
+
+Lemma clos_refl_trans_prod_l {A B} (R : relation A) (S : relation (A * B)) :
+  (forall x y b, R x y -> S (x, b) (y, b)) ->
+  forall (x y : A) b,
+    clos_refl_trans R x y ->
+    clos_refl_trans S (x, b) (y, b).
+Proof.
+  intros. induction X0; try solve [econstructor; eauto].
+Qed.
+
+Lemma clos_refl_trans_prod_r {A B} (R : relation B) (S : relation (A * B)) a :
+  (forall x y, R x y -> S (a, x) (a, y)) ->
+  forall (x y : B),
+    clos_refl_trans R x y ->
+    clos_refl_trans S (a, x) (a, y).
+Proof.
+  intros. induction X0; try solve [econstructor; eauto].
+Qed.
+
+Lemma clos_rt_t_incl {A} {R : relation A} `{Reflexive A R} :
+  inclusion (clos_refl_trans R) (trans_clos R).
+Proof.
+  intros x y. induction 1; try solve [econstructor; eauto].
+Qed.
+
+Lemma clos_t_rt_incl {A} {R : relation A} `{Reflexive A R} :
+  inclusion (trans_clos R) (clos_refl_trans R).
+Proof.
+  intros x y. induction 1; try solve [econstructor; eauto].
+Qed.
+
+Lemma clos_t_rt_equiv {A} {R} `{Reflexive A R} :
+  relation_equivalence (trans_clos R) (clos_refl_trans R).
+Proof.
+  apply relation_equivalence_inclusion.
+  apply clos_t_rt_incl.
+  apply clos_rt_t_incl.
+Qed.
+
+Global Instance relation_disjunction_refl_l {A} {R S : relation A} :
+  Reflexive R -> Reflexive (relation_disjunction R S).
+Proof.
+  intros HR x. left; auto.
+Qed.
+
+Global Instance relation_disjunction_refl_r {A} {R S : relation A} :
+  Reflexive S -> Reflexive (relation_disjunction R S).
+Proof.
+  intros HR x. right; auto.
+Qed.

--- a/pcuic/theories/PCUICRelations.v
+++ b/pcuic/theories/PCUICRelations.v
@@ -126,3 +126,39 @@ Global Instance relation_disjunction_refl_r {A} {R S : relation A} :
 Proof.
   intros HR x. right; auto.
 Qed.
+
+Global Instance clos_rt_trans_Symmetric A R :
+  Symmetric R -> Symmetric (@clos_refl_trans A R).
+Proof.
+  intros X x y H. induction H; eauto.
+  eapply clos_rt_trans; eassumption.
+Qed.
+
+Definition clos_sym {A} (R : relation A) := relation_disjunction R (flip R).
+
+Global Instance clos_sym_Symmetric A R :
+  Symmetric (@clos_sym A R).
+Proof.
+  intros x y []; [right|left]; assumption.
+Qed.
+
+Global Instance clos_refl_sym_trans_Symmetric A R :
+  Symmetric (@clos_refl_sym_trans A R)
+  := rst_sym R.
+
+Global Instance clos_refl_sym_trans_Reflexive A R :
+  Reflexive (@clos_refl_sym_trans A R)
+  := rst_refl R.
+
+Global Instance clos_refl_sym_trans_Transitive A R :
+  Transitive (@clos_refl_sym_trans A R)
+  := rst_trans R.
+
+Global Instance relation_disjunction_Symmetric {A} {R S : relation A} :
+  Symmetric R -> Symmetric S -> Symmetric (relation_disjunction R S).
+Proof.
+  intros HR HS x y [X|X]; [left|right]; eauto.
+Qed.
+
+Ltac rst_induction h :=
+  induction h; [constructor|reflexivity|etransitivity].

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -1068,7 +1068,7 @@ Proof.
       rewrite firstn_skipn_comm nth_error_skipn.
       rewrite -{1}[args0](firstn_skipn (ind_npars mdecl + narg)).
       rewrite nth_error_app1 // firstn_length_le; autorewrite with len; try lia.
-      constructor. }
+      reflexivity. }
     { simpl. autorewrite with len.
       rewrite -(subst_instance_context_length u (ind_params mdecl)).
       eapply weakening_wf_local; auto. }
@@ -1163,7 +1163,7 @@ Proof.
     * eapply wf_fixpoint_red1_type; eauto.
     * eapply All_nth_error in X2; eauto.
     * apply conv_cumul, conv_sym, red_conv. destruct disj as [<-|red].
-      constructor. apply red1_red. apply red.
+      reflexivity. apply red1_red. apply red.
 
   - (* Fix congruence in body *)
     assert(fixl :#|fix_context mfix| = #|fix_context mfix1|) by now (rewrite !fix_context_length; apply (OnOne2_length o)).
@@ -1205,7 +1205,7 @@ Proof.
     * eapply wf_fixpoint_red1_body; eauto.
     * eapply All_nth_error in X2; eauto.
     * apply conv_cumul, conv_sym, red_conv. destruct disj as [<-|[_ eq]].
-      constructor. noconf eq. simpl in H0; noconf H0. rewrite H2; constructor.
+      reflexivity. noconf eq. simpl in H0; noconf H0. rewrite H2; reflexivity.
 
   - (* CoFix congruence type *)
     assert(fixl :#|fix_context mfix| = #|fix_context mfix1|) by now (rewrite !fix_context_length; apply (OnOne2_length o)).
@@ -1252,7 +1252,7 @@ Proof.
     * eapply wf_cofixpoint_red1_type; eauto.
     * eapply All_nth_error in X2; eauto.
     * apply conv_cumul, conv_sym, red_conv. destruct disj as [<-|red].
-      constructor. apply red1_red. apply red.
+      reflexivity. apply red1_red. apply red.
 
   - (* CoFix congruence in body *)
     assert(fixl :#|fix_context mfix| = #|fix_context mfix1|) by now (rewrite !fix_context_length; apply (OnOne2_length o)).
@@ -1290,7 +1290,7 @@ Proof.
     * now eapply wf_cofixpoint_red1_body.
     * eapply All_nth_error in X2; eauto.
     * apply conv_cumul, conv_sym, red_conv. destruct disj as [<-|[_ eq]].
-      constructor. noconf eq. simpl in H0; noconf H0. rewrite H2; constructor.
+      reflexivity. noconf eq. simpl in H0; noconf H0. rewrite H2; reflexivity.
  
   - (* Conversion *)
     specialize (forall_u _ Hu).
@@ -1309,8 +1309,8 @@ Theorem subject_reduction {cf:checker_flags} :
   forall (Σ : global_env_ext) Γ t u T, wf Σ -> Σ ;;; Γ |- t : T -> red Σ Γ t u -> Σ ;;; Γ |- u : T.
 Proof.
   intros * wfΣ Hty Hred.
-  induction Hred. auto.
-  eapply sr_red1 in IHHred; eauto with wf.
+  induction Hred; eauto.
+  eapply sr_red1 in Hty; eauto with wf.
 Qed.
 
 Lemma subject_reduction1 {cf:checker_flags} {Σ Γ t u T}
@@ -1341,7 +1341,7 @@ Section SRContext.
       Σ ;;; Γ |- t <= u.
   Proof.
     intros Σ Γ t u hΣ h.
-    induction h.
+    induction h using red_rect'.
     - eapply cumul_refl'.
     - eapply PCUICConversion.cumul_trans ; try eassumption.
       eapply cumul_red_l.
@@ -1629,7 +1629,7 @@ Section SRContext.
      isWfArity typing Σ Γ A ->
      isWfArity typing Σ Γ B.
    Proof.
-     induction 2.
+     induction 2 using red_rect'.
      - easy.
      - intro. now eapply isWfArity_red1.
    Qed.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -11,7 +11,6 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICWeakeningEnv PCUICGeneration PCUICParallelReductionConfluence.
 
 Require Import Equations.Prop.DepElim.
-Derive Signature for red.
 Import MonadNotation.
 
 Local Set Keyed Unification.
@@ -302,7 +301,7 @@ Section Lemmata.
       cored Σ Γ v u \/ u = v.
   Proof.
     intros Γ u v h.
-    induction h.
+    induction h using red_rect'.
     - right. reflexivity.
     - destruct IHh.
       + left. eapply cored_trans ; eassumption.
@@ -363,7 +362,7 @@ Section Lemmata.
       cored Σ Γ w u.
   Proof.
     intros Γ u v w h1 h2.
-    revert w h2. induction h1 ; intros w h2.
+    revert w h2. induction h1 using red_rect'; intros w h2.
     - constructor. assumption.
     - eapply cored_trans.
       + eapply IHh1. eassumption.
@@ -611,11 +610,9 @@ Section Lemmata.
   Proof.
     intros Γ u v h.
     induction h.
-    - constructor. econstructor.
-      + constructor.
-      + assumption.
+    - constructor. now constructor.
     - destruct IHh as [r].
-      constructor. econstructor ; eassumption.
+      constructor. etransitivity; eauto.
   Qed.
 
   Lemma cored_context :
@@ -994,11 +991,9 @@ Section Lemmata.
       red (fst Σ) Γ (tConst c u) (subst_instance_constr u cb).
   Proof.
     intros Γ c u cty cb cu e.
-    econstructor.
-    - econstructor.
-    - econstructor.
-      + symmetry in e.  exact e.
-      + reflexivity.
+    econstructor. econstructor.
+    - symmetry in e. exact e.
+    - reflexivity.
   Qed.
 
   Lemma cored_const :
@@ -1109,18 +1104,17 @@ Section Lemmata.
       destruct bot as [? [? [? [[r ?] ?]]]].
       exfalso. clear - r wΣ.
       revert r. generalize (Universe.sort_of_product s1 s2). intro s. clear.
-      intro r.
+      intro r. eapply Relation_Properties.clos_rt_rt1n in r.
       dependent induction r.
-      assert (h : P = tSort s).
-      { clear - r. induction r ; auto. subst.
-        dependent destruction r0.
+      assert (h : y = tSort s).
+      { clear - r. dependent destruction r.
         assert (h : isSort (mkApps (tFix mfix idx) args)).
         { rewrite <- H. constructor. }
         apply isSortmkApps in h. subst. cbn in H.
         discriminate.
       }
       subst.
-      dependent destruction r0.
+      dependent destruction r.
       assert (h : isSort (mkApps (tFix mfix idx) args)).
       { rewrite <- H. constructor. }
       apply isSortmkApps in h. subst. cbn in H.
@@ -1297,7 +1291,7 @@ Section Lemmata.
       cored Σ Γ v u.
   Proof.
     intros Γ u v r n.
-    destruct r.
+    destruct r using red_rect'.
     - exfalso. apply n. reflexivity.
     - eapply cored_red_cored ; try eassumption.
       constructor. assumption.
@@ -1311,7 +1305,7 @@ Section Lemmata.
   Proof.
     destruct hΣ as [wΣ]; clear hΣ.
     intros Γ u v h [r].
-    revert h. induction r ; intros h.
+    revert h. induction r using red_rect' ; intros h.
     - assumption.
     - specialize IHr with (1 := ltac:(eassumption)).
       destruct IHr as [A ?]. exists A.
@@ -1325,7 +1319,7 @@ Section Lemmata.
       cored Σ Γ w u.
   Proof.
     intros Γ u v w h1 h2.
-    revert u h2. induction h1 ; intros t h2.
+    revert u h2. induction h1 using red_rect' ; intros t h2.
     - assumption.
     - eapply cored_trans.
       + eapply IHh1. assumption.

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -402,7 +402,7 @@ Proof.
   eapply inst_ext_closed; eauto.
   intros.
   unfold ids, subst_consn. simpl.
-  destruct (equiv_inv _ _ (nth_error_Some' s x) H). rewrite e.
+  destruct (snd (nth_error_Some' s x) H). rewrite e.
   subst s.
   rewrite /to_extended_list /to_extended_list_k in e.
   rewrite List.rev_length in cl, H. autorewrite with len in *.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -1226,7 +1226,7 @@ Proof.
       destruct (nth_error_spec (all_rels Δ 0 #|Δ|) (#|Δ| + n - #|Δ'|));
       rewrite all_rels_length in l0 |- *. lia.
       assert (#|Δ| + n - #|Δ| = n) as -> by lia.
-      constructor. lia.
+      reflexivity. lia.
     **
       elim: leb_spec_Set => Hle.
       destruct (nth_error_spec (all_rels Δ 0 #|Δ|) (n - #|Δ'|));
@@ -1272,8 +1272,8 @@ Proof.
         now rewrite skipn_length in Xb; try lia.
         rewrite skipn_length; lia.
       + simpl. assert(#|Δ'| + (n - #|Δ'|) = n) as -> by lia.
-        constructor.
-      + constructor.
+        reflexivity.
+      + reflexivity.
 
   * simpl; eapply red_evar.
     do 2 apply All2_map_right.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -5,9 +5,9 @@
 From Coq Require Import Bool List Arith Lia.
 From MetaCoq.Template Require Import utils config.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
-  PCUICLiftSubst PCUICEquality PCUICPosition PCUICSigmaCalculus
-  PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICClosed
-  PCUICReduction PCUICWeakening PCUICCumulativity PCUICUnivSubstitution.
+     PCUICLiftSubst PCUICEquality PCUICPosition PCUICSigmaCalculus
+     PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICClosed
+     PCUICReduction PCUICWeakening PCUICCumulativity PCUICUnivSubstitution.
 Require Import ssreflect.
 
 From Equations Require Import Equations.
@@ -1664,7 +1664,7 @@ Proof.
            simpl. rewrite subst_skipn. 1: auto with arith.
            rewrite simpl_lift; auto with arith.
            assert(S (i - #|Γ'|) + #|Γ'| = S i) as -> by lia.
-           constructor.
+           reflexivity.
         -- noconf H.
       * apply nth_error_None in Heq.
         assert(S i = #|s| + (S (i - #|s|))) by lia.
@@ -1698,7 +1698,7 @@ Proof.
     now rewrite nth_error_map H.
 
   - specialize (IHred1 Γ0 Δ Γ' eq_refl wfΓ Hs).
-    apply red_abs. 1: auto. constructor.
+    apply red_abs. 1: auto. reflexivity.
 
   - specialize (IHred1 Γ0 Δ (Γ' ,, _) eq_refl wfΓ Hs).
     apply red_abs; auto.
@@ -1831,7 +1831,7 @@ Proof.
         simpl. rewrite subst_skipn. 1: auto with arith.
         rewrite simpl_lift; auto with arith.
         assert(S (i - #|Γ'|) + #|Γ'| = S i) as -> by lia.
-        constructor.
+        reflexivity.
       * apply nth_error_None in Heq.
         assert(S i = #|s| + (S (i - #|s|))) by lia.
         rewrite H1. rewrite -> simpl_subst; try lia.
@@ -1864,7 +1864,7 @@ Proof.
     now rewrite nth_error_map H.
 
   - specialize (IHred1 Γ0 Δ Γ' eq_refl Hs).
-    apply red_abs. 1: auto. constructor.
+    apply red_abs. 1: auto. reflexivity.
 
   - specialize (IHred1 Γ0 Δ (Γ' ,, _) eq_refl Hs).
     apply red_abs; auto with pcuic.
@@ -1969,11 +1969,9 @@ Lemma substitution_untyped_red {cf:checker_flags} Σ Γ Δ Γ' s M N :
   red Σ (Γ ,,, subst_context s 0 Γ') (subst s #|Γ'| M) (subst s #|Γ'| N).
 Proof.
   intros wfΣ subsl.
-  induction 1. 
-  - constructor.
-  - etransitivity.
-    * eapply IHX.
-    * eapply substitution_untyped_let_red; eauto.
+  induction 1; trea.
+  - eapply substitution_untyped_let_red; eassumption.
+  - etransitivity; eauto.
 Qed.
 
 Lemma subst_eq_decl `{checker_flags} Σ ϕ l k d d' :
@@ -1999,9 +1997,9 @@ Lemma substitution_red `{cf : checker_flags} (Σ : global_env_ext) Γ Δ Γ' s M
   red Σ (Γ ,,, Δ ,,, Γ') M N ->
   red Σ (Γ ,,, subst_context s 0 Γ') (subst s #|Γ'| M) (subst s #|Γ'| N).
 Proof.
-  intros HG Hs Hl Hred. induction Hred. 1: constructor.
-  eapply red_trans with (subst s #|Γ'| P); auto.
-  eapply substitution_let_red; eauto.
+  intros HG Hs Hl Hred. induction Hred; trea. 
+  - eapply substitution_let_red; eauto.
+  - etransitivity; eauto.
 Qed.
 
 Lemma red_red {cf:checker_flags} (Σ : global_env_ext) Γ Δ Γ' s s' b : wf Σ ->
@@ -2025,8 +2023,8 @@ Proof.
       * destruct (All2_nth_error_Some _ _ Hall Heq') as [t' [-> Ptt']].
         intros. apply (weakening_red Σ Γ [] Γ' t t'); auto.
       * rewrite (All2_nth_error_None _ Hall Heq').
-        apply All2_length in Hall as ->. constructor.
-    + constructor.
+        apply All2_length in Hall as ->. reflexivity.
+    + reflexivity.
 
   - apply red_evar. apply All2_map. solve_all.
   - apply red_prod; eauto.
@@ -2059,9 +2057,9 @@ Lemma untyped_substitution_red {cf:checker_flags} Σ Γ Δ Γ' s M N :
   red Σ (Γ ,,, Δ ,,, Γ') M N ->
   red Σ (Γ ,,, subst_context s 0 Γ') (subst s #|Γ'| M) (subst s #|Γ'| N).
 Proof.
-  intros HG Hs Hred. induction Hred. 1: constructor.
-  eapply red_trans with (subst s #|Γ'| P); auto.
-  eapply substitution_untyped_let_red; eauto.
+  intros HG Hs Hred. induction Hred; trea.
+  - eapply substitution_untyped_let_red; eauto.
+  - etransitivity; eauto.
 Qed.
 
 (** The cumulativity relation is substitutive, yay! *)

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -366,7 +366,7 @@ Proof.
     * simpl; intros.
       move: H. rewrite /closed_inductive_body.
       destruct x; simpl. move=> /andP[/andP [ci ct] cp].
-      f_equal. 
+      f_equal.
       + rewrite subst_closedn; eauto.
         eapply closed_upwards; eauto; lia.
       + eapply All_map_id. eapply forallb_All in ct.
@@ -443,10 +443,10 @@ Proof.
   intros.
   eapply (declared_projection_closed (Σ:=empty_ext Σ)) in H; auto.
   unfold on_snd. simpl.
-  rewrite subst_closedn. 
+  rewrite subst_closedn.
   - eapply closed_upwards; eauto; try lia.
   - destruct pdecl; reflexivity.
-Qed.  
+Qed.
 
 Lemma subst_fix_context:
   forall (mfix : list (def term)) n (k : nat),
@@ -687,11 +687,11 @@ Proof.
   rewrite app_nil_r /= //.
 Qed.
 
-Lemma subst_telescope_cons s k d Γ : 
-  subst_telescope s k (d :: Γ) = 
+Lemma subst_telescope_cons s k d Γ :
+  subst_telescope s k (d :: Γ) =
   map_decl (subst s k) d :: subst_telescope s (S k) Γ.
 Proof.
-  simpl. 
+  simpl.
   unfold subst_telescope, mapi. simpl.
   rewrite Nat.add_0_r; f_equal.
   rewrite mapi_rec_Sk. apply mapi_rec_ext.
@@ -979,9 +979,9 @@ Inductive untyped_subslet (Γ : context) : list term -> context -> Type :=
 | untyped_cons_let_def Δ s na t T :
     untyped_subslet Γ s Δ ->
     untyped_subslet Γ (subst0 s t :: s) (Δ ,, vdef na t T).
- 
+
 Lemma decompose_prod_assum_it_mkProd_or_LetIn ctx t ctx' t' :
- decompose_prod_assum ctx t = (ctx', t') -> 
+ decompose_prod_assum ctx t = (ctx', t') ->
  it_mkProd_or_LetIn ctx t = it_mkProd_or_LetIn ctx' t'.
 Proof.
   induction t in ctx, ctx', t' |- *; simpl; try intros [= -> <-]; auto.
@@ -992,7 +992,7 @@ Qed.
 Inductive decompose_prod_assum_graph : term -> (context * term) -> Type :=
 | decompose_arity ctx t : decompose_prod_assum_graph (it_mkProd_or_LetIn ctx t) (ctx, t).
 
-Lemma decompose_prod_assum_spec ctx t : 
+Lemma decompose_prod_assum_spec ctx t :
   decompose_prod_assum_graph (it_mkProd_or_LetIn ctx t) (decompose_prod_assum ctx t).
 Proof.
  induction t in ctx |- *; simpl; try constructor 1.
@@ -1003,7 +1003,7 @@ Qed.
 
 Lemma subst_decompose_prod_assum_rec ctx t s k :
   let (ctx', t') := decompose_prod_assum ctx t in
-  ∑ ctx'' t'', 
+  ∑ ctx'' t'',
     (decompose_prod_assum [] (subst s (#|ctx'| + k) t') = (ctx'', t'')) *
   (decompose_prod_assum (subst_context s k ctx) (subst s (length ctx + k) t) =
   (subst_context s k ctx' ,,, ctx'', t'')).
@@ -1067,11 +1067,11 @@ Proof.
       subst c. rewrite app_context_assoc.
       unfold snoc. simpl. lia_f_equal.
 Qed.
-(* 
+(*
 
 Lemma subst_decompose_prod_assum_rec ctx t s k :
   let (ctx', t') := decompose_prod_assum ctx t in
-  let (ctx'', t'') := decompose_prod_assum (subst_context s k ctx) (subst s (length ctx + k) t) in 
+  let (ctx'', t'') := decompose_prod_assum (subst_context s k ctx) (subst s (length ctx + k) t) in
   subst s k (it_mkProd_or_LetIn ctx' t') = it_mkProd_or_LetIn ctx'' t''.
 Proof.
   rewrite decompose_prod_assum_ctx.
@@ -1101,7 +1101,7 @@ Proof.
     apply mapi_ext=> n' x.
     destruct x as [na' [b'|] ty']; simpl.
     * rewrite !mapi_length /subst_decl /= /map_decl /=; f_equal.
-      + rewrite Nat.add_0_r distr_subst_rec. simpl. lia_f_equal. 
+      + rewrite Nat.add_0_r distr_subst_rec. simpl. lia_f_equal.
       + rewrite Nat.add_0_r distr_subst_rec; simpl. lia_f_equal.
     * rewrite !mapi_length /subst_decl /= /map_decl /=; f_equal.
       rewrite Nat.add_0_r distr_subst_rec /=. lia_f_equal.
@@ -1125,17 +1125,17 @@ Arguments Nat.sub : simpl nomatch.
 Lemma extended_subst_length Γ n : #|extended_subst Γ n| = #|Γ|.
 Proof.
   induction Γ in n |- *; simpl; auto.
-  now destruct a as [? [?|] ?] => /=; simpl; rewrite IHΓ. 
+  now destruct a as [? [?|] ?] => /=; simpl; rewrite IHΓ.
 Qed.
 Hint Rewrite extended_subst_length : len.
 
-Lemma assumption_context_skipn Γ n : 
-  assumption_context Γ -> 
+Lemma assumption_context_skipn Γ n :
+  assumption_context Γ ->
   assumption_context (skipn n Γ).
 Proof.
   induction 1 in n |- *; simpl.
   - destruct n; constructor.
-  - destruct n. 
+  - destruct n.
     * rewrite skipn_0. constructor; auto.
     * now rewrite skipn_S.
 Qed.
@@ -1147,7 +1147,7 @@ Proof.
   intros -> ; reflexivity.
 Qed.
 
-Lemma lift_extended_subst (Γ : context) k : 
+Lemma lift_extended_subst (Γ : context) k :
   extended_subst Γ k = map (lift0 k) (extended_subst Γ 0).
 Proof.
   induction Γ as [|[? [] ?] ?] in k |- *; simpl; auto.
@@ -1175,7 +1175,7 @@ Proof.
     rewrite simpl_lift; lia_f_equal.
 Qed.
 
-Lemma subst_extended_subst_k s Γ k k' : extended_subst (subst_context s k Γ) k' = 
+Lemma subst_extended_subst_k s Γ k k' : extended_subst (subst_context s k Γ) k' =
   map (subst s (k + context_assumptions Γ + k')) (extended_subst Γ k').
 Proof.
   induction Γ as [|[na [b|] ty] Γ]; simpl; auto; rewrite subst_context_snoc /=;
@@ -1185,11 +1185,11 @@ Proof.
     rewrite distr_subst. autorewrite with len. f_equal.
     now rewrite context_assumptions_fold.
   - elim: Nat.leb_spec => //. lia.
-  - rewrite (lift_extended_subst' _ 1 k') IHΓ. 
-    rewrite (lift_extended_subst' _ 1 k'). 
+  - rewrite (lift_extended_subst' _ 1 k') IHΓ.
+    rewrite (lift_extended_subst' _ 1 k').
     rewrite !map_map_compose.
     apply map_ext.
-    intros x. 
+    intros x.
     erewrite (commut_lift_subst_rec); lia_f_equal.
 Qed.
 
@@ -1208,7 +1208,7 @@ Qed.
 
 Local Open Scope sigma_scope.
 
-Lemma inst_extended_subst_shift (Γ : context) k : 
+Lemma inst_extended_subst_shift (Γ : context) k :
   map (inst ((extended_subst Γ 0 ⋅n ids) ∘s ↑^k)) (idsn #|Γ|) =
   map (inst (extended_subst Γ k ⋅n ids)) (idsn #|Γ|).
 Proof.
@@ -1230,7 +1230,7 @@ Proof.
   now autorewrite with sigma.
 Qed.
 
-Lemma subst_context_decompo s s' Γ k : 
+Lemma subst_context_decompo s s' Γ k :
   subst_context (s ++ s') k Γ =
   subst_context s' k (subst_context (map (lift0 #|s'|) s) k Γ).
 Proof.
@@ -1247,7 +1247,7 @@ Proof.
     rewrite !mapi_length. now rewrite subst_app_decomp.
 Qed.
 
-Lemma fold_context_compose f g Γ : 
+Lemma fold_context_compose f g Γ :
   fold_context f (fold_context g Γ) = fold_context (fun n x => f n (g n x)) Γ.
 Proof.
   induction Γ; simpl; auto; rewrite !fold_context_snoc0.
@@ -1256,7 +1256,7 @@ Proof.
   now rewrite fold_context_length.
 Qed.
 
-Lemma fold_context_ext f g Γ : 
+Lemma fold_context_ext f g Γ :
   f =2 g ->
   fold_context f Γ = fold_context g Γ.
 Proof.
@@ -1266,7 +1266,7 @@ Proof.
   intros. now apply hfg.
 Qed.
 
-Lemma smash_context_acc Γ Δ : 
+Lemma smash_context_acc Γ Δ :
   smash_context Δ Γ =
       subst_context (extended_subst Γ 0) 0 (lift_context (context_assumptions Γ) #|Γ| Δ)
    ++ smash_context [] Γ.
@@ -1291,13 +1291,13 @@ Proof.
     setoid_rewrite ren_lift_renaming.
     autorewrite with sigma.
     rewrite !Upn_compose.
-    apply Upn_ext. 
+    apply Upn_ext.
     autorewrite with sigma.
     unfold Up.
     rewrite subst_consn_subst_cons.
     autorewrite with sigma.
     reflexivity.
-    
+
   - simpl.
     rewrite IHΓ /=. auto.
     rewrite (IHΓ [_]). auto. rewrite !app_assoc. f_equal.
@@ -1317,7 +1317,7 @@ Proof.
     autorewrite with sigma.
     apply Upn_ext.
     unfold Up.
-    
+
     rewrite subst_consn_subst_cons.
     autorewrite with sigma.
     apply subst_cons_proper; auto.
@@ -1340,7 +1340,7 @@ Proof.
     rewrite -shiftk_compose subst_compose_assoc.
     rewrite subst_consn_shiftn.
     2:now autorewrite with len.
-    autorewrite with sigma. 
+    autorewrite with sigma.
     rewrite -shiftk_shift.
     rewrite -shiftk_compose subst_compose_assoc.
     rewrite subst_consn_shiftn.
@@ -1350,7 +1350,7 @@ Qed.
 
 Hint Rewrite context_assumptions_app context_assumptions_fold : len.
 
-Lemma map_option_out_impl {A B} (l : list A) (f g : A -> option B) x : 
+Lemma map_option_out_impl {A B} (l : list A) (f g : A -> option B) x :
   (forall x y, f x = Some y -> g x = Some y) ->
   map_option_out (map f l) = Some x ->
   map_option_out (map g l) = Some x.
@@ -1388,7 +1388,7 @@ Proof.
   rewrite List.rev_app_distr.
   destruct (nth_error_spec (List.rev (smash_context [] c0)) rarg) => /= //;
   autorewrite with len in l; simpl in *.
-  rewrite nth_error_app_lt; autorewrite with len; simpl; try lia. 
+  rewrite nth_error_app_lt; autorewrite with len; simpl; try lia.
   rewrite (smash_context_subst []) /=.
   rewrite nth_error_rev_inv; autorewrite with len; simpl; try lia.
   rewrite nth_error_subst_context /=.
@@ -1400,7 +1400,7 @@ Proof.
   destruct t0; try discriminate. simpl in *.
   erewrite decompose_app_subst; eauto. simpl. auto.
 Qed.
- 
+
 Lemma decompose_prod_assum_mkApps ctx ind u args :
   decompose_prod_assum ctx (mkApps (tInd ind u) args) = (ctx, mkApps (tInd ind u) args).
 Proof.
@@ -1997,7 +1997,7 @@ Lemma substitution_red `{cf : checker_flags} (Σ : global_env_ext) Γ Δ Γ' s M
   red Σ (Γ ,,, Δ ,,, Γ') M N ->
   red Σ (Γ ,,, subst_context s 0 Γ') (subst s #|Γ'| M) (subst s #|Γ'| N).
 Proof.
-  intros HG Hs Hl Hred. induction Hred; trea. 
+  intros HG Hs Hl Hred. induction Hred; trea.
   - eapply substitution_let_red; eauto.
   - etransitivity; eauto.
 Qed.
@@ -2472,7 +2472,7 @@ Proof.
       * exists (tu.π1). rewrite Nat.add_0_r; now eapply t0.
       * exists (tu.π1). rewrite Nat.add_0_r; now eapply t1.
       * rewrite Nat.add_0_r; now eapply t0.
-      
+
   - elim (leb_spec_Set); intros Hn.
     + elim nth_error_spec.
       * intros x Heq Hlt.
@@ -2652,7 +2652,7 @@ Proof.
       rewrite subst_context_app Nat.add_0_r app_context_assoc in IH.
       rewrite app_context_length fix_context_length in IH.
       rewrite subst_context_length fix_context_length.
-      rewrite commut_lift_subst_rec; try lia. now rewrite (Nat.add_comm #|Δ|).      
+      rewrite commut_lift_subst_rec; try lia. now rewrite (Nat.add_comm #|Δ|).
     * move: H1.
       rewrite /wf_cofixpoint.
       pose proof (substitution_check_one_cofix s #|Δ| mfix).
@@ -2671,7 +2671,7 @@ Proof.
         clear -sub a.
         induction ctx; try constructor; depelim a.
         -- rewrite subst_context_snoc.
-           unfold snoc. 
+           unfold snoc.
            econstructor; auto.
            ++ eapply IHctx. eapply a.
            ++ simpl. destruct tu as [u tu]. exists u.
@@ -2752,7 +2752,7 @@ Qed.
 
 (* TODO Move to liftsubst *)
 
-Lemma subst_context_comm s s' Γ : 
+Lemma subst_context_comm s s' Γ :
   subst_context s 0 (subst_context s' 0 Γ) =
   subst_context (map (subst s 0) s' ++ s) 0 Γ.
 Proof.
@@ -2789,7 +2789,7 @@ Proof.
     now rewrite subst_app_simpl.
 Qed.
 
-Lemma context_assumptions_subst s n Γ : 
+Lemma context_assumptions_subst s n Γ :
   context_assumptions (subst_context s n Γ) = context_assumptions Γ.
 Proof. apply context_assumptions_fold. Qed.
 Hint Rewrite context_assumptions_subst : pcuic.
@@ -2802,13 +2802,13 @@ Proof. intros ->; apply subst_app_simpl. Qed.
 
 
 Lemma subst_app_context' (s s' : list term) (Γ : context) n :
-  n = #|s| ->  
+  n = #|s| ->
   subst_context (s ++ s') 0 Γ = subst_context s 0 (subst_context s' n Γ).
 Proof.
   intros ->; apply subst_app_context.
 Qed.
 
-Lemma map_subst_app_simpl l l' k (ts : list term) : 
+Lemma map_subst_app_simpl l l' k (ts : list term) :
   map (subst l k ∘ subst l' (k + #|l|)) ts =
   map (subst (l ++ l') k) ts.
 Proof.
@@ -2817,7 +2817,7 @@ Proof.
 Qed.
 
 Lemma simpl_map_lift x n k :
-  map (lift0 n ∘ lift0 k) x = 
+  map (lift0 n ∘ lift0 k) x =
   map (lift k n ∘ lift0 n) x.
 Proof.
   apply map_ext => t.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -7,6 +7,7 @@ From MetaCoq.Template Require Import config utils monad_utils
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
   PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils
   PCUICPosition.
+From MetaCoq.PCUIC Require Export PCUICReduction PCUICCumulativity.
 
 From MetaCoq Require Export LibHypsNaming.
 Require Import ssreflect.
@@ -15,6 +16,7 @@ Require Import Equations.Type.Relation.
 From Equations Require Import Equations.
 Import MonadNotation.
 
+Local Open Scope type_scope.
 (** * Typing derivations
 
   Inductive relations for reduction, conversion and typing of PCUIC terms.
@@ -22,6 +24,12 @@ Import MonadNotation.
   deal with arities, declarations in the environment etc...
 
  *)
+
+Hint Rewrite subst_context_length subst_instance_context_length
+  app_context_length map_context_length fix_context_length fix_subst_length cofix_subst_length
+  map_length app_length lift_context_length
+  @mapi_length @mapi_rec_length List.rev_length Nat.add_0_r : len.
+
 
 Definition isSort T :=
   match T with
@@ -38,7 +46,6 @@ Fixpoint isArity T :=
   end.
 
 
-Module PCUICLookup := Lookup PCUICTerm PCUICEnvironment.
 Include PCUICLookup.
 
 (** Inductive substitution, to produce a constructors' type *)
@@ -66,349 +73,6 @@ Qed.
 Definition type_of_constructor mdecl (cdecl : ident * term * nat) (c : inductive * nat) (u : list Level.t) :=
   let mind := inductive_mind (fst c) in
   subst0 (inds mind u mdecl.(ind_bodies)) (subst_instance_constr u (snd (fst cdecl))).
-
-(** ** Reduction *)
-
-(** *** Helper functions for reduction *)
-
-Definition fix_subst (l : mfixpoint term) :=
-  let fix aux n :=
-      match n with
-      | 0 => []
-      | S n => tFix l n :: aux n
-      end
-  in aux (List.length l).
-
-Definition unfold_fix (mfix : mfixpoint term) (idx : nat) :=
-  match List.nth_error mfix idx with
-  | Some d => Some (d.(rarg), subst0 (fix_subst mfix) d.(dbody))
-  | None => None
-  end.
-
-Definition cofix_subst (l : mfixpoint term) :=
-  let fix aux n :=
-      match n with
-      | 0 => []
-      | S n => tCoFix l n :: aux n
-      end
-  in aux (List.length l).
-
-Definition unfold_cofix (mfix : mfixpoint term) (idx : nat) :=
-  match List.nth_error mfix idx with
-  | Some d => Some (d.(rarg), subst0 (cofix_subst mfix) d.(dbody))
-  | None => None
-  end.
-
-Definition is_constructor n ts :=
-  match List.nth_error ts n with
-  | Some a => isConstruct_app a
-  | None => false
-  end.
-
-Lemma fix_subst_length mfix : #|fix_subst mfix| = #|mfix|.
-Proof.
-  unfold fix_subst. generalize (tFix mfix). intros.
-  induction mfix; simpl; auto.
-Qed.
-
-Lemma cofix_subst_length mfix : #|cofix_subst mfix| = #|mfix|.
-Proof.
-  unfold cofix_subst. generalize (tCoFix mfix). intros.
-  induction mfix; simpl; auto.
-Qed.
-
-Lemma fix_context_length mfix : #|fix_context mfix| = #|mfix|.
-Proof. unfold fix_context. now rewrite List.rev_length mapi_length. Qed.
-
-Hint Rewrite subst_context_length subst_instance_context_length 
-  app_context_length map_context_length fix_context_length fix_subst_length cofix_subst_length 
-  map_length app_length lift_context_length 
-  @mapi_length @mapi_rec_length List.rev_length Nat.add_0_r : len.
-
-Definition tDummy := tVar String.EmptyString.
-
-Definition iota_red npar c args brs :=
-  (mkApps (snd (List.nth c brs (0, tDummy))) (List.skipn npar args)).
-
-
-(** *** One step strong beta-zeta-iota-fix-delta reduction
-
-  Inspired by the reduction relation from Coq in Coq [Barras'99].
-*)
-
-Local Open Scope type_scope.
-Arguments OnOne2 {A} P%type l l'.
-
-Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
-(** Reductions *)
-(** Beta *)
-| red_beta na t b a :
-    red1 Σ Γ (tApp (tLambda na t b) a) (subst10 a b)
-
-(** Let *)
-| red_zeta na b t b' :
-    red1 Σ Γ (tLetIn na b t b') (subst10 b b')
-
-| red_rel i body :
-    option_map decl_body (nth_error Γ i) = Some (Some body) ->
-    red1 Σ Γ (tRel i) (lift0 (S i) body)
-
-(** Case *)
-| red_iota ind pars c u args p brs :
-    red1 Σ Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs)
-         (iota_red pars c args brs)
-
-(** Fix unfolding, with guard *)
-| red_fix mfix idx args narg fn :
-    unfold_fix mfix idx = Some (narg, fn) ->
-    is_constructor narg args = true ->
-    red1 Σ Γ (mkApps (tFix mfix idx) args) (mkApps fn args)
-
-(** CoFix-case unfolding *)
-| red_cofix_case ip p mfix idx args narg fn brs :
-    unfold_cofix mfix idx = Some (narg, fn) ->
-    red1 Σ Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs)
-         (tCase ip p (mkApps fn args) brs)
-
-(** CoFix-proj unfolding *)
-| red_cofix_proj p mfix idx args narg fn :
-    unfold_cofix mfix idx = Some (narg, fn) ->
-    red1 Σ Γ (tProj p (mkApps (tCoFix mfix idx) args))
-         (tProj p (mkApps fn args))
-
-(** Constant unfolding *)
-| red_delta c decl body (isdecl : declared_constant Σ c decl) u :
-    decl.(cst_body) = Some body ->
-    red1 Σ Γ (tConst c u) (subst_instance_constr u body)
-
-(** Proj *)
-| red_proj i pars narg args u arg:
-    nth_error args (pars + narg) = Some arg ->
-    red1 Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg
-
-
-| abs_red_l na M M' N : red1 Σ Γ M M' -> red1 Σ Γ (tLambda na M N) (tLambda na M' N)
-| abs_red_r na M M' N : red1 Σ (Γ ,, vass na N) M M' -> red1 Σ Γ (tLambda na N M) (tLambda na N M')
-
-| letin_red_def na b t b' r : red1 Σ Γ b r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na r t b')
-| letin_red_ty na b t b' r : red1 Σ Γ t r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b r b')
-| letin_red_body na b t b' r : red1 Σ (Γ ,, vdef na b t) b' r -> red1 Σ Γ (tLetIn na b t b') (tLetIn na b t r)
-
-| case_red_pred ind p p' c brs : red1 Σ Γ p p' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p' c brs)
-| case_red_discr ind p c c' brs : red1 Σ Γ c c' -> red1 Σ Γ (tCase ind p c brs) (tCase ind p c' brs)
-| case_red_brs ind p c brs brs' :
-    OnOne2 (on_Trel_eq (red1 Σ Γ) snd fst) brs brs' ->
-    red1 Σ Γ (tCase ind p c brs) (tCase ind p c brs')
-
-| proj_red p c c' : red1 Σ Γ c c' -> red1 Σ Γ (tProj p c) (tProj p c')
-
-| app_red_l M1 N1 M2 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tApp M1 M2) (tApp N1 M2)
-| app_red_r M2 N2 M1 : red1 Σ Γ M2 N2 -> red1 Σ Γ (tApp M1 M2) (tApp M1 N2)
-
-| prod_red_l na M1 M2 N1 : red1 Σ Γ M1 N1 -> red1 Σ Γ (tProd na M1 M2) (tProd na N1 M2)
-| prod_red_r na M2 N2 M1 : red1 Σ (Γ ,, vass na M1) M2 N2 ->
-                               red1 Σ Γ (tProd na M1 M2) (tProd na M1 N2)
-
-| evar_red ev l l' : OnOne2 (red1 Σ Γ) l l' -> red1 Σ Γ (tEvar ev l) (tEvar ev l')
-
-| fix_red_ty mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
-
-| fix_red_body mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x)))
-           mfix0 mfix1 ->
-    red1 Σ Γ (tFix mfix0 idx) (tFix mfix1 idx)
-
-| cofix_red_ty mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)
-
-| cofix_red_body mfix0 mfix1 idx :
-    OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, fix_context mfix0)) dbody (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
-    red1 Σ Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx).
-
-Lemma red1_ind_all :
-  forall (Σ : global_env) (P : context -> term -> term -> Type),
-
-       (forall (Γ : context) (na : name) (t b a : term),
-        P Γ (tApp (tLambda na t b) a) (b {0 := a})) ->
-
-       (forall (Γ : context) (na : name) (b t b' : term), P Γ (tLetIn na b t b') (b' {0 := b})) ->
-
-       (forall (Γ : context) (i : nat) (body : term),
-        option_map decl_body (nth_error Γ i) = Some (Some body) -> P Γ (tRel i) ((lift0 (S i)) body)) ->
-
-       (forall (Γ : context) (ind : inductive) (pars c : nat) (u : Instance.t) (args : list term)
-          (p : term) (brs : list (nat * term)),
-        P Γ (tCase (ind, pars) p (mkApps (tConstruct ind c u) args) brs) (iota_red pars c args brs)) ->
-
-       (forall (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
-        unfold_fix mfix idx = Some (narg, fn) ->
-        is_constructor narg args = true -> P Γ (mkApps (tFix mfix idx) args) (mkApps fn args)) ->
-
-       (forall (Γ : context) (ip : inductive * nat) (p : term) (mfix : mfixpoint term) (idx : nat)
-          (args : list term) (narg : nat) (fn : term) (brs : list (nat * term)),
-        unfold_cofix mfix idx = Some (narg, fn) ->
-        P Γ (tCase ip p (mkApps (tCoFix mfix idx) args) brs) (tCase ip p (mkApps fn args) brs)) ->
-
-       (forall (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
-          (narg : nat) (fn : term),
-        unfold_cofix mfix idx = Some (narg, fn) -> P Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
-
-       (forall (Γ : context) c (decl : constant_body) (body : term),
-        declared_constant Σ c decl ->
-        forall u : Instance.t, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance_constr u body)) ->
-
-       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
-         (arg : term),
-           nth_error args (pars + narg) = Some arg ->
-           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
-
-       (forall (Γ : context) (na : name) (M M' N : term),
-        red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->
-
-       (forall (Γ : context) (na : name) (M M' N : term),
-        red1 Σ (Γ,, vass na N) M M' -> P (Γ,, vass na N) M M' -> P Γ (tLambda na N M) (tLambda na N M')) ->
-
-       (forall (Γ : context) (na : name) (b t b' r : term),
-        red1 Σ Γ b r -> P Γ b r -> P Γ (tLetIn na b t b') (tLetIn na r t b')) ->
-
-       (forall (Γ : context) (na : name) (b t b' r : term),
-        red1 Σ Γ t r -> P Γ t r -> P Γ (tLetIn na b t b') (tLetIn na b r b')) ->
-
-       (forall (Γ : context) (na : name) (b t b' r : term),
-        red1 Σ (Γ,, vdef na b t) b' r -> P (Γ,, vdef na b t) b' r -> P Γ (tLetIn na b t b') (tLetIn na b t r)) ->
-
-       (forall (Γ : context) (ind : inductive * nat) (p p' c : term) (brs : list (nat * term)),
-        red1 Σ Γ p p' -> P Γ p p' -> P Γ (tCase ind p c brs) (tCase ind p' c brs)) ->
-
-       (forall (Γ : context) (ind : inductive * nat) (p c c' : term) (brs : list (nat * term)),
-        red1 Σ Γ c c' -> P Γ c c' -> P Γ (tCase ind p c brs) (tCase ind p c' brs)) ->
-
-       (forall (Γ : context) (ind : inductive * nat) (p c : term) (brs brs' : list (nat * term)),
-           OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) snd fst) brs brs' ->
-           P Γ (tCase ind p c brs) (tCase ind p c brs')) ->
-
-       (forall (Γ : context) (p : projection) (c c' : term), red1 Σ Γ c c' -> P Γ c c' ->
-                                                             P Γ (tProj p c) (tProj p c')) ->
-
-       (forall (Γ : context) (M1 N1 : term) (M2 : term), red1 Σ Γ M1 N1 -> P Γ M1 N1 ->
-                                                         P Γ (tApp M1 M2) (tApp N1 M2)) ->
-
-       (forall (Γ : context) (M2 N2 : term) (M1 : term), red1 Σ Γ M2 N2 -> P Γ M2 N2 ->
-                                                         P Γ (tApp M1 M2) (tApp M1 N2)) ->
-
-       (forall (Γ : context) (na : name) (M1 M2 N1 : term),
-        red1 Σ Γ M1 N1 -> P Γ M1 N1 -> P Γ (tProd na M1 M2) (tProd na N1 M2)) ->
-
-       (forall (Γ : context) (na : name) (M2 N2 M1 : term),
-        red1 Σ (Γ,, vass na M1) M2 N2 -> P (Γ,, vass na M1) M2 N2 -> P Γ (tProd na M1 M2) (tProd na M1 N2)) ->
-
-       (forall (Γ : context) (ev : nat) (l l' : list term),
-           OnOne2 (Trel_conj (red1 Σ Γ) (P Γ)) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
-                                      (P (Γ ,,, fix_context mfix0))) dbody
-                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
-        P Γ (tFix mfix0 idx) (tFix mfix1 idx)) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ Γ) (P Γ)) dtype (fun x => (dname x, dbody x, rarg x))) mfix0 mfix1 ->
-        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
-
-       (forall (Γ : context) (mfix0 mfix1 : list (def term)) (idx : nat),
-        OnOne2 (on_Trel_eq (Trel_conj (red1 Σ (Γ ,,, fix_context mfix0))
-                                      (P (Γ ,,, fix_context mfix0))) dbody
-                           (fun x => (dname x, dtype x, rarg x))) mfix0 mfix1 ->
-        P Γ (tCoFix mfix0 idx) (tCoFix mfix1 idx)) ->
-
-       forall (Γ : context) (t t0 : term), red1 Σ Γ t t0 -> P Γ t t0.
-Proof.
-  intros. rename X26 into Xlast. revert Γ t t0 Xlast.
-  fix aux 4. intros Γ t T.
-  move aux at top.
-  destruct 1; match goal with
-              | |- P _ (tFix _ _) (tFix _ _) => idtac
-              | |- P _ (tCoFix _ _) (tCoFix _ _) => idtac
-              | |- P _ (mkApps (tFix _ _) _) _ => idtac
-              | |- P _ (tCase _ _ (mkApps (tCoFix _ _) _) _) _ => idtac
-              | |- P _ (tProj _ (mkApps (tCoFix _ _) _)) _ => idtac
-              | H : _ |- _ => eapply H; eauto
-              end.
-  - eapply X3; eauto.
-  - eapply X4; eauto.
-  - eapply X5; eauto.
-
-  - revert brs brs' o.
-    fix auxl 3.
-    intros l l' Hl. destruct Hl.
-    constructor. intuition auto. constructor. intuition auto.
-
-  - revert l l' o.
-    fix auxl 3.
-    intros l l' Hl. destruct Hl.
-    constructor. split; auto.
-    constructor. auto.
-
-  - eapply X22.
-    revert mfix0 mfix1 o; fix auxl 3; intros l l' Hl; destruct Hl;
-      constructor; try split; auto; intuition.
-
-  - eapply X23.
-    revert o. generalize (fix_context mfix0). intros c Xnew.
-    revert mfix0 mfix1 Xnew; fix auxl 3; intros l l' Hl;
-    destruct Hl; constructor; try split; auto; intuition.
-
-  - eapply X24.
-    revert mfix0 mfix1 o.
-    fix auxl 3; intros l l' Hl; destruct Hl;
-      constructor; try split; auto; intuition.
-
-  - eapply X25.
-    revert o. generalize (fix_context mfix0). intros c new.
-    revert mfix0 mfix1 new; fix auxl 3; intros l l' Hl; destruct Hl;
-      constructor; try split; auto; intuition.
-Defined.
-
-
-(** *** Reduction
-
-  The reflexive-transitive closure of 1-step reduction. *)
-
-Inductive red Σ Γ M : term -> Type :=
-| refl_red : red Σ Γ M M
-| trans_red : forall (P : term) N, red Σ Γ M P -> red1 Σ Γ P N -> red Σ Γ M N.
-
-Reserved Notation " Σ ;;; Γ |- t : T " (at level 50, Γ, t, T at next level).
-Reserved Notation " Σ ;;; Γ |- t <= u " (at level 50, Γ, t, u at next level).
-Reserved Notation " Σ ;;; Γ |- t = u " (at level 50, Γ, t, u at next level).
-
-(** ** Cumulativity *)
-
-Inductive cumul `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
-| cumul_refl t u : leq_term Σ.1 (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t <= u
-| cumul_red_l t u v : red1 Σ.1 Γ t v -> Σ ;;; Γ |- v <= u -> Σ ;;; Γ |- t <= u
-| cumul_red_r t u v : Σ ;;; Γ |- t <= v -> red1 Σ.1 Γ u v -> Σ ;;; Γ |- t <= u
-
-where " Σ ;;; Γ |- t <= u " := (cumul Σ Γ t u) : type_scope.
-
-(** *** Conversion   
- *)
-
-Inductive conv `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
-| conv_refl t u : eq_term Σ.1 (global_ext_constraints Σ) t u -> Σ ;;; Γ |- t = u
-| conv_red_l t u v : red1 Σ Γ t v -> Σ ;;; Γ |- v = u -> Σ ;;; Γ |- t = u
-| conv_red_r t u v : Σ ;;; Γ |- t = v -> red1 (fst Σ) Γ u v -> Σ ;;; Γ |- t = u
-
-where " Σ ;;; Γ |- t = u " := (@conv _ Σ Γ t u) : type_scope.
-
-Hint Resolve cumul_refl conv_refl : pcuic.
 
 
 (** ** Typing relation *)

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -833,10 +833,10 @@ Proof.
 Qed.
 
 Definition precompose_subst_instance_instance__1 Rle u i i'
-  := equiv _ _ (precompose_subst_instance_instance Rle u i i').
+  := fst (precompose_subst_instance_instance Rle u i i').
 
 Definition precompose_subst_instance_instance__2 Rle u i i'
-  := equiv_inv _ _ (precompose_subst_instance_instance Rle u i i').
+  := snd (precompose_subst_instance_instance Rle u i i').
 
 Lemma precompose_subst_instance_global Σ Re Rle gr napp u i i' :
   precompose (R_global_instance Σ Re Rle gr napp) (subst_instance_instance u) i i'
@@ -859,10 +859,10 @@ Proof.
 Qed.
 
 Definition precompose_subst_instance_global__1 Σ Re Rle gr napp u i i'
-  := equiv _ _ (precompose_subst_instance_global Σ Re Rle gr napp u i i').
+  := fst (precompose_subst_instance_global Σ Re Rle gr napp u i i').
 
 Definition precompose_subst_instance_global__2 Σ Re Rle gr napp u i i'
-  := equiv_inv _ _ (precompose_subst_instance_global Σ Re Rle gr napp u i i').
+  := snd (precompose_subst_instance_global Σ Re Rle gr napp u i i').
 
 Global Instance eq_term_upto_univ_subst_instance Σ
          (Re Rle : ConstraintSet.t -> Universe.t -> Universe.t -> Prop) napp

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -859,4 +859,3 @@ Arguments eval_deterministic {_ _ _ _}.
 
 Conjecture closed_typed_wcbeval : forall {cf : checker_flags} (Σ : global_env_ext) t T,
     Σ ;;; [] |- t : T -> ∑ u, eval (fst Σ) t u.
-

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -667,9 +667,9 @@ Lemma weakening_red `{CF:checker_flags} Σ Γ Γ' Γ'' M N :
   red Σ (Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ') (lift #|Γ''| #|Γ'| M) (lift #|Γ''| #|Γ'| N).
 Proof.
   intros wfΣ; induction 1.
-  - constructor.
-  - eapply red_trans with (lift #|Γ''| #|Γ'| P); eauto.
-    simpl; eapply red1_red. eapply weakening_red1; auto.
+  - constructor. eapply weakening_red1; auto.
+  - reflexivity.
+  - etransitivity; eassumption.
 Qed.
 
 Fixpoint lift_stack n k π :=

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -39,6 +39,8 @@ src/pCUICReflect.mli
 src/pCUICReflect.ml
 src/pCUICEquality.mli
 src/pCUICEquality.ml
+src/pCUICReduction.ml
+src/pCUICReduction.mli
 src/pCUICTyping.ml
 src/pCUICTyping.mli
 src/pCUICUnivSubst.ml

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -1168,7 +1168,7 @@ Section Conversion.
     pose proof (decompose_stack_eq _ _ _ e'). subst.
     rewrite stack_context_appstack in r1.
     rewrite stack_context_appstack.
-    econstructor.
+    eapply trans_red.
     - eapply red_app_r. exact r1.
     - repeat lazymatch goal with
       | |- context [ tApp (mkApps ?t ?l) ?u ] =>
@@ -1217,7 +1217,7 @@ Section Conversion.
     rewrite <- 2!mkApps_nested. cbn. eapply red_mkApps_f.
     pose proof (decompose_stack_eq _ _ _ e'). subst.
     rewrite stack_context_appstack in r1.
-    econstructor.
+    eapply trans_red.
     - eapply red_app_r. exact r1.
     - repeat lazymatch goal with
       | |- context [ tApp (mkApps ?t ?l) ?u ] =>
@@ -1260,7 +1260,7 @@ Section Conversion.
     rewrite <- e1 in r1. cbn in r1.
     rewrite <- e1 in hd. cbn in hd.
     do 2 zip fold. constructor. eapply red_context.
-    econstructor.
+    eapply trans_red.
     - eapply red_app_r. exact r1.
     - repeat lazymatch goal with
       | |- context [ tApp (mkApps ?t ?l) ?u ] =>
@@ -2500,7 +2500,7 @@ Section Conversion.
       constructor.
       eapply red_zipc.
       eapply red_case.
-      + constructor.
+      + reflexivity.
       + assumption.
       + clear.
         induction brs ; eauto.
@@ -2515,7 +2515,7 @@ Section Conversion.
       constructor.
       eapply red_zipc.
       eapply red_case.
-      + constructor.
+      + reflexivity.
       + assumption.
       + clear.
         induction brs' ; eauto.
@@ -2601,7 +2601,7 @@ Section Conversion.
     - eapply red_conv_cum_l ; try assumption.
       eapply red_zipp.
       eapply red_case.
-      + constructor.
+      + reflexivity.
       + eassumption.
       + instantiate (1 := brs).
         clear.
@@ -2612,7 +2612,7 @@ Section Conversion.
       + eapply red_conv_cum_r. 1: assumption.
         eapply red_zipp.
         eapply red_case. 2: eassumption.
-        * constructor.
+        * reflexivity.
         * clear.
           induction brs' ; eauto.
       + eapply conv_context_sym. all: auto.
@@ -2963,7 +2963,7 @@ Section Conversion.
   Next Obligation.
     destruct h1 as [h1].
     destruct hΣ.
-    eapply conv_conv_cum_l. 1: assumption.
+    eapply conv_conv_cum_l.
     change (true = eqb idx idx') in eq4.
     destruct (eqb_spec idx idx'). 2: discriminate.
     subst.
@@ -3390,7 +3390,7 @@ Section Conversion.
       case_eq (decompose_stack π). intros l s eq.
       eapply red_mkApps_f.
       eapply trans_red.
-      + constructor.
+      + reflexivity.
       + eapply red_delta.
         * unfold declared_constant. eauto.
         * reflexivity.
@@ -3424,7 +3424,7 @@ Section Conversion.
       case_eq (decompose_stack π). intros l s eq.
       eapply red_it_mkLambda_or_LetIn. eapply red_mkApps_f.
       eapply trans_red.
-      + constructor.
+      + reflexivity.
       + eapply red_delta.
         * unfold declared_constant. eauto.
         * reflexivity.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -252,11 +252,11 @@ Section Reduce.
     intros Γ [t π] [t' π'] h. cbn.
     dependent destruction h.
     - repeat zip fold. rewrite H.
-      constructor. constructor.
+      constructor. reflexivity.
     - dependent destruction H.
       + eapply cored_red. assumption.
       + cbn in H0. inversion H0.
-        constructor. constructor.
+        constructor. reflexivity.
   Qed.
 
   (* Show Obligation Tactic. *)

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -56,8 +56,6 @@ gen-src/list0.ml
 gen-src/list0.mli
 gen-src/logic0.ml
 gen-src/logic0.mli
-gen-src/mCPrelude.mli
-gen-src/mCPrelude.ml
 gen-src/mCCompare.ml
 gen-src/mCCompare.mli
 gen-src/mCList.ml

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -200,7 +200,7 @@ Module NoPropLevel.
 
   Definition eq : t -> t -> Prop := Logic.eq.
 
-  Definition eq_equiv : RelationClasses.Equivalence eq := _.
+  Definition eq_equiv : Equivalence eq := _.
 
   Definition eq_dec (l1 l2 : t) : {l1 = l2}+{l1 <> l2}.
   Proof.
@@ -1064,7 +1064,7 @@ Module ConstraintType.
   Inductive t_ : Set := Lt | Le | Eq.
   Definition t := t_.
   Definition eq : t -> t -> Prop := eq.
-  Definition eq_equiv : RelationClasses.Equivalence eq := _.
+  Definition eq_equiv : Equivalence eq := _.
 
   Inductive lt_ : t -> t -> Prop :=
   | LtLe : lt_ Lt Le
@@ -1109,7 +1109,7 @@ End ConstraintType.
 Module UnivConstraint.
   Definition t : Set := Level.t * ConstraintType.t * Level.t.
   Definition eq : t -> t -> Prop := eq.
-  Definition eq_equiv : RelationClasses.Equivalence eq := _.
+  Definition eq_equiv : Equivalence eq := _.
 
   Definition make l1 ct l2 : t := (l1, ct, l2).
 
@@ -1376,12 +1376,6 @@ Context {cf:checker_flags}.
 
 
   (** **** Lemmas about eq and leq **** *)
-
-  (** We show that equality and inequality of universes form an equivalence and
-      a partial order (one w.r.t. the other).
-      We use classes from [CRelationClasses] for consistency with the rest of the
-      development which uses relations in [Type] rather than [Prop].
-      These definitions hence use [Prop <= Type]. *)
 
   Global Instance eq_universe0_refl φ : Reflexive (eq_universe0 φ).
   Proof.

--- a/template-coq/theories/utils/All_Forall.v
+++ b/template-coq/theories/utils/All_Forall.v
@@ -416,8 +416,7 @@ Proof.
 Qed.
 
 Lemma Alli_mapi {A B} {P : nat -> B -> Type} (f : nat -> A -> B) k l :
-  CRelationClasses.iffT (Alli (fun n a => P n (f n a)) k l)
-                        (Alli P k (mapi_rec f l k)).
+  Alli (fun n a => P n (f n a)) k l <~> Alli P k (mapi_rec f l k).
 Proof.
   split.
   { induction 1. simpl. constructor.
@@ -825,15 +824,6 @@ Proof.
   destruct n; discriminate.
   revert Hnth. destruct n. intros [= ->]. now rewrite Nat.add_0_r.
   intros H'; eauto. rewrite <- Nat.add_succ_comm. eauto.
-Qed.
-
-Lemma nth_error_Some' {A} l n : (exists x : A, nth_error l n = Some x) <-> n < length l.
-Proof.
-  revert n. induction l; destruct n; simpl.
-  - split; [now destruct 1 | inversion 1].
-  - split; [now destruct 1 | inversion 1].
-  - split; now intuition eauto with arith.
-  - rewrite IHl; split; auto with arith.
 Qed.
 
 Lemma nth_error_forallb {A} P l n :

--- a/template-coq/theories/utils/MCPrelude.v
+++ b/template-coq/theories/utils/MCPrelude.v
@@ -1,4 +1,8 @@
+Require Import CRelationClasses.
+
 Declare Scope metacoq_scope.
+
+Infix "<~>" := iffT (at level 90).
 
 Notation "'eta_compose'" := (fun g f x => g (f x)).
 
@@ -6,13 +10,6 @@ Notation "'eta_compose'" := (fun g f x => g (f x)).
 Notation "g ∘ f" := (eta_compose g f) (at level 40, left associativity).
 
 Notation " ! " := (@False_rect _ _) : metacoq_scope.
-
-(** "Incoherent" notion of equivalence, that we only apply to hProps actually. *)
-Record isEquiv (A B : Type) :=
-  { equiv : A -> B;
-    equiv_inv : B -> A}.
-
-Infix "<~>" := isEquiv (at level 90).
 
 (* Use \sum to input ∑ in Company Coq (it is not a sigma Σ). *)
 Notation "'∑' x .. y , p" := (sigT (fun x => .. (sigT (fun y => p%type)) ..))


### PR DESCRIPTION
This PR:

- Defines `red` with `clos_refl_trans` instead of a dedicated inductive type.

```
Definition red Σ Γ := clos_refl_trans (red1 Σ Γ).
```

As a consequences there is no more `red_alt`.
`red_rect'` is introduced for the compatibility.

- Defines `conv1` and `cumul1` which are the "natural" definitions for cumulativity and conversion:

```
  Definition conv0 : relation term
    := clos_refl_sym_trans (relation_disjunction (red1 Σ Γ) (eq_term Σ Σ)).

  Definition conv1 : relation term
    := clos_refl_trans (relation_disjunction (clos_sym (red1 Σ Γ)) (eq_term Σ Σ)).

  Lemma conv0_conv1 M N :
    conv0 M N <~> conv1 M N.

  Definition cumul1 : relation term
    := clos_refl_trans (relation_disjunction (clos_sym (red1 Σ Γ)) (leq_term Σ Σ)).
```

We then show that they are equivalent to `cumul` and `conv` in PCUICConversion (we need transitivity).


And less importantly:

- moves the definition of PCUICLookup from PCUICTyping to PCUICAst

- puts the definition of reduction in PCUICReduction and the definition of conversion/cumulativity in PCUICCumulativity

- adds a file PCUICRelations with stuffs about relations

- removes a unused argument to `conv_conv_cum_l` and to another lemma

- removes non-coherent `isEquiv` and uses `<~>` for `iffT`