### PR TITLE
Prove uniqueness of evaluation derivations

### DIFF
--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -4,6 +4,7 @@ theories/EAst.v
 theories/EAstUtils.v
 theories/EInduction.v
 theories/ELiftSubst.v
+theories/EReflect.v
 theories/EPretty.v
 theories/ECSubst.v
 theories/EWcbvEval.v

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -72,7 +72,7 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     depelim H0.
     constructor; [|easy].
-    now apply H.
+    now apply p.
   - depelim er.
     constructor.
     induction H in k, H, H0 |- *; [easy|].
@@ -80,7 +80,7 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     depelim H0.
     constructor; [|easy].
-    now apply H.
+    now apply p.
 Qed.
 
 Lemma erases_deps_subst Σ Σ' s k t :
@@ -120,7 +120,7 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     depelim H0.
     constructor; [|easy].
-    now apply H.
+    now apply p.
   - depelim er.
     constructor.
     induction H in k, H, H0 |- *; [easy|].
@@ -128,7 +128,7 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     depelim H0.
     constructor; [|easy].
-    now apply H.
+    now apply p.
 Qed.
 
 Lemma erases_deps_subst1 Σ Σ' t k u :
@@ -175,7 +175,7 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     depelim H0.
     constructor; [|easy].
-    now apply H.
+    now apply p.
   - depelim er.
     constructor.
     induction H in k, H, H0 |- *; [easy|].
@@ -183,7 +183,7 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     depelim H0.
     constructor; [|easy].
-    now apply H.
+    now apply p.
 Qed.
 
 Lemma erases_deps_substl Σ Σ' s t :

--- a/erasure/theories/EInduction.v
+++ b/erasure/theories/EInduction.v
@@ -11,11 +11,11 @@ From MetaCoq.Erasure Require Import EAst.
 (** Custom induction principle on syntax, dealing with the various lists appearing in terms. *)
 
 Lemma term_forall_list_ind :
-  forall P : term -> Prop,
+  forall P : term -> Type,
     (P tBox) ->
     (forall n : nat, P (tRel n)) ->
     (forall i : ident, P (tVar i)) ->
-    (forall (n : nat) (l : list term), Forall P l -> P (tEvar n l)) ->
+    (forall (n : nat) (l : list term), All P l -> P (tEvar n l)) ->
     (forall (n : name) (t : term), P t -> P (tLambda n t)) ->
     (forall (n : name) (t : term),
         P t -> forall t0 : term, P t0 -> P (tLetIn n t t0)) ->
@@ -26,8 +26,8 @@ Lemma term_forall_list_ind :
         P t -> forall l : list (nat * term),
             tCaseBrsProp P l -> P (tCase p t l)) ->
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
-    (forall (m : mfixpoint term) (n : nat), Forall (fun x => P (dbody x)) m -> P (tFix m n)) ->
-    (forall (m : mfixpoint term) (n : nat), Forall (fun x => P (dbody x)) m -> P (tCoFix m n)) ->
+    (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tFix m n)) ->
+    (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -1,0 +1,155 @@
+From MetaCoq.Erasure Require Import EAst EInduction.
+From MetaCoq.PCUIC Require Import PCUICReflect.
+From Equations Require Import Equations.
+
+Local Ltac finish :=
+  let h := fresh "h" in
+  right ;
+  match goal with
+  | e : ?t <> ?u |- _ =>
+    intro h ; apply e ; now inversion h
+  end.
+
+Local Ltac fcase c :=
+  let e := fresh "e" in
+  case c ; intro e ; [ subst ; try (left ; reflexivity) | finish ].
+
+Local Ltac term_dec_tac term_dec :=
+  repeat match goal with
+         | t : term, u : term |- _ => fcase (term_dec t u)
+         | n : nat, m : nat |- _ => fcase (Nat.eq_dec n m)
+         | i : ident, i' : ident |- _ => fcase (string_dec i i')
+         | i : kername, i' : kername |- _ => fcase (kername_eq_dec i i')
+         | i : string, i' : kername |- _ => fcase (string_dec i i')
+         | n : name, n' : name |- _ => fcase (eq_dec n n')
+         | i : inductive, i' : inductive |- _ => fcase (eq_dec i i')
+         | x : inductive * nat, y : inductive * nat |- _ =>
+           fcase (eq_dec x y)
+         | x : projection, y : projection |- _ => fcase (eq_dec x y)
+         end.
+
+Ltac nodec :=
+  let bot := fresh "bot" in
+  try solve [ constructor ; intro bot ; inversion bot ; subst ; tauto ].
+
+Derive NoConfusion NoConfusionHom for term.
+
+Instance EqDec_term : EqDec term.
+Proof.
+  intro x; induction x using term_forall_list_ind ; intro t ;
+    destruct t ; try (right ; discriminate).
+  all: term_dec_tac term_dec.
+  - left; reflexivity.
+  - revert l0. induction H ; intro l0.
+    + destruct l0.
+      * left. reflexivity.
+      * right. discriminate.
+    + destruct l0.
+      * right. discriminate.
+      * destruct (IHAll l0) ; nodec.
+        destruct (p t) ; nodec.
+        subst. left. inversion e. reflexivity.
+  - destruct (IHx t) ; nodec.
+    subst; left; reflexivity.
+  - destruct (IHx1 t1) ; nodec.
+    destruct (IHx2 t2) ; nodec.
+    subst. left. reflexivity.
+  - destruct (IHx1 t1) ; nodec.
+    destruct (IHx2 t2) ; nodec.
+    subst. left. reflexivity.
+  - destruct (IHx t) ; nodec.
+    subst. revert l0. clear IHx.
+    induction X ; intro l0.
+    + destruct l0.
+      * left. reflexivity.
+      * right. discriminate.
+    + destruct l0.
+      * right. discriminate.
+      * destruct (IHX l0) ; nodec.
+        destruct (p (snd p1)) ; nodec.
+        destruct (eq_dec (fst x) (fst p1)) ; nodec.
+        destruct x, p1.
+        left.
+        cbn in *. subst. inversion e. reflexivity.
+  - destruct (IHx t) ; nodec.
+    left. subst. reflexivity.
+  - revert m0. induction H ; intro m0.
+    + destruct m0.
+      * left. reflexivity.
+      * right. discriminate.
+    + destruct m0.
+      * right. discriminate.
+      * destruct (p (dbody d)) ; nodec.
+        destruct (IHAll m0) ; nodec.
+        destruct x, d ; subst. cbn in *.
+        destruct (eq_dec dname dname0) ; nodec.
+        subst. inversion e0. subst.
+        destruct (eq_dec rarg rarg0) ; nodec.
+        subst. left. reflexivity.
+  - revert m0. induction H ; intro m0.
+    + destruct m0.
+      * left. reflexivity.
+      * right. discriminate.
+    + destruct m0.
+      * right. discriminate.
+      * destruct (p (dbody d)) ; nodec.
+        destruct (IHAll m0) ; nodec.
+        destruct x, d ; subst. cbn in *.
+        destruct (eq_dec dname dname0) ; nodec.
+        subst. inversion e0. subst.
+        destruct (eq_dec rarg rarg0) ; nodec.
+        subst. left. reflexivity.
+Defined.
+
+Instance ReflectEq_term : PCUICReflect.ReflectEq _ :=
+  @EqDec_ReflectEq _ EqDec_term.
+
+Definition eqb_constant_body (x y : constant_body) :=
+  eqb (cst_body x) (cst_body y).
+
+Instance reflect_constant_body : ReflectEq constant_body.
+Proof.
+  refine {| eqb := eqb_constant_body |}.
+  intros [] [].
+  unfold eqb_constant_body.
+  cbn -[eqb].
+  finish_reflect.
+Defined.
+
+Definition eqb_one_inductive_body (x y : one_inductive_body) :=
+  let (n, k, c, p) := x in
+  let (n', k', c', p') := y in
+  eqb n n' && eqb k k' && eqb c c' && eqb p p'.
+
+Instance reflect_one_inductive_body : ReflectEq one_inductive_body.
+Proof.
+  refine {| eqb := eqb_one_inductive_body |}.
+  intros [] [].
+  unfold eqb_one_inductive_body; finish_reflect.
+Defined.
+
+Definition eqb_mutual_inductive_body (x y : mutual_inductive_body) :=
+  let (n, b) := x in
+  let (n', b') := y in
+  eqb n n' && eqb b b'.
+
+Instance reflect_mutual_inductive_body : ReflectEq mutual_inductive_body.
+Proof.
+  refine {| eqb := eqb_mutual_inductive_body |}.
+  intros [] [].
+  unfold eqb_mutual_inductive_body; finish_reflect.
+Defined.
+
+Definition eqb_global_decl x y :=
+  match x, y with
+  | ConstantDecl cst, ConstantDecl cst' => eqb cst cst'
+  | InductiveDecl mib, InductiveDecl mib' => eqb mib mib'
+  | _, _ => false
+  end.
+
+Instance reflect_global_decl : ReflectEq global_decl.
+Proof.
+  refine {| eqb := eqb_global_decl |}.
+  unfold eqb_global_decl.
+  intros [] []; finish_reflect.
+Defined.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1,7 +1,8 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Program.
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst ETyping.
+From MetaCoq.PCUIC Require PCUICWcbvEval.
+From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst EReflect ETyping.
 
 From Equations Require Import Equations.
 Require Import ssreflect ssrbool.
@@ -491,156 +492,168 @@ Proof.
     now apply eval_stuck_fix.
 Qed.
 
+Set Equations With UIP.
+
 Unset SsrRewrite.
+Lemma eval_unique_sig {t v v'} :
+  forall (ev1 : eval t v) (ev2 : eval t v'),
+    {| pr1 := v; pr2 := ev1 |} = {| pr1 := v'; pr2 := ev2 |}.
+Proof.
+  Local Ltac go :=
+    solve [
+        repeat
+          match goal with
+          | [H: _, H' : _ |- _] =>
+            specialize (H _ H');
+            try solve [apply (f_equal pr1) in H; cbn in *; solve_discr];
+            noconf H
+          end; easy].
+  intros ev.
+  revert v'.
+  depind ev; intros v' ev'.
+  - depelim ev'; go.
+  - depelim ev'; go.
+  - depelim ev'; go.
+  - depelim ev'; try go.
+    + specialize (IHev1 _ ev'1); noconf IHev1.
+      apply (f_equal pr1) in IHev1 as apps_eq; cbn in *.
+      apply mkApps_eq_inj in apps_eq as (eq1 & eq2); try easy.
+      noconf eq1.
+      noconf eq2.
+      noconf IHev1.
+      now specialize (IHev2 _ ev'2); noconf IHev2.
+    + apply eval_mkApps_tCoFix in ev1 as H.
+      destruct H as (? & ?); solve_discr.
+  - depelim ev'; try go.
+    + subst.
+      noconf e0.
+      specialize (IHev1 _ ev'1); noconf IHev1.
+      now specialize (IHev2 _ ev'2); noconf IHev2.
+    + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
+  - depelim ev'; try go.
+    + specialize (IHev1 _ ev'1).
+      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+      noconf H.
+      noconf IHev1.
+      specialize (IHev2 _ ev'2); noconf IHev2.
+      assert (fn0 = fn) as -> by congruence.
+      assert (e0 = e) as -> by now apply uip.
+      now specialize (IHev3 _ ev'3); noconf IHev3.
+    + specialize (IHev1 _ ev'1).
+      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+      noconf H.
+      exfalso; rewrite e0 in e.
+      noconf e.
+      lia.
+    + specialize (IHev1 _ ev'1).
+      noconf IHev1.
+      exfalso.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+  - depelim ev'; try go.
+    + specialize (IHev1 _ ev'1).
+      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+      noconf H.
+      exfalso; rewrite e0 in e.
+      noconf e.
+      lia.
+    + specialize (IHev1 _ ev'1).
+      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+      noconf H.
+      noconf IHev1.
+      specialize (IHev2 _ ev'2); noconf IHev2.
+      assert (narg0 = narg) as -> by congruence.
+      assert (fn0 = fn) as -> by congruence.
+      assert (e0 = e) as -> by now apply uip.
+      now assert (l0 = l) as -> by now apply PCUICWcbvEval.le_irrel.
+    + specialize (IHev1 _ ev'1).
+      noconf IHev1.
+      exfalso.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+  - depelim ev'; try go.
+    + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
+    + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
+    + apply mkApps_eq_inj in e' as H'; auto.
+      destruct H' as (H' & <-).
+      noconf H'.
+      assert (narg0 = narg) as -> by congruence.
+      assert (fn0 = fn) as -> by congruence.
+      assert (e' = eq_refl) as -> by now apply uip.
+      assert (e0 = e) as -> by now apply uip.
+      cbn in *; subst.
+      now specialize (IHev _ ev'); noconf IHev.
+  - depelim ev'; try go.
+    + apply mkApps_eq_inj in e1 as H'; auto.
+      destruct H' as (H' & <-).
+      noconf H'.
+      assert (narg0 = narg) as -> by congruence.
+      assert (fn0 = fn) as -> by congruence.
+      assert (e1 = eq_refl) as -> by now apply uip.
+      assert (e0 = e) as -> by now apply uip.
+      cbn in *; subst.
+      now specialize (IHev _ ev'); noconf IHev.
+    + exfalso; apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+    + exfalso; apply eval_mkApps_tCoFix in ev' as (? & ?); solve_discr.
+  - depelim ev'; try go.
+    unfold ETyping.declared_constant in *.
+    assert (decl0 = decl) as -> by congruence.
+    assert (body0 = body) as -> by congruence.
+    assert (e0 = e) as -> by now apply uip.
+    assert (isdecl0 = isdecl) as -> by now apply uip.
+    now specialize (IHev _ ev'); noconf IHev.
+  - depelim ev'; try go.
+    + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
+    + specialize (IHev1 _ ev'1).
+      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+      noconf H.
+      noconf IHev1.
+      now specialize (IHev2 _ ev'2); noconf IHev2.
+  - depelim ev'; try go.
+    apply eval_mkApps_tCoFix in ev as H; destruct H; solve_discr.
+  - depelim ev'; try go.
+    + specialize (IHev1 _ ev'1); noconf IHev1.
+      exfalso.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+    + specialize (IHev1 _ ev'1); noconf IHev1.
+      exfalso.
+      rewrite isFixApp_mkApps in i by easy.
+      cbn in *.
+      now rewrite Bool.orb_true_r in i.
+    + specialize (IHev1 _ ev'1); noconf IHev1.
+      specialize (IHev2 _ ev'2); noconf IHev2.
+      now assert (i0 = i) as -> by now apply uip.
+  - depelim ev'; try go.
+    now assert (i0 = i) as -> by now apply uip.
+Qed.
+
 Lemma eval_deterministic {t v v'} :
   eval t v ->
   eval t v' ->
   v = v'.
 Proof.
-  intros ev.
-  revert v'.
-  depind ev; intros v' ev'.
-  - depelim ev'.
-    + easy.
-    + now apply IHev1 in ev'1.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; subst; easy.
-    + easy.
-  - depelim ev'.
-    + now apply IHev1 in ev'1.
-    + apply IHev1 in ev'1; subst.
-      apply IHev2 in ev'2; subst.
-      noconf ev'1.
-      now apply IHev3 in ev'3.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; subst; easy.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; subst.
-      now apply IHev2 in ev'2.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; solve_discr.
-      noconf H.
-      now apply IHev2 in ev'2.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; solve_discr.
-    + subst.
-      noconf e0.
-      now apply IHev2 in ev'2.
-    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1.
-      apply mkApps_eq_inj in ev'1; try easy.
-      depelim ev'1.
-      noconf H.
-      subst.
-      apply IHev2 in ev'2; subst.
-      rewrite e0 in e.
-      now noconf e.
-    + apply IHev1 in ev'1.
-      apply mkApps_eq_inj in ev'1; try easy.
-      depelim ev'1.
-      noconf H.
-      subst.
-      apply IHev2 in ev'2.
-      subst.
-      rewrite e0 in e.
-      noconf e. lia.
-    + apply IHev1 in ev'1.
-      subst.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite orb_true_r in i.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      apply mkApps_eq_inj in ev'1 as (ev'1 & <-); try easy.
-      noconf ev'1.
-      subst.
-      rewrite e0 in e.
-      noconf e. lia.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      now apply mkApps_eq_inj in ev'1 as (ev'1 & <-).
-    + apply IHev1 in ev'1.
-      subst.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in i.
-      now rewrite orb_true_r in i.
-    + easy.
-  - depelim ev'.
-    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + apply mkApps_eq_inj in H as (H & <-); try easy.
-      noconf H.
-      rewrite e0 in e.
-      noconf e.
-      now apply IHev in ev'.
-    + easy.
-  - depelim ev'.
-    + apply mkApps_eq_inj in H as (H & <-); try easy.
-      noconf H.
-      rewrite e0 in e.
-      noconf e.
-      now apply IHev in ev'.
-    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + apply eval_mkApps_tCoFix in ev' as (? & ?); solve_discr.
-    + easy.
-  - depelim ev'.
-    + unfold ETyping.declared_constant in *.
-      rewrite isdecl0 in isdecl.
-      noconf isdecl.
-      rewrite e0 in e.
-      noconf e.
-      now apply IHev in ev'.
-    + easy.
-  - depelim ev'.
-    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
-    + apply IHev1 in ev'1.
-      now apply mkApps_eq_inj in ev'1 as (ev'1 & <-).
-    + apply IHev1 in ev'; solve_discr.
-    + easy.
-  - depelim ev'.
-    + apply eval_mkApps_tCoFix in ev as (? & ?); solve_discr.
-    + apply IHev in ev'1; solve_discr.
-    + easy.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      now subst.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      now subst.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      subst.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in i.
-      now rewrite orb_true_r in i.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      now subst.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      congruence.
-    + easy.
-  - now depelim ev'.
+  intros ev ev'.
+  pose proof (eval_unique_sig ev ev').
+  now noconf H.
 Qed.
+
+Lemma eval_unique {t v} :
+  forall (ev1 : eval t v) (ev2 : eval t v),
+    ev1 = ev2.
+Proof.
+  intros ev ev'.
+  pose proof (eval_unique_sig ev ev').
+  now noconf H.
+Qed.
+
 Set SsrRewrite.
 
 End Wcbv.
 
+Arguments eval_unique_sig {_ _ _ _}.
 Arguments eval_deterministic {_ _ _ _}.
+Arguments eval_unique {_ _ _}.

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -452,3 +452,143 @@ Proof.
   refine {| eqb := eqb_recursivity_kind |}.
   destruct x, y; simpl; constructor; congruence.
 Defined.
+
+Definition eqb_ConstraintType x y :=
+  match x, y with
+  | ConstraintType.Lt, ConstraintType.Lt
+  | ConstraintType.Le, ConstraintType.Le
+  | ConstraintType.Eq, ConstraintType.Eq => true
+  | _, _ => false
+  end.
+
+Instance reflect_ConstraintType : ReflectEq ConstraintType.t.
+Proof.
+  refine {| eqb := eqb_ConstraintType |}.
+  destruct x, y; simpl; constructor; congruence.
+Defined.
+
+Definition eqb_ConstraintSet x y :=
+  eqb (ConstraintSet.this x) (ConstraintSet.this y).
+
+Instance reflect_ConstraintSet : ReflectEq ConstraintSet.t.
+Proof.
+  refine {| eqb := eqb_ConstraintSet |}.
+  intros [thisx okx] [thisy oky].
+  unfold eqb_ConstraintSet.
+  cbn -[eqb].
+  destruct (eqb_spec thisx thisy); subst; constructor.
+  - f_equal; apply uip.
+  - congruence.
+Defined.
+
+Definition eqb_LevelSet x y :=
+  eqb (LevelSet.this x) (LevelSet.this y).
+
+Instance reflect_LevelSet : ReflectEq LevelSet.t.
+Proof.
+  refine {| eqb := eqb_LevelSet |}.
+  intros [thisx okx] [thisy oky].
+  unfold eqb_LevelSet.
+  cbn -[eqb].
+  destruct (eqb_spec thisx thisy); subst; constructor.
+  - f_equal; apply uip.
+  - congruence.
+Defined.
+
+Definition eqb_universes_decl x y :=
+  match x, y with
+  | Monomorphic_ctx cx, Monomorphic_ctx cy => eqb cx cy
+  | Polymorphic_ctx cx, Polymorphic_ctx cy => eqb cx cy
+  | _, _ => false
+  end.
+
+Ltac finish_reflect :=
+  (repeat
+    match goal with
+    | |- context[eqb ?a ?b] => destruct (eqb_spec a b); [subst|constructor; congruence]
+    end);
+  constructor; trivial; congruence.
+Instance reflect_universes_decl : ReflectEq universes_decl.
+Proof.
+  refine {| eqb := eqb_universes_decl |}.
+  unfold eqb_universes_decl.
+  intros [] []; finish_reflect.
+Defined.
+
+Definition eqb_constant_body (x y : constant_body) :=
+  let (tyx, bodyx, univx) := x in
+  let (tyy, bodyy, univy) := y in
+  eqb tyx tyy && eqb bodyx bodyy && eqb univx univy.
+
+Instance reflect_constant_body : ReflectEq constant_body.
+Proof.
+  refine {| eqb := eqb_constant_body |}.
+  intros [] [].
+  unfold eqb_constant_body; finish_reflect.
+Defined.
+
+Definition eqb_sort_family x y :=
+  match x, y with
+  | InProp, InProp
+  | InSet, InSet
+  | InType, InType => true
+  | _, _ => false
+  end.
+
+Instance reflect_sort_family : ReflectEq sort_family.
+Proof.
+  refine {| eqb := eqb_sort_family |}.
+  intros [] []; simpl; constructor; congruence.
+Defined.
+
+Definition eqb_one_inductive_body (x y : one_inductive_body) :=
+  let (n, t, k, c, p) := x in
+  let (n', t', k', c', p') := y in
+  eqb n n' && eqb t t' && eqb k k' && eqb c c' && eqb p p'.
+
+Instance reflect_one_inductive_body : ReflectEq one_inductive_body.
+Proof.
+  refine {| eqb := eqb_one_inductive_body |}.
+  intros [] [].
+  unfold eqb_one_inductive_body; finish_reflect.
+Defined.
+
+Definition eqb_Variance x y :=
+  match x, y with
+  | Variance.Irrelevant, Variance.Irrelevant
+  | Variance.Covariant, Variance.Covariant
+  | Variance.Invariant, Variance.Invariant => true
+  | _, _ => false
+  end.
+
+Instance reflect_Variance : ReflectEq Variance.t.
+Proof.
+  refine {| eqb := eqb_Variance |}.
+  intros [] []; constructor; congruence.
+Defined.
+
+Definition eqb_mutual_inductive_body (x y : mutual_inductive_body) :=
+  let (f, n, p, b, u, v) := x in
+  let (f', n', p', b', u', v') := y in
+  eqb f f' && eqb n n' && eqb b b' && eqb p p' && eqb u u' && eqb v v'.
+
+Instance reflect_mutual_inductive_body : ReflectEq mutual_inductive_body.
+Proof.
+  refine {| eqb := eqb_mutual_inductive_body |}.
+  intros [] [].
+  unfold eqb_mutual_inductive_body; finish_reflect.
+Defined.
+
+Definition eqb_global_decl x y :=
+  match x, y with
+  | ConstantDecl cst, ConstantDecl cst' => eqb cst cst'
+  | InductiveDecl mib, InductiveDecl mib' => eqb mib mib'
+  | _, _ => false
+  end.
+
+Instance reflect_global_decl : ReflectEq global_decl.
+Proof.
+  refine {| eqb := eqb_global_decl |}.
+  unfold eqb_global_decl.
+  intros [] []; finish_reflect.
+Defined.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -687,115 +687,167 @@ Section Wcbv.
         now rewrite <- mkApps_nested.
       * easy.
   Qed.
- 
+  
+  Set Equations With UIP.
+  
+  Scheme Induction for le Sort Prop.
+  
+  Lemma le_irrel n m (p q : n <= m) : p = q.
+  Proof.
+    revert q.
+    now induction p using le_ind_dep; intros q; depelim q.
+  Qed.
+
   Unset SsrRewrite.
+  Lemma eval_unique_sig {t v v'} :
+    forall (ev1 : eval t v) (ev2 : eval t v'),
+      {| pr1 := v; pr2 := ev1 |} = {| pr1 := v'; pr2 := ev2 |}.
+  Proof.
+    Local Ltac go :=
+      solve [
+          repeat
+            match goal with
+            | [H: _, H' : _ |- _] =>
+              specialize (H _ H');
+              try solve [apply (f_equal pr1) in H; cbn in *; solve_discr];
+              noconf H
+            end; easy].
+    intros ev.
+    revert v'.
+    depind ev; intros v' ev'.
+    - depelim ev'; go.
+    - depelim ev'; go.
+    - depelim ev'; try go.
+      pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) as <-.
+      assert (body0 = body) as -> by congruence.
+      assert (e0 = e) as -> by now apply uip.
+      assert (isdecl0 = isdecl) as -> by now apply uip.
+      now specialize (IHev _ ev'); noconf IHev.
+    - depelim ev'; try go.
+      pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) as <-.
+      assert (isdecl0 = isdecl) as -> by now apply uip.
+      now assert (e0 = e) as -> by now apply uip.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        apply (f_equal pr1) in IHev1 as apps_eq; cbn in *.
+        apply mkApps_eq_inj in apps_eq as (eq1 & eq2); try easy.
+        noconf eq1.
+        noconf eq2.
+        noconf IHev1.
+        now specialize (IHev2 _ ev'2); noconf IHev2.
+      + apply eval_mkApps_tCoFix in ev1 as H.
+        destruct H as (? & ?); solve_discr.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        noconf IHev1.
+        assert (a0 = a) as -> by congruence.
+        assert (e0 = e) as -> by now apply uip.
+        now specialize (IHev2 _ ev'2); noconf IHev2.
+      + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        noconf IHev1.
+        specialize (IHev2 _ ev'2); noconf IHev2.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e0 = e) as -> by now apply uip.
+        now specialize (IHev3 _ ev'3); noconf IHev3.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        exfalso; rewrite e0 in e.
+        noconf e.
+        lia.
+      + specialize (IHev1 _ ev'1).
+        noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        exfalso; rewrite e0 in e.
+        noconf e.
+        lia.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        noconf IHev1.
+        specialize (IHev2 _ ev'2); noconf IHev2.
+        assert (narg0 = narg) as -> by congruence.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e0 = e) as -> by now apply uip.
+        now assert (l0 = l) as -> by now apply le_irrel.
+      + specialize (IHev1 _ ev'1).
+        noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+    - depelim ev'; try go.
+      + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
+      + apply mkApps_eq_inj in e' as H'; auto.
+        destruct H' as (H' & <-).
+        noconf H'.
+        assert (narg0 = narg) as -> by congruence.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e' = eq_refl) as -> by now apply uip.
+        assert (e0 = e) as -> by now apply uip.
+        cbn in *; subst.
+        now specialize (IHev _ ev'); noconf IHev.
+    - depelim ev'; try go.
+      + exfalso; apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+      + apply mkApps_eq_inj in e1 as H'; auto.
+        destruct H' as (H' & <-).
+        noconf H'.
+        assert (narg0 = narg) as -> by congruence.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e1 = eq_refl) as -> by now apply uip.
+        assert (e0 = e) as -> by now apply uip.
+        cbn in *; subst.
+        now specialize (IHev _ ev'); noconf IHev.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        specialize (IHev2 _ ev'2); noconf IHev2.
+        now assert (i0 = i) as -> by now apply uip.
+    - depelim ev'; try go.
+      now assert (i0 = i) as -> by now apply uip.
+  Qed.
+  
   Lemma eval_deterministic {t v v'} :
     eval t v ->
     eval t v' ->
     v = v'.
   Proof.
-  intros ev.
-  revert v'.
-  depind ev; intros v' ev'.
-  - depelim ev'.
-    + apply IHev1 in ev'1.
-      apply IHev2 in ev'2.
-      subst.
-      noconf ev'1.
-      now apply IHev3 in ev'3.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; subst; easy.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1.
-      subst.
-      now apply IHev2 in ev'2.
-    + easy.
-  - depelim ev'.
-    + rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
-      replace body0 with body in * by congruence.
-      now apply IHev in ev'.
-    + now rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
-    + easy.
-  - depelim ev'.
-    + now rewrite (PCUICWeakeningEnv.declared_constant_inj _ _ isdecl isdecl0) in *.
-    + easy.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1.
-      apply mkApps_eq_inj in ev'1; try easy.
-      depelim ev'1.
-      noconf H.
-      noconf H0.
-      now apply IHev2 in ev'2.
-    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1.
-      apply mkApps_eq_inj in ev'1 as (ev'1 & <-); try easy.
-      noconf ev'1.
-      replace a0 with a in * by congruence.
-      now apply IHev2 in ev'2.
-    + apply eval_mkApps_tCoFix in ev1 as (? & ?); solve_discr.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1.
-      solve_discr.
-      rewrite e0 in e. noconf e.
-      apply IHev2 in ev'2. subst.
-      now apply IHev3 in ev'3.
-    + apply IHev1 in ev'1; solve_discr.
-      apply IHev2 in ev'2; subst.
-      rewrite e0 in e. noconf e. lia.
-    + apply IHev1 in ev'1.
-      subst f'.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite orb_true_r in i.
-    + easy.
-  - depelim ev'.
-    + apply IHev1 in ev'1; solve_discr.
-    + apply IHev1 in ev'1; solve_discr.
-      apply IHev2 in ev'2; subst.
-      rewrite e0 in e; noconf e. lia.
-    + apply IHev1 in ev'1; solve_discr.
-      now apply IHev2 in ev'2; subst.
-    + apply IHev1 in ev'1; subst.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite orb_true_r in i.
-    + easy.
-  - depelim ev'.
-    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + solve_discr.
-      rewrite e0 in e.
-      noconf e.
-      now apply IHev in ev'.
-    + easy.
-  - depelim ev'.
-    + apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + solve_discr.
-      rewrite e0 in e.
-      noconf e.
-      now apply IHev in ev'.
-    + easy.
-  - depelim ev'.
-    + now apply IHev1 in ev'1; subst.
-    + apply IHev1 in ev'1; subst.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite orb_true_r in i.
-    + apply IHev1 in ev'1; subst.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite orb_true_r in i.
-    + apply IHev1 in ev'1; subst.
-      now apply IHev2 in ev'2; subst.
-    + easy.
-  - now depelim ev'.
+    intros ev ev'.
+    pose proof (eval_unique_sig ev ev').
+    now noconf H.
   Qed.
+
+  Lemma eval_unique {t v} :
+    forall (ev1 : eval t v) (ev2 : eval t v),
+      ev1 = ev2.
+  Proof.
+    intros ev ev'.
+    pose proof (eval_unique_sig ev ev').
+    now noconf H.
+  Qed.
+  
   Set SsrRewrite.
 
   Lemma eval_LetIn {n b ty t v} :
@@ -847,7 +899,9 @@ Section Wcbv.
 
 End Wcbv.
 
+Arguments eval_unique_sig {_ _ _ _}.
 Arguments eval_deterministic {_ _ _ _}.
+Arguments eval_unique {_ _ _}.
 
 (** Well-typed closed programs can't go wrong: they always evaluate to a value. *)
 


### PR DESCRIPTION
This proves that PCUIC and erasure wcbv evaluation relations are unique,
i.e. there is only one possible way to evaluate a term.