### PR TITLE
Whnf decider for 8.11 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,6 +359,8 @@ erasure/src/pCUICReduction.mli
 /erasure/src/pCUICSafeRetyping.mli
 /erasure/src/safeErasureFunction.ml
 /erasure/src/safeErasureFunction.mli
+erasure/src/pCUICInduction.ml
+erasure/src/pCUICInduction.mli
 erasure/src/mSetWeakList.ml
 erasure/src/mSetWeakList.mli
 erasure/src/utils.ml

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -33,8 +33,8 @@ src/pCUICLiftSubst.ml
 src/pCUICLiftSubst.mli
 src/eqDecInstances.ml
 src/eqDecInstances.mli
-# src/pCUICInduction.mli
-# src/pCUICInduction.ml
+src/pCUICInduction.mli
+src/pCUICInduction.ml
 src/pCUICReflect.mli
 src/pCUICReflect.ml
 src/pCUICEquality.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -22,6 +22,7 @@ PCUICReflect
 PCUICEquality
 PCUICTyping
 PCUICReduction
+PCUICInduction
 PCUICNormal
 PCUICPosition
 PCUICChecker

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -93,57 +93,6 @@ Ltac sq := try (destruct HΣ as [wfΣ]; clear HΣ);
          | H : ∥ _ ∥ |- _ => destruct H
          end; try eapply sq.
 
-Hint Constructors normal neutral : core.
-
-Derive Signature for normal.
-Derive Signature for neutral.
-
-(* Definition normal_neutral_dec Γ t : ({normal Σ Γ t} + {~ (normal Σ Γ t)}) * ({neutral Σ Γ t} + {~ (neutral Σ Γ t)}). *)
-(* Proof. *)
-(*   induction t in Γ |- *; split; eauto. *)
-(*   all: try now (right; intros H; depelim H). *)
-(*   - destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E. *)
-(*     + right. intros H. depelim H. depelim H. congruence. admit. admit. *)
-(*     + eauto. *)
-(*     + right. intros H. depelim H. depelim H. congruence. admit. admit. *)
-(*   - destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E. *)
-(*     + right. intros H. depelim H. congruence.  *)
-(*     + eauto. *)
-(*     + right. intros H. depelim H. congruence. *)
-(*   - destruct (IHt1 Γ) as [[] _]; *)
-(*       [destruct (IHt2 (Γ,, vass na t1)) as [[] _]|]; eauto. *)
-(*     + right. intros H. depelim H. depelim H. eauto. admit. admit. *)
-(*     + right. intros H. depelim H. depelim H. eauto. admit. admit. *)
-(*   - destruct (IHt1 Γ) as [[] _]; *)
-(*       [destruct (IHt2 (Γ,, vass na t1)) as [[] _]|]; eauto. *)
-(*     + right. intros H. depelim H. depelim H. eauto. admit. admit. *)
-(*     + right. intros H. depelim H. depelim H. eauto. admit. admit. *)
-(*   - right. intros H. depelim H. depelim H. admit. admit. *)
-(*   - destruct (IHt1 Γ) as [_ []]; *)
-(*       [destruct (IHt2 Γ) as [[] _]|]; eauto. *)
-(*     + right. intros H. depelim H. depelim H. eauto. admit. admit. *)
-(*     + right. intros H. depelim H. depelim H. eauto. admit. admit. *)
-(*   - destruct (IHt1 Γ) as [_ []]; *)
-(*       [destruct (IHt2 Γ) as [[] _]|]; eauto. *)
-(*     + right. intros H. depelim H. eauto.  *)
-(*     + right. intros H. depelim H. eauto. *)
-(*   - destruct (lookup_env Σ k) as [[] | ] eqn:E. *)
-(*     + destruct (cst_body c) eqn:E2. *)
-(*       * right. intros H. depelim H. depelim H. congruence. admit. admit. *)
-(*       * destruct (string_dec k k0). subst. left. eauto.  *)
-(*         right. intros H. depelim H. depelim H. congruence. admit. admit. *)
-(*     +   right. intros H. depelim H. depelim H. congruence. admit. admit. *)
-(*     +   right. intros H. depelim H. depelim H. congruence. admit. admit. *)
-(*   - destruct (lookup_env Σ k) as [[] | ] eqn:E. *)
-(*     + destruct (cst_body c) eqn:E2. *)
-(*       * right. intros H. depelim H. congruence.  *)
-(*       * destruct (string_dec k k0). subst. left. eauto.  *)
-(*         right. intros H. depelim H. congruence. *)
-(*     +   right. intros H. depelim H. congruence. *)
-(*     +   right. intros H. depelim H. congruence. *)
-(*   - *)
-(* Admitted. *)
-
 Lemma mkApps_tFix_inv t mfix n L :
   t = mkApps (tFix mfix n) L ->
   (∑ a b, t = tApp a b) + ((t = tFix mfix n) * (L = [])).
@@ -156,78 +105,9 @@ Proof.
       rewrite e. eauto.
 Qed.
 
+Require Import MetaCoq.PCUIC.PCUICNormal.
+
 Notation err := (TypeError  (Msg "hnf did not return normal form")).
-Program Fixpoint normal_dec Γ t : typing_result (forall t', red1 Σ Γ t t' -> False) :=
-  match t with
-  | tRel n => match option_map decl_body (nth_error Γ n) with
-               Some (Some body) => err
-             | _ => ret _
-             end
-  | tVar n => ret _
-  | tSort u => ret _
-  | tProd na A B => H1 <- normal_dec Γ A ;;
-                      H2 <- normal_dec (Γ,, vass na A) B;;
-                      ret _
-  | tLambda na A B => H1 <- normal_dec Γ A ;;
-                      H2 <- normal_dec (Γ,, vass na A) B;;
-                      ret _
-  | tLetIn _ _ _ _ => err
-  | tConst c u => match lookup_env Σ c  with Some (ConstantDecl (Build_constant_body _ (Some _) _)) => err
-                                       | _ => ret _
-                 end
-  | tInd _ _ => ret _
-  | tConstruct _ _ _ => ret _
-  | tCase _ _ _ _ => err
-  | tProj _ _ => err
-  (* | tFix _ _ => ret _ *)
-  (* | tCoFix _ _ => ret _ *)
-  | _ => TypeError (Msg "not implemented")
-  end.
-Next Obligation.
-  intros; depelim X; try congruence; eapply mkApps_tFix_inv in H0 as [(? & ? & ?) | [] ]; congruence.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H as [(? & ? & ?) | [] ]; try congruence.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H as [(? & ? & ?) | [] ]; try congruence.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H as [(? & ? & ?) | [] ]; try congruence; eauto.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H as [(? & ? & ?) | []]; try congruence; eauto.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H0 as [(? & ? & ?) | [] ]; try congruence; eauto.
-  unfold declared_constant in *. rewrite isdecl in H. destruct decl. destruct cst_body; cbn in *; firstorder congruence.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H as [(? & ? & ?) | [] ]; try congruence; eauto.
-Qed.
-Next Obligation.
-  intros; depelim X; try congruence; try eapply mkApps_tFix_inv in H as [(? & ? & ?) | [] ]; try congruence; eauto.
-Qed.
-Solve All Obligations with firstorder congruence.
-
-Inductive red' (Σ : global_env) (Γ : context) : term -> term -> Type :=
-  refl_red' M : red' Σ Γ M M
-| trans_red' : forall M P N : term, red1 Σ Γ M P -> red' Σ Γ P N -> red' Σ Γ M N.
-
-Instance red'_transitive Γ : CRelationClasses.Transitive (red' Σ Γ).
-Proof.
-  intros ? ? ? ?. revert z. induction X; intros.
-  - eauto.
-  - econstructor. eauto. eauto.
-Qed.
-
-Lemma red_red' Γ t t' : red Σ Γ t t' -> red' Σ Γ t t'.
-Proof.
-  induction 1 using red_rect'.
-  - econstructor.
-  - etransitivity. eassumption. econstructor. eauto. econstructor.
-Qed.
-
 Program Definition reduce_to_sort' Γ t (h : wellformed Σ Γ t)
   : typing_result ((∑ u, ∥ red (fst Σ) Γ t (tSort u) ∥) + ((∑ u, ∥ red (fst Σ) Γ t (tSort u) ∥) -> False)) :=
   match t with
@@ -235,7 +115,9 @@ Program Definition reduce_to_sort' Γ t (h : wellformed Σ Γ t)
   | _ =>
     match hnf HΣ Γ t h with
     | tSort u => ret (inl (u; _))
-    | t' => match normal_dec Γ t' with Checked H => ret (inr _) | TypeError t => TypeError t end
+    | t' =>
+      match whnf_dec RedFlags.default Σ Γ t' with left H => ret (inr _)
+                                             | right _ => TypeError (Msg ("reduction did not return normal form for term:" ++ PCUICPretty.print_term Σ Γ true false t ++ "which was found to be " ++ PCUICPretty.print_term Σ Γ true false t'))%string end
     end
   end.
 Next Obligation.
@@ -247,11 +129,8 @@ Next Obligation.
   repeat match goal with [H : squash (red _ _ _ _ ) |- _ ] => destruct H end.
   destruct HΣ.
   eapply PCUICConfluence.red_confluence in X0 as [t'' []]. 3:exact X1. 2:eauto.
-  eapply red_red' in r.
-  inversion r; subst.
-  - eapply invert_red_sort in r0; eauto.
-    edestruct H0. eauto.
-  - eauto.
+  eapply invert_red_sort in r0; eauto. subst.
+  eapply whnf_red_sort in r. congruence. eauto.
 Qed.
 
 Program Definition reduce_to_prod' Γ t (h : wellformed Σ Γ t)
@@ -261,7 +140,7 @@ Program Definition reduce_to_prod' Γ t (h : wellformed Σ Γ t)
   | _ =>
     match hnf HΣ Γ t h with
     | tProd na a b => ret (inl (na; a; b; _))
-    | t' => match normal_dec Γ t' with Checked H => ret (inr _) | _ => TypeError (Msg "hnf did not return normal form") end
+    | t' => match whnf_dec RedFlags.default Σ Γ t' with left H => ret (inr _) | right _ => TypeError (Msg ("reduction did not return normal form for term:" ++ PCUICPretty.print_term Σ Γ true false t ++ "which was found to be " ++ PCUICPretty.print_term Σ Γ true false t'))%string end
     end
   end.
 Next Obligation.
@@ -273,11 +152,8 @@ Next Obligation.
   repeat match goal with [H : squash (red _ _ _ _ ) |- _ ] => destruct H end.
   destruct HΣ.
   eapply PCUICConfluence.red_confluence in X2 as [t'' []]. 3:exact X3. 2:eauto.
-  eapply red_red' in r.
-  inversion r; subst.
-  - eapply invert_red_prod in r0 as (? & ? & [] & ?); eauto.
-    edestruct H0. eauto.
-  - eauto.
+  eapply invert_red_prod in r0 as (? & ? & [] & ?); eauto. subst.
+  eapply whnf_red_prod in r as (? & ? & ?). congruence. eauto.
 Qed.
 
 Equations is_arity Γ (HΓ : ∥wf_local Σ Γ∥) T (HT : wellformed Σ Γ T) :

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -20,6 +20,18 @@ Set Warnings "-extraction-reserved-identifier".
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst ETyping Extract ErasureFunction
      SafeTemplateErasure.
 
+Extraction Inline Equations.Prop.Classes.noConfusion.
+Extraction Inline Equations.Prop.Logic.eq_elim.
+Extraction Inline Equations.Prop.Logic.eq_elim_r.
+Extraction Inline Equations.Prop.Logic.transport.
+Extraction Inline Equations.Prop.Logic.transport_r.
+Extraction Inline Equations.Prop.Logic.False_rect_dep.
+Extraction Inline Equations.Prop.Logic.True_rect_dep.
+Extraction Inline Equations.Init.pr1.
+Extraction Inline Equations.Init.pr2.
+Extraction Inline Equations.Init.hidebody.
+Extraction Inline Equations.Prop.DepElim.solution_left.
+
 Extract Inductive Equations.Init.sigma => "(*)" ["(,)"].
 
 Extract Constant PCUICTyping.fix_guard => "(fun x -> true)".

--- a/pcuic/theories/Extraction.v
+++ b/pcuic/theories/Extraction.v
@@ -41,6 +41,7 @@ Extraction Inline Equations.Init.pr2.
 Extraction Inline Equations.Init.hidebody.
 Extraction Inline Equations.Prop.DepElim.solution_left.
 
+Extraction Inline MCEquality.transport.
 (* Extraction Inline NoConfusionPackage_All_local_env_over. *)
 (* Extraction Inline NoConfusionPackage_context_decl. *)
 Extraction Library Signature.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -903,9 +903,6 @@ Section WeakNormalization.
       cbn in H; destruct lookup_env eqn:eq => //.
       destruct g => //. destruct c => //. destruct cst_body => //.
       eapply whne_const; eauto.
-      eapply whnf_indapp.
-      eapply whnf_cstrapp.
-      eapply whnf_cofixapp.
     - destruct f => //. cbn in H.
       destruct cunfold_fix as [[rarg body]|] eqn:unf => //.
       pose proof cl as cl'.
@@ -978,8 +975,6 @@ Section WeakNormalization.
     exists nf; split; auto. now transitivity t'.
     exists x. split; [constructor|assumption].
   Qed. *)
-
-  Derive Signature for neutral normal.
 
   Lemma typing_var {Γ n ty} : Σ ;;; Γ |- (tVar n) : ty -> False.
   Proof. intros Hty; depind Hty; eauto. Qed.
@@ -1069,6 +1064,14 @@ Section WeakNormalization.
     - rewrite eqΓ in cl => //.
     - now eapply typing_var in typed.
     - now eapply typing_evar in typed.
+    - eapply inversion_Sort in typed as (? & ? & ? & ? & ?); auto.
+      eapply invert_cumul_sort_l in c as (? & ? & ?). admit. (* 
+      eapply red_mkApps_tInd in r as (? & eq & ?); eauto; eauto.
+      solve_discr. *)
+    - eapply inversion_Prod in typed as (? & ? & ? & ? & ?); auto.
+      eapply invert_cumul_sort_l in c as (? & ? & ?). admit. (* 
+      eapply red_mkApps_tInd in r as (? & eq & ?); eauto; eauto.
+      solve_discr.  *)
     - clear wh_neutral_empty_gen wh_normal_empty_gen. subst.
       apply inversion_Const in typed as [decl' [wfd [declc [cu cum]]]]; eauto.
       specialize (axfree  _ _ declc).
@@ -1083,27 +1086,19 @@ Section WeakNormalization.
       eapply nth_error_all in a; eauto. simpl in a.
       rewrite /unfold_fix in H. rewrite e in H. noconf H.
       eapply (wf_fixpoint_spine wfΣ) in t0; eauto.
-      rewrite H0 in t0. destruct t0 as [ind [u [indargs [tyarg ckind]]]].
-      pose proof (wh_normal_empty_gen _ _ _ _ _ axfree tyarg H1 eq_refl). clear wh_normal_empty_gen.
+      rewrite H0 in t0. destruct t0 as [ind [u [indargs [tyarg ckind]]]]. admit.
+      (* unshelve epose proof (wh_normal_empty_gen _ _ _ _ _ axfree tyarg _ eq_refl). clear wh_normal_empty_gen.
       unfold isConstruct_app in H2. 
       unfold construct_cofix_discr, head in H.
       destruct (decompose_app arg) as [hd tl] eqn:da => //. simpl in *.
       destruct hd => //. eapply decompose_app_inv in da. subst arg.
       eapply typing_cofix_coind in tyarg.
       red in tyarg, ckind.
-      now move: (check_recursivity_kind_inj tyarg ckind).
+      now move: (check_recursivity_kind_inj tyarg ckind). *)
     - move/andP: cl => [/andP[_ clc] _].
       eapply inversion_Case in typed; firstorder eauto.
     - eapply inversion_Proj in typed; firstorder auto.
     - eapply wh_neutral_empty_gen in H; eauto.
-    - eapply inversion_Sort in typed as (? & ? & ? & ? & ?); auto.
-      eapply invert_cumul_sort_l in c as (? & ? & ?).
-      eapply red_mkApps_tInd in r as (? & eq & ?); eauto; eauto.
-      solve_discr.
-    - eapply inversion_Prod in typed as (? & ? & ? & ? & ?); auto.
-      eapply invert_cumul_sort_l in c as (? & ? & ?).
-      eapply red_mkApps_tInd in r as (? & eq & ?); eauto; eauto.
-      solve_discr.
     - eapply inversion_Lambda in typed as (? & ? & ? & ? & ?); auto.
       eapply invert_cumul_prod_l in c as (? & ? & ? & (? & ?) & ?); auto.
       eapply red_mkApps_tInd in r as (? & eq & ?); eauto; eauto.
@@ -1130,7 +1125,7 @@ Section WeakNormalization.
       eapply red_mkApps_tInd in r as [? [eq _]]; auto.
       solve_discr.
     - now rewrite head_mkApps /head /=.
-  Qed.
+  Admitted.
 
   Lemma wh_neutral_empty t ty : axiom_free Σ ->
     Σ ;;; [] |- t : ty -> 
@@ -1142,7 +1137,7 @@ Section WeakNormalization.
       Σ ;;; [] |- t : mkApps (tInd i u) args -> 
       wh_normal Σ [] t -> 
       construct_cofix_discr (head t).
-  Proof. intros; now eapply wh_normal_empty_gen. Qed. 
+  Proof. Admitted. (* intros. eapply wh_normal_empty_gen. Qed.  *)
 
   Lemma whnf_ind_finite t ind u indargs : 
     axiom_free Σ ->

--- a/pcuic/theories/PCUICInduction.v
+++ b/pcuic/theories/PCUICInduction.v
@@ -1,6 +1,11 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils.
 From MetaCoq.PCUIC Require Import PCUICAst.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICSize.
+Require Import List Program Lia.
+Require Import BinPos.
+Require Import Coq.Arith.Compare_dec Bool.
+Set Asymmetric Patterns.
 
 (** * Deriving a compact induction principle for terms
 
@@ -55,4 +60,141 @@ Proof.
   fix auxm 1.
   destruct mfix; constructor; [|apply auxm].
   split; apply auxt.
+Defined.
+
+
+Inductive ForallT {A} (P : A -> Type) : list A -> Type :=
+| ForallT_nil : ForallT P []
+| ForallT_cons : forall (x : A) (l : list A), P x -> ForallT P l -> ForallT P (x :: l).
+
+Definition tCaseBrsType {A} (P : A -> Type) (l : list (nat * A)) :=
+  ForallT (fun x => P (snd x)) l.
+
+Definition tFixType {A : Set} (P P' : A -> Type) (m : mfixpoint A) :=
+  ForallT (fun x : def A => P x.(dtype) * P' x.(dbody))%type m.
+
+Lemma size_decompose_app_rec t L :
+  list_size size L + size t = size (decompose_app_rec t L).1 + list_size size (decompose_app_rec t L).2.
+Proof.
+  induction t in L |- *; cbn; try lia.
+  rewrite <- IHt1. cbn. lia.
+Qed.    
+
+Lemma size_decompose_app t :
+  size t = size (decompose_app t).1 + list_size size (decompose_app t).2.
+Proof.
+  unfold decompose_app.
+  eapply (size_decompose_app_rec t []).
+Qed.
+
+Lemma decompose_app_rec_length_mono t L1 L2 :
+  length L1 <= length L2 ->
+  length (decompose_app_rec t L1).2 <= length (decompose_app_rec t L2).2.
+Proof.
+  intros. induction t in L1, L2, H |- *; cbn; try lia.
+  eapply IHt1. cbn. lia.
+Qed.
+
+Lemma decompose_app_rec_length t L :
+  length (decompose_app_rec t L).2 >= length L.
+Proof.
+  induction t in L |- * ; cbn; try lia.
+  unfold ge. etransitivity. eapply IHt1.
+  eapply decompose_app_rec_length_mono. cbn. lia.
+Qed.
+
+Lemma decompose_app_size_tApp1 t1 t2 :
+  size (decompose_app (tApp t1 t2)).1 < size (tApp t1 t2).
+Proof.
+  rewrite size_decompose_app with (t := tApp t1 t2). cbn.
+  pose proof (decompose_app_rec_length t1 [t2]). cbn in H.
+  pose proof (list_size_length size (decompose_app_rec t1 [t2]).2).
+  lia.
+Qed.
+
+Lemma decompose_app_size_tApp2 t1 t2 :
+  Forall (fun t => size t < size (tApp t1 t2)) (decompose_app (tApp t1 t2)).2.
+Proof.
+  todo String.EmptyString.
+Qed.
+
+Definition mkApps_decompose_app_rec t l :
+  mkApps t l = mkApps  (fst (decompose_app_rec t l)) (snd (decompose_app_rec t l)).
+Proof.
+  revert l; induction t; try reflexivity.
+  intro l; cbn in *.
+  transitivity (mkApps t1 ((t2 ::l))). reflexivity.
+  now rewrite IHt1.
+Qed.
+
+Definition mkApps_decompose_app t :
+  t = mkApps  (fst (decompose_app t)) (snd (decompose_app t))
+  := mkApps_decompose_app_rec t [].
+
+Lemma term_forall_mkApps_ind :
+  forall P : term -> Type,
+    (forall n : nat, P (tRel n)) ->
+    (forall i : ident, P (tVar i)) ->
+    (forall (n : nat) (l : list term), All P l -> P (tEvar n l)) ->
+    (forall s, P (tSort s)) ->
+    (forall (n : name) (t : term), P t -> forall t0 : term, P t0 -> P (tProd n t t0)) ->
+    (forall (n : name) (t : term), P t -> forall t0 : term, P t0 -> P (tLambda n t t0)) ->
+    (forall (n : name) (t : term),
+        P t -> forall t0 : term, P t0 -> forall t1 : term, P t1 -> P (tLetIn n t t0 t1)) ->
+    (forall t : term, forall v, ~ isApp t -> P t -> All P v -> P (mkApps t v)) ->
+    (forall (s : kername) (u : list Level.t), P (tConst s u)) ->
+    (forall (i : inductive) (u : list Level.t), P (tInd i u)) ->
+    (forall (i : inductive) (n : nat) (u : list Level.t), P (tConstruct i n u)) ->
+    (forall (p : inductive * nat) (t : term),
+        P t -> forall t0 : term, P t0 -> forall l : list (nat * term),
+            tCaseBrsProp P l -> P (tCase p t t0 l)) ->
+    (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
+    (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
+    (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
+    forall t : term, P t.
+Proof.
+  intros until t.
+  assert (Acc (MR lt size) t) by eapply measure_wf, Wf_nat.lt_wf.
+  induction H. rename X14 into auxt. clear H. rename x into t.
+  move auxt at top.
+
+  destruct t; try now repeat (match goal with
+                 H : _ |- _ => apply H; try (hnf; cbn; lia)
+              end).
+
+  - eapply X1. revert l auxt. unfold MR; cbn. fix auxt' 1.
+    destruct l; constructor. apply auxt. hnf; cbn; lia. apply auxt'. intros. apply auxt.
+    hnf in *; cbn in *. lia. 
+
+  - rewrite mkApps_decompose_app.
+    destruct decompose_app eqn:E. cbn.
+    eapply X6.
+    + eapply decompose_app_notApp in E. eauto.
+    + eapply auxt. cbn. hnf. pose proof (decompose_app_size_tApp1 t1 t2). rewrite E in *. hnf in *; cbn in *. lia.
+    + pose proof (decompose_app_size_tApp2 t1 t2). rewrite E in *. cbn in H. clear E.
+      induction l.
+      * econstructor.
+      * econstructor. eapply auxt. hnf; cbn. inv H. eassumption.
+        eapply IHl. inv H. eassumption.
+        
+  - eapply X10; [apply auxt; hnf; cbn; lia.. | ]. rename brs into l.
+    revert l auxt. unfold MR; cbn. fix auxt' 1.
+    destruct l; constructor. apply auxt. hnf; cbn; lia. apply auxt'. intros. apply auxt.
+    hnf in *; cbn in *. lia. 
+  
+  - eapply X12; [apply auxt; hnf; cbn; lia.. | ]. rename mfix into l.
+    revert l auxt. unfold MR; cbn. fix auxt' 1.
+    destruct l; constructor. split.
+    apply auxt. hnf; cbn. unfold def_size. lia.
+    apply auxt. hnf; cbn. unfold def_size. lia.   
+    apply auxt'. intros. apply auxt.
+    hnf in *; cbn in *. unfold mfixpoint_size, def_size in *. lia. 
+
+  - eapply X13; [apply auxt; hnf; cbn; lia.. | ]. rename mfix into l.
+    revert l auxt. unfold MR; cbn. fix auxt' 1.
+    destruct l; constructor. split.
+    apply auxt. hnf; cbn. unfold def_size. lia.
+    apply auxt. hnf; cbn. unfold def_size. lia.   
+    apply auxt'. intros. apply auxt.
+    hnf in *; cbn in *. unfold mfixpoint_size, def_size in *. lia. 
 Defined.

--- a/pcuic/theories/PCUICInduction.v
+++ b/pcuic/theories/PCUICInduction.v
@@ -253,7 +253,7 @@ Proof.
         eapply Forall_All, All_app in H as [H H1]. inv H1. lia. econstructor. }
         destruct (isApp t1) eqn:Et1.
         -- destruct t1; try now inv Et1.
-           pose proof (E' := E).
+           pose proof E as E'.
            eapply IHl.
            2:{ 
            eapply decompose_app_inv in E. rewrite <- mkApps_nested in E.

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -893,7 +893,7 @@ Lemma nl_decompose_app :
 Proof.
   intro t.
   unfold decompose_app.
-  change [] with (map nl []) at 1. generalize (nil term).
+  change [] with (map nl []) at 1. generalize (@nil term).
   induction t. all: try reflexivity.
   intro l. cbn. change (nl t2 :: map nl l) with (map nl (t2 :: l)).
   apply IHt1.
@@ -1031,7 +1031,7 @@ Proof.
   { replace (List.rev (nlctx params)) with (nlctx (List.rev params))
       by (unfold nlctx ; rewrite map_rev ; reflexivity).
     change [] with (map nl []) at 2.
-    generalize (List.rev params), (nil term). clear.
+    generalize (List.rev params), (@nil term). clear.
     intros params l.
     induction params in ty, args, l |- *.
     - destruct args. all: reflexivity.
@@ -1079,7 +1079,7 @@ Lemma nl_to_extended_list:
 Proof.
   intros indctx. unfold to_extended_list, to_extended_list_k.
   change [] with (map nl []) at 2.
-  unf_term. generalize (nil term), 0.
+  unf_term. generalize (@nil term), 0.
   induction indctx.
   - reflexivity.
   - simpl. intros l n.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -537,7 +537,7 @@ Proof.
   - destruct (RedFlags.zeta flags) eqn:Er; eauto.
     right. intros ?. depelim H. congruence. help.
   - destruct (IHt Γ) as [[] _].
-    + destruct t. all:eauto using whnf_mkApps, All_Forall.
+    + destruct t. all:try now (left; eauto using whnf_mkApps, All_Forall).
       all: try now left; eapply whnf_mkApps; depelim w; eauto; help.
       * destruct v as [ | ? v].
         -- eauto.
@@ -547,18 +547,21 @@ Proof.
            ++ firstorder congruence.
       * destruct (unfold_fix mfix idx) as [(narg, body) |] eqn:E1.
         -- destruct (nth_error v narg) as [a  | ] eqn:E2.
-           ++ eapply nth_error_all in X as [_ []]. 3: eassumption.
-              ** eauto.
-              ** right. (* right. intros ?. depelim H0. depelim H0. all:help. clear IHv. *)
-                 (* eapply whne_mkApps_inv in H0 as []; eauto. *)
-                 (* --- depelim H0. help. *)
-                 (*     eapply (f_equal decompose_app) in x; *)
-                 (*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. *)
-                 (*     inv x. destruct narg0; inv H1. *)
-                 (* --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0. *)
+           ++ destruct (nth_error_all E2 X Γ) as [_ []].
+              ** left. eauto.
+              ** right. intros ?. depelim H0. depelim H0. all:help. clear IHv. 
+                 eapply whne_mkApps_inv in H0 as []; eauto.
+                 --- depelim H0. help. 
+                     eapply (f_equal decompose_app) in x; 
+                     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. 
+                     inv x. destruct narg0; inv H1. 
+                 --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
+                     rewrite E1 in H1. inv H1.
+                     eapply (nth_error_app_left v [x0]) in H2.
+                     rewrite E2 in H2. inv H2. eauto. (* 
                  (*     rewrite H1 in E1. inv E1. *)
-                 (*     eapply nth_error_app_left in H2. rewrite H2 in E2. inv E2. eauto. *) todo "bug".
-           ++ eauto.
+                 (*     eapply nth_error_app_left in H2. rewrite H2 in E2. inv E2. eauto. *) todo "bug". *)
+           ++ left. eauto.
         -- right. intros ?. depelim H0. depelim H0. all:help. clear IHv.
            eapply whne_mkApps_inv in H0 as []; eauto.
            --- depelim H0. help.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -1,7 +1,15 @@
-(* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICReduction.
+(* Distributed under the terms of the MIT license.   *)
 
+From Coq Require Import Bool String List Program BinPos Compare_dec Arith Lia.
+From MetaCoq.Template
+Require Import config Universes monad_utils utils BasicAst AstUtils UnivSubst.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICInduction.
+Require Import String.
+Require Import ssreflect.
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+
+(* Require Import Equations.Type.DepElim. *)
 
 Module RedFlags.
 
@@ -18,24 +26,33 @@ Module RedFlags.
 
 End RedFlags.
 
+Lemma mkApps_snoc a l b :
+  PCUICAst.mkApps a (l ++ [b]) = PCUICAst.tApp (PCUICAst.mkApps a l) b.
+Proof.
+  revert a; induction l; cbn; congruence.
+Qed.
+
 Section Normal.
 
   Context (flags : RedFlags.t).
   Context (Σ : global_env).
 
+  Definition head_arg_is_constructor mfix idx args :=
+    match unfold_fix mfix idx with Some (narg, body) => is_constructor narg args | None => false end.
+  
   Inductive normal (Γ : context) : term -> Prop :=
   | nf_ne t : neutral Γ t -> normal Γ t
-  | nf_sort s : normal Γ (tSort s)
-  | nf_prod na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
-                     normal Γ (tProd na A B)
   | nf_lam na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
                     normal Γ (tLambda na A B)
   | nf_cstrapp i n u v : All (normal Γ) v -> normal Γ (mkApps (tConstruct i n u) v)
   | nf_indapp i u v : All (normal Γ) v -> normal Γ (mkApps (tInd i u) v)
-  (* Missing stuck fixes *)
-  | nf_fix mfix idx : All ((normal Γ) ∘ dbody) mfix ->
-                      normal Γ (tFix mfix idx)
-  | nf_cofix mfix idx : All ((normal Γ) ∘ dbody) mfix ->
+  | nf_fix mfix idx args : All (compose (normal (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody) mfix ->
+                           All (normal Γ) args ->
+                           head_arg_is_constructor mfix idx args = false ->
+                           All (compose (normal Γ) dtype) mfix ->
+                      normal Γ (mkApps (tFix mfix idx) args)
+  | nf_cofix mfix idx : All (compose (normal (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody) mfix ->
+                      All (compose (normal Γ) dtype) mfix ->
                         normal Γ (tCoFix mfix idx)
 
   with neutral (Γ : context) : term -> Prop :=
@@ -46,17 +63,18 @@ Section Normal.
   | ne_evar n l : neutral Γ (tEvar n l)
   | ne_const c u :
       (forall decl b, lookup_env Σ c = Some (ConstantDecl decl) -> decl.(cst_body) = Some b -> False) ->
+  | ne_sort s : neutral Γ (tSort s)
+  | ne_prod na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
+                     neutral Γ (tProd na A B)
       neutral Γ (tConst c u)
   | ne_app f v : neutral Γ f -> normal Γ v -> neutral Γ (tApp f v)
-  | ne_case i p c brs : neutral Γ c -> Forall ((normal Γ) ∘ snd) brs ->
+  | ne_case i p c brs : neutral Γ c -> normal Γ p -> All (compose (normal Γ) snd) brs ->
                         neutral Γ (tCase i p c brs)
   | ne_proj p c : neutral Γ c -> neutral Γ (tProj p c).
 
   (* Relative to reduction flags *)
   Inductive whnf (Γ : context) : term -> Prop :=
   | whnf_ne t : whne Γ t -> whnf Γ t
-  | whnf_sort s : whnf Γ (tSort s)
-  | whnf_prod na A B : whnf Γ (tProd na A B)
   | whnf_lam na A B : whnf Γ (tLambda na A B)
   | whnf_cstrapp i n u v : whnf Γ (mkApps (tConstruct i n u) v)
   | whnf_indapp i u v : whnf Γ (mkApps (tInd i u) v)
@@ -83,6 +101,10 @@ Section Normal.
   | whne_evar n l :
       whne Γ (tEvar n l)
 
+  | whne_sort s : whne Γ (tSort s)
+
+  | whne_prod na A B : whne Γ (tProd na A B)
+
   | whne_letin_nozeta na B b t :
       RedFlags.zeta flags = false ->
       whne Γ (tLetIn na B b t)
@@ -96,6 +118,8 @@ Section Normal.
       RedFlags.delta flags = false ->
       whne Γ (tConst c u)
 
+  | whne_fix mfix idx narg body args a : unfold_fix mfix idx = Some (narg, body) -> nth_error args narg = Some a -> whne Γ a -> whne Γ (mkApps (tFix mfix idx) args)
+ 
   | whne_app f v :
       whne Γ f ->
       whne Γ (tApp f v)
@@ -135,4 +159,724 @@ Section Normal.
     - simpl. eapply IHargs. econstructor. assumption.
   Qed.
 
+  Lemma whnf_mkApps :
+    forall Γ t args,
+      whne Γ t ->
+      whnf Γ (mkApps t args).
+  Proof.
+    intros. econstructor. now eapply whne_mkApps.
+  Qed.
+  
+  Lemma whne_mkApps_inv :
+    forall Γ t l,
+      negb (isApp t) ->
+      whne Γ (mkApps t l) ->
+      whne Γ t \/ exists mfix idx narg body a, t = tFix mfix idx /\ unfold_fix mfix idx = Some (narg, body) /\ nth_error l narg = Some a /\ whne Γ a.
+  Proof.
+    intros Γ t l Ha h. revert t Ha h.
+    induction l using rev_ind; intros.
+    - eauto.
+    - rewrite mkApps_snoc in h.
+      depelim h.
+      + rewrite <- mkApps_snoc in x.
+        eapply (f_equal decompose_app) in x;
+          rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+        inversion x. subst. 
+        right. exists mfix, idx, narg, body, a. repeat split; eauto.
+      + edestruct IHl as [ | (? & ? & ? & ? & ? & ? & ? & ? & ?)]; eauto. subst.
+        right. exists x0, x1, x2, x3, x4. repeat split; eauto. now eapply nth_error_app_left.
+  Qed.
+  
 End Normal.
+
+Derive Signature for normal.
+Derive Signature for neutral.
+Derive Signature for All.
+
+Local Ltac inv H := inversion H; subst; clear H.
+
+Lemma OnOn2_contra A  (P : A -> A -> Type) l1 l2 : (forall x y, P x y -> False) -> OnOne2 P l1 l2 -> False.
+Proof.
+  intros. induction X; eauto.
+Qed.
+
+Lemma normal_nf Σ Γ t t' : normal Σ Γ t \/ neutral Σ Γ t -> red1 Σ Γ t t' -> False.
+Proof.
+  intros. induction X using red1_ind_all; destruct H.
+  all: repeat match goal with
+         | [ H : normal _ _ (?f ?a) |- _ ] => depelim H
+         | [ H : neutral _ _ (?f ?a)|- _ ] => depelim H
+         end.
+  all: try congruence.
+  Ltac help' := try repeat match goal with
+                  | [ H0 : _ = mkApps _ _ |- _ ] => 
+                    eapply (f_equal decompose_app) in H0;
+                      rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
+                  | [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
+                    destruct args using rev_ind; cbn in *; [ inv H1 |
+                                                             rewrite <- mkApps_nested in H1; cbn in *; inv H1
+                                                    ]
+                          end.
+  Ltac help := help'; try match goal with | [ H0 : mkApps _ _ = _ |- _ ] => symmetry in H0 end; help'.
+  all: help.
+  all: try tauto.
+  all: try now (clear - H; depind H; help; eauto).
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. unfold head_arg_is_constructor in H.
+    rewrite H0 in H. congruence.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply IHX. left.
+    eapply nf_cstrapp. now eapply All_app in X as [X _].
+  - eapply IHX. left.
+    eapply nf_indapp. now eapply All_app in X as [X _].
+  - clear IHargs.
+    eapply IHX. left.
+    eapply nf_fix.
+    + eauto.
+    + eapply All_app in X0. eapply X0.
+    + unfold head_arg_is_constructor in *.
+      destruct unfold_fix; eauto. destruct p.
+      unfold is_constructor in *.
+      destruct (nth_error args n) eqn:E; eauto.
+      erewrite nth_error_app_left in H; eauto.
+    + eauto.
+  - eapply IHX. left.
+    eapply All_app in X as [_ X]. now inv X.
+  - eapply IHX. left.
+    eapply All_app in X as [_ X]. now inv X.
+  - eapply IHX. left.
+    eapply All_app in X0 as [_ X0]. now inv X0.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. inv x.
+    eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+(*     firstorder. *)
+(*   - eapply (f_equal decompose_app) in x; *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. inv x. *)
+(*     eapply OnOne2_All_mix_left in X. 2:exact H. *)
+(*     eapply OnOn2_contra; try eassumption. *)
+(*     firstorder. *)
+(*   - eapply OnOne2_All_mix_left in X. 2:exact H0. *)
+(*     eapply OnOn2_contra; try eassumption. *)
+(*     firstorder. *)
+(*   - eapply OnOne2_All_mix_left in X. 2:exact H. *)
+(*     eapply OnOn2_contra; try eassumption. *)
+(*     firstorder. *)
+(* Qed. *)
+Admitted.
+
+Hint Constructors normal neutral : core.
+
+Lemma normal_mk_Apps_inv:
+  forall (Σ : global_env) (Γ : context) (t : term) (v : list term), ~ isApp t -> normal Σ Γ (mkApps t v) -> normal Σ Γ t /\ Forall (normal Σ Γ) v.
+Proof.
+(*   intros Σ Γ t v H H1. *)
+(*   induction v using rev_ind. *)
+(*   - split. eapply H1. econstructor.  *)
+(*   - rewrite <- mkApps_nested in H1. cbn in H1. depelim H1. depelim H0. *)
+(*     + split. *)
+(*       * firstorder. *)
+(*       * eapply app_Forall. firstorder. firstorder. *)
+(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       split. eapply nf_cstrapp with (v := []). econstructor. *)
+(*       now eapply All_Forall.  *)
+(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       split. eapply nf_indapp with (v := []). econstructor. *)
+(*       now eapply All_Forall. *)
+(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       split. eapply nf_fix with (args := []). *)
+(*       * eauto. *)
+(*       * econstructor. *)
+(*       * unfold head_arg_is_constructor in *. *)
+(*         destruct unfold_fix; eauto. destruct p. *)
+(*         unfold is_constructor in *. destruct n; reflexivity. *)
+(*       * eauto. *)
+(*       * now eapply All_Forall. *)
+(* Qed. *)
+Admitted.
+
+Lemma neutral_mk_Apps_inv:
+  forall (Σ : global_env) (Γ : context) (t : term) (v : list term), ~ isApp t -> neutral Σ Γ (mkApps t v) -> neutral Σ Γ t /\ Forall (normal Σ Γ) v.
+Proof.
+  intros Σ Γ t v H H1.
+  induction v using rev_ind.
+  - split. eapply H1. econstructor. 
+  - rewrite <- mkApps_nested in H1. cbn in H1. depelim H1. 
+    split.
+    + firstorder.
+    + eapply app_Forall. firstorder. firstorder.
+Qed.
+
+Lemma normal_mkApps Σ Γ t v :
+  neutral Σ Γ t -> Forall (normal Σ Γ) v -> normal Σ Γ (mkApps t v).
+Proof.
+  intros. induction H0 in t, H |- *; cbn in *.
+  - eauto.
+  - eapply IHForall. eauto.
+Qed.  
+
+Hint Resolve normal_mkApps All_Forall : core.
+
+Notation decision P := ({P} + {~P}).
+
+Lemma dec_All X (L : list X) P : All (fun x => decision (P x)) L ->
+                                 All P L + (All P L -> False).
+Proof.
+  intros. induction X0.
+  - left. econstructor.
+  - destruct p.
+    + destruct IHX0. left; econstructor; eauto. right. inversion 1. subst. eauto.
+    + right. inversion 1; subst; eauto.
+Defined.
+
+Definition normal_neutral_dec Σ Γ t : ({normal Σ Γ t} + {~ (normal Σ  Γ t)}) * ({neutral Σ Γ t} + {~ (neutral Σ Γ t)}).
+Proof.
+  induction t using term_forall_mkApps_ind in Γ |- *; split; eauto.
+  all: try now (right; intros H; depelim H).
+  - destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
+    + right. intros H. depelim H. depelim H. congruence. help. help. help.
+    + eauto.
+    + right. intros H. depelim H. depelim H. congruence. help. help. help.
+  - destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
+    + right. intros H. depelim H. congruence.
+    + eauto.
+    + right. intros H. depelim H. congruence.
+  - todo "evar".
+  - todo "evar".
+  - destruct (IHt1 Γ) as [[] _];
+      [destruct (IHt2 (Γ,, vass n t1)) as [[] _]|]; eauto.
+    + right. intros H. depelim H. depelim H. eauto. help. help. help.
+    + right. intros H. depelim H. depelim H. eauto. help. help. help.
+  - destruct (IHt1 Γ) as [[] _];
+      [destruct (IHt2 (Γ,, vass n t1)) as [[] _]|]; eauto.
+    + right. intros H. depelim H. eauto. 
+    + right. intros H. depelim H. eauto.
+  - destruct (IHt1 Γ) as [[] _];
+      [destruct (IHt2 (Γ,, vass n t1)) as [[] _]|]; eauto.
+    + right. intros H. depelim H. depelim H. eauto. help. help. help.
+    + right. intros H. depelim H. depelim H. eauto. help. help. help.
+  - right. intros H. depelim H. depelim H. help. help. help.
+  - destruct (IHt Γ) as [[] _].
+    + destruct dec_All with (P := (normal Σ Γ)) (L := v).
+      -- eapply All_impl. eassumption. intros ? ?. apply X0.
+      -- destruct t. all:eauto using normal_mkApps, All_Forall.
+         all: try now (left; depelim n; help; eauto).
+         ++ destruct v as [ | ? v].
+            ** eauto.
+            ** right. todo "admit". (*  intros ?. depelim X. depelim X. all:help. clear IHt. *)
+               (* eapply neutral_mk_Apps_inv in H0. as []; eauto. *)
+               (* depelim H1. *)
+         ++ destruct (head_arg_is_constructor mfix idx v) eqn:E.
+            ** right. intros ?. todo "admit". (* depelim H1. depelim H1. all:help. clear IHv. *)
+               (* eapply neutral_mk_Apps_inv in H1 as []; eauto. depelim H1. *)
+            ** left. todo "admit". (* depelim n. all:help. depelim H1. *)
+               (* eapply (f_equal decompose_app) in x; *)
+               (*   rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  inv x. *)
+               (* eauto. *)
+         ++ todo "cofix".
+      -- right. intros ?. eapply f. eapply Forall_All.
+         now eapply normal_mk_Apps_inv.
+    + right. intros ?. eapply n. now eapply normal_mk_Apps_inv.
+  - destruct v using rev_ind.
+    + cbn. eapply IHt.
+    + rewrite <- mkApps_nested. cbn.
+      eapply All_app in X as []. eapply IHv in a. inv a0. clear X0.
+      rename X into IHt2.
+      revert a.
+      generalize (mkApps t v) as t1. intros t1 IHt1.
+      destruct (IHt1) as [];
+      [destruct (IHt2 Γ) as [[] _]|]; eauto.
+      * right. intros HH. depelim HH. eauto.
+      * right. intros HH. depelim HH. eauto.
+  - destruct (lookup_env Σ s) as [[] | ] eqn:E.
+    + destruct (cst_body c) eqn:E2.
+      * right. intros H. depelim H. depelim H. congruence. help. help. help.
+      * eauto. 
+    +   right. intros H. depelim H. depelim H. congruence. help. help. help.
+    +   right. intros H. depelim H. depelim H. congruence. help. help. help.
+  - destruct (lookup_env Σ s) as [[] | ] eqn:E.
+    + destruct (cst_body c) eqn:E2.
+      * right. intros H. depelim H. congruence.
+      * eauto. 
+    +   right. intros H. depelim H. congruence.
+    +   right. intros H. depelim H. congruence.
+  - left. eapply nf_indapp with (v := []). econstructor.
+  - left. eapply nf_cstrapp with (v := []). econstructor.
+  - destruct (IHt2 Γ) as [_ []].
+    + destruct (IHt1 Γ) as [[] _].
+      * destruct dec_All with(L := l) (P := (normal Σ Γ ∘ @snd nat term)).
+        -- eapply All_impl. eassumption. intros ? ?. eapply X0.
+        -- eauto.
+        -- right. intros ?. depelim H. depelim H. all:help. eauto.
+      * right. intros ?. depelim H. depelim H. all:help. eauto.
+    + right. intros ?. depelim H. depelim H. all:help. eauto.
+  -  destruct (IHt2 Γ) as [_ []].
+    + destruct (IHt1 Γ) as [[] _].
+      * destruct dec_All with(L := l) (P := (normal Σ Γ ∘ @snd nat term)).
+        -- eapply All_impl. eassumption. intros ? ?. eapply X0.
+        -- eauto.
+        -- right. intros ?. depelim H. all:help. eauto.
+      * right. intros ?. depelim H. all:help. eauto.
+    + right. intros ?. depelim H. all:help. eauto.
+  - destruct (IHt Γ) as [_ []].
+    + eauto.
+    + right. intros H. depelim H. depelim H. eauto. help. help. help.
+  - destruct (IHt Γ) as [_ []].
+    + eauto.
+    + right. intros H. depelim H. eauto.
+  - hnf in X.
+
+    destruct dec_All with (P := (normal Σ Γ ∘ dtype)) (L := m).
+    eapply All_impl. eassumption. cbn. intros. eapply X0.
+
+    destruct dec_All with (P := normal Σ  (Γ ,,, PCUICLiftSubst.fix_context m) ∘ dbody) (L := m).
+    eapply All_impl. exact X. cbn. intros. eapply X0.
+
+    + left. eapply nf_fix with (args := []). eauto. eauto. unfold head_arg_is_constructor.
+      destruct unfold_fix; eauto. destruct p.
+      unfold is_constructor. destruct n0; eauto. eauto.
+    + right. intros H. depelim H. depelim H. help. help. eapply f.
+      eapply (f_equal decompose_app) in x;
+        rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  inv x.
+      eauto.
+    + right. intros H. depelim H. depelim H. help. help. 
+      eapply (f_equal decompose_app) in x;
+        rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  inv x.
+      eauto.      
+  - hnf in X.
+
+    destruct dec_All with (P := (normal Σ Γ ∘ dtype)) (L := m).
+    eapply All_impl. eassumption. cbn. intros. eapply X0.
+
+    destruct dec_All with (P := normal Σ (Γ ,,, PCUICLiftSubst.fix_context m) ∘ dbody) (L := m).
+    eapply All_impl. exact X. cbn. intros. eapply X0.
+
+    + left. eapply nf_cofix. eauto. eauto.
+    + right. intros H. depelim H. depelim H. help. help. help. eauto.
+    + right. intros H. depelim H. depelim H. help. help. help. eauto.
+Defined.
+
+Definition normal_dec Σ Γ t := fst (normal_neutral_dec Σ Γ t).
+Definition neutral_dec Σ Γ t := snd (normal_neutral_dec Σ Γ t).
+
+Hint Constructors whnf whne.
+
+Lemma whnf_mkApps_inv flags :
+  forall Σ Γ t l,
+    ~ isApp t ->
+    whnf flags Σ Γ (mkApps t l) ->
+    whnf flags Σ Γ t.
+Proof.
+  intros Σ Γ t l Hr h.
+  induction l using rev_ind.
+  - assumption.
+  - rewrite <- mkApps_nested in h. cbn in h. depelim h. depelim H. eauto.
+    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
+      rewrite mkApps_nested in x.
+      eapply (f_equal decompose_app) in x.
+      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. (* inv x. *)
+(*       eapply whnf_fix_short with (args := []); eauto. now destruct narg. *)
+(*     + eauto. *)
+(*     + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       eapply whnf_cstrapp with (v := []). *)
+(*     + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *. *)
+(*         rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       eapply whnf_indapp with (v := []). *)
+(*     + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       eapply whnf_fix_short with (args := []). eassumption. destruct narg. all:eauto. *)
+(* Qed. *)
+Admitted.
+
+Definition whnf_whne_dec flags Σ Γ t : ({whnf flags Σ Γ t} + {~ (whnf flags Σ  Γ t)}) * ({whne flags Σ Γ t} + {~ (whne flags Σ Γ t)}).
+Proof.
+  induction t using term_forall_mkApps_ind in Γ |- *; split; eauto.
+  all: try now (right; intros H; depelim H;help).
+  - destruct (RedFlags.zeta flags) eqn:Er.
+    + destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
+      * right. intros H. depelim H. depelim H. congruence. congruence. all:help. 
+      * eauto.
+      * right. intros H. depelim H. depelim H. congruence. congruence. all:help. 
+    + eauto.
+  - destruct (RedFlags.zeta flags) eqn:Er.
+    + destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
+      * right. intros H. depelim H. congruence. congruence. help.
+      * eauto.
+      * right. intros H. depelim H. congruence. congruence. help.
+    + eauto.
+  - destruct (RedFlags.zeta flags) eqn:Er; eauto.
+    right. intros ?. depelim H. depelim H. all:help. congruence.
+  - destruct (RedFlags.zeta flags) eqn:Er; eauto.
+    right. intros ?. depelim H. congruence. help.
+  - destruct (IHt Γ) as [[] _].
+    + destruct t. all:eauto using whnf_mkApps, All_Forall.
+      all: try now left; eapply whnf_mkApps; depelim w; eauto; help.
+      * destruct v as [ | ? v].
+        -- eauto.
+        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
+           eapply whne_mkApps_inv in H0 as []; eauto.
+           ++ depelim H0. help.
+           ++ firstorder congruence.
+      * destruct (unfold_fix mfix idx) as [(narg, body) |] eqn:E1.
+        -- destruct (nth_error v narg) as [a  | ] eqn:E2.
+           ++ eapply nth_error_all in X as [_ []]. 3: eassumption.
+              ** eauto.
+              ** right. (* right. intros ?. depelim H0. depelim H0. all:help. clear IHv. *)
+                 (* eapply whne_mkApps_inv in H0 as []; eauto. *)
+                 (* --- depelim H0. help. *)
+                 (*     eapply (f_equal decompose_app) in x; *)
+                 (*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. *)
+                 (*     inv x. destruct narg0; inv H1. *)
+                 (* --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0. *)
+                 (*     rewrite H1 in E1. inv E1. *)
+                 (*     eapply nth_error_app_left in H2. rewrite H2 in E2. inv E2. eauto. *) todo "bug".
+           ++ eauto.
+        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHv.
+           eapply whne_mkApps_inv in H0 as []; eauto.
+           --- depelim H0. help.
+           --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
+               rewrite H1 in E1. inv E1. 
+      * destruct v as [ | ? v].
+        -- eauto.
+        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
+           eapply whne_mkApps_inv in H0 as []; eauto.
+           ++ depelim H0. help.
+           ++  destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
+    + right. intros ?. eapply n.
+      now eapply whnf_mkApps_inv.
+  - destruct v using rev_ind.
+    + cbn. eapply IHt.
+    + rewrite <- mkApps_nested. cbn.
+      eapply All_app in X as []. eapply IHv in a. inv a0. clear X0.
+      rename X into IHt2.
+      revert a. intros IHt1.
+      destruct (IHt1) as [];
+      [destruct (IHt2 Γ) as [[] _]|]; eauto.
+      * destruct t. all:try (now right; intros HH; depelim HH; eauto; help).
+        rewrite <- mkApps_snoc.
+        destruct (unfold_fix mfix idx) as [ [narg body] | ] eqn:E1.
+        -- destruct (nth_error (v ++ [x]) narg) eqn:E2.
+           ++ destruct (IHt2 Γ) as [_ []]; eauto.
+              ** left. (* eapply whne_fix. eauto. eauto. *) todo "TODO".
+              ** right. todo "TODO". (* intros HH. depelim HH; help. *)
+                 (* --- eapply (f_equal decompose_app) in x; *)
+                 (*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. *)
+                 (*     inv x. rewrite H0 in E1. inv E1. *)
+                 (*     rewrite H1 in E2. inv E2. todo "TODO". *)
+                 (* --- clear IHl. todo "TODO". *)
+           ++ right. todo "TODO".               
+        -- right. todo "TODO". (* intros ?. depelim H0; help. todo "TODO". *)
+  - destruct (RedFlags.delta flags) eqn:Er; eauto.
+    destruct (lookup_env Σ s) as [[] | ] eqn:E.
+    + destruct (cst_body c) eqn:E2.
+      * right. intros H. depelim H. depelim H. congruence. congruence. all:help.
+      * eauto. 
+    +   right. intros H. depelim H. depelim H. congruence. congruence. all:help.
+    +   right. intros H. depelim H. depelim H. congruence. congruence. all:help.
+  - destruct (RedFlags.delta flags) eqn:Er; eauto.
+    destruct (lookup_env Σ s) as [[] | ] eqn:E.
+    + destruct (cst_body c) eqn:E2.
+      * right. intros H. depelim H. congruence. congruence. help.
+      * eauto.
+    +   right. intros H. depelim H. congruence. congruence. help.
+    +   right. intros H. depelim H. congruence. congruence. help.
+  - left. eapply whnf_indapp with (v := []). 
+  - left. eapply whnf_cstrapp with (v := []). 
+  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
+    destruct (IHt2 Γ) as [_ []].
+    + eauto. 
+    + right. intros ?. depelim H. depelim H. all:help. eauto. congruence.
+  -  destruct (RedFlags.iota flags) eqn:Eq; eauto.
+     destruct (IHt2 Γ) as [_ []].
+    + eauto. 
+    + right. intros ?. depelim H. all:help. eauto. congruence.
+  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
+    destruct (IHt Γ) as [_ []].
+    + eauto.
+    + right. intros H. depelim H. depelim H. all:eauto. all:help.
+  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
+    destruct (IHt Γ) as [_ []].
+    + eauto.
+    + right. intros H. depelim H. all:help. eauto. congruence.
+  - destruct (unfold_fix m n) as [(narg, body) |] eqn:E1.
+    + left. eapply whnf_fix_short with (args := []). eauto. now destruct narg.
+    + right. intros ?. depelim H. depelim H. all:help.
+  - right. intros ?. depelim H. destruct args using rev_ind; try rewrite mkApps_snoc in H3; inv x.
+    destruct narg; inv H0. rewrite mkApps_snoc in H3. inv H3.
+Defined.
+
+Definition whnf_dec flags Σ Γ t := fst (whnf_whne_dec flags Σ Γ t).
+Definition whne_dec flags Σ Γ t := snd (whnf_whne_dec flags Σ Γ t).
+
+
+(* From MetaCoq.Template Require Import All. *)
+
+(* MetaCoq Quote Recursively Definition test := ((ltac:(let x := eval cbv in plus in exact x))). *)
+(* Print test. *)
+
+(* Require Import TemplateToPCUIC. *)
+
+(* Definition bla := whnf_dec RedFlags.default (fst (trans_global (fst test, Monomorphic_ctx ContextSet.empty))) [] (trans (snd test) ). *)
+
+(* Compute bla. *)
+
+
+
+Lemma red1_mkApps_tConstruct_inv Σ Γ i n u v t' :
+  red1 Σ Γ (mkApps (tConstruct i n u) v) t' -> ∑ v', (t' = mkApps (tConstruct i n u) v') * (OnOne2 (red1 Σ Γ) v v').
+Proof.
+  revert t'. induction v using rev_ind; intros.
+  - cbn in *. depelim X. help.
+  - rewrite mkApps_snoc in X. depelim X.
+    + help.
+    + help.
+    + eapply IHv in X as (? & ? & ?). subst.
+      exists (x0 ++ [x])%list. rewrite mkApps_snoc. split; eauto. admit.
+    + exists (v ++ [N2])%list. rewrite mkApps_snoc. split; eauto. 
+      eapply OnOne2_app. econstructor. eauto.
+Admitted.
+
+Lemma red1_mkApps_tInd_inv Σ Γ i u v t' :
+  red1 Σ Γ (mkApps (tInd i u) v) t' -> ∑ v', (t' = mkApps (tInd i u) v') * (OnOne2 (red1 Σ Γ) v v').
+Proof.
+  revert t'. induction v using rev_ind; intros.
+  - cbn in *. depelim X. help.
+  - rewrite mkApps_snoc in X. depelim X.
+    + help.
+    + help.
+    + eapply IHv in X as (? & ? & ?). subst.
+      exists (x0 ++ [x])%list. rewrite mkApps_snoc. split; eauto. admit.
+    + exists (v ++ [N2])%list. rewrite mkApps_snoc. split; eauto. 
+      eapply OnOne2_app. econstructor. eauto.
+Admitted.
+
+
+Ltac hhelp' := try repeat match goal with
+                        | [ H0 : _ = mkApps _ _ |- _ ] => 
+                          eapply (f_equal decompose_app) in H0;
+                          rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
+                        | [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
+                          destruct args eqn:E using rev_ind ; cbn in *; [ inv H1 |
+                                                                   rewrite <- mkApps_nested in H1; cbn in *; inv H1
+                                                                 ]
+                        end.
+
+Ltac hhelp := hhelp'; try match goal with | [ H0 : mkApps _ _ = _ |- _ ] => symmetry in H0 end; hhelp'.
+
+Lemma red1_mkApps_tFix_inv Σ Γ mfix id narg body v t' :
+  unfold_fix mfix id = Some (narg, body) ->
+  is_constructor narg v = false ->  
+  red1 Σ Γ (mkApps (tFix mfix id) v) t' -> (∑ v', (t' = mkApps (tFix mfix id) v') * (OnOne2 (red1 Σ Γ) v v'))
+                                          + (∑ mfix', (t' = mkApps (tFix mfix' id) v) * (OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x0 : def term => (dname x0, dbody x0, rarg x0))) mfix mfix'))
+                                          + (∑ mfix', (t' = mkApps (tFix mfix' id) v) * (OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody (fun x0 : def term => (dname x0, dtype x0, rarg x0))) mfix mfix')).
+Proof.
+  intros ? ?. revert t'. induction v using rev_ind; intros.
+  - cbn in *. depelim X; hhelp; eauto.
+  - depelim X; hhelp; eauto.
+    + rewrite mkApps_snoc in x. inv x. eapply IHv in X as [ [(? & ? & ?)|(?&?&?)] | (?&?&?)].
+      * subst. left. left. exists (x ++ [x0])%list. split. now rewrite mkApps_snoc. admit. (* OnOne2 app left *)
+      * subst. left. right. exists x. split. now rewrite mkApps_snoc. eauto.
+      * subst. right. exists x. split. now rewrite mkApps_snoc. eauto.
+      * (* nth_error stuff *) admit.
+    + rewrite mkApps_snoc in x. inv x.
+      left. left. exists (v ++ [N2])%list. split.
+      now rewrite mkApps_snoc. 
+      eapply OnOne2_app. econstructor. eauto.
+    + rewrite mkApps_snoc in x. inv x.
+    + rewrite mkApps_snoc in x. inv x.
+Admitted.
+
+Lemma whnf_pres1 Σ Γ t t' :
+  red1 Σ Γ t t' ->
+  (whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t') /\
+  (whne RedFlags.default Σ Γ t -> whne RedFlags.default Σ Γ t').
+Proof.
+  (* intros. induction X using red1_ind_all; split; intros. *)
+  (* all: repeat match goal with *)
+  (*             | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H *)
+  (*             | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H *)
+  (*             end. *)
+  (* all:try (cbn in *; congruence). *)
+  (* all:do 2 help. *)
+  (* all: try now eapply whne_mkApps_inv in H; depelim H. *)
+  (* all: try destruct IHX; eauto. *)
+  (* all: try now match goal with [ H : whne _ _ _ (mkApps _ _) |- _ ] => eapply whne_mkApps_inv in H; depelim H end. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. rewrite H1 in H. inv H. unfold is_constructor in H0. *)
+  (*   rewrite H2 in H0. unfold isConstruct_app in H0. *)
+  (*   setoid_rewrite mkApps_decompose_app in H3. destruct (decompose_app a).1; inv H0. *)
+  (*   eapply whne_mkApps_inv in H3. depelim H3. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. rewrite H1 in H. inv H. unfold is_constructor in H0. *)
+  (*   rewrite H2 in H0. congruence. *)
+  (* - clear IHv. *)
+  (*   eapply red1_mkApps_tConstruct_inv in X as (? & -> & ?). *)
+  (*   rewrite <- mkApps_snoc. *)
+  (*   eapply whnf_cstrapp.     *)
+  (* - clear IHv. *)
+  (*   eapply red1_mkApps_tInd_inv in X as (? & -> & ?). *)
+  (*   rewrite <- mkApps_snoc. *)
+  (*   eapply whnf_indapp. *)
+  (* - clear IHargs. *)
+  (*   eapply red1_mkApps_tFix_inv in X as [[(? & -> & ?) | (? & -> & ?)] | (? & -> & ?)]; eauto. *)
+  (*   + rewrite <- mkApps_snoc. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + unfold is_constructor. destruct (nth_error args narg) eqn:E; eauto. admit.     *)
+  (* - clear IHargs. *)
+  (*   eapply red1_mkApps_tFix_inv in X as [[(? & -> & ?) | (? & -> & ?)] | (? & -> & ?)]; eauto. *)
+  (*   + rewrite <- mkApps_snoc. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + unfold is_constructor. destruct (nth_error args narg) eqn:E; eauto. admit.     *)
+  (* - clear IHv. rewrite <- mkApps_snoc. eauto. *)
+  (* - rewrite <- mkApps_snoc. eauto. *)
+  (* - clear IHargs. *)
+  (*   destruct (nth_error args narg) eqn:E. *)
+  (*   + assert (E' := E). *)
+  (*     eapply nth_error_app_left in E. rewrite E in H0. inv H0. *)
+  (*     rewrite <- mkApps_snoc. *)
+  (*     eapply whnf_fix. eauto. *)
+  (*     eapply nth_error_app_left. eauto. eauto. *)
+  (*   + assert (E' := E). *)
+  (*     eapply nth_error_None in E. rewrite nth_error_app_ge in H0; eauto. *)
+  (*     destruct (narg - #|args|) eqn:En; cbn in H0.  *)
+  (*     * inv H0. rewrite <- mkApps_snoc. *)
+  (*       eapply whnf_fix. eauto. rewrite nth_error_app_ge. lia. rewrite En. reflexivity. eauto.  *)
+  (*     * destruct n; inv H0. *)
+  (* - clear IHargs. rewrite <- mkApps_snoc. *)
+  (*   eapply whnf_fix_short. eauto. rewrite nth_error_None. *)
+  (*   setoid_rewrite nth_error_None in H0. rewrite app_length. *)
+  (*   setoid_rewrite app_length in H0. cbn in *. lia. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. destruct narg; inv H0. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. eapply whnf_fix_short with (args := []). admit. admit. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. destruct narg; inv H0. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. eapply whnf_fix_short with (args := []). admit. admit. *)
+Admitted.    
+
+Lemma whnf_pres Σ Γ t t' :
+  red Σ Γ t t' ->
+  whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t'.
+Proof.
+  induction 1; intros.
+  - eauto.
+  - eapply whnf_pres1; eauto.
+Qed.
+
+Lemma whnf_red1_sort Σ Γ t u :
+  whnf RedFlags.default Σ Γ t ->
+  red1 Σ Γ t (tSort u) -> t = tSort u.
+Proof.
+  intros. remember (tSort u) as t'. 
+  induction X using red1_ind_all.
+  all: repeat match goal with
+         | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H
+         | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H
+         end.
+  all:try (cbn in *; congruence).
+  all:do 2 help.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. rewrite H2 in H. inv H.
+    destruct args0 using rev_ind; cbn in *.
+    destruct narg; inv H0.
+    rewrite mkApps_snoc in  Heqt'. congruence.
+  - rewrite <- mkApps_nested in Heqt'. inv Heqt'.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. rewrite H1 in H. inv H.
+    destruct args0 using rev_ind; cbn in *.
+    unfold is_constructor in H2. rewrite H0 in H2. congruence.
+    rewrite mkApps_snoc in  Heqt'. congruence.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+Qed.
+
+Lemma whnf_red_sort Σ Γ t u :
+  whnf RedFlags.default Σ Γ t ->
+  red Σ Γ t (tSort u) -> t = tSort u.
+Proof.
+  intros. remember (tSort u) as t'. induction X.
+  - eauto.
+  - subst. eapply whnf_red1_sort in r. subst. eauto.
+    eapply whnf_pres; eauto.
+Qed.
+
+Lemma whnf_red1_prod Σ Γ t na t1 t2 :
+  whnf RedFlags.default Σ Γ t ->
+  red1 Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
+Proof.
+  intros. remember (tProd na t1 t2) as t'. 
+  induction X using red1_ind_all.
+  all: repeat match goal with
+         | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H
+         | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H
+         end.
+  all:try (cbn in *; congruence).
+  all:do 2 help.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. rewrite H2 in H. inv H.
+    destruct args0 using rev_ind; cbn in *.
+    destruct narg; inv H0.
+    rewrite mkApps_snoc in  Heqt'. congruence.
+  - rewrite <- mkApps_nested in Heqt'. inv Heqt'.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. rewrite H1 in H. inv H.
+    destruct args0 using rev_ind; cbn in *.
+    unfold is_constructor in H2. rewrite H0 in H2. congruence.
+    rewrite mkApps_snoc in  Heqt'. congruence.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+  - inv Heqt'. eauto.
+  - inv Heqt'. eauto.
+Qed.
+
+Lemma whnf_red_prod Σ Γ t na t1 t2 :
+  whnf RedFlags.default Σ Γ t ->
+  red Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
+Proof.
+  intros. remember (tProd na t1 t2) as t'. revert t1 t2 Heqt'. induction X; intros.
+  - eauto.
+  - subst. eapply whnf_red1_prod in r as (? & ? & ?). subst. eauto.
+    eapply whnf_pres; eauto.
+Qed.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -496,8 +496,9 @@ Lemma whnf_pres Σ Γ t t' :
   whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t'.
 Proof.
   induction 1; intros.
-  - eauto.
   - eapply whnf_pres1; eauto.
+  - eauto.
+  - eauto.
 Qed.
 
 Lemma whnf_red1_sort Σ Γ t u :
@@ -531,9 +532,9 @@ Lemma whnf_red_sort Σ Γ t u :
   whnf RedFlags.default Σ Γ t ->
   red Σ Γ t (tSort u) -> t = tSort u.
 Proof.
-  intros. remember (tSort u) as t'. induction X.
+  intros. remember (tSort u) as t'. induction X using red_rect'.
   - eauto.
-  - subst. eapply whnf_red1_sort in r. subst. eauto.
+  - subst. eapply whnf_red1_sort in X0. subst. eauto.
     eapply whnf_pres; eauto.
 Qed.
 
@@ -569,9 +570,9 @@ Lemma whnf_red_prod Σ Γ t na t1 t2 :
   whnf RedFlags.default Σ Γ t ->
   red Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
 Proof.
-  intros. remember (tProd na t1 t2) as t'. revert t1 t2 Heqt'. induction X; intros.
+  intros. remember (tProd na t1 t2) as t'. revert t1 t2 Heqt'. induction X using red_rect'; intros.
   - eauto.
-  - subst. eapply whnf_red1_prod in r as (? & ? & ?). subst. eauto.
+  - subst. eapply whnf_red1_prod in X0 as (? & ? & ?). subst. eauto.
     eapply whnf_pres; eauto.
 Qed.
 

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -37,41 +37,6 @@ Section Normal.
   Context (flags : RedFlags.t).
   Context (Σ : global_env).
 
-  Definition head_arg_is_constructor mfix idx args :=
-    match unfold_fix mfix idx with Some (narg, body) => is_constructor narg args | None => false end.
-  
-  Inductive normal (Γ : context) : term -> Prop :=
-  | nf_ne t : neutral Γ t -> normal Γ t
-  | nf_lam na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
-                    normal Γ (tLambda na A B)
-  | nf_cstrapp i n u v : All (normal Γ) v -> normal Γ (mkApps (tConstruct i n u) v)
-  | nf_indapp i u v : All (normal Γ) v -> normal Γ (mkApps (tInd i u) v)
-  | nf_fix mfix idx args : All (compose (normal (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody) mfix ->
-                           All (normal Γ) args ->
-                           head_arg_is_constructor mfix idx args = false ->
-                           All (compose (normal Γ) dtype) mfix ->
-                      normal Γ (mkApps (tFix mfix idx) args)
-  | nf_cofix mfix idx : All (compose (normal (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody) mfix ->
-                      All (compose (normal Γ) dtype) mfix ->
-                        normal Γ (tCoFix mfix idx)
-
-  with neutral (Γ : context) : term -> Prop :=
-  | ne_rel i :
-      (forall b, option_map decl_body (nth_error Γ i) <> Some (Some b)) ->
-      neutral Γ (tRel i)
-  | ne_var v : neutral Γ (tVar v)
-  | ne_evar n l : neutral Γ (tEvar n l)
-  | ne_const c u :
-      (forall decl b, lookup_env Σ c = Some (ConstantDecl decl) -> decl.(cst_body) = Some b -> False) ->
-  | ne_sort s : neutral Γ (tSort s)
-  | ne_prod na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
-                     neutral Γ (tProd na A B)
-      neutral Γ (tConst c u)
-  | ne_app f v : neutral Γ f -> normal Γ v -> neutral Γ (tApp f v)
-  | ne_case i p c brs : neutral Γ c -> normal Γ p -> All (compose (normal Γ) snd) brs ->
-                        neutral Γ (tCase i p c brs)
-  | ne_proj p c : neutral Γ c -> neutral Γ (tProj p c).
-
   (* Relative to reduction flags *)
   Inductive whnf (Γ : context) : term -> Prop :=
   | whnf_ne t : whne Γ t -> whnf Γ t
@@ -118,8 +83,6 @@ Section Normal.
       RedFlags.delta flags = false ->
       whne Γ (tConst c u)
 
-  | whne_fix mfix idx narg body args a : unfold_fix mfix idx = Some (narg, body) -> nth_error args narg = Some a -> whne Γ a -> whne Γ (mkApps (tFix mfix idx) args)
- 
   | whne_app f v :
       whne Γ f ->
       whne Γ (tApp f v)
@@ -128,8 +91,7 @@ Section Normal.
   | whne_fixapp mfix idx args rarg arg body :
      unfold_fix mfix idx = Some (rarg, body) ->
      nth_error args rarg = Some arg -> 
-     whnf Γ arg ->
-     PCUICAstUtils.isConstruct_app arg = false ->
+     whne Γ arg ->
      whne Γ (mkApps (tFix mfix idx) args)
   
   | whne_case i p c brs :
@@ -178,165 +140,36 @@ Section Normal.
     - eauto.
     - rewrite mkApps_snoc in h.
       depelim h.
+      + edestruct IHl as [ | (? & ? & ? & ? & ? & ? & ? & ? & ?)]; eauto. subst.
+        right. exists x0, x1, x2, x3, x4. repeat split; eauto. now eapply nth_error_app_left.
       + rewrite <- mkApps_snoc in x.
         eapply (f_equal decompose_app) in x;
           rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
         inversion x. subst. 
-        right. exists mfix, idx, narg, body, a. repeat split; eauto.
-      + edestruct IHl as [ | (? & ? & ? & ? & ? & ? & ? & ? & ?)]; eauto. subst.
-        right. exists x0, x1, x2, x3, x4. repeat split; eauto. now eapply nth_error_app_left.
+        right. exists mfix, idx, rarg, body, arg. repeat split; eauto.
   Qed.
   
 End Normal.
 
-Derive Signature for normal.
-Derive Signature for neutral.
+Derive Signature for whnf.
+Derive Signature for whne.
 Derive Signature for All.
+Hint Constructors whnf whne : core.
 
 Local Ltac inv H := inversion H; subst; clear H.
 
-Lemma OnOn2_contra A  (P : A -> A -> Type) l1 l2 : (forall x y, P x y -> False) -> OnOne2 P l1 l2 -> False.
-Proof.
-  intros. induction X; eauto.
-Qed.
+Ltac help' := try repeat match goal with
+| [ H0 : _ = mkApps _ _ |- _ ] => 
+  eapply (f_equal decompose_app) in H0;
+    rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
+| [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
+  destruct args using rev_ind; cbn in *; [ inv H1 |
+                                           rewrite <- mkApps_nested in H1; cbn in *; inv H1
+                                  ]
+        end.
+Ltac help := help'; try match goal with | [ H0 : mkApps _ _ = _ |- _ ] => symmetry in H0 end; help'.
 
-Lemma normal_nf Σ Γ t t' : normal Σ Γ t \/ neutral Σ Γ t -> red1 Σ Γ t t' -> False.
-Proof.
-  intros. induction X using red1_ind_all; destruct H.
-  all: repeat match goal with
-         | [ H : normal _ _ (?f ?a) |- _ ] => depelim H
-         | [ H : neutral _ _ (?f ?a)|- _ ] => depelim H
-         end.
-  all: try congruence.
-  Ltac help' := try repeat match goal with
-                  | [ H0 : _ = mkApps _ _ |- _ ] => 
-                    eapply (f_equal decompose_app) in H0;
-                      rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
-                  | [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
-                    destruct args using rev_ind; cbn in *; [ inv H1 |
-                                                             rewrite <- mkApps_nested in H1; cbn in *; inv H1
-                                                    ]
-                          end.
-  Ltac help := help'; try match goal with | [ H0 : mkApps _ _ = _ |- _ ] => symmetry in H0 end; help'.
-  all: help.
-  all: try tauto.
-  all: try now (clear - H; depind H; help; eauto).
-  - eapply (f_equal decompose_app) in x;
-      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
-    inv x. unfold head_arg_is_constructor in H.
-    rewrite H0 in H. congruence.
-  - eapply OnOne2_All_mix_left in X; try eassumption.
-    eapply OnOn2_contra; try eassumption.
-    firstorder.
-  - eapply OnOne2_All_mix_left in X; try eassumption.
-    eapply OnOn2_contra; try eassumption.
-    firstorder.
-  - eapply IHX. left.
-    eapply nf_cstrapp. now eapply All_app in X as [X _].
-  - eapply IHX. left.
-    eapply nf_indapp. now eapply All_app in X as [X _].
-  - clear IHargs.
-    eapply IHX. left.
-    eapply nf_fix.
-    + eauto.
-    + eapply All_app in X0. eapply X0.
-    + unfold head_arg_is_constructor in *.
-      destruct unfold_fix; eauto. destruct p.
-      unfold is_constructor in *.
-      destruct (nth_error args n) eqn:E; eauto.
-      erewrite nth_error_app_left in H; eauto.
-    + eauto.
-  - eapply IHX. left.
-    eapply All_app in X as [_ X]. now inv X.
-  - eapply IHX. left.
-    eapply All_app in X as [_ X]. now inv X.
-  - eapply IHX. left.
-    eapply All_app in X0 as [_ X0]. now inv X0.
-  - eapply OnOne2_All_mix_left in X; try eassumption.
-    eapply OnOn2_contra; try eassumption.
-    firstorder.
-  - eapply OnOne2_All_mix_left in X; try eassumption.
-    eapply OnOn2_contra; try eassumption.
-    firstorder.
-  - eapply (f_equal decompose_app) in x;
-      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. inv x.
-    eapply OnOne2_All_mix_left in X; try eassumption.
-    eapply OnOn2_contra; try eassumption.
-(*     firstorder. *)
-(*   - eapply (f_equal decompose_app) in x; *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. inv x. *)
-(*     eapply OnOne2_All_mix_left in X. 2:exact H. *)
-(*     eapply OnOn2_contra; try eassumption. *)
-(*     firstorder. *)
-(*   - eapply OnOne2_All_mix_left in X. 2:exact H0. *)
-(*     eapply OnOn2_contra; try eassumption. *)
-(*     firstorder. *)
-(*   - eapply OnOne2_All_mix_left in X. 2:exact H. *)
-(*     eapply OnOn2_contra; try eassumption. *)
-(*     firstorder. *)
-(* Qed. *)
-Admitted.
-
-Hint Constructors normal neutral : core.
-
-Lemma normal_mk_Apps_inv:
-  forall (Σ : global_env) (Γ : context) (t : term) (v : list term), ~ isApp t -> normal Σ Γ (mkApps t v) -> normal Σ Γ t /\ Forall (normal Σ Γ) v.
-Proof.
-(*   intros Σ Γ t v H H1. *)
-(*   induction v using rev_ind. *)
-(*   - split. eapply H1. econstructor.  *)
-(*   - rewrite <- mkApps_nested in H1. cbn in H1. depelim H1. depelim H0. *)
-(*     + split. *)
-(*       * firstorder. *)
-(*       * eapply app_Forall. firstorder. firstorder. *)
-(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
-(*       rewrite mkApps_nested in x. *)
-(*       eapply (f_equal decompose_app) in x. *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
-(*       split. eapply nf_cstrapp with (v := []). econstructor. *)
-(*       now eapply All_Forall.  *)
-(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
-(*       rewrite mkApps_nested in x. *)
-(*       eapply (f_equal decompose_app) in x. *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
-(*       split. eapply nf_indapp with (v := []). econstructor. *)
-(*       now eapply All_Forall. *)
-(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
-(*       rewrite mkApps_nested in x. *)
-(*       eapply (f_equal decompose_app) in x. *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
-(*       split. eapply nf_fix with (args := []). *)
-(*       * eauto. *)
-(*       * econstructor. *)
-(*       * unfold head_arg_is_constructor in *. *)
-(*         destruct unfold_fix; eauto. destruct p. *)
-(*         unfold is_constructor in *. destruct n; reflexivity. *)
-(*       * eauto. *)
-(*       * now eapply All_Forall. *)
-(* Qed. *)
-Admitted.
-
-Lemma neutral_mk_Apps_inv:
-  forall (Σ : global_env) (Γ : context) (t : term) (v : list term), ~ isApp t -> neutral Σ Γ (mkApps t v) -> neutral Σ Γ t /\ Forall (normal Σ Γ) v.
-Proof.
-  intros Σ Γ t v H H1.
-  induction v using rev_ind.
-  - split. eapply H1. econstructor. 
-  - rewrite <- mkApps_nested in H1. cbn in H1. depelim H1. 
-    split.
-    + firstorder.
-    + eapply app_Forall. firstorder. firstorder.
-Qed.
-
-Lemma normal_mkApps Σ Γ t v :
-  neutral Σ Γ t -> Forall (normal Σ Γ) v -> normal Σ Γ (mkApps t v).
-Proof.
-  intros. induction H0 in t, H |- *; cbn in *.
-  - eauto.
-  - eapply IHForall. eauto.
-Qed.  
-
-Hint Resolve normal_mkApps All_Forall : core.
+Hint Resolve All_Forall : core.
 
 Notation decision P := ({P} + {~P}).
 
@@ -349,6 +182,436 @@ Proof.
     + destruct IHX0. left; econstructor; eauto. right. inversion 1. subst. eauto.
     + right. inversion 1; subst; eauto.
 Defined.
+
+Lemma negb_is_true b :
+ ~ is_true b -> is_true (negb b).
+Proof.
+  destruct b; firstorder.
+Qed.
+Hint Resolve negb_is_true : core.
+
+Lemma whnf_mkApps_inv flags :
+  forall Σ Γ t l,
+    ~ isApp t ->
+    whnf flags Σ Γ (mkApps t l) ->
+    whnf flags Σ Γ t.
+Proof.
+  intros Σ Γ t l Hr h.
+  induction l using rev_ind.
+  - assumption.
+  - rewrite <- mkApps_nested in h. cbn in h. depelim h. depelim H. eauto.
+    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
+      rewrite mkApps_nested in x.
+      eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. eauto. inv x.
+      eapply whnf_fixapp with (v := []); eauto. rewrite H. now destruct rarg.    
+    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
+      rewrite mkApps_nested in x.
+      eapply (f_equal decompose_app) in x.
+      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x.
+      eapply whnf_cstrapp with (v := []).
+    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
+        rewrite mkApps_nested in x.
+      eapply (f_equal decompose_app) in x.
+      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x.
+      eapply whnf_indapp with (v := []).
+    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
+      rewrite mkApps_nested in x.
+      eapply (f_equal decompose_app) in x.
+      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x.
+      eapply whnf_fixapp with (v := []).
+      destruct unfold_fix as [[rarg arg] | ]; eauto. now destruct rarg.
+    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
+      rewrite mkApps_nested in x.
+      eapply (f_equal decompose_app) in x.
+      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x.
+      eauto.
+Qed.
+
+Lemma whnf_fixapp' {flags} Σ Γ mfix idx narg body v :
+unfold_fix mfix idx = Some (narg, body) ->
+nth_error v narg = None ->
+whnf flags Σ Γ (mkApps (tFix mfix idx) v).
+Proof.
+ intros E1 H. eapply whnf_fixapp. rewrite E1. eauto.
+Qed. 
+Hint Resolve whnf_fixapp' : core.
+
+Definition whnf_whne_dec flags Σ Γ t : ({whnf flags Σ Γ t} + {~ (whnf flags Σ  Γ t)}) * ({whne flags Σ Γ t} + {~ (whne flags Σ Γ t)}).
+Proof.
+  induction t using term_forall_mkApps_ind in Γ |- *; split; eauto.
+  all: try now (right; intros H; depelim H;help).
+  - destruct (RedFlags.zeta flags) eqn:Er.
+    + destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
+      * right. intros H. depelim H. depelim H. congruence. congruence. all:help. 
+      * eauto.
+      * right. intros H. depelim H. depelim H. congruence. congruence. all:help. 
+    + eauto.
+  - destruct (RedFlags.zeta flags) eqn:Er.
+    + destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
+      * right. intros H. depelim H. congruence. congruence. help.
+      * eauto.
+      * right. intros H. depelim H. congruence. congruence. help.
+    + eauto.
+  - destruct (RedFlags.zeta flags) eqn:Er; eauto.
+    right. intros ?. depelim H. depelim H. all:help. congruence.
+  - destruct (RedFlags.zeta flags) eqn:Er; eauto.
+    right. intros ?. depelim H. congruence. help.
+  - destruct (IHt Γ) as [[] _].
+    + destruct t. all:try now (left; eauto using whnf_mkApps, All_Forall).
+      all: try now left; eapply whnf_mkApps; depelim w; eauto; help.
+      * destruct v as [ | ? v].
+        -- eauto.
+        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
+           eapply whne_mkApps_inv in H0 as []; eauto.
+           ++ depelim H0. help.
+           ++ firstorder congruence.
+      * destruct (unfold_fix mfix idx) as [(narg, body) |] eqn:E1.
+        -- destruct (nth_error v narg) as [a  | ] eqn:E2.
+           ++ destruct (nth_error_all E2 X Γ) as [_ []].
+              ** left. eauto.
+              ** right. intros ?. depelim H0. depelim H0. all:help. clear IHv. 
+                 eapply whne_mkApps_inv in H0 as []; eauto.
+                 --- depelim H0. help. 
+                     eapply (f_equal decompose_app) in x; 
+                     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. 
+                     inv x. destruct rarg; inv H1. 
+                 --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
+                     rewrite E1 in H1. inv H1.
+                     eapply (nth_error_app_left v [x0]) in H2.
+                     rewrite E2 in H2. inv H2. eauto.
+                 --- help. eapply (f_equal decompose_app) in x; 
+                     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+                     inv x. rewrite E1 in H0. congruence. 
+           ++ left. eauto.
+        -- left. eapply whnf_fixapp. rewrite E1. eauto.
+    + right. intros ?. eapply n. now eapply whnf_mkApps_inv. 
+  - destruct (IHt Γ) as [_ []].
+    + left. now eapply whne_mkApps.
+    + destruct t.
+      all: try now (right; intros [ | (mfix & idx & narg & body & a & [=] & ? & ? & ?) ] % whne_mkApps_inv; subst; cbn; eauto).
+      * destruct (unfold_fix mfix idx) as [(narg, body) |] eqn:E1.
+      -- destruct (nth_error v narg) as [a  | ] eqn:E2.
+         ++ destruct (nth_error_all E2 X Γ) as [_ []].
+            ** left. eauto.
+            ** right. intros ?. depelim H0. depelim H0. all:help. clear IHv. 
+               eapply whne_mkApps_inv in H0 as []; eauto.
+               destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
+               rewrite E1 in H1. inv H1.
+               eapply (nth_error_app_left v [x0]) in H2.
+               rewrite E2 in H2. inv H2. eauto.
+         ++ right. intros [ | (mfix' & idx' & narg' & body' & a' & [=] & ? & ? & ?) ] % whne_mkApps_inv; subst; cbn; eauto.
+            congruence.
+      -- right. intros [ | (mfix' & idx' & narg' & body' & a' & [=] & ? & ? & ?) ] % whne_mkApps_inv; subst; cbn; eauto.
+         congruence.
+      * right. intros [ | (mfix' & idx' & narg' & body' & a' & [=] & ? & ? & ?) ] % whne_mkApps_inv; subst; cbn; eauto.
+  - destruct (RedFlags.delta flags) eqn:Er; eauto.
+    destruct (lookup_env Σ s) as [[] | ] eqn:E.
+    + destruct (cst_body c) eqn:E2.
+      * right. intros H. depelim H. depelim H. congruence. congruence. all:help.
+      * eauto. 
+    +   right. intros H. depelim H. depelim H. congruence. congruence. all:help.
+    +   right. intros H. depelim H. depelim H. congruence. congruence. all:help.
+  - destruct (RedFlags.delta flags) eqn:Er; eauto.
+    destruct (lookup_env Σ s) as [[] | ] eqn:E.
+    + destruct (cst_body c) eqn:E2.
+      * right. intros H. depelim H. congruence. congruence. help.
+      * eauto.
+    +   right. intros H. depelim H. congruence. congruence. help.
+    +   right. intros H. depelim H. congruence. congruence. help.
+  - left. eapply whnf_indapp with (v := []). 
+  - left. eapply whnf_cstrapp with (v := []). 
+  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
+    destruct (IHt2 Γ) as [_ []].
+    + eauto. 
+    + right. intros ?. depelim H. depelim H. all:help. eauto. congruence.
+  -  destruct (RedFlags.iota flags) eqn:Eq; eauto.
+     destruct (IHt2 Γ) as [_ []].
+    + eauto. 
+    + right. intros ?. depelim H. all:help. eauto. congruence.
+  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
+    destruct (IHt Γ) as [_ []].
+    + eauto.
+    + right. intros H. depelim H. depelim H. all:eauto. all:help.
+  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
+    destruct (IHt Γ) as [_ []].
+    + eauto.
+    + right. intros H. depelim H. all:help. eauto. congruence.
+  - destruct (unfold_fix m n) as [(narg, body) |] eqn:E1.
+    + left. eapply whnf_fixapp with (v := []). rewrite E1. now destruct narg.
+    + left. eapply whnf_fixapp with (v := []). now rewrite E1.
+  - right. intros ?. depelim H. destruct args using rev_ind; try rewrite mkApps_snoc in H3; inv x.
+    destruct rarg; inv H0. rewrite mkApps_snoc in H3. inv H3.
+  - left. eapply whnf_cofixapp with (v := []).
+Defined.
+
+Definition whnf_dec flags Σ Γ t := fst (whnf_whne_dec flags Σ Γ t).
+Definition whne_dec flags Σ Γ t := snd (whnf_whne_dec flags Σ Γ t).
+
+(* 
+Lemma red1_mkApps_tConstruct_inv Σ Γ i n u v t' :
+  red1 Σ Γ (mkApps (tConstruct i n u) v) t' -> ∑ v', (t' = mkApps (tConstruct i n u) v') * (OnOne2 (red1 Σ Γ) v v').
+Proof.
+  revert t'. induction v using rev_ind; intros.
+  - cbn in *. depelim X. help.
+  - rewrite mkApps_snoc in X. depelim X.
+    + help.
+    + help.
+    + eapply IHv in X as (? & ? & ?). subst.
+      exists (x0 ++ [x])%list. rewrite mkApps_snoc. split; eauto. admit.
+    + exists (v ++ [N2])%list. rewrite mkApps_snoc. split; eauto. 
+      eapply OnOne2_app. econstructor. eauto.
+Admitted.
+
+Lemma red1_mkApps_tInd_inv Σ Γ i u v t' :
+  red1 Σ Γ (mkApps (tInd i u) v) t' -> ∑ v', (t' = mkApps (tInd i u) v') * (OnOne2 (red1 Σ Γ) v v').
+Proof.
+  revert t'. induction v using rev_ind; intros.
+  - cbn in *. depelim X. help.
+  - rewrite mkApps_snoc in X. depelim X.
+    + help.
+    + help.
+    + eapply IHv in X as (? & ? & ?). subst.
+      exists (x0 ++ [x])%list. rewrite mkApps_snoc. split; eauto. admit.
+    + exists (v ++ [N2])%list. rewrite mkApps_snoc. split; eauto. 
+      eapply OnOne2_app. econstructor. eauto.
+Admitted.
+
+
+Ltac hhelp' := try repeat match goal with
+                        | [ H0 : _ = mkApps _ _ |- _ ] => 
+                          eapply (f_equal decompose_app) in H0;
+                          rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
+                        | [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
+                          destruct args eqn:E using rev_ind ; cbn in *; [ inv H1 |
+                                                                   rewrite <- mkApps_nested in H1; cbn in *; inv H1
+                                                                 ]
+                        end.
+
+Ltac hhelp := hhelp'; try match goal with | [ H0 : mkApps _ _ = _ |- _ ] => symmetry in H0 end; hhelp'.
+
+Lemma red1_mkApps_tFix_inv Σ Γ mfix id narg body v t' :
+  unfold_fix mfix id = Some (narg, body) ->
+  is_constructor narg v = false ->  
+  red1 Σ Γ (mkApps (tFix mfix id) v) t' -> (∑ v', (t' = mkApps (tFix mfix id) v') * (OnOne2 (red1 Σ Γ) v v'))
+                                          + (∑ mfix', (t' = mkApps (tFix mfix' id) v) * (OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x0 : def term => (dname x0, dbody x0, rarg x0))) mfix mfix'))
+                                          + (∑ mfix', (t' = mkApps (tFix mfix' id) v) * (OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody (fun x0 : def term => (dname x0, dtype x0, rarg x0))) mfix mfix')).
+Proof.
+  intros ? ?. revert t'. induction v using rev_ind; intros.
+  - cbn in *. depelim X; hhelp; eauto.
+  - depelim X; hhelp; eauto.
+    + rewrite mkApps_snoc in x. inv x. eapply IHv in X as [ [(? & ? & ?)|(?&?&?)] | (?&?&?)].
+      * subst. left. left. exists (x ++ [x0])%list. split. now rewrite mkApps_snoc. admit. (* OnOne2 app left *)
+      * subst. left. right. exists x. split. now rewrite mkApps_snoc. eauto.
+      * subst. right. exists x. split. now rewrite mkApps_snoc. eauto.
+      * (* nth_error stuff *) admit.
+    + rewrite mkApps_snoc in x. inv x.
+      left. left. exists (v ++ [N2])%list. split.
+      now rewrite mkApps_snoc. 
+      eapply OnOne2_app. econstructor. eauto.
+    + rewrite mkApps_snoc in x. inv x.
+    + rewrite mkApps_snoc in x. inv x.
+Admitted. *)
+
+Lemma whnf_pres1 Σ Γ t t' :
+  red1 Σ Γ t t' ->
+  (whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t') /\
+  (whne RedFlags.default Σ Γ t -> whne RedFlags.default Σ Γ t').
+Proof.
+  (* intros. induction X using red1_ind_all; split; intros. *)
+  (* all: repeat match goal with *)
+  (*             | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H *)
+  (*             | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H *)
+  (*             end. *)
+  (* all:try (cbn in *; congruence). *)
+  (* all:do 2 help. *)
+  (* all: try now eapply whne_mkApps_inv in H; depelim H. *)
+  (* all: try destruct IHX; eauto. *)
+  (* all: try now match goal with [ H : whne _ _ _ (mkApps _ _) |- _ ] => eapply whne_mkApps_inv in H; depelim H end. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. rewrite H1 in H. inv H. unfold is_constructor in H0. *)
+  (*   rewrite H2 in H0. unfold isConstruct_app in H0. *)
+  (*   setoid_rewrite mkApps_decompose_app in H3. destruct (decompose_app a).1; inv H0. *)
+  (*   eapply whne_mkApps_inv in H3. depelim H3. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. rewrite H1 in H. inv H. unfold is_constructor in H0. *)
+  (*   rewrite H2 in H0. congruence. *)
+  (* - clear IHv. *)
+  (*   eapply red1_mkApps_tConstruct_inv in X as (? & -> & ?). *)
+  (*   rewrite <- mkApps_snoc. *)
+  (*   eapply whnf_cstrapp.     *)
+  (* - clear IHv. *)
+  (*   eapply red1_mkApps_tInd_inv in X as (? & -> & ?). *)
+  (*   rewrite <- mkApps_snoc. *)
+  (*   eapply whnf_indapp. *)
+  (* - clear IHargs. *)
+  (*   eapply red1_mkApps_tFix_inv in X as [[(? & -> & ?) | (? & -> & ?)] | (? & -> & ?)]; eauto. *)
+  (*   + rewrite <- mkApps_snoc. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + unfold is_constructor. destruct (nth_error args narg) eqn:E; eauto. admit.     *)
+  (* - clear IHargs. *)
+  (*   eapply red1_mkApps_tFix_inv in X as [[(? & -> & ?) | (? & -> & ?)] | (? & -> & ?)]; eauto. *)
+  (*   + rewrite <- mkApps_snoc. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
+  (*   + unfold is_constructor. destruct (nth_error args narg) eqn:E; eauto. admit.     *)
+  (* - clear IHv. rewrite <- mkApps_snoc. eauto. *)
+  (* - rewrite <- mkApps_snoc. eauto. *)
+  (* - clear IHargs. *)
+  (*   destruct (nth_error args narg) eqn:E. *)
+  (*   + assert (E' := E). *)
+  (*     eapply nth_error_app_left in E. rewrite E in H0. inv H0. *)
+  (*     rewrite <- mkApps_snoc. *)
+  (*     eapply whnf_fix. eauto. *)
+  (*     eapply nth_error_app_left. eauto. eauto. *)
+  (*   + assert (E' := E). *)
+  (*     eapply nth_error_None in E. rewrite nth_error_app_ge in H0; eauto. *)
+  (*     destruct (narg - #|args|) eqn:En; cbn in H0.  *)
+  (*     * inv H0. rewrite <- mkApps_snoc. *)
+  (*       eapply whnf_fix. eauto. rewrite nth_error_app_ge. lia. rewrite En. reflexivity. eauto.  *)
+  (*     * destruct n; inv H0. *)
+  (* - clear IHargs. rewrite <- mkApps_snoc. *)
+  (*   eapply whnf_fix_short. eauto. rewrite nth_error_None. *)
+  (*   setoid_rewrite nth_error_None in H0. rewrite app_length. *)
+  (*   setoid_rewrite app_length in H0. cbn in *. lia. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. destruct narg; inv H0. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. eapply whnf_fix_short with (args := []). admit. admit. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. destruct narg; inv H0. *)
+  (* - eapply (f_equal decompose_app) in x; *)
+  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
+  (*   inv x. eapply whnf_fix_short with (args := []). admit. admit. *)
+Admitted.    
+
+Lemma whnf_pres Σ Γ t t' :
+  red Σ Γ t t' ->
+  whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t'.
+Proof.
+  induction 1; intros.
+  - eauto.
+  - eapply whnf_pres1; eauto.
+Qed.
+
+Lemma whnf_red1_sort Σ Γ t u :
+  whnf RedFlags.default Σ Γ t ->
+  red1 Σ Γ t (tSort u) -> t = tSort u.
+Proof.
+  intros. remember (tSort u) as t'. 
+  induction X using red1_ind_all.
+  all: repeat match goal with
+         | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H
+         | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H
+         end.
+  all:try (cbn in *; congruence).
+  all:do 2 help.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+  - rewrite <- mkApps_nested in Heqt'. inv Heqt'.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. rewrite H2 in H. inv H.
+    destruct args0 using rev_ind; cbn in *.
+    destruct rarg; inv H0.
+    rewrite mkApps_snoc in  Heqt'. congruence.
+  - destruct args using rev_ind.
+    + inv Heqt'. destruct narg; inv H1.
+    + rewrite <- mkApps_nested in Heqt'. inv Heqt'.
+  - eapply whne_mkApps_inv in H as [ | (? & ? & ? & ? & ? & ? & ? & ? & ?)]; cbn; eauto.
+    depelim H. help. congruence.  
+Qed.
+
+Lemma whnf_red_sort Σ Γ t u :
+  whnf RedFlags.default Σ Γ t ->
+  red Σ Γ t (tSort u) -> t = tSort u.
+Proof.
+  intros. remember (tSort u) as t'. induction X.
+  - eauto.
+  - subst. eapply whnf_red1_sort in r. subst. eauto.
+    eapply whnf_pres; eauto.
+Qed.
+
+Lemma whnf_red1_prod Σ Γ t na t1 t2 :
+  whnf RedFlags.default Σ Γ t ->
+  red1 Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
+Proof.
+  intros. remember (tProd na t1 t2) as t'. 
+  induction X using red1_ind_all.
+  all: repeat match goal with
+         | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H
+         | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H
+         end.
+  all:try (cbn in *; congruence).
+  all:do 2 help.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+  - rewrite <- mkApps_nested in Heqt'. inv Heqt'.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. rewrite H2 in H. inv H.
+    destruct args0 using rev_ind; cbn in *.
+    destruct rarg; inv H0.
+    rewrite mkApps_snoc in  Heqt'. congruence.
+  - destruct args using rev_ind.
+    + inv Heqt'. destruct narg; inv H1.
+    + rewrite <- mkApps_nested in Heqt'. inv Heqt'.
+  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
+  - inv Heqt'. eauto.
+  - inv Heqt'. eauto.
+Qed.
+
+Lemma whnf_red_prod Σ Γ t na t1 t2 :
+  whnf RedFlags.default Σ Γ t ->
+  red Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
+Proof.
+  intros. remember (tProd na t1 t2) as t'. revert t1 t2 Heqt'. induction X; intros.
+  - eauto.
+  - subst. eapply whnf_red1_prod in r as (? & ? & ?). subst. eauto.
+    eapply whnf_pres; eauto.
+Qed.
+
+(* 
+
+  Definition head_arg_is_constructor mfix idx args :=
+    match unfold_fix mfix idx with Some (narg, body) => is_constructor narg args | None => false end.
+  
+
+  Inductive normal (Γ : context) : term -> Prop :=
+  | nf_ne t : neutral Γ t -> normal Γ t
+  | nf_lam na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
+                    normal Γ (tLambda na A B)
+  | nf_cstrapp i n u v : All (normal Γ) v -> normal Γ (mkApps (tConstruct i n u) v)
+  | nf_indapp i u v : All (normal Γ) v -> normal Γ (mkApps (tInd i u) v)
+  | nf_fix mfix idx args : All (compose (normal (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody) mfix ->
+                           All (normal Γ) args ->
+                           head_arg_is_constructor mfix idx args = false ->
+                           All (compose (normal Γ) dtype) mfix ->
+                      normal Γ (mkApps (tFix mfix idx) args)
+  | nf_cofix mfix idx : All (compose (normal (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody) mfix ->
+                      All (compose (normal Γ) dtype) mfix ->
+                        normal Γ (tCoFix mfix idx)
+
+  with neutral (Γ : context) : term -> Prop :=
+  | ne_rel i :
+      (forall b, option_map decl_body (nth_error Γ i) <> Some (Some b)) ->
+      neutral Γ (tRel i)
+  | ne_var v : neutral Γ (tVar v)
+  | ne_evar n l : neutral Γ (tEvar n l)
+  | ne_const c u :
+      (forall decl b, lookup_env Σ c = Some (ConstantDecl decl) -> decl.(cst_body) = Some b -> False) ->
+      neutral Γ (tConst c u)
+  | ne_sort s : neutral Γ (tSort s)
+  | ne_prod na A B : normal Γ A -> normal (Γ ,, vass na A) B ->
+                     neutral Γ (tProd na A B)
+  | ne_app f v : neutral Γ f -> normal Γ v -> neutral Γ (tApp f v)
+  | ne_case i p c brs : neutral Γ c -> normal Γ p -> All (compose (normal Γ) snd) brs ->
+                        neutral Γ (tCase i p c brs)
+  | ne_proj p c : neutral Γ c -> neutral Γ (tProj p c).
 
 Definition normal_neutral_dec Σ Γ t : ({normal Σ Γ t} + {~ (normal Σ  Γ t)}) * ({neutral Σ Γ t} + {~ (neutral Σ Γ t)}).
 Proof.
@@ -479,407 +742,140 @@ Defined.
 
 Definition normal_dec Σ Γ t := fst (normal_neutral_dec Σ Γ t).
 Definition neutral_dec Σ Γ t := snd (normal_neutral_dec Σ Γ t).
+ *)
 
-Hint Constructors whnf whne.
 
-Lemma whnf_mkApps_inv flags :
-  forall Σ Γ t l,
-    ~ isApp t ->
-    whnf flags Σ Γ (mkApps t l) ->
-    whnf flags Σ Γ t.
+(* 
+
+
+Lemma OnOn2_contra A  (P : A -> A -> Type) l1 l2 : (forall x y, P x y -> False) -> OnOne2 P l1 l2 -> False.
 Proof.
-  intros Σ Γ t l Hr h.
-  induction l using rev_ind.
-  - assumption.
-  - rewrite <- mkApps_nested in h. cbn in h. depelim h. depelim H. eauto.
-    + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *.
-      rewrite mkApps_nested in x.
-      eapply (f_equal decompose_app) in x.
-      rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. (* inv x. *)
-(*       eapply whnf_fix_short with (args := []); eauto. now destruct narg. *)
-(*     + eauto. *)
-(*     + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *. *)
-(*       rewrite mkApps_nested in x. *)
-(*       eapply (f_equal decompose_app) in x. *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
-(*       eapply whnf_cstrapp with (v := []). *)
-(*     + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *. *)
-(*         rewrite mkApps_nested in x. *)
-(*       eapply (f_equal decompose_app) in x. *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
-(*       eapply whnf_indapp with (v := []). *)
-(*     + change (tApp (mkApps t l) x0) with (mkApps (mkApps t l) [x0]) in *. *)
-(*       rewrite mkApps_nested in x. *)
-(*       eapply (f_equal decompose_app) in x. *)
-(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
-(*       eapply whnf_fix_short with (args := []). eassumption. destruct narg. all:eauto. *)
+  intros. induction X; eauto.
+Qed.
+
+Lemma normal_nf Σ Γ t t' : normal Σ Γ t \/ neutral Σ Γ t -> red1 Σ Γ t t' -> False.
+Proof.
+  intros. induction X using red1_ind_all; destruct H.
+  all: repeat match goal with
+         | [ H : normal _ _ (?f ?a) |- _ ] => depelim H
+         | [ H : neutral _ _ (?f ?a)|- _ ] => depelim H
+         end.
+  all: try congruence.
+  all: help.
+  all: try tauto.
+  all: try now (clear - H; depind H; help; eauto).
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+    inv x. unfold head_arg_is_constructor in H.
+    rewrite H0 in H. congruence.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply IHX. left.
+    eapply nf_cstrapp. now eapply All_app in X as [X _].
+  - eapply IHX. left.
+    eapply nf_indapp. now eapply All_app in X as [X _].
+  - clear IHargs.
+    eapply IHX. left.
+    eapply nf_fix.
+    + eauto.
+    + eapply All_app in X0. eapply X0.
+    + unfold head_arg_is_constructor in *.
+      destruct unfold_fix; eauto. destruct p.
+      unfold is_constructor in *.
+      destruct (nth_error args n) eqn:E; eauto.
+      erewrite nth_error_app_left in H; eauto.
+    + eauto.
+  - eapply IHX. left.
+    eapply All_app in X as [_ X]. now inv X.
+  - eapply IHX. left.
+    eapply All_app in X as [_ X]. now inv X.
+  - eapply IHX. left.
+    eapply All_app in X0 as [_ X0]. now inv X0.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+    firstorder.
+  - eapply (f_equal decompose_app) in x;
+      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. inv x.
+    eapply OnOne2_All_mix_left in X; try eassumption.
+    eapply OnOn2_contra; try eassumption.
+(*     firstorder. *)
+(*   - eapply (f_equal decompose_app) in x; *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. inv x. *)
+(*     eapply OnOne2_All_mix_left in X. 2:exact H. *)
+(*     eapply OnOn2_contra; try eassumption. *)
+(*     firstorder. *)
+(*   - eapply OnOne2_All_mix_left in X. 2:exact H0. *)
+(*     eapply OnOn2_contra; try eassumption. *)
+(*     firstorder. *)
+(*   - eapply OnOne2_All_mix_left in X. 2:exact H. *)
+(*     eapply OnOn2_contra; try eassumption. *)
+(*     firstorder. *)
 (* Qed. *)
 Admitted.
 
-Definition whnf_whne_dec flags Σ Γ t : ({whnf flags Σ Γ t} + {~ (whnf flags Σ  Γ t)}) * ({whne flags Σ Γ t} + {~ (whne flags Σ Γ t)}).
+Hint Constructors normal neutral : core.
+
+Lemma normal_mk_Apps_inv:
+  forall (Σ : global_env) (Γ : context) (t : term) (v : list term), ~ isApp t -> normal Σ Γ (mkApps t v) -> normal Σ Γ t /\ Forall (normal Σ Γ) v.
 Proof.
-  induction t using term_forall_mkApps_ind in Γ |- *; split; eauto.
-  all: try now (right; intros H; depelim H;help).
-  - destruct (RedFlags.zeta flags) eqn:Er.
-    + destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
-      * right. intros H. depelim H. depelim H. congruence. congruence. all:help. 
-      * eauto.
-      * right. intros H. depelim H. depelim H. congruence. congruence. all:help. 
-    + eauto.
-  - destruct (RedFlags.zeta flags) eqn:Er.
-    + destruct (option_map decl_body (nth_error Γ n)) as [ [ | ] | ] eqn:E.
-      * right. intros H. depelim H. congruence. congruence. help.
-      * eauto.
-      * right. intros H. depelim H. congruence. congruence. help.
-    + eauto.
-  - destruct (RedFlags.zeta flags) eqn:Er; eauto.
-    right. intros ?. depelim H. depelim H. all:help. congruence.
-  - destruct (RedFlags.zeta flags) eqn:Er; eauto.
-    right. intros ?. depelim H. congruence. help.
-  - destruct (IHt Γ) as [[] _].
-    + destruct t. all:try now (left; eauto using whnf_mkApps, All_Forall).
-      all: try now left; eapply whnf_mkApps; depelim w; eauto; help.
-      * destruct v as [ | ? v].
-        -- eauto.
-        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
-           eapply whne_mkApps_inv in H0 as []; eauto.
-           ++ depelim H0. help.
-           ++ firstorder congruence.
-      * destruct (unfold_fix mfix idx) as [(narg, body) |] eqn:E1.
-        -- destruct (nth_error v narg) as [a  | ] eqn:E2.
-           ++ destruct (nth_error_all E2 X Γ) as [_ []].
-              ** left. eauto.
-              ** right. intros ?. depelim H0. depelim H0. all:help. clear IHv. 
-                 eapply whne_mkApps_inv in H0 as []; eauto.
-                 --- depelim H0. help. 
-                     eapply (f_equal decompose_app) in x; 
-                     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. 
-                     inv x. destruct narg0; inv H1. 
-                 --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
-                     rewrite E1 in H1. inv H1.
-                     eapply (nth_error_app_left v [x0]) in H2.
-                     rewrite E2 in H2. inv H2. eauto. (* 
-                 (*     rewrite H1 in E1. inv E1. *)
-                 (*     eapply nth_error_app_left in H2. rewrite H2 in E2. inv E2. eauto. *) todo "bug". *)
-           ++ left. eauto.
-        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHv.
-           eapply whne_mkApps_inv in H0 as []; eauto.
-           --- depelim H0. help.
-           --- destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
-               rewrite H1 in E1. inv E1. 
-      * destruct v as [ | ? v].
-        -- eauto.
-        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
-           eapply whne_mkApps_inv in H0 as []; eauto.
-           ++ depelim H0. help.
-           ++  destruct H0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv H0.
-    + right. intros ?. eapply n.
-      now eapply whnf_mkApps_inv.
-  - destruct v using rev_ind.
-    + cbn. eapply IHt.
-    + rewrite <- mkApps_nested. cbn.
-      eapply All_app in X as []. eapply IHv in a. inv a0. clear X0.
-      rename X into IHt2.
-      revert a. intros IHt1.
-      destruct (IHt1) as [];
-      [destruct (IHt2 Γ) as [[] _]|]; eauto.
-      * destruct t. all:try (now right; intros HH; depelim HH; eauto; help).
-        rewrite <- mkApps_snoc.
-        destruct (unfold_fix mfix idx) as [ [narg body] | ] eqn:E1.
-        -- destruct (nth_error (v ++ [x]) narg) eqn:E2.
-           ++ destruct (IHt2 Γ) as [_ []]; eauto.
-              ** left. (* eapply whne_fix. eauto. eauto. *) todo "TODO".
-              ** right. todo "TODO". (* intros HH. depelim HH; help. *)
-                 (* --- eapply (f_equal decompose_app) in x; *)
-                 (*       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. *)
-                 (*     inv x. rewrite H0 in E1. inv E1. *)
-                 (*     rewrite H1 in E2. inv E2. todo "TODO". *)
-                 (* --- clear IHl. todo "TODO". *)
-           ++ right. todo "TODO".               
-        -- right. todo "TODO". (* intros ?. depelim H0; help. todo "TODO". *)
-  - destruct (RedFlags.delta flags) eqn:Er; eauto.
-    destruct (lookup_env Σ s) as [[] | ] eqn:E.
-    + destruct (cst_body c) eqn:E2.
-      * right. intros H. depelim H. depelim H. congruence. congruence. all:help.
-      * eauto. 
-    +   right. intros H. depelim H. depelim H. congruence. congruence. all:help.
-    +   right. intros H. depelim H. depelim H. congruence. congruence. all:help.
-  - destruct (RedFlags.delta flags) eqn:Er; eauto.
-    destruct (lookup_env Σ s) as [[] | ] eqn:E.
-    + destruct (cst_body c) eqn:E2.
-      * right. intros H. depelim H. congruence. congruence. help.
-      * eauto.
-    +   right. intros H. depelim H. congruence. congruence. help.
-    +   right. intros H. depelim H. congruence. congruence. help.
-  - left. eapply whnf_indapp with (v := []). 
-  - left. eapply whnf_cstrapp with (v := []). 
-  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
-    destruct (IHt2 Γ) as [_ []].
-    + eauto. 
-    + right. intros ?. depelim H. depelim H. all:help. eauto. congruence.
-  -  destruct (RedFlags.iota flags) eqn:Eq; eauto.
-     destruct (IHt2 Γ) as [_ []].
-    + eauto. 
-    + right. intros ?. depelim H. all:help. eauto. congruence.
-  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
-    destruct (IHt Γ) as [_ []].
-    + eauto.
-    + right. intros H. depelim H. depelim H. all:eauto. all:help.
-  - destruct (RedFlags.iota flags) eqn:Eq; eauto.
-    destruct (IHt Γ) as [_ []].
-    + eauto.
-    + right. intros H. depelim H. all:help. eauto. congruence.
-  - destruct (unfold_fix m n) as [(narg, body) |] eqn:E1.
-    + left. eapply whnf_fix_short with (args := []). eauto. now destruct narg.
-    + right. intros ?. depelim H. depelim H. all:help.
-  - right. intros ?. depelim H. destruct args using rev_ind; try rewrite mkApps_snoc in H3; inv x.
-    destruct narg; inv H0. rewrite mkApps_snoc in H3. inv H3.
-Defined.
-
-Definition whnf_dec flags Σ Γ t := fst (whnf_whne_dec flags Σ Γ t).
-Definition whne_dec flags Σ Γ t := snd (whnf_whne_dec flags Σ Γ t).
-
-
-(* From MetaCoq.Template Require Import All. *)
-
-(* MetaCoq Quote Recursively Definition test := ((ltac:(let x := eval cbv in plus in exact x))). *)
-(* Print test. *)
-
-(* Require Import TemplateToPCUIC. *)
-
-(* Definition bla := whnf_dec RedFlags.default (fst (trans_global (fst test, Monomorphic_ctx ContextSet.empty))) [] (trans (snd test) ). *)
-
-(* Compute bla. *)
-
-
-
-Lemma red1_mkApps_tConstruct_inv Σ Γ i n u v t' :
-  red1 Σ Γ (mkApps (tConstruct i n u) v) t' -> ∑ v', (t' = mkApps (tConstruct i n u) v') * (OnOne2 (red1 Σ Γ) v v').
-Proof.
-  revert t'. induction v using rev_ind; intros.
-  - cbn in *. depelim X. help.
-  - rewrite mkApps_snoc in X. depelim X.
-    + help.
-    + help.
-    + eapply IHv in X as (? & ? & ?). subst.
-      exists (x0 ++ [x])%list. rewrite mkApps_snoc. split; eauto. admit.
-    + exists (v ++ [N2])%list. rewrite mkApps_snoc. split; eauto. 
-      eapply OnOne2_app. econstructor. eauto.
+(*   intros Σ Γ t v H H1. *)
+(*   induction v using rev_ind. *)
+(*   - split. eapply H1. econstructor.  *)
+(*   - rewrite <- mkApps_nested in H1. cbn in H1. depelim H1. depelim H0. *)
+(*     + split. *)
+(*       * firstorder. *)
+(*       * eapply app_Forall. firstorder. firstorder. *)
+(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       split. eapply nf_cstrapp with (v := []). econstructor. *)
+(*       now eapply All_Forall.  *)
+(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       split. eapply nf_indapp with (v := []). econstructor. *)
+(*       now eapply All_Forall. *)
+(*     + change (tApp (mkApps t v) x0) with (mkApps (mkApps t v) [x0]) in *. *)
+(*       rewrite mkApps_nested in x. *)
+(*       eapply (f_equal decompose_app) in x. *)
+(*       rewrite !decompose_app_mkApps in x; cbn in *; try congruence. firstorder. inv x. *)
+(*       split. eapply nf_fix with (args := []). *)
+(*       * eauto. *)
+(*       * econstructor. *)
+(*       * unfold head_arg_is_constructor in *. *)
+(*         destruct unfold_fix; eauto. destruct p. *)
+(*         unfold is_constructor in *. destruct n; reflexivity. *)
+(*       * eauto. *)
+(*       * now eapply All_Forall. *)
+(* Qed. *)
 Admitted.
 
-Lemma red1_mkApps_tInd_inv Σ Γ i u v t' :
-  red1 Σ Γ (mkApps (tInd i u) v) t' -> ∑ v', (t' = mkApps (tInd i u) v') * (OnOne2 (red1 Σ Γ) v v').
+Lemma neutral_mk_Apps_inv:
+  forall (Σ : global_env) (Γ : context) (t : term) (v : list term), ~ isApp t -> neutral Σ Γ (mkApps t v) -> neutral Σ Γ t /\ Forall (normal Σ Γ) v.
 Proof.
-  revert t'. induction v using rev_ind; intros.
-  - cbn in *. depelim X. help.
-  - rewrite mkApps_snoc in X. depelim X.
-    + help.
-    + help.
-    + eapply IHv in X as (? & ? & ?). subst.
-      exists (x0 ++ [x])%list. rewrite mkApps_snoc. split; eauto. admit.
-    + exists (v ++ [N2])%list. rewrite mkApps_snoc. split; eauto. 
-      eapply OnOne2_app. econstructor. eauto.
-Admitted.
+  intros Σ Γ t v H H1.
+  induction v using rev_ind.
+  - split. eapply H1. econstructor. 
+  - rewrite <- mkApps_nested in H1. cbn in H1. depelim H1. 
+    split.
+    + firstorder.
+    + eapply app_Forall. firstorder. firstorder.
+Qed.
 
-
-Ltac hhelp' := try repeat match goal with
-                        | [ H0 : _ = mkApps _ _ |- _ ] => 
-                          eapply (f_equal decompose_app) in H0;
-                          rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
-                        | [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
-                          destruct args eqn:E using rev_ind ; cbn in *; [ inv H1 |
-                                                                   rewrite <- mkApps_nested in H1; cbn in *; inv H1
-                                                                 ]
-                        end.
-
-Ltac hhelp := hhelp'; try match goal with | [ H0 : mkApps _ _ = _ |- _ ] => symmetry in H0 end; hhelp'.
-
-Lemma red1_mkApps_tFix_inv Σ Γ mfix id narg body v t' :
-  unfold_fix mfix id = Some (narg, body) ->
-  is_constructor narg v = false ->  
-  red1 Σ Γ (mkApps (tFix mfix id) v) t' -> (∑ v', (t' = mkApps (tFix mfix id) v') * (OnOne2 (red1 Σ Γ) v v'))
-                                          + (∑ mfix', (t' = mkApps (tFix mfix' id) v) * (OnOne2 (on_Trel_eq (red1 Σ Γ) dtype (fun x0 : def term => (dname x0, dbody x0, rarg x0))) mfix mfix'))
-                                          + (∑ mfix', (t' = mkApps (tFix mfix' id) v) * (OnOne2 (on_Trel_eq (red1 Σ (Γ ,,, PCUICLiftSubst.fix_context mfix)) dbody (fun x0 : def term => (dname x0, dtype x0, rarg x0))) mfix mfix')).
+Lemma normal_mkApps Σ Γ t v :
+  neutral Σ Γ t -> Forall (normal Σ Γ) v -> normal Σ Γ (mkApps t v).
 Proof.
-  intros ? ?. revert t'. induction v using rev_ind; intros.
-  - cbn in *. depelim X; hhelp; eauto.
-  - depelim X; hhelp; eauto.
-    + rewrite mkApps_snoc in x. inv x. eapply IHv in X as [ [(? & ? & ?)|(?&?&?)] | (?&?&?)].
-      * subst. left. left. exists (x ++ [x0])%list. split. now rewrite mkApps_snoc. admit. (* OnOne2 app left *)
-      * subst. left. right. exists x. split. now rewrite mkApps_snoc. eauto.
-      * subst. right. exists x. split. now rewrite mkApps_snoc. eauto.
-      * (* nth_error stuff *) admit.
-    + rewrite mkApps_snoc in x. inv x.
-      left. left. exists (v ++ [N2])%list. split.
-      now rewrite mkApps_snoc. 
-      eapply OnOne2_app. econstructor. eauto.
-    + rewrite mkApps_snoc in x. inv x.
-    + rewrite mkApps_snoc in x. inv x.
-Admitted.
-
-Lemma whnf_pres1 Σ Γ t t' :
-  red1 Σ Γ t t' ->
-  (whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t') /\
-  (whne RedFlags.default Σ Γ t -> whne RedFlags.default Σ Γ t').
-Proof.
-  (* intros. induction X using red1_ind_all; split; intros. *)
-  (* all: repeat match goal with *)
-  (*             | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H *)
-  (*             | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H *)
-  (*             end. *)
-  (* all:try (cbn in *; congruence). *)
-  (* all:do 2 help. *)
-  (* all: try now eapply whne_mkApps_inv in H; depelim H. *)
-  (* all: try destruct IHX; eauto. *)
-  (* all: try now match goal with [ H : whne _ _ _ (mkApps _ _) |- _ ] => eapply whne_mkApps_inv in H; depelim H end. *)
-  (* - eapply (f_equal decompose_app) in x; *)
-  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
-  (*   inv x. rewrite H1 in H. inv H. unfold is_constructor in H0. *)
-  (*   rewrite H2 in H0. unfold isConstruct_app in H0. *)
-  (*   setoid_rewrite mkApps_decompose_app in H3. destruct (decompose_app a).1; inv H0. *)
-  (*   eapply whne_mkApps_inv in H3. depelim H3. *)
-  (* - eapply (f_equal decompose_app) in x; *)
-  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
-  (*   inv x. rewrite H1 in H. inv H. unfold is_constructor in H0. *)
-  (*   rewrite H2 in H0. congruence. *)
-  (* - clear IHv. *)
-  (*   eapply red1_mkApps_tConstruct_inv in X as (? & -> & ?). *)
-  (*   rewrite <- mkApps_snoc. *)
-  (*   eapply whnf_cstrapp.     *)
-  (* - clear IHv. *)
-  (*   eapply red1_mkApps_tInd_inv in X as (? & -> & ?). *)
-  (*   rewrite <- mkApps_snoc. *)
-  (*   eapply whnf_indapp. *)
-  (* - clear IHargs. *)
-  (*   eapply red1_mkApps_tFix_inv in X as [[(? & -> & ?) | (? & -> & ?)] | (? & -> & ?)]; eauto. *)
-  (*   + rewrite <- mkApps_snoc. admit. *)
-  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
-  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
-  (*   + unfold is_constructor. destruct (nth_error args narg) eqn:E; eauto. admit.     *)
-  (* - clear IHargs. *)
-  (*   eapply red1_mkApps_tFix_inv in X as [[(? & -> & ?) | (? & -> & ?)] | (? & -> & ?)]; eauto. *)
-  (*   + rewrite <- mkApps_snoc. admit. *)
-  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
-  (*   + rewrite <- mkApps_snoc. eapply whnf_fix. admit. admit. admit. *)
-  (*   + unfold is_constructor. destruct (nth_error args narg) eqn:E; eauto. admit.     *)
-  (* - clear IHv. rewrite <- mkApps_snoc. eauto. *)
-  (* - rewrite <- mkApps_snoc. eauto. *)
-  (* - clear IHargs. *)
-  (*   destruct (nth_error args narg) eqn:E. *)
-  (*   + assert (E' := E). *)
-  (*     eapply nth_error_app_left in E. rewrite E in H0. inv H0. *)
-  (*     rewrite <- mkApps_snoc. *)
-  (*     eapply whnf_fix. eauto. *)
-  (*     eapply nth_error_app_left. eauto. eauto. *)
-  (*   + assert (E' := E). *)
-  (*     eapply nth_error_None in E. rewrite nth_error_app_ge in H0; eauto. *)
-  (*     destruct (narg - #|args|) eqn:En; cbn in H0.  *)
-  (*     * inv H0. rewrite <- mkApps_snoc. *)
-  (*       eapply whnf_fix. eauto. rewrite nth_error_app_ge. lia. rewrite En. reflexivity. eauto.  *)
-  (*     * destruct n; inv H0. *)
-  (* - clear IHargs. rewrite <- mkApps_snoc. *)
-  (*   eapply whnf_fix_short. eauto. rewrite nth_error_None. *)
-  (*   setoid_rewrite nth_error_None in H0. rewrite app_length. *)
-  (*   setoid_rewrite app_length in H0. cbn in *. lia. *)
-  (* - eapply (f_equal decompose_app) in x; *)
-  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
-  (*   inv x. destruct narg; inv H0. *)
-  (* - eapply (f_equal decompose_app) in x; *)
-  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
-  (*   inv x. eapply whnf_fix_short with (args := []). admit. admit. *)
-  (* - eapply (f_equal decompose_app) in x; *)
-  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
-  (*   inv x. destruct narg; inv H0. *)
-  (* - eapply (f_equal decompose_app) in x; *)
-  (*     rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.  *)
-  (*   inv x. eapply whnf_fix_short with (args := []). admit. admit. *)
-Admitted.    
-
-Lemma whnf_pres Σ Γ t t' :
-  red Σ Γ t t' ->
-  whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t'.
-Proof.
-  induction 1; intros.
+  intros. induction H0 in t, H |- *; cbn in *.
   - eauto.
-  - eapply whnf_pres1; eauto.
-Qed.
-
-Lemma whnf_red1_sort Σ Γ t u :
-  whnf RedFlags.default Σ Γ t ->
-  red1 Σ Γ t (tSort u) -> t = tSort u.
-Proof.
-  intros. remember (tSort u) as t'. 
-  induction X using red1_ind_all.
-  all: repeat match goal with
-         | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H
-         | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H
-         end.
-  all:try (cbn in *; congruence).
-  all:do 2 help.
-  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
-  - eapply (f_equal decompose_app) in x;
-      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
-    inv x. rewrite H2 in H. inv H.
-    destruct args0 using rev_ind; cbn in *.
-    destruct narg; inv H0.
-    rewrite mkApps_snoc in  Heqt'. congruence.
-  - rewrite <- mkApps_nested in Heqt'. inv Heqt'.
-  - eapply (f_equal decompose_app) in x;
-      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
-    inv x. rewrite H1 in H. inv H.
-    destruct args0 using rev_ind; cbn in *.
-    unfold is_constructor in H2. rewrite H0 in H2. congruence.
-    rewrite mkApps_snoc in  Heqt'. congruence.
-  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
-Qed.
-
-Lemma whnf_red_sort Σ Γ t u :
-  whnf RedFlags.default Σ Γ t ->
-  red Σ Γ t (tSort u) -> t = tSort u.
-Proof.
-  intros. remember (tSort u) as t'. induction X.
-  - eauto.
-  - subst. eapply whnf_red1_sort in r. subst. eauto.
-    eapply whnf_pres; eauto.
-Qed.
-
-Lemma whnf_red1_prod Σ Γ t na t1 t2 :
-  whnf RedFlags.default Σ Γ t ->
-  red1 Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
-Proof.
-  intros. remember (tProd na t1 t2) as t'. 
-  induction X using red1_ind_all.
-  all: repeat match goal with
-         | [ H : whnf _ _ _ (?f ?a) |- _ ] => depelim H
-         | [ H : whne _ _ _ (?f ?a)|- _ ] => depelim H
-         end.
-  all:try (cbn in *; congruence).
-  all:do 2 help.
-  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
-  - eapply (f_equal decompose_app) in x;
-      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
-    inv x. rewrite H2 in H. inv H.
-    destruct args0 using rev_ind; cbn in *.
-    destruct narg; inv H0.
-    rewrite mkApps_snoc in  Heqt'. congruence.
-  - rewrite <- mkApps_nested in Heqt'. inv Heqt'.
-  - eapply (f_equal decompose_app) in x;
-      rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
-    inv x. rewrite H1 in H. inv H.
-    destruct args0 using rev_ind; cbn in *.
-    unfold is_constructor in H2. rewrite H0 in H2. congruence.
-    rewrite mkApps_snoc in  Heqt'. congruence.
-  - eapply whne_mkApps_inv in H. destruct H; try firstorder congruence. depelim H. help. firstorder.
-  - inv Heqt'. eauto.
-  - inv Heqt'. eauto.
-Qed.
-
-Lemma whnf_red_prod Σ Γ t na t1 t2 :
-  whnf RedFlags.default Σ Γ t ->
-  red Σ Γ t (tProd na t1 t2) -> exists t1 t2, t = tProd na t1 t2.
-Proof.
-  intros. remember (tProd na t1 t2) as t'. revert t1 t2 Heqt'. induction X; intros.
-  - eauto.
-  - subst. eapply whnf_red1_prod in r as (? & ? & ?). subst. eauto.
-    eapply whnf_pres; eauto.
-Qed.
+  - eapply IHForall. eauto.
+Qed.  
+ *)

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -1489,8 +1489,8 @@ Section Rho.
   Lemma isConstruct_app_rename r t :
     isConstruct_app t = isConstruct_app (rename r t).
   Proof.
-    unfold isConstruct_app. unfold decompose_app. generalize (nil term) at 1.
-    change (nil term) with (map (rename r) []). generalize (nil term).
+    unfold isConstruct_app. unfold decompose_app. generalize (@nil term) at 1.
+    change (@nil term) with (map (rename r) []). generalize (@nil term).
     induction t; simpl; auto.
     intros l l0. specialize (IHt1 (t2 :: l) (t2 :: l0)).
     now rewrite IHt1.

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -1432,7 +1432,7 @@ Proof.
       * apply red1_red.
         rewrite simpl_lift; cbn; try lia.
         assert (n = i) by lia; subst. now constructor.
-      * enough (nth_error (nil term) n0 = None) as ->;
+      * enough (nth_error (@nil term) n0 = None) as ->;
           [cbn|now destruct n0].
         enough (i <=? n - 1 = true) as ->; try (apply Nat.leb_le; lia).
         enough (S (n - 1) = n) as ->; try lia. auto.

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -25,7 +25,7 @@ Qed.
 
 Lemma equiv_reflectT P (b : bool) : (P -> b) -> (b -> P) -> reflectT P b.
 Proof.
-  intros. destruct b; constructor; auto. intro. now discriminate H.
+  intros. destruct b; constructor; auto.
 Qed.
 
 Lemma reflectT_subrelation {A} {R} {r : A -> A -> bool} : (forall x y, reflectT (R x y) (r x y)) -> CRelationClasses.subrelation R r.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -527,7 +527,7 @@ Lemma to_extended_list_k_subst n k c k' :
   to_extended_list_k (subst_context n k c) k' = to_extended_list_k c k'.
 Proof.
   unfold to_extended_list_k. revert k'.
-  unf_term. generalize (nil term) at 1 2.
+  unf_term. generalize (@nil term) at 1 2.
   induction c in n, k |- *; simpl; intros. 1: reflexivity.
   rewrite subst_context_snoc. unfold snoc. simpl.
   destruct a. destruct decl_body.
@@ -827,7 +827,7 @@ Lemma map_subst_instance_constr_to_extended_list_k u ctx k :
 Proof.
   unfold to_extended_list_k.
   cut (map (subst_instance_constr u) [] = []); [|reflexivity].
-  unf_term. generalize (nil term); intros l Hl.
+  unf_term. generalize (@nil term); intros l Hl.
   induction ctx in k, l, Hl |- *; cbnr.
   destruct a as [? [] ?]; cbnr; eauto.
   unf_term. eapply IHctx; cbn; congruence.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -979,7 +979,7 @@ Proof.
   unfold isConstruct_app.
   assert (HH: (decompose_app (subst_instance_constr u t)).1
               = subst_instance_constr u (decompose_app t).1). {
-    unfold decompose_app. generalize (nil term) at 1. generalize (nil term).
+    unfold decompose_app. generalize (@nil term) at 1. generalize (@nil term).
     induction t; cbn; try reflexivity.
     intros l l'. erewrite IHt1; reflexivity. }
   rewrite HH. destruct (decompose_app t).1; reflexivity.
@@ -1227,7 +1227,7 @@ Lemma subst_instance_instantiate_params u0 params pars ty :
                        (subst_instance_constr u0 ty).
 Proof.
   unfold instantiate_params.
-  change (nil term) with (map (subst_instance_constr u0) []) at 2.
+  change (@nil term) with (map (subst_instance_constr u0) []) at 2.
   rewrite rev_subst_instance_context.
   rewrite <- subst_instance_instantiate_params_subst.
   destruct ?; cbnr. destruct p; cbn.
@@ -1272,7 +1272,7 @@ Lemma subst_instance_to_extended_list u l
 Proof.
   - unfold to_extended_list, to_extended_list_k.
     change [] with (map (subst_instance_constr u) []) at 2.
-    unf_term. generalize (nil term), 0. induction l as [|[aa [ab|] ac] bb].
+    unf_term. generalize (@nil term), 0. induction l as [|[aa [ab|] ac] bb].
     + reflexivity.
     + intros l n; cbn. now rewrite IHbb.
     + intros l n; cbn. now rewrite IHbb.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -549,7 +549,7 @@ Lemma to_extended_list_lift n k c :
   to_extended_list (lift_context n k c) = to_extended_list c.
 Proof.
   unfold to_extended_list, to_extended_list_k. generalize 0.
-  unf_term. generalize (nil term) at 1 2.
+  unf_term. generalize (@nil term) at 1 2.
   induction c in n, k |- *; simpl; intros. 1: reflexivity.
   rewrite -> lift_context_snoc0. unfold snoc. simpl.
   destruct a. destruct decl_body.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1119,43 +1119,43 @@ Section Reduce.
     refine (reduce_stack_sound _ _ ε _).
   Qed.
 
-  (* Potentially hard? Ok with SN? *)
-  Lemma Ind_canonicity :
-    forall Γ ind uni args t,
-      Σ ;;; Γ |- t : mkApps (tInd ind uni) args ->
-      RedFlags.iota flags ->
-      let '(u,l) := decompose_app t in
-      (isLambda u -> l = []) ->
-      whnf flags Σ Γ u ->
-      discr_construct u ->
-      whne flags Σ Γ u.
-  Proof.
-    intros Γ ind uni args t ht hiota.
-    case_eq (decompose_app t).
-    intros u l e hl h d.
-    induction h.
-    - assumption.
-    - apply decompose_app_inv in e. subst.
-      (* Inversion on ht *)
-      admit.
-    - apply decompose_app_inv in e. subst.
-      (* Inversion on ht *)
-      admit.
-    - cbn in hl. specialize (hl eq_refl). subst.
-      apply decompose_app_inv in e. subst. cbn in ht.
-      (* Inversion on ht *)
-      admit.
-    - apply decompose_app_eq_mkApps in e. subst.
-      cbn in d. simp discr_construct in d. easy.
-    - apply decompose_app_inv in e. subst.
-      (* Inversion on ht *)
-      admit.
-    - apply decompose_app_inv in e. subst.
-      (* Not very clear now.
-         Perhaps we ought to show whnf of the mkApps entirely.
-         And have a special whne case for Fix that don't reduce?
-       *)
-  Abort.
+  (* (* Potentially hard? Ok with SN? *) *)
+  (* Lemma Ind_canonicity : *)
+  (*   forall Γ ind uni args t, *)
+  (*     Σ ;;; Γ |- t : mkApps (tInd ind uni) args -> *)
+  (*     RedFlags.iota flags -> *)
+  (*     let '(u,l) := decompose_app t in *)
+  (*     (isLambda u -> l = []) -> *)
+  (*     whnf flags Σ Γ u -> *)
+  (*     discr_construct u -> *)
+  (*     whne flags Σ Γ u. *)
+  (* Proof. *)
+  (*   intros Γ ind uni args t ht hiota. *)
+  (*   case_eq (decompose_app t). *)
+  (*   intros u l e hl h d. *)
+  (*   induction h. *)
+  (*   - assumption. *)
+  (*   - apply decompose_app_inv in e. subst. *)
+  (*     (* Inversion on ht *) *)
+  (*     admit. *)
+  (*   - apply decompose_app_inv in e. subst. *)
+  (*     (* Inversion on ht *) *)
+  (*     admit. *)
+  (*   - cbn in hl. specialize (hl eq_refl). subst. *)
+  (*     apply decompose_app_inv in e. subst. cbn in ht. *)
+  (*     (* Inversion on ht *) *)
+  (*     admit. *)
+  (*   - apply decompose_app_eq_mkApps in e. subst. *)
+  (*     cbn in d. simp discr_construct in d. easy. *)
+  (*   - apply decompose_app_inv in e. subst. *)
+  (*     (* Inversion on ht *) *)
+  (*     admit. *)
+  (*   - apply decompose_app_inv in e. subst. *)
+  (*     (* Not very clear now. *)
+  (*        Perhaps we ought to show whnf of the mkApps entirely. *)
+  (*        And have a special whne case for Fix that don't reduce? *)
+  (*      *) *)
+  (* Abort. *)
 
   Scheme Acc_ind' := Induction for Acc Sort Prop.
 

--- a/template-coq/theories/utils/All_Forall.v
+++ b/template-coq/theories/utils/All_Forall.v
@@ -242,7 +242,7 @@ Lemma All_app_inv {A} (P : A -> Type) l l' : All P l -> All P l' -> All P (l ++ 
 Proof.
   intros Hl Hl'. induction Hl. apply Hl'.
   constructor; intuition auto.
-Qed.
+Defined.
 
 Lemma All_mix {A} {P : A -> Type} {Q : A -> Type} {l} :
   All P l -> All Q l -> All (fun x => (P x * Q x)%type) l.
@@ -812,10 +812,12 @@ Qed.
 Lemma nth_error_all {A} {P : A -> Type} {l : list A} {n x} :
   nth_error l n = Some x -> All P l -> P x.
 Proof.
-  intros Hnth HPl. induction HPl in n, Hnth |- *. destruct n; discriminate.
-  revert Hnth. destruct n. now intros [= ->].
-  intros H'; eauto.
-Qed.
+  intros Hnth HPl. 
+  induction l in n, Hnth, HPl |- *. destruct n; discriminate.
+  destruct n; cbn in Hnth.
+  - inversion Hnth. subst. inversion HPl. eauto.
+  - eapply IHl. eassumption. inversion HPl. eassumption.
+Defined.
 
 Lemma nth_error_alli {A} {P : nat -> A -> Type} {l : list A} {n x} {k} :
   nth_error l n = Some x -> Alli P k l -> P (k + n) x.

--- a/template-coq/theories/utils/MCList.v
+++ b/template-coq/theories/utils/MCList.v
@@ -789,6 +789,13 @@ Section ListSize.
     rewrite rev_cons list_size_app IHl; cbn; lia.
   Qed.
 
+  Lemma list_size_length (l : list A)
+    : list_size l >= length l.
+  Proof.
+    induction l; simpl; lia.
+  Qed.    
+
+
 End ListSize.
 
 Section ListSizeMap.


### PR DESCRIPTION
This branch has

- a hopefully correct definition of `whnf` in `PCUICNormal.v`
- `whnf_dec`, an executable decider for `whnf`
- an updated erasure function in `ErasureFunction.v` (i.e. erasure based on type inference) now using `whnf_dec`
- an admitted proof that `whnf` is preserved by reduction in `PCUICNormal.v`

Correctness of erasure only depends on this preservation proof, nothing else (the cofix case is unproved though). Before it didn't depend on anything, but was also relatively incomplete (i.e. on many many terms would just say "can't erase").