### PR TITLE
Complete safe erasure

### DIFF
--- a/erasure/src/g_metacoq_erasure.mlg
+++ b/erasure/src/g_metacoq_erasure.mlg
@@ -39,9 +39,7 @@ let check env evm c =
       (SafeTemplateErasure.erase_and_print_template_program checker_flags)
       term
   in
-  match erase with
-  | Coq_inl s -> Feedback.msg_info (pr_char_list s)
-  | Coq_inr s -> CErrors.user_err ~hdr:"metacoq" (pr_char_list s)
+  Feedback.msg_info (pr_char_list erase)
 }
 
 VERNAC COMMAND EXTEND MetaCoqErase CLASSIFIED AS QUERY

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -96,7 +96,7 @@ Section print_term.
                                 ^ " => " ^ print_term (vass na' :: Γ) true false body)
   | tLetIn na def body =>
     let na' := fresh_name Γ na t in
-    parens top ("let" ^ string_of_name na' ^
+    parens top ("let " ^ string_of_name na' ^
                       " := " ^ print_term Γ true false def ^ " in " ^ nl ^
                       print_term (vdef na' def :: Γ) true false body)
   | tApp f l =>

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -4,7 +4,7 @@ From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICTyping PCUICLiftSubst PCUICInversion PCUICConfluence PCUICConversion 
      PCUICCumulativity PCUICSR PCUICNormal PCUICSafeLemmata
-     PCUICValidity PCUICPrincipality PCUICElimination PCUICSN.
+     PCUICValidity PCUICPrincipality PCUICElimination PCUICSN PCUICNormal.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker.
 Require Import EArities Extract Prelim EDeps.
 
@@ -104,8 +104,6 @@ Proof.
     + cbn. edestruct IHL as (? & ? & ?).
       rewrite e. eauto.
 Qed.
-
-Require Import MetaCoq.PCUIC.PCUICNormal.
 
 Notation err := (TypeError  (Msg "hnf did not return normal form")).
 Program Definition reduce_to_sort' Γ t (h : wellformed Σ Γ t)

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -197,7 +197,7 @@ Definition erases_one_inductive_body (Σ : global_env_ext) (npars : nat) (aritie
 Definition erases_mutual_inductive_body (Σ : global_env_ext) (mib : mutual_inductive_body) (mib' : E.mutual_inductive_body) :=
   let bds := mib.(ind_bodies) in
   let arities := arities_context bds in
-  Forall2 (erases_one_inductive_body Σ mib.(ind_npars) arities) bds (mib'.(E.ind_bodies)) /\
+  Forall2 (erases_one_inductive_body Σ #|ind_params mib| arities) bds (mib'.(E.ind_bodies)) /\
   mib.(ind_npars) = mib'.(E.ind_npars).
 
 Inductive erases_global_decls : global_env -> E.global_declarations -> Prop :=

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -44,6 +44,6 @@ Cd "src".
 
 Separate Extraction ErasureFunction.erase SafeTemplateErasure
          (* The following directives ensure separate extraction does not produce name clashes *)
-         String utils Template.UnivSubst ELiftSubst ETyping.
+         Coq.Strings.String utils Template.UnivSubst ELiftSubst ETyping.
 
 Cd "..".

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -224,6 +224,19 @@ Local Ltac sq :=
          | H : ∥ _ ∥ |- _ => destruct H
          end; try eapply sq.
 
+Lemma nIs_conv_to_Arity_isWfArity_elim {Σ : global_env_ext} {Γ x} : 
+  ~ Is_conv_to_Arity Σ Γ x ->
+  isWfArity typing Σ Γ x ->
+  False.
+Proof.
+  intros nis [ctx [s [da wf]]]. apply nis.
+  red. exists (it_mkProd_or_LetIn ctx (tSort s)).
+  split. sq. apply PCUICArities.destArity_spec_Some in da.
+  simpl in da. subst x.
+  reflexivity.
+  now eapply it_mkProd_isArity.
+Qed.
+
 Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (t : PCUICAst.term) (Ht : welltyped Sigma Gamma t) :
   typing_result ({∥isErasable Sigma Gamma t∥} +{∥(isErasable Sigma Gamma t -> False)∥}) :=
   let T := @type_of extraction_checker_flags Sigma _ _ Gamma t Ht in
@@ -268,8 +281,8 @@ Next Obligation.
   destruct infer as [x [[Htx Hp]]]. simpl.
   simpl in *.
   eapply validity in Htx as [|]; auto.
-  todo "~ Is_conv_to_Arity pat -> isWfArity pat -> False".
-  destruct i as [s Hs]. econstructor; eauto.
+  - elim (nIs_conv_to_Arity_isWfArity_elim H i).
+  - destruct i as [s Hs]. econstructor; eauto.
 Qed.
 Next Obligation.
   sq. apply w.
@@ -301,30 +314,13 @@ Next Obligation.
   intros (? & ? & ?).
   destruct s as [ | (? & ? & ?)]; simpl in *.
   + destruct H. eapply arity_type_inv; eauto using typing_wf_local.
-  + specialize (c0 _ t2). eapply principal_typing in X2 as (? & ? & ? &?). 2:eauto. 2:exact t0.
-    eapply cumul_prop1 in c; eauto.
-    eapply cumul_prop2 in c0; eauto.
-
+  + pose proof (c0 _ t2).
     eapply type_reduction in X0; eauto.
-
-    eapply principal_typing in c0 as (? & ? & ? & ?). 2:eauto. 2:{ exact X0. }
-
-    eapply cumul_prop1 in c; eauto.
-
-    destruct (invert_cumul_sort_r _ _ _ _ c0) as (? & ? & ?).
-    destruct (invert_cumul_sort_r _ _ _ _ c1) as (? & ? & ?).
-    eapply red_confluence in r as (? & ? & ?); eauto.
-
-    eapply invert_red_sort in r.
-    eapply invert_red_sort in r1. subst. inv r1.
-
-    eapply leq_universe_prop in l0; auto.
-    eapply leq_universe_prop_no_prop_sub_type in l; auto.
-    intuition eauto.
-
-    2:reflexivity. now right; exists x0.
-    now apply PCUICValidity.validity in X1.
-    now apply PCUICValidity.validity in t2.
+    eapply cumul_prop1 in t3; eauto.
+    eapply leq_term_prop_sorted_l in X0; eauto.
+    2:reflexivity.
+    2:eapply validity; eauto.
+    eapply leq_universe_prop in X0; auto. congruence.
 Qed.
 
 (* Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (HΓ : ∥wf_local Sigma Gamma∥) (t : PCUICAst.term) : *)
@@ -449,6 +445,16 @@ Section Erase.
 
   End EraseMfix.
 
+  (* Bug in equationa: it produces huge goals leading to stack overflow if we
+    don't try reflexivity here. *)
+  Ltac Equations.Prop.DepElim.solve_equation c ::= 
+    intros; try reflexivity; try Equations.Prop.DepElim.simplify_equation c;
+     try
+	  match goal with
+    | |- ImpossibleCall _ => DepElim.find_empty
+    | _ => try red; try reflexivity || discriminates
+    end.
+
   Equations(noind) erase (Γ : context) (t : term) (Ht : welltyped Σ Γ t) : typing_result E.term :=
     erase Γ t Ht with (is_erasable Σ HΣ Γ t Ht) :=
     {
@@ -457,43 +463,43 @@ Section Erase.
       erase Γ (tRel i) Ht _ := ret (E.tRel i) ;
       erase Γ (tVar n) Ht _ := ret (E.tVar n) ;
       erase Γ (tEvar m l) Ht _ := l' <- monad_map (fun x => erase Γ x _) l;; ret (E.tEvar m l') ;
-      erase Γ (tSort u) Ht _ := ret E.tBox
+      erase Γ (tSort u) Ht _ := ret E.tBox ;
 
-      ; erase Γ (tConst kn u) Ht _ := ret (E.tConst kn)
-      ; erase Γ (tInd kn u) Ht _ := ret E.tBox
-      ; erase Γ (tConstruct kn k u) Ht _ := ret (E.tConstruct kn k)
-      ; erase Γ (tProd na b t) Ht _ := ret E.tBox
-      ; erase Γ (tLambda na b t) Ht _ :=
-                           t' <- erase (vass na b :: Γ) t _;;
-                              ret (E.tLambda na t')
-      ; erase Γ (tLetIn na b t0 t1) Ht _ :=
-                              b' <- erase Γ b _;;
-                                 t1' <- erase (vdef na b t0 :: Γ) t1 _;;
-                                 ret (E.tLetIn na b' t1')
-      ; erase Γ (tApp f u) Ht _ :=
-                     f' <- erase Γ f _;;
-                     l' <- erase Γ u _;;
-                     ret (E.tApp f' l')
-      ; erase Γ (tCase ip p c brs) Ht _ :=
-          c' <- erase Γ c _;;
-          if is_box c' then
-            match brs with
-            | (a, b) :: brs => b' <- erase Γ b _ ;; ret (E.mkApps b' (repeat E.tBox a))
-            | [] => ret (E.tCase ip c' [])
-            end
-          else
-            brs' <- monad_map (T :=typing_result) (fun x => x' <- erase Γ (snd x) _;; ret (fst x, x')) brs;;
-            ret (E.tCase ip c' brs')
-      ; erase Γ (tProj p c) Ht _ :=
-          c' <- erase Γ c _;;
-          if is_box c' then ret (E.tBox) else
-          ret (E.tProj p c')
-      ; erase Γ (tFix mfix n) Ht _ :=
-          mfix' <- erase_mfix erase Γ mfix;;
-          ret (E.tFix mfix' n)
-      ; erase Γ (tCoFix mfix n) Ht _ :=
-                          mfix' <- erase_mfix (erase) Γ mfix;;
-                                ret (E.tCoFix mfix' n)
+      erase Γ (tConst kn u) Ht _ := ret (E.tConst kn) ;
+      erase Γ (tInd kn u) Ht _ := ret E.tBox ;
+      erase Γ (tConstruct kn k u) Ht _ := ret (E.tConstruct kn k) ;
+      erase Γ (tProd na b t) Ht _ := ret E.tBox ;
+      erase Γ (tLambda na b t) Ht _ :=
+        t' <- erase (vass na b :: Γ) t _;;
+        ret (E.tLambda na t');
+      erase Γ (tLetIn na b t0 t1) Ht _ :=
+        b' <- erase Γ b _;;
+        t1' <- erase (vdef na b t0 :: Γ) t1 _;;
+        ret (E.tLetIn na b' t1') ;
+      erase Γ (tApp f u) Ht _ :=
+        f' <- erase Γ f _;;
+        l' <- erase Γ u _;;
+        ret (E.tApp f' l');
+      erase Γ (tCase ip p c brs) Ht _ :=
+        c' <- erase Γ c _;;
+        if is_box c' then
+          match brs with
+          | (a, b) :: brs => b' <- erase Γ b _ ;; ret (E.mkApps b' (repeat E.tBox a))
+          | [] => ret (E.tCase ip c' [])
+          end
+        else
+          brs' <- monad_map (T :=typing_result) (fun x => x' <- erase Γ (snd x) _;; ret (fst x, x')) brs;;
+          ret (E.tCase ip c' brs') ;
+      erase Γ (tProj p c) Ht _ :=
+        c' <- erase Γ c _;;
+        if is_box c' then ret (E.tBox) else
+        ret (E.tProj p c') ;
+      erase Γ (tFix mfix n) Ht _ :=
+        mfix' <- erase_mfix erase Γ mfix;;
+        ret (E.tFix mfix' n);
+      erase Γ (tCoFix mfix n) Ht _ :=
+        mfix' <- erase_mfix (erase) Γ mfix;;
+        ret (E.tCoFix mfix' n)
     }.
   Next Obligation. todo "monad_map enhancement for erasing lists". Qed.
   Next Obligation.
@@ -520,6 +526,26 @@ Opaque wf_reduction.
 Arguments iswelltyped {cf Σ Γ t A}.
 Hint Constructors typing erases : core.
 
+Lemma isType_isErasable Σ Γ T : isType Σ Γ T -> isErasable Σ Γ T.
+Proof.
+  intros [s Hs].
+  exists (tSort s). intuition auto. left; simpl; auto.
+Qed.
+Require Import PCUICGeneration.
+(* 
+Lemma isWAT_isErasable Σ Γ T : isWfArity_or_Type Σ Γ T -> isErasable Σ Γ T.
+Proof.
+  intros [|]. destruct i as [ctx [s [da wf]]].
+  generalize (PCUICArities.destArity_spec_Some [] T ctx s).
+  rewrite da.
+  intros Ha. specialize (Ha eq_refl).
+  simpl in Ha; subst T.
+  red.
+
+  exists (tSort s). intuition auto. left; simpl; auto.
+Qed. *)
+
+
 Lemma erases_erase (Σ : global_env_ext) Γ t T (wfΣ : ∥wf_ext Σ∥) t' :
   Σ ;;; Γ |- t : T ->
                  forall (wt : welltyped Σ Γ t),
@@ -542,7 +568,7 @@ Proof.
        forall (wt : welltyped Σ Γ t) (t' : E.term) (wfΣ' : ∥ wf_ext Σ ∥),
   erase Σ wfΣ' Γ t wt = Checked t' -> Σ;;; Γ |- t ⇝ℇ t'
          )
-         (fun Σ Γ wfΓ => wf_local Σ Γ)); intros; auto.
+         (fun Σ Γ wfΓ => wf_local Σ Γ)); intros; auto; clear Σ w; rename Σ0 into Σ.
 
   all:eauto.
 
@@ -557,16 +583,20 @@ Proof.
                                              end; sq; eauto).
 
   - repeat econstructor; eauto.
-  - econstructor. econstructor. clear E.
-    eapply inversion_Prod in X2 as (? & ? & ? & ? & ?) ; auto.
-    split. econstructor; eauto. left. econstructor.
-  - econstructor. eauto. econstructor. clear E.
-    eapply inversion_Ind in X1 as (? & ? & ? & ? & ? & ?) ; auto.
-    split. econstructor; eauto. left. subst.
+  - econstructor. eapply isType_isErasable.
+    eexists. econstructor; eauto.
+
+  - econstructor.
+    clear E.
+    eapply inversion_Ind in t as (? & ? & ? & ? & ? & ?) ; auto.
+    red. eexists. split. econstructor; eauto. left.
     eapply isArity_subst_instance.
     eapply isArity_ind_type; eauto.
-  - admit.
-  - admit.
+  - specialize (H4 _ _ _ E1).
+    econstructor; eauto.
+    eapply elim_restriction_works; eauto.
+    intros isp. eapply isErasable_Proof in isp. eauto.
+  - specialize (H4 _ _ _ E1). admit.
   - admit.
   - admit.
   - admit.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -226,11 +226,11 @@ Local Ltac sq :=
 
 Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (t : PCUICAst.term) (Ht : welltyped Sigma Gamma t) :
   typing_result ({∥isErasable Sigma Gamma t∥} +{∥(isErasable Sigma Gamma t -> False)∥}) :=
-  mlet (T; _) <- @type_of extraction_checker_flags Sigma _ _ Gamma t Ht ;;
+  mlet T <- @type_of extraction_checker_flags Sigma _ _ Gamma t Ht ;;
   mlet b <- is_arity Sigma _ Gamma _ T _ ;;
   if b : {_} + {_} then
     ret (left _)
-  else mlet (K; _) <- @type_of extraction_checker_flags Sigma _ _ Gamma T _ ;;
+  else mlet K <- @type_of extraction_checker_flags Sigma _ _ Gamma T _ ;;
        mlet (u;_) <- @reduce_to_sort _ Sigma _ Gamma K _ ;;
       match Universe.is_prop u with true => ret (left _) | false => ret (right _) end
 .

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -226,11 +226,11 @@ Local Ltac sq :=
 
 Program Definition is_erasable (Sigma : PCUICAst.global_env_ext) (HΣ : ∥wf_ext Sigma∥) (Gamma : context) (t : PCUICAst.term) (Ht : welltyped Sigma Gamma t) :
   typing_result ({∥isErasable Sigma Gamma t∥} +{∥(isErasable Sigma Gamma t -> False)∥}) :=
-  mlet T <- @type_of extraction_checker_flags Sigma _ _ Gamma t Ht ;;
+  let T := @type_of extraction_checker_flags Sigma _ _ Gamma t Ht in
   mlet b <- is_arity Sigma _ Gamma _ T _ ;;
   if b : {_} + {_} then
     ret (left _)
-  else mlet K <- @type_of extraction_checker_flags Sigma _ _ Gamma T _ ;;
+  else let K := @type_of extraction_checker_flags Sigma _ _ Gamma T _ in
        mlet (u;_) <- @reduce_to_sort _ Sigma _ Gamma K _ ;;
       match Universe.is_prop u with true => ret (left _) | false => ret (right _) end
 .
@@ -239,51 +239,69 @@ Next Obligation.
   sq. red in X. red in X. apply X.
 Qed.
 Next Obligation.
-  sq. apply X1.
+  sq. apply X.
 Qed.
 Next Obligation.
-  sq. eauto using typing_wf_local.
+  destruct Ht. sq. eauto using typing_wf_local.
 Qed.
 Next Obligation.
-  apply wat_wellformed. sq; auto.
-  sq; auto. now apply validity in X.
+  unfold type_of. destruct infer. simpl.
+  destruct s as [[Htx _]]. 
+  eapply typing_wellformed; eauto; sq; auto. apply X.
 Qed.
 Next Obligation.
+  unfold type_of in *.
+  destruct infer as [x [[Htx Hp]]].
   destruct H as [T' [redT' isar]].
   sq. econstructor. split. eapply type_reduction; eauto.
   eauto.
 Qed.
 Next Obligation.
-  sq. apply X1.
+  sq. apply w.
 Qed.
 Next Obligation.
-  sq. apply X1.
+  sq. apply w.
 Qed.
 Next Obligation.
-  sq. eapply validity in X as [validΣ|]; auto. (* contradiction *)
+  sq.
+  unfold type_of in *.
+  destruct infer as [x [[Htx Hp]]]. simpl.
+  simpl in *.
+  eapply validity in Htx as [|]; auto.
   todo "~ Is_conv_to_Arity pat -> isWfArity pat -> False".
   destruct i as [s Hs]. econstructor; eauto.
 Qed.
 Next Obligation.
-  sq. apply X2.
+  sq. apply w.
 Qed.
 Next Obligation.
-  sq. eapply typing_wellformed; eauto. sq; auto. sq; auto. apply X2.
+  sq.
+  unfold type_of.
+  destruct (infer _ (is_erasable_obligation_7 _ _ _ _ _ _ _)).
+  simpl. sq.
+  destruct X. eapply validity in t0; auto.
+  eapply wat_wellformed; eauto. sq; auto.
+  now sq.
 Qed.
 Next Obligation.
-  sq. red. eexists; split; eauto.
+  unfold type_of in *.
+  destruct (infer _ (is_erasable_obligation_7 _ _ _ _ _ _ _)).
+  destruct (infer _ (is_erasable_obligation_1 _ _)).
+  simpl in *.
+  destruct Ht.
+  sq. red. exists x0 ; split; intuition eauto.
   right. exists pat; split; eauto.
   eapply type_reduction; eauto using typing_wf_local.
 Qed.
 Next Obligation.
-  rename pat0 into T.
-  rename pat1 into K.
-  rename pat into u.
+  unfold type_of in *.
+  destruct (infer _ (is_erasable_obligation_7 _ _ _ _ _ _ _)) as [? [[? ?]]].
+  destruct (infer _ (is_erasable_obligation_1 _ _)) as [? [[? ?]]].
   sq.
   intros (? & ? & ?).
-  destruct s as [ | (? & ? & ?)].
+  destruct s as [ | (? & ? & ?)]; simpl in *.
   + destruct H. eapply arity_type_inv; eauto using typing_wf_local.
-  + eapply principal_typing in X2 as (? & ? & ? &?). 2:eauto. 2:exact t0.
+  + specialize (c0 _ t2). eapply principal_typing in X2 as (? & ? & ? &?). 2:eauto. 2:exact t0.
     eapply cumul_prop1 in c; eauto.
     eapply cumul_prop2 in c0; eauto.
 

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -2,13 +2,16 @@
 From Coq Require Import Program.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
-     PCUICTyping PCUICInversion
+     PCUICTyping PCUICInversion PCUICGeneration
      PCUICConfluence PCUICConversion 
      PCUICCumulativity PCUICSR PCUICSafeLemmata
      PCUICValidity PCUICPrincipality PCUICElimination PCUICSN.
-From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker
-     PCUICSafeRetyping.
-From MetaCoq.Erasure Require Import EArities Extract Prelim.
+From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker PCUICSafeRetyping.
+From MetaCoq.Erasure Require Import EArities Extract Prelim ErasureCorrectness.
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Import MonadNotation.
 
 From Equations Require Import Equations.
 
@@ -25,10 +28,7 @@ Extract Constant time =>
               temp)". *)
 
 Set Equations Transparent.
-
 Local Set Keyed Unification.
-
-
 
 Section fix_sigma.
 Local Existing Instance extraction_checker_flags.
@@ -520,7 +520,6 @@ Section Erase.
 End Erase.
 
 Local Arguments bind _ _ _ _ ! _.
-From MetaCoq Require Import ErasureCorrectness.
 
 Opaque wf_reduction.
 Arguments iswelltyped {cf Σ Γ t A}.
@@ -531,7 +530,6 @@ Proof.
   intros [s Hs].
   exists (tSort s). intuition auto. left; simpl; auto.
 Qed.
-Require Import PCUICGeneration.
 (* 
 Lemma isWAT_isErasable Σ Γ T : isWfArity_or_Type Σ Γ T -> isErasable Σ Γ T.
 Proof.

--- a/erasure/theories/SafeTemplateErasure.v
+++ b/erasure/theories/SafeTemplateErasure.v
@@ -143,36 +143,26 @@ From MetaCoq.Erasure Require Import SafeErasureFunction.
 
 Program Definition erase_template_program (p : Ast.program)
   : EnvCheck (EAst.global_context * EAst.term) :=
-  let Σ := 
-    (* To get timing info, use 
-      SafeErasureFunction.time "Translating global environment to PCUIC" (fun _ => *)
-    (trans_global (Ast.empty_ext p.1)).1 in
-  t <- 
-  (* SafeErasureFunction.time "Erasing main term" (fun _ =>  *)
-  wrap_error (empty_ext Σ) ("During erasure of " ++ string_of_term (trans p.2)) 
-    (SafeErasureFunction.erase (empty_ext Σ) _ nil (trans p.2) _);;
-  Σ' <-
-  (* SafeErasureFunction.time "Erasing environment" (fun _ => *)
-   (SafeErasureFunction.erase_global (SafeErasureFunction.term_global_deps t) Σ _) ;;
+  let Σ := (trans_global (Ast.empty_ext p.1)).1 in
+  Σ' <- (SafeErasureFunction.erase_global Σ _) ;;
+  t <- wrap_error (empty_ext Σ) ("During erasure of " ^ string_of_term (trans p.2)) (SafeErasureFunction.erase (empty_ext Σ) _ nil (trans p.2) _);;
   ret (Monad:=envcheck_monad) (Σ', t).
 
 Next Obligation.
   unfold trans_global.
-  simpl. unfold wf_ext, empty_ext. simpl. 
-  unfold on_global_env_ext. constructor.
-  split; auto. simpl. todo "global env is correct".
-  simpl. todo "on_udecl empty".
-Qed.
+  simpl. unfold wf_ext, empty_ext. simpl.
+  unfold on_global_env_ext. constructor. todo "assuming wf environment".
+Defined.
 
 Next Obligation.
   unfold trans_global.
   simpl. unfold wf_ext, empty_ext. simpl.
-  unfold on_global_env_ext. todo "assuming well-typedness".
-Qed.
+  unfold on_global_env_ext. constructor. todo "assuming wf env".
+Defined.
 
 Next Obligation.
-  sq. todo "assuming wf env".
-Qed.
+  todo "assuming well-typedness".
+Defined.
 
 
 Local Open Scope string_scope.

--- a/erasure/theories/SafeTemplateErasure.v
+++ b/erasure/theories/SafeTemplateErasure.v
@@ -141,11 +141,11 @@ Program Fixpoint check_wf_env_only_univs (Σ : global_env)
 
 From MetaCoq.Erasure Require Import SafeErasureFunction.
 
-Program Definition erase_template_program (p : Ast.program)
+Program Definition erase_template_program (p : Ast.program) 
   : (EAst.global_context * EAst.term) :=
   let Σ := (trans_global (Ast.empty_ext p.1)).1 in
-  let Σ' := SafeErasureFunction.erase_global Σ _ in
   let t := SafeErasureFunction.erase (empty_ext Σ) _ nil (trans p.2) _ in
+  let Σ' := SafeErasureFunction.erase_global (term_global_deps t) Σ _ in
   (Σ', t).
 
 Next Obligation.
@@ -157,14 +157,11 @@ Defined.
 Next Obligation.
   unfold trans_global.
   simpl. unfold wf_ext, empty_ext. simpl.
-  unfold on_global_env_ext. constructor. todo "assuming wf env".
+  unfold on_global_env_ext. todo "assuming well-typedness".
 Defined.
-
 Next Obligation.
-  todo "assuming well-typedness".
+  constructor. todo "assuming wf environment".
 Defined.
-
-
 Local Open Scope string_scope.
 
 (** This uses the checker-based erasure *)

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -4,7 +4,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICTyping PCUICSubstitution PCUICEquality
      PCUICReduction PCUICCumulativity PCUICConfluence
      PCUICContextConversion PCUICConversion PCUICInversion PCUICUnivSubst
-     PCUICArities PCUICValidity PCUICInductives PCUICSR.
+     PCUICArities PCUICValidity PCUICInductives PCUICSR PCUICGeneration.
 
 Require Import ssreflect.
 Require Import Equations.Prop.DepElim.
@@ -105,183 +105,169 @@ Section Principality.
   Qed.
   Hint Extern 10 (isWfArity _ _ _ (tSort _)) => apply isWfArity_sort : pcuic.
 
-  Theorem principal_typing {Γ u A B} : Σ ;;; Γ |- u : A -> Σ ;;; Γ |- u : B ->
-    ∑ C, Σ ;;; Γ |- C <= A  ×  Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C.
+  Theorem principal_type {Γ u A} : Σ ;;; Γ |- u : A ->
+    ∑ C, Σ ;;; Γ |- u : C × forall B, Σ ;;; Γ |- u : B -> Σ ;;; Γ |- C <= B.
   Proof.
-    intros hA hB.
-    induction u in Γ, A, B, hA, hB |- * using term_forall_list_ind.
+    intros hA.
+    induction u in Γ, A, hA |- * using term_forall_list_ind.
     - apply inversion_Rel in hA as iA. 2: auto.
       destruct iA as [decl [? [e ?]]].
+      exists (lift0 (S n) (decl_type decl)).
+      split; [constructor|]; eauto.
+      intros B hB.
       apply inversion_Rel in hB as iB. 2: auto.
       destruct iB as [decl' [? [e' ?]]].
       rewrite e' in e. inversion e. subst. clear e.
-      repeat insum. repeat intimes.
       all: try eassumption.
-      constructor ; assumption.
     - apply inversion_Var in hA. destruct hA.
     - apply inversion_Evar in hA. destruct hA.
     - apply inversion_Sort in hA as iA. 2: auto.
+      destruct iA as (l & wf & inl & eqs & Ht).
+      exists (tSort (Universe.super l)); split.
+      subst s. econstructor; eauto.
+      intros B hB.
       apply inversion_Sort in hB as iB. 2: auto.
       repeat outsum. repeat outtimes. subst.
-      assert (x0 = x) as ee. {
-        clear -e. destruct x, x0; cbnr; invs e; reflexivity. }
+      assert (l = x) as ee. {
+        clear -e. destruct x, l; cbnr; invs e; reflexivity. }
       subst. repeat insum. repeat intimes; tea.
-      constructor ; assumption.
     - apply inversion_Prod in hA as [dom1 [codom1 iA]]; auto.
-      apply inversion_Prod in hB as [dom2 [codom2 iB]]=> //.
       repeat outsum. repeat outtimes.
       repeat pih.
-      destruct IHu1 as [dom Hdom].
-      destruct IHu2 as [codom Hcodom].
-      repeat outsum. repeat outtimes.
-      destruct (cumul_sort_confluence c3 c4) as [dom' [dom'dom [leq0 leq1]]].
-      destruct (cumul_sort_confluence c1 c2) as [codom' [codom'dom [leq0' leq1']]].
-      exists (tSort (Universe.sort_of_product dom' codom')).
-      repeat split.
-      + eapply cumul_trans. 1: auto. 2:eapply c0.
-        constructor. constructor.
-        apply leq_universe_product_mon; auto.
-      + eapply cumul_trans. 1: auto. 2:eapply c.
-        constructor. constructor.
-        apply leq_universe_product_mon; auto.
-      + eapply type_Prod.
-        * eapply type_Cumul; eauto.
-          -- left; eapply isWfArity_sort. now eapply typing_wf_local in t1.
-          -- eapply conv_cumul; auto.
-        * eapply type_Cumul; eauto.
-          -- left; eapply isWfArity_sort. now eapply typing_wf_local in t3.
-          -- eapply conv_cumul; auto.
+      specialize (IHu1 _ _ t).
+      specialize (IHu2 _ _ t0).
+      destruct IHu1 as [dom [Hdom Hdom']].
+      destruct IHu2 as [codom [Hcodom Hcodom']].
+      pose proof (Hdom' _ t).
+      
+      destruct (invert_cumul_sort_r _ _ _ _ X) as [u' [red leq]].
+      pose proof (Hcodom' _ t0).
+      destruct (invert_cumul_sort_r _ _ _ _ X0) as [u'' [red' leq']].
+      exists (tSort (Universe.sort_of_product u' u'')).
+      split; [econstructor; eauto|].
+      eapply type_Cumul; eauto. left; eexists _, _; intuition eauto. now eapply typing_wf_local.
+      now eapply red_cumul.
+      eapply type_Cumul; eauto. left; eexists _, _; intuition eauto. now eapply typing_wf_local.
+      now eapply red_cumul.
 
+      intros B hB.
+      apply inversion_Prod in hB as [dom2 [codom2 iB]]=> //.
+      repeat outtimes.
+      etransitivity; eauto.
+      specialize (Hdom' _ t1).
+      specialize (Hcodom' _ t2).
+      eapply invert_cumul_sort_r in Hdom' as (? & ? & ?).
+      eapply invert_cumul_sort_r in Hcodom' as (? & ? & ?).
+      destruct (red_confluence wfΣ red r) as [nf [redl redr]].
+      eapply invert_red_sort in redl.
+      eapply invert_red_sort in redr. subst. noconf redr.
+      destruct (red_confluence wfΣ red' r0) as [nf [redl redr]].
+      eapply invert_red_sort in redl.
+      eapply invert_red_sort in redr. subst. noconf redr.
+      constructor. constructor. now eapply leq_universe_product_mon.
+      
     - apply inversion_Lambda in hA => //.
-      apply inversion_Lambda in hB => //.
       repeat outsum. repeat outtimes.
+      specialize (IHu1 _ _ t) as [x' [Hdom Hdom']].
+      specialize (IHu2 _ _ t0) as [x0' [Hcodom Hcodom']].
+      exists (tProd n u1 x0').
+      split. econstructor; eauto.
+      intros B hB.
+      apply inversion_Lambda in hB => //.
       repeat pih.
       repeat outsum. repeat outtimes.
+      specialize (Hdom' _ t1). specialize (Hcodom' _ t2).
       apply invert_cumul_prod_l in c0 as [na' [A' [B' [[redA u1eq] ?]]]] => //.
       apply invert_cumul_prod_l in c as [na'' [A'' [B'' [[redA' u1eq'] ?]]]] => //.
-      exists (tProd n u1 x3).
-      repeat split; auto.
-      + eapply cumul_trans with (tProd na' A' B'); auto.
-        * eapply congr_cumul_prod => //.
-          eapply cumul_trans with x2 => //.
-        * now eapply red_cumul_inv.
-      + eapply cumul_trans with (tProd na'' A'' B''); auto.
-        * eapply congr_cumul_prod => //.
-          eapply cumul_trans with x0 => //.
-        * now eapply red_cumul_inv.
-      + eapply type_Lambda; eauto.
+      eapply cumul_trans with (tProd na' A' x2); auto.
+      * eapply congr_cumul_prod => //.
+      * eapply cumul_trans with (tProd na' A' B'); auto.
+        2:{ eapply cumul_red_l_inv; eauto. reflexivity. }
+        eapply congr_cumul_prod => //. reflexivity.
+        eapply cumul_conv_ctx; eauto. constructor; pcuic.
 
     - eapply inversion_LetIn in hA; auto.
-      eapply inversion_LetIn in hB; auto.
       destruct hA as [tty [bty ?]].
+      repeat outtimes.
+      specialize (IHu1 _ _ t0) as (u1' & tyu1 & Hu1).
+      specialize (IHu2 _ _ t) as (u1'' & tyu1' & Hu1').
+      specialize (IHu3 _ _ t1) as (u3' & tyu3' & Hu3').
+      exists (tLetIn n u1 u2 u3').
+      split. econstructor; eauto.
+      intros B hB. eapply inversion_LetIn in hB; auto.
       destruct hB as [tty' [bty' ?]].
       repeat outtimes.
-      specialize (IHu3 _ _ _ t4 t1) as [C' ?].
-      repeat outtimes.
-      exists (tLetIn n u1 u2 C'). repeat split.
-      + clear IHu1 IHu2.
-        eapply invert_cumul_letin_l in c0 => //.
-        eapply invert_cumul_letin_l in c => //.
-        eapply cumul_trans with (C' {0 := u1}). 1: auto.
-        * eapply red_cumul. eapply red_step.
-          -- econstructor.
-          -- auto.
-        * eapply cumul_trans with (bty {0 := u1}) => //.
-          eapply (substitution_cumul Σ Γ [vdef n u1 u2] []) => //.
-          -- constructor; auto.
-             ++ now eapply typing_wf_local in t3.
-             ++ red. exists tty' => //.
-          -- pose proof (cons_let_def Σ Γ [] [] n u1 u2).
-             rewrite !subst_empty in X. apply X. 1: constructor.
-             auto.
-      + clear IHu1 IHu2.
-        eapply invert_cumul_letin_l in c0 => //.
-        eapply invert_cumul_letin_l in c => //.
-        eapply cumul_trans with (C' {0 := u1}). 1: auto.
-        * eapply red_cumul. eapply red_step.
-          -- econstructor.
-          -- auto.
-        * eapply cumul_trans with (bty' {0 := u1}) => //.
-          eapply (substitution_cumul Σ Γ [vdef n u1 u2] []) => //.
-          -- constructor; auto.
-             ++ now eapply typing_wf_local in t3.
-             ++ red. exists tty' => //.
-          -- pose proof (cons_let_def Σ Γ [] [] n u1 u2).
-             rewrite !subst_empty in X. apply X. 1: constructor.
-             auto.
-      + eapply type_LetIn; eauto.
+      etransitivity; [|eassumption].
+      specialize (Hu3' _ t4).
+      now eapply cumul_LetIn_bo.
 
     - eapply inversion_App in hA as [na [dom [codom [tydom [tyarg tycodom]]]]] => //.
-      eapply inversion_App in hB as [na' [dom' [codom' [tydom' [tyarg' tycodom']]]]] => //.
-      specialize (IHu2 _ _ _ tyarg tyarg').
-      specialize (IHu1 _ _ _ tydom tydom').
-      destruct IHu1, IHu2.
-      repeat outtimes.
-      apply invert_cumul_prod_r in c1 as [? [A' [B' [[redA u1eq] ?]]]] => //.
-      apply invert_cumul_prod_r in c2 as [? [A'' [B'' [[redA' u1eq'] ?]]]] => //.
+      specialize (IHu1 _ _ tydom) as (tyf & Htyfg & Hf).
+      specialize (IHu2 _ _ tyarg) as (tyarg' & Htyarg & Harg).
+      epose proof (Hf _ tydom).
+      epose proof (Harg _ tyarg).
+      apply invert_cumul_prod_r in X as [? [A' [B' [[redA u1eq] ?]]]] => //.
+      eapply type_reduction in Htyfg; eauto.
+      exists (subst1 u2 0 B').
+      split. econstructor; eauto.
+      eapply type_Cumul; auto. eapply Htyarg.
+      eapply validity in Htyfg; auto.
+      eapply isWAT_tProd in Htyfg; pcuic. auto.
+      etransitivity; eauto. now apply conv_cumul.
+      intros B hB.
+      eapply inversion_App in hB as [na' [dom' [codom' [tydom' [tyarg'' tycodom']]]]] => //.
+      specialize (Hf _ tydom').
+      specialize (Harg _ tyarg'').
+      apply invert_cumul_prod_r in Hf as [? [A'' [B'' [[redA' u1eq'] ?]]]] => //.
       destruct (red_confluence wfΣ redA redA') as [nfprod [redl redr]].
       eapply invert_red_prod in redl as [? [? [[? ?] ?]]] => //. subst.
       eapply invert_red_prod in redr as [? [? [[? ?] ?]]] => //. noconf e.
       assert(Σ ;;; Γ |- A' = A'').
-      { apply conv_trans with x3 => //.
+      { apply conv_trans with x1 => //.
         - now eapply red_conv.
         - apply conv_sym; auto.
       }
-      assert(Σ ;;; Γ ,, vass x1 A' |- B' = B'').
-      { apply conv_trans with x4 => //.
+      assert(Σ ;;; Γ ,, vass x0 A' |- B' = B'').
+      { apply conv_trans with x2 => //.
         - now eapply red_conv.
         - apply conv_sym; auto.
           eapply conv_conv_ctx; eauto.
           constructor; auto. 1: eapply conv_ctx_refl.
           constructor. now eapply conv_sym.
       }
-      exists (B' {0 := u2}).
-      repeat split.
-      + eapply cumul_trans with (codom {0 := u2}) => //.
-        eapply substitution_cumul0 => //. eapply c1.
-      + eapply cumul_trans with (B'' {0 := u2}); eauto.
-        * eapply substitution_cumul0 => //. eapply conv_cumul in X0; eauto.
-        * eapply cumul_trans with (codom' {0 := u2}) => //.
-          eapply substitution_cumul0 => //. eauto.
-      + eapply (type_App _ _ _ x1 A').
-        eapply type_Cumul.
-        * eapply t0.
-        * have v := validity_term wfΣ t0; auto.
-          eapply isWfArity_or_Type_red in v.
-          3:eapply redA. now apply v. auto.
-        * apply red_cumul; eauto.
-        * eapply type_Cumul. eauto.
-          have v := validity_term wfΣ t0; auto.
-          eapply isWfArity_or_Type_red in v.
-          3:eapply redA.
-          eapply isWAT_tProd in v as [HA' _].
-          right; apply HA'. all:auto. now apply typing_wf_local in tydom'.
-          transitivity A''; eauto. now apply conv_cumul.
-          apply conv_cumul. now symmetry.
+      eapply cumul_trans with (codom' {0 := u2}) => //.
+      eapply cumul_trans with (B'' {0 := u2}) => //.  
+      eapply substitution_cumul0 => //. eapply conv_cumul. eapply X1. 
+      eapply substitution_cumul0 => //. eapply c0.
 
     - eapply inversion_Const in hA as [decl ?] => //.
-      eapply inversion_Const in hB as [decl' ?] => //.
       repeat outtimes.
       exists (subst_instance_constr u (cst_type decl)).
-      red in d0, d. rewrite d0 in d.
-      change PCUICEnvironment.ConstantDecl with ConstantDecl in d.
-      noconf d.
-      repeat intimes; eauto.
-      eapply type_Const; eauto.
+      split. constructor; eauto.
+      intros B hB.
+      eapply inversion_Const in hB as [decl' ?] => //.
+      repeat outtimes.
+      red in d, d0. rewrite d in d0. noconf d0.
+      auto.
 
     - eapply inversion_Ind in hA as [mdecl [idecl [? [Hdecl ?]]]] => //.
-      eapply inversion_Ind in hB as [mdecl' [idecl' [? [Hdecl' ?]]]] => //.
       repeat outtimes.
       exists (subst_instance_constr u (ind_type idecl)).
-      red in Hdecl, Hdecl'. destruct Hdecl as [? ?].
+      split; [econstructor; eauto|].
+      intros B hB.
+      red in Hdecl. destruct Hdecl as [? ?].
+      eapply inversion_Ind in hB as [mdecl' [idecl' [? [Hdecl' ?]]]] => //.
+      repeat outtimes.
       destruct Hdecl' as [? ?]. red in H, H1.
       rewrite H1 in H; noconf H.
       rewrite H2 in H0; noconf H0.
       repeat intimes; eauto.
-      eapply type_Ind; eauto.
-      split; eauto.
 
     - eapply inversion_Construct in hA as [mdecl [idecl [? [? [Hdecl ?]]]]] => //.
+      repeat outtimes.
+      exists (type_of_constructor mdecl (i0, t, n0) (i, n) u).
+      split; [econstructor; eauto|].
+      intros b hB.
       eapply inversion_Construct in hB as [mdecl' [idecl' [? [? [Hdecl' ?]]]]] => //.
       repeat outtimes.
       red in Hdecl, Hdecl'.
@@ -290,13 +276,16 @@ Section Principality.
       red in H, H2. rewrite H2 in H. noconf H.
       rewrite H3 in H0. noconf H0.
       rewrite H4 in H1. noconf H1.
-      exists (type_of_constructor mdecl (i1, t0, n1) (i, n) u).
       repeat split; eauto.
-      eapply type_Construct; eauto. repeat split; eauto.
 
     - destruct p as [ind n].
       eapply inversion_Case in hA=>//.
-      eapply inversion_Case in hB=>//.
+      admit.
+
+    - admit.
+    - admit.
+    - admit.
+    (* eapply inversion_Case in hB=>//.
       repeat outsum. repeat outtimes. simpl in *.
       repeat outtimes.
       subst.
@@ -305,6 +294,12 @@ Section Principality.
       specialize (IHu1 _ _ _ t t1). clear t. eapply PCUICValidity.validity in t1.
       specialize (IHu2 _ _ _ t0 t2).
       repeat outsum. repeat outtimes.
+      eapply inversion_Case in hB=>//.
+      repeat outsum. repeat outtimes. simpl in *.
+      repeat outtimes.
+      subst.
+
+
       eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]]; auto.
       eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]]; auto.
       assert (All2 (fun a a' => Σ ;;; Γ |- a = a') x0 x7).
@@ -348,75 +343,15 @@ Section Principality.
       rewrite -e in e0.
       specialize (IHu _ _ _ t t1) as [C' [? [? ?]]].
       destruct (cumul_ind_confluence c1 c2) as [nfu [nfargs [[[conv convargs] convargs'] [ru ru']]]].
-      exists (subst0 (u :: List.rev nfargs) (subst_instance_constr nfu t2)).
-      assert(wfnf : PCUICGeneration.isWfArity_or_Type Σ Γ (mkApps (tInd ind nfu) nfargs)).
-      { eapply validity; eauto. eapply type_reduction; eauto. }
-      repeat split; auto.
-      + etransitivity; [|eapply c0].
-        eapply conv_cumul.
-        eapply (subst_conv _ (projection_context x5 x6 ind nfu)
-          (projection_context x5 x6 ind x4) []); auto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        eapply type_reduction; eauto. simpl.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        simpl; auto.
-        eapply validity; eauto.
-        constructor; auto. apply All2_rev. eapply All2_sym.
-        eapply (All2_impl convargs'). apply conv_sym.
-        eapply (wf_projection_context _ _ _ _ (ind, k, pars)); eauto.
-        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in wfnf.
-        destruct wfnf as [s Hs].
-        eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto.
-        eapply declp. now apply typing_wf_local in t0.
-        constructor.
-        apply PCUICUnivSubstitution.eq_term_upto_univ_subst_instance_constr;
-           try typeclasses eauto; auto.
-        todo "univs"%string.
-      + etransitivity; [|eapply c].
-        transitivity (subst0 (u :: List.rev nfargs) (subst_instance_constr x t2)).
-        todo "univs"%string.
-        eapply conv_cumul.
-        eapply (subst_conv _ (projection_context x5 x6 ind nfu)
-          (projection_context x5 x6 ind x) []); auto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        eapply type_reduction; eauto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        simpl; auto.
-        eapply validity; eauto.
-        constructor; auto. apply All2_rev. eapply All2_sym.
-        eapply (All2_impl convargs). apply conv_sym.
-        eapply (wf_projection_context _ _ _ _ (ind, k, pars)); eauto.
-        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in wfnf.
-        destruct wfnf as [s Hs].
-        eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto.
-        eapply declp. now apply typing_wf_local in t0.
-      + eapply refine_type.
-        * eapply type_Proj.
-          -- repeat split; eauto.
-          -- simpl. eapply type_Cumul.
-             1: eapply t0.
-             1: right.
-             2:eapply conv_cumul; eauto.
-             eapply type_reduction in t0; [|auto|apply conv].
-             eapply validity_term in t0; eauto. 
-             now apply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in t0.
-          -- rewrite H3. simpl. simpl in H0.
-             rewrite -H0. rewrite -(All2_length _ _ convargs). congruence.
-        * simpl. reflexivity.
+      exists (subst0 (u :: List.rev nfar*)
+  Admitted.
 
-    - pose proof (typing_wf_local hA).
-      apply inversion_Fix in hA as [decl [hguard [nthe [wfΓ [? [? ?]]]]]]=>//.
-      eapply inversion_Fix in hB as [decl' [hguard' [nthe' [wfΓ' [? [? ?]]]]]]=>//.
-      rewrite nthe' in nthe; noconf nthe.
-      exists (dtype decl); repeat split; eauto.
-      eapply type_Fix; eauto.
-
-    - pose proof (typing_wf_local hA).
-      eapply inversion_CoFix in hA as [decl [allow [nthe [wfΓ [? [? ?]]]]]]=>//.
-      eapply inversion_CoFix in hB as [decl' [allpw [nthe' [wfΓ' [? [? ?]]]]]]=>//.
-      rewrite nthe' in nthe; noconf nthe.
-      exists (dtype decl); repeat split; eauto.
-      eapply type_CoFix; eauto.
+  Theorem principal_typing {Γ u A B} : Σ ;;; Γ |- u : A -> Σ ;;; Γ |- u : B ->
+    ∑ C, Σ ;;; Γ |- C <= A  × Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C.
+  Proof.
+    intros hA hB.
+    destruct (principal_type hA) as [P [pty Hp]].
+    exists P; split; auto.
   Qed.
 
 End Principality.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -11,6 +11,16 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction PCUICLiftSubst
      PCUICCumulativity PCUICConversion PCUICConfluence PCUICArities
      PCUICWeakeningEnv.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker.
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Import monad_utils.MonadNotation.
+
+Derive NoConfusion for type_error.
+
+Set Equations With UIP.
+Set Equations Transparent.
+
+Add Search Blacklist "_graph_mut".
 
 Require Import ssreflect.
 
@@ -218,7 +228,8 @@ Section TypeOf.
         | ret None => ! }
   }.
   Proof.
-    all:destruct hΣ, Hφ; destruct wt as [T HT]; try clear infer.
+    all:try clear infer.
+    all:destruct hΣ, Hφ; destruct wt as [T HT].
     all:try solve [econstructor; eauto].
 
     - sq. destruct (nth_error Γ n) eqn:hnth => //.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -35,14 +35,6 @@ Proof.
 Qed.
 
 
-Derive NoConfusion for type_error.
-
-Set Equations With UIP.
-
-Add Search Blacklist "_graph_mut".
-
-Notation ret t := (exist t _).
-
 Definition well_sorted {cf:checker_flags} Σ Γ T := 
   ∥ ∑ s, Σ ;;; Γ |- T : tSort s ∥.
 
@@ -89,7 +81,8 @@ Section TypeOf.
   Context {cf : checker_flags}.
   Context (Σ : global_env_ext).
   Context (hΣ : ∥ wf Σ ∥) (Hφ : ∥ on_udecl Σ.1 Σ.2 ∥).
-  Context (G : universes_graph) (HG : is_graph_of_uctx G (global_ext_uctx Σ)).
+
+  Local Notation ret t := (exist t _).
 
   Section SortOf.
     Obligation Tactic := idtac.
@@ -126,7 +119,7 @@ Section TypeOf.
     end.
     Next Obligation. exact (todo "completeness"). Qed.
     Next Obligation. exact (todo "completeness"). Qed.
-  Check !.
+  
   
   Equations lookup_ind_decl ind : typing_result
         ({decl & {body & declared_inductive (fst Σ) decl ind body}}) :=
@@ -154,8 +147,6 @@ Section TypeOf.
   Qed.
 
   Obligation Tactic := idtac.
-  
-  Local Notation ret t := (exist t _).
 
   Equations? infer (Γ : context) (t : term) (wt : welltyped Σ Γ t) : principal_type Σ Γ t 
     by struct t :=

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -1,17 +1,38 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import config utils uGraph.
+
+Require Import Equations.Prop.DepElim.
+From Equations Require Import Equations.
+
+From Coq Require Import Bool String List Program.
+From MetaCoq.Template Require Import config monad_utils utils uGraph.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction PCUICLiftSubst
-     PCUICUnivSubst PCUICTyping PCUICSafeLemmata PCUICValidity.
+     PCUICUnivSubst PCUICTyping PCUICSafeLemmata PCUICSubstitution PCUICValidity
+     PCUICGeneration PCUICInversion PCUICValidity PCUICInductives PCUICSR
+     PCUICCumulativity PCUICConversion PCUICConfluence PCUICArities
+     PCUICWeakeningEnv.
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker.
 
-(** * Retyping
+Require Import ssreflect.
 
-  The [type_of] function provides a fast (and loose) type inference
-  function which assumes that the provided term is already well-typed in
-  the given context and recomputes its type. Only reduction (for
-  head-reducing types to uncover dependent products or inductives) and
-  substitution are costly here. No universe checking or conversion is done
-  in particular. *)
+
+Require Import PCUICAstUtils.
+Lemma cumul_Ind_Ind_inv {cf:checker_flags} {Σ : global_env_ext} Γ ind u args ind' u' args' : 
+  wf Σ ->
+  Σ ;;; Γ |- mkApps (tInd ind u) args <= mkApps (tInd ind' u') args' ->
+  eq_inductive ind ind' *
+  PCUICEquality.R_global_instance Σ (eq_universe Σ) (leq_universe Σ) (IndRef ind) #|args| u u' *
+  All2 (conv Σ Γ) args args'.
+Proof.
+  intros wfΣ cum.
+  eapply invert_cumul_ind_l in cum as [ui' [l' [redl [ru conv]]]]; auto.
+  eapply red_mkApps_tInd in redl as [args'' [eqind red']]; auto.
+  apply mkApps_eq_inj in eqind as [eq ->]=> //; auto. noconf eq.
+  intuition auto.
+  eapply eq_inductive_refl.
+  transitivity args''; auto.
+  eapply All2_symmetry. typeclasses eauto.
+  eapply (All2_impl red'). intros x y; apply red_conv.
+Qed.
 
 
 Derive NoConfusion for type_error.
@@ -19,6 +40,29 @@ Derive NoConfusion for type_error.
 Set Equations With UIP.
 
 Add Search Blacklist "_graph_mut".
+
+Notation ret t := (exist t _).
+
+Definition well_sorted {cf:checker_flags} Σ Γ T := 
+  ∥ ∑ s, Σ ;;; Γ |- T : tSort s ∥.
+
+
+(** * Retyping
+
+  The [infer] function provides a fast (and loose) type inference
+  function which assumes that the provided term is already well-typed in
+  the given context and recomputes its type. Only reduction (for
+  head-reducing types to uncover dependent products or inductives) and
+  substitution are costly here. No universe checking or conversion is done
+  in particular. *)
+
+Definition principal_type {cf:checker_flags} Σ Γ t := { T : term | ∥ (Σ ;;; Γ |- t : T) * (forall T', Σ ;;; Γ |- t : T' -> Σ ;;; Γ |- T <= T') ∥ }.
+Definition principal_sort {cf:checker_flags} Σ Γ T := { s : Universe.t | ∥ (Σ ;;; Γ |- T : tSort s) * (forall s', Σ ;;; Γ |- T : tSort s' -> leq_universe Σ s s') ∥ }.
+
+Definition principal_typed_type {cf:checker_flags} {Σ Γ t} (wt : principal_type Σ Γ t) := proj1_sig wt.
+Definition principal_sort_sort {cf:checker_flags} Σ Γ T (ps : principal_sort Σ Γ T) : Universe.t := proj1_sig ps.
+Coercion principal_typed_type : principal_type >-> term.
+Coercion principal_sort_sort : principal_sort >-> Universe.t.
 
 Section TypeOf.
   Context {cf : checker_flags}.
@@ -33,278 +77,492 @@ Section TypeOf.
     apply validity in H; auto. destruct H as [wfA | [s tyT]].
     right. constructor. auto. left. econstructor; eauto.
   Qed.
+End TypeOf.
 
+Lemma reduce_to_ind_complete {cf:checker_flags} {Σ : global_env_ext} (wfΣ : wf Σ) Γ ty wat e : 
+  reduce_to_ind (sq wfΣ) Γ ty wat = TypeError e ->  
+  (∑ ind u args, red Σ Γ ty (mkApps (tInd ind u) args)) -> False.
+Proof.
+Admitted.
+
+Section TypeOf.
+  Context {cf : checker_flags}.
+  Context (Σ : global_env_ext).
+  Context (hΣ : ∥ wf Σ ∥) (Hφ : ∥ on_udecl Σ.1 Σ.2 ∥).
+  Context (G : universes_graph) (HG : is_graph_of_uctx G (global_ext_uctx Σ)).
 
   Section SortOf.
-    Context (type_of : forall Γ t, welltyped Σ Γ t -> typing_result (∑ T, ∥ Σ ;;; Γ |- t : T ∥)).
-
-    Program Definition type_of_as_sort Γ t (wf : welltyped Σ Γ t) : typing_result Universe.t :=
-      tx <- type_of Γ t wf ;;
-      wfs <- @reduce_to_sort cf Σ hΣ Γ (projT1 tx) _ ;;
-      ret (m:=typing_result) (projT1 wfs).
-    Next Obligation. destruct X. now eapply typing_wellformed. Qed.
-
+    Obligation Tactic := idtac.
+    Program Definition infer_as_sort {Γ t} (wf : well_sorted Σ Γ t)
+      (tx : principal_type Σ Γ t) : principal_sort Σ Γ t :=
+      match @reduce_to_sort cf Σ hΣ Γ tx _ with
+      | Checked (u ; _) => u
+      | TypeError e => !
+      end.
+      
+    Next Obligation. intros Γ t [[s Hs]] [ty [[Hty Hp]]]; simpl.
+      eapply typing_wellformed; eauto. Defined.
+    Next Obligation. intros Γ t ws [s [[Hs Hp]]]. simpl in *.
+      unfold infer_as_sort_obligation_1.
+      destruct ws as [[s' Hs']]. 
+      specialize (Hp _ Hs').
+      eapply invert_cumul_sort_r in Hp as [u' [redu' leq]].
+      destruct reduce_to_sort => //.
+      intros u wc [= <-].
+      todo "Needs completeness of reduce_to_sort"%string.
+    Qed.
+    Next Obligation.
+      simpl. intros.
+      todo "sort"%string.
+    Qed.
   End SortOf.
 
-  Program Definition option_or {A} (a : option A) (e : type_error) : typing_result (∑ x : A, a = Some x) :=
-    match a with
-    | Some d => ret (d; eq_refl)
-    | None => raise e
+  Program Definition infer_as_prod Γ T
+    (isprod : ∥ ∑ na A B, Σ ;;; Γ |- T <= tProd na A B ∥) : 
+    ∑ na' A' B', ∥ red Σ.1 Γ T (tProd na' A' B') ∥ :=
+    match @reduce_to_prod cf Σ hΣ Γ T _ with
+    | Checked p => p
+    | TypeError e => !
     end.
-
-  Program Fixpoint type_of (Γ : context) (t : term) : welltyped Σ Γ t ->
-                                                      typing_result (∑ T : term, ∥ Σ ;;; Γ |- t : T ∥) :=
-    match t return welltyped Σ Γ t -> typing_result (∑ T : term, ∥ Σ ;;; Γ |- t : T ∥) with
-    | tRel n => fun wf =>
-                  t <- option_or (option_map (lift0 (S n) ∘ decl_type) (nth_error Γ n)) (UnboundRel n);;
-                  ret (t.π1; _)
-
-    | tVar n => fun wf => raise (UnboundVar n)
-    | tEvar ev args => fun wf => raise (UnboundEvar ev)
-
-    | tSort s => fun wf => ret (tSort (Universe.try_suc s); _)
-
-    | tProd n t b => fun wf =>
-      s1 <- type_of_as_sort type_of Γ t _ ;;
-      s2 <- type_of_as_sort type_of (Γ ,, vass n t) b _ ;;
-      ret (tSort (Universe.sort_of_product s1 s2); _)
-
-    | tLambda n t b => fun wf =>
-      t2 <- type_of (Γ ,, vass n t) b _;;
-      ret (tProd n t t2.π1; _)
-
-    | tLetIn n b b_ty b' => fun wf =>
-      b'_ty <- type_of (Γ ,, vdef n b b_ty) b' _ ;;
-      ret (tLetIn n b b_ty b'_ty.π1; _)
-
-    | tApp t a => fun wf =>
-      ty <- type_of Γ t _ ;;
-      pi <- reduce_to_prod hΣ Γ ty.π1 _ ;;
-      ret (subst10 a pi.π2.π2.π1; _)
-
-    | tConst cst u => fun wf =>
-          match lookup_env (fst Σ) cst with
-          | Some (ConstantDecl d) =>
-            let ty := subst_instance_constr u d.(cst_type) in
-            ret (ty; _)
-          |  _ => raise (UndeclaredConstant cst)
-          end
-
-    | tInd ind u => fun wf =>
-          d <- @lookup_ind_decl Σ ind ;;
-          let ty := subst_instance_constr u d.π2.π1.(ind_type) in
-          ret (ty; _)
-
-    | tConstruct ind k u => fun wf =>
-          d <- @lookup_ind_decl Σ ind ;;
-          match nth_error d.π2.π1.(ind_ctors) k with
-          | Some cdecl =>
-            ret (type_of_constructor d.π1 cdecl (ind, k) u; _)
-          | None => raise (UndeclaredConstructor ind k)
-          end
-
-    | tCase (ind, par) p c brs => fun wf =>
-      ty <- type_of Γ c _ ;;
-      indargs <- reduce_to_ind hΣ Γ ty.π1 _ ;;
-      ret (mkApps p (List.skipn par indargs.π2.π2.π1 ++ [c]); _)
-
-    | tProj (ind, n, k) c => fun wf =>
-       d <- @lookup_ind_decl Σ ind ;;
-       match nth_error d.π2.π1.(ind_projs) k with
-       | Some pdecl =>
-            c_ty <- type_of Γ c _ ;;
-            indargs <- reduce_to_ind hΣ Γ c_ty.π1 _ ;;
-            let ty := snd pdecl in
-            ret (subst0 (c :: List.rev (indargs.π2.π2.π1)) (subst_instance_constr indargs.π2.π1 ty);
-                   _)
-       | None => !
-       end
-
-    | tFix mfix n => fun wf =>
-      match nth_error mfix n with
-      | Some f => ret (f.(dtype); _)
-      | None => raise (IllFormedFix mfix n)
-      end
-
-    | tCoFix mfix n => fun wf =>
-      match nth_error mfix n with
-      | Some f => ret (f.(dtype); _)
-      | None => raise (IllFormedFix mfix n)
-      end
-    end.
-
+    Next Obligation. exact (todo "completeness"). Qed.
+    Next Obligation. exact (todo "completeness"). Qed.
+  Check !.
+  
+  Equations lookup_ind_decl ind : typing_result
+        ({decl & {body & declared_inductive (fst Σ) decl ind body}}) :=
+  lookup_ind_decl ind with inspect (lookup_env (fst Σ) ind.(inductive_mind)) :=
+    { | exist (Some (InductiveDecl decl)) look with inspect (nth_error decl.(ind_bodies) ind.(inductive_ind)) :=
+      { | exist (Some body) eqnth => Checked (decl; body; _);
+        | ret None => raise (UndeclaredInductive ind) };
+      | _ => raise (UndeclaredInductive ind) }.
   Next Obligation.
-    destruct wf. sq.
-    destruct (nth_error Γ n) eqn:Heq; try discriminate. injection X. intros <-.
-    econstructor; eauto using typing_wf_local.
+    split.
+    - symmetry in look.
+      etransitivity. eassumption. reflexivity.
+    - now symmetry.
   Defined.
 
-  Solve All Obligations with Program.Tactics.program_simpl; try match goal with
-                                              [ |- ∥ _ ∥ ] => todo "PCUICSafeRetyping.type_of"
-                                            | [ |- welltyped _ _ _ ] => todo "PCUICSafeRetyping.type_of"
-                                            | [ |- wellformed _ _ _ ] => todo "PCUICSafeRetyping.type_of"
-                             end.
-  Next Obligation.
-    todo "PCUICSafeRetyping.type_of".
+  Lemma lookup_ind_decl_complete ind e : lookup_ind_decl ind = TypeError e -> 
+    ((∑ mdecl idecl, declared_inductive Σ mdecl ind idecl) -> False).
+  Proof.
+    apply_funelim (lookup_ind_decl ind).
+    1-2:intros * _ her [mdecl [idecl [declm decli]]];
+    red in declm; rewrite declm in e0; congruence.
+    1-2:intros * _ _ => // => _ [mdecl [idecl [declm /= decli]]].
+    red in declm. rewrite declm in e1. noconf e1.
+    congruence.
+  Qed.
+
+  Obligation Tactic := idtac.
+  
+  Local Notation ret t := (exist t _).
+
+  Equations? infer (Γ : context) (t : term) (wt : welltyped Σ Γ t) : principal_type Σ Γ t 
+    by struct t :=
+  { infer Γ (tRel n) wt with 
+    inspect (option_map (lift0 (S n) ∘ decl_type) (nth_error Γ n)) := 
+    { | ret None => !;
+      | ret (Some t) => ret t };
+    
+    infer Γ (tVar n) wt := !;
+    infer Γ (tEvar ev args) wt := !;
+
+    infer Γ (tSort s) _ := ret (tSort (Universe.try_suc s));
+
+    infer Γ (tProd n ty b) wt :=
+      let ty1 := infer Γ ty _ in
+      let s1 := infer_as_sort (todo "wt") ty1 in
+      let ty2 := infer (Γ ,, vass n ty) b _  in
+      let s2 := infer_as_sort (todo "wt2") ty2 in
+      ret (tSort (Universe.sort_of_product s1 s2));
+
+    infer Γ (tLambda n t b) wt :=
+      let t2 := infer (Γ ,, vass n t) b _ in
+      ret (tProd n t t2);
+
+    infer Γ (tLetIn n b b_ty b') wt :=
+      let b'_ty := infer (Γ ,, vdef n b b_ty) b' _ in
+      ret (tLetIn n b b_ty b'_ty);
+
+    infer Γ (tApp t a) wt :=
+      let ty := infer Γ t _ in
+      let pi := infer_as_prod Γ ty _  in
+      ret (subst10 a pi.π2.π2.π1);
+
+    infer Γ (tConst cst u) wt with inspect (lookup_env (fst Σ) cst) :=
+      { | ret (Some (ConstantDecl d)) := ret (subst_instance_constr u d.(cst_type));
+        |  _ := ! };
+
+    infer Γ (tInd ind u) wt with inspect (lookup_ind_decl ind) :=
+      { | ret (Checked decl) := ret (subst_instance_constr u decl.π2.π1.(ind_type));
+        | ret (TypeError e) := ! };
+    
+    infer Γ (tConstruct ind k u) wt with inspect (lookup_ind_decl ind) :=
+      { | ret (Checked d) with inspect (nth_error d.π2.π1.(ind_ctors) k) := 
+        { | ret (Some cdecl) => ret (type_of_constructor d.π1 cdecl (ind, k) u);
+          | ret None => ! };
+      | ret (TypeError e) => ! };
+
+    infer Γ (tCase (ind, par) p c brs) wt with inspect (reduce_to_ind hΣ Γ (infer Γ c _) _) :=
+      { | ret (Checked indargs) =>
+          ret (mkApps p (List.skipn par indargs.π2.π2.π1 ++ [c]));
+        | ret (TypeError _) => ! };
+
+    infer Γ (tProj (ind, n, k) c) wt with inspect (@lookup_ind_decl ind) :=
+      { | ret (Checked d) with inspect (nth_error d.π2.π1.(ind_projs) k) :=
+        { | ret (Some pdecl) with inspect (reduce_to_ind hΣ Γ (infer Γ c _) _) :=
+          { | ret (Checked indargs) => 
+              let ty := snd pdecl in
+              ret (subst0 (c :: List.rev (indargs.π2.π2.π1)) (subst_instance_constr indargs.π2.π1 ty));
+            | ret (TypeError _) => ! };
+         | ret None => ! };
+        | ret (TypeError e) => ! };
+
+    infer Γ (tFix mfix n) wt with inspect (nth_error mfix n) :=
+      { | ret (Some f) => ret f.(dtype);
+        | ret None => ! };
+
+    infer Γ (tCoFix mfix n) wt with inspect (nth_error mfix n) :=
+      { | ret (Some f) => ret f.(dtype);
+        | ret None => ! }
+  }.
+  Proof.
+    all:destruct hΣ, Hφ; destruct wt as [T HT]; try clear infer.
+    all:try solve [econstructor; eauto].
+
+    - sq. destruct (nth_error Γ n) eqn:hnth => //.
+      eapply inversion_Rel in HT as (? & ? & ? & ?); auto.
+      rewrite e in hnth; noconf hnth. noconf wildcard0.
+      split; [now constructor|].
+      intros T' Ht'.
+      eapply inversion_Rel in Ht' as (? & ? & ? & ?); auto.
+      now rewrite e in e0; noconf e0.
+      
+    - eapply inversion_Rel in HT as (? & ? & ? & ?); auto.
+      rewrite e in wildcard => //.
+     
+    - depind HT. eapply IHHT; eauto.
+
+    - depind HT; eapply IHHT; eauto.
+
+    - eapply inversion_Sort in HT as (l & wf & inl & eqs & cum); auto; subst s.
+      sq.
+      split. eapply meta_conv. econstructor; eauto.
+      f_equal; eapply eq_univ''. simpl.
+      unfold UnivExpr.make, Universe.super.
+      destruct (NoPropLevel.of_level l); simpl; auto.
+      destruct t; simpl; auto.
+      intros T' (l' & wf' & inl' & eqs' & cum')%inversion_Sort; auto.
+      eapply Universe.make_inj in eqs'; subst l'.
+      etransitivity; eauto.
+      do 2 constructor.
+      unfold Universe.make, UnivExpr.make, Universe.super.
+      destruct (NoPropLevel.of_level l); simpl; auto;
+      try destruct t; simpl; auto; reflexivity.
+            
+    - eapply inversion_Prod in HT as (? & ? & ? & ? & ?); try econstructor; eauto.
+    - destruct hΣ. destruct Hφ. destruct (inversion_Prod Σ w HT) as (? & ? & ? & ? & ?); try econstructor; eauto.
+    - simpl in *.
+      destruct (inversion_Prod Σ w HT) as (? & ? & ? & ? & ?).
+      subst ty1 ty2.
+      destruct infer_as_sort as [x1 [[Hx1 Hx1p]]]; simpl.
+      destruct infer_as_sort as [x2 [[Hx2 Hx2p]]]; simpl.
+      subst s1 s2; simpl in *. sq.
+      split.
+      * specialize (Hx1p _ t).
+        specialize (Hx2p _ t0).
+        econstructor; eauto.
+      * intros T' Ht'.
+        eapply inversion_Prod in Ht' as (? & ? & ? & ? & ?); auto.
+        etransitivity; eauto. constructor. constructor.
+        eapply leq_universe_product_mon; eauto.
+
+    - eapply inversion_Lambda in HT as (? & ? & ? & ? & ?); try econstructor; eauto.
+    - simpl in t2. destruct (inversion_Lambda Σ w HT) as (? & ? & ? & ? & ?).
+      destruct infer as [bty' [[Hbty pbty]]]; subst t2; simpl in *.
+      sq. split.
+      * econstructor; eauto.
+      * intros T' (? & ? & ? & ? & ?)%inversion_Lambda; auto.
+        specialize (pbty _ t3).
+        transitivity (tProd n t x2); eauto.
+        eapply congr_cumul_prod; auto.
+
+    - eapply inversion_LetIn in HT as (? & ? & ? & ? & ? & ?); auto.
+      eexists; eauto.
+    - simpl in b'_ty.
+      destruct (inversion_LetIn Σ w HT) as (? & ? & ? & ? & ? & ?).
+      destruct infer as [bty' [[Hbty pbty]]]; subst b'_ty; simpl in *.
+      sq; split.
+      * econstructor; eauto.
+      * intros T' (? & ? & ? & ? & ? & ?)%inversion_LetIn; auto.
+        etransitivity; eauto.
+        eapply cumul_LetIn_bo; eauto.
+
+    - eapply inversion_App in HT as (? & ? & ? & ? & ?); try econstructor; eauto.
+    - simpl in ty. destruct inversion_App as (? & ? & ? & ? & ? & ?).
+      destruct infer as [bty' [[Hbty pbty]]]; subst ty; simpl in *.
+      sq. exists x, x0, x1. now eapply pbty.
+      
+    - simpl in *. destruct inversion_App as (? & ? & ? & ? & ? & ?).
+      destruct infer as [tty [[Htty pbty]]]; subst ty; simpl in *.
+      destruct pi as [na' [A' [B' [red]]]].
+      sq. split.
+      * simpl.
+        eapply type_reduction in Htty; eauto.
+        eapply type_App; eauto.
+        specialize (pbty _ t0).
+        assert (Σ ;;; Γ |- tProd na' A' B' <= tProd x x0 x1).
+        eapply cumul_red_l_inv; eauto.
+        eapply cumul_Prod_Prod_inv in X as [Ha _]; auto.
+        eapply type_Cumul; eauto.
+        eapply validity in Htty; auto.
+        eapply isWAT_tProd in Htty; pcuic.
+        eapply conv_cumul. now symmetry.
+      * intros T' (? & ? & ? & ? & ? & ?)%inversion_App; auto.
+        specialize (pbty _ t2). simpl.
+        etransitivity; [|eassumption].
+        assert (Σ ;;; Γ |- tProd na' A' B' <= tProd x2 x3 x4).
+        { eapply cumul_red_l_inv; eauto. }
+        eapply cumul_Prod_Prod_inv in X as [Ha Hb]; auto.
+        eapply (substitution_cumul _ Γ [vass x2 x3] []); eauto.
+        eapply validity in t2; pcuic.
+        eapply isWAT_tProd in t2 as [_ isWAT]; auto.
+        now eapply isWAT_wf_local in isWAT. pcuic.
+        constructor. constructor.
+        now rewrite subst_empty.
+
+    - eapply inversion_Const in HT as [decl ?] => //.
+      intuition auto. red in a0. rewrite a0 in wildcard. noconf wildcard.
+      sq. split.
+      * constructor; eauto.
+      * intros T' [decl [wf [lookup [cu cum]]]]%inversion_Const; auto.
+        red in lookup. congruence.
+    - apply inversion_Const in HT as [decl [wf [lookup [cu cum]]]]; auto.
+      red in lookup. subst wildcard0. rewrite lookup in e. congruence.
+    - apply inversion_Const in HT as [decl [wf [lookup [cu cum]]]]; auto.
+      red in lookup. subst wildcard0. rewrite lookup in e. congruence.
+
+    - destruct decl as [decl [body decli]].
+      eapply inversion_Ind in HT; auto.
+      dependent elimination HT as [(mdecl; idecl; (wf'', (decli', (rest, cum))))].
+      pose proof (declared_inductive_inj decli decli') as [-> ->].
+      sq. split.
+      * econstructor; eauto.
+      * intros T' HT'.
+        eapply inversion_Ind in HT'; auto.
+        dependent elimination HT' as [(mdecl'; idecl'; (wf''', (decli'', (rest', cum'))))].
+        simpl.
+        now destruct (declared_inductive_inj decli decli'') as [-> ->].
+    - eapply inversion_Ind in HT; auto.
+      dependent elimination HT as [(mdecl; idecl; (wf'', (decli', (rest, cum))))].
+      move: wildcard0. destruct decli' as [look hnth].
+      move=> looki.
+      eapply lookup_ind_decl_complete. now symmetry.
+      exists mdecl, idecl. split; auto.
+
+    - destruct d as [decl [body decli]].
+      assert (declared_constructor Σ decl body (ind, k) cdecl) as declc.
+      { red; intuition auto. }
+      eapply inversion_Construct in HT; auto.
+      dependent elimination HT as [(mdecl; idecl; cdecl; (wf'', (declc', (rest, cum))))].
+      pose proof (declared_constructor_inj declc declc') as [-> [-> ->]].
+      sq. split.
+      * econstructor; eauto.
+      * intros T' HT'.
+        eapply inversion_Construct in HT'; auto.
+        dependent elimination HT' as [(mdecl'; idecl'; cdecl'; (wf''', (declc'', (rest', cum'))))].
+        simpl.
+        now destruct (declared_constructor_inj declc declc'') as [-> [-> ->]].
+    - eapply inversion_Construct in HT; auto.
+      dependent elimination HT as [(mdecl; idecl; cdecl'; (wf'', (declc'', (rest, cum))))].
+      destruct declc''.
+      destruct d as [decl [body decli]].
+      pose proof (declared_inductive_inj decli H0) as [-> ->]. simpl in *. congruence.
+    
+    - symmetry in wildcard2.
+      eapply inversion_Construct in HT; auto.
+      dependent elimination HT as [(mdecl; idecl; cdecl; (wf'', (declc', (rest, cum))))].
+      eapply lookup_ind_decl_complete in wildcard2; eauto.
+      now destruct declc'.
+    
+    - eapply inversion_Case in HT; auto.
+      destruct HT as (u & args & mdecl & idecl & ps & pty & btys & decli & indp & bcp & Hpty & lebs
+        & isco & Hc & Hbtys & all & cum).
+      eexists; eauto.
+    - simpl. destruct inversion_Case as (u & args & mdecl & idecl & ps & pty & btys & decli & indp & bcp & Hpty & lebs
+        & isco & Hc & Hbtys & all & cum).
+      destruct infer as [cty [[Hty Hp]]]. simpl.
+      eapply validity in Hty.
+      eapply wat_wellformed; auto. sq; auto. auto.
+    - simpl in *. 
+      destruct inversion_Case as (u & args & mdecl & idecl & ps & pty & btys & decli & indp & bcp & Hpty & lebs
+        & isco & Hc & Hbtys & all & cum).
+      destruct infer as [cty [[Hty Hp]]].
+      simpl in wildcard. destruct reduce_to_ind => //.
+      injection wildcard. intros ->. clear wildcard.
+      destruct a as [i [u' [l [red]]]].
+      simpl.
+      eapply type_reduction in Hty; eauto.
+      pose proof (Hp _ Hc).
+      assert (Σ ;;; Γ |- mkApps (tInd i u') l <= mkApps (tInd ind u) args).
+      { eapply cumul_red_l_inv; eauto. }
+      eapply cumul_Ind_Ind_inv in X0 as [[eqi Ru] cl]; auto.
+      sq; split; simpl.
+      * eapply type_Cumul. econstructor. 3:eauto. all:eauto.
+        todo "cumulativity here"%string.
+        eapply conv_cumul.
+        eapply mkApps_conv_args; auto.
+        eapply All2_app. 2:repeat (constructor; auto).
+        eapply All2_skipn. now symmetry in cl.
+      * intros T'' Hc'.
+        eapply inversion_Case in Hc' as (u'' & args' & mdecl' & idecl' & ps' & pty'
+           & btys' & decli' & indp' & bcp' & Hpty' & lebs' & isco' & Hc' & Hbtys' & all' & cum'); auto.
+        etransitivity. simpl in cum'. 2:eassumption.
+        eapply conv_cumul, mkApps_conv_args; auto.
+        eapply All2_app. 2:repeat (constructor; auto).
+        eapply All2_skipn.
+        specialize (Hp _ Hc').
+        assert (Σ ;;; Γ |- mkApps (tInd i u') l <= mkApps (tInd ind u'') args').
+        { eapply cumul_red_l_inv; eauto. }
+        eapply cumul_Ind_Ind_inv in X0 as [[eqi' Ru'] cl']; auto.
+      
+    - simpl in wildcard1.
+      destruct inversion_Case as (u & args & mdecl & idecl & ps & pty & btys & decli & indp & bcp & Hpty & lebs
+        & isco & Hc & Hbtys & all & cum).
+      destruct infer as [cty [[Hty Hp]]]. simpl.
+      destruct validity as [_ i]. simpl in wildcard1.
+      specialize (Hp _ Hc).
+      eapply invert_cumul_ind_r in Hp as [ui' [l' [red [Ru ca]]]]; auto.
+      symmetry in wildcard1; eapply reduce_to_ind_complete in wildcard1 => //.
+      now exists ind, ui', l'.
+
+    - eapply inversion_Proj in HT as (u & mdecl & idecl & pdecl' & args & declp & Hc & Hargs & cum); auto.
+      simpl in cum.
+      eexists; eauto.
+    - simpl; destruct inversion_Proj as (u & mdecl & idecl & pdecl' & args & declp & Hc & Hargs & cum); auto.
+      destruct infer as [cty [[Hc' Hc'']]]. simpl.
+      eapply validity in Hc'; auto.
+      eapply wat_wellformed; auto. sq; auto.
+    - simpl in *. destruct inversion_Proj as (u & mdecl & idecl & pdecl' & args & declp & Hc & Hargs & cum); auto.
+      destruct infer as [cty [[Hc' Hc'']]]. simpl.
+      destruct reduce_to_ind => //. injection wildcard1. intros ->.
+      clear wildcard1.
+      destruct a as [i [u' [l [red]]]]. simpl.
+      simpl in red.
+      eapply type_reduction in Hc'; eauto.
+      pose proof (Hc'' _ Hc).
+      assert (Σ ;;; Γ |- mkApps (tInd i u') l <= mkApps (tInd ind u) args).
+      { eapply cumul_red_l_inv; eauto. }
+      eapply cumul_Ind_Ind_inv in X0 as [[eqi' Ru'] cl']; eauto.
+      destruct d as [decl [body decli]].
+      pose proof (declared_inductive_inj (proj1 declp) decli) as [-> ->].
+      assert (declared_projection Σ mdecl idecl (ind, n, k) pdecl).
+      { red; intuition eauto. simpl. eapply declp. }
+      pose proof (@PCUICReflect.eqb_eq inductive _). apply H0 in eqi'. subst ind.
+      destruct (declared_projection_inj declp H) as [_ [_ ->]].
+      sq. split; auto.
+      * econstructor; eauto. now rewrite (All2_length _ _ cl').
+      * intros.
+        eapply inversion_Proj in X0 as (u'' & mdecl' & idecl' & pdecl'' & args' & 
+            declp' & Hc''' & Hargs' & cum'); auto.
+        simpl in *. subst ty.
+        destruct (declared_projection_inj H declp') as [-> [-> ->]].
+        etransitivity; eauto.
+        specialize (Hc'' _ Hc''').
+        assert (Σ ;;; Γ |- mkApps (tInd i u') l <= mkApps (tInd i u'') args').
+        { eapply cumul_red_l_inv; eauto. }
+        eapply cumul_Ind_Ind_inv in X0 as [[eqi'' Ru''] cl'']; auto.
+        todo "cumulative inductives here"%string.
+
+    - simpl in *.
+      destruct inversion_Proj as (u & mdecl & idecl & pdecl' & args & declp & Hc & Hargs & cum); auto.
+      destruct infer as [cty [[Hc' Hc'']]]. simpl.
+      symmetry in wildcard3.
+      eapply reduce_to_ind_complete in wildcard3; auto.
+      clear wildcard3; simpl. specialize (Hc'' _ Hc).
+      eapply invert_cumul_ind_r in Hc'' as [ui' [l' [red [Rgl Ra]]]]; auto.
+      eexists _, _, _; eauto.      
+
+    - eapply inversion_Proj in HT as (u & mdecl & idecl & pdecl' & args & declp & Hc & Hargs & cum); auto.
+      destruct declp; simpl in *.
+      destruct d as [decl [body decli]].
+      destruct (declared_inductive_inj decli H0) as [-> ->].
+      simpl in *. intuition congruence.
+
+    - eapply inversion_Proj in HT as (u & mdecl & idecl & pdecl' & args & declp & Hc & Hargs & cum); auto.
+      symmetry in wildcard5.
+      eapply lookup_ind_decl_complete in wildcard5; auto.
+      destruct declp. do 2 eexists; eauto.
+    
+    - eapply inversion_Fix in HT as [decl [fg [hnth [htys [hbods [wf cum]]]]]]; auto.
+      sq; split.
+      * econstructor; eauto.
+        eapply nth_error_all in htys; eauto. destruct htys as [s Hs]. pcuic.
+        eapply typing_wf_local; eauto.
+      * intros T' HT'.
+        eapply inversion_Fix in HT' as [decl' [fg' [hnth' [htys' [hbods' [wf' cum']]]]]]; auto.
+        congruence.
+      
+    - now eapply inversion_Fix in HT as [decl [fg [hnth [htys [hbods [wf cum]]]]]]; auto.
+
+  - eapply inversion_CoFix in HT as [decl [fg [hnth [htys [hbods [wf cum]]]]]]; auto.
+    sq; split.
+    * econstructor; eauto.
+      eapply nth_error_all in htys; eauto. destruct htys as [s Hs]. pcuic.
+      eapply typing_wf_local; eauto.
+    * intros T' HT'.
+      eapply inversion_CoFix in HT' as [decl' [fg' [hnth' [htys' [hbods' [wf' cum']]]]]]; auto.
+      congruence.
+    
+  - now eapply inversion_CoFix in HT as [decl [fg [hnth [htys [hbods [wf cum]]]]]]; auto.
   Defined.
 
-  (* Program Definition sort_of (Γ : context) (t : term) (wf : welltyped Σ Γ t) : typing_result universe := *)
-  (*   ty <- type_of Γ t wf;; *)
-  (*   type_of_as_sort type_of Γ ty.π1 _. *)
-  (* Next Obligation. *)
-
-
+  Definition type_of Γ t wt : term := (infer Γ t wt).
+  
   Open Scope type_scope.
-
-  Conjecture cumul_reduce_to_sort : forall {Γ T wf s},
-    reduce_to_sort hΣ Γ T wf = Checked s ->
-    Σ ;;; Γ |- T <= tSort s.π1.
-
-  Conjecture cumul_reduce_to_prod : forall {Γ T wf na A B H},
-    reduce_to_prod hΣ Γ T wf = Checked (na; A; B; H) ->
-    forall n, Σ ;;; Γ |- T <= tProd n A B.
-
-  Conjecture congr_cumul_letin : forall {Γ n a A t n' a' A' t'},
-    Σ ;;; Γ |- a <= a' ->
-    Σ ;;; Γ |- A <= A' ->
-    Σ ;;; Γ ,, vdef n a A' |- t <= t' ->
-    Σ ;;; Γ |- tLetIn n a A t <= tLetIn n' a' A' t'.
-
-  Ltac case_eq_match :=
-    lazymatch goal with
-    | |- context [ match ?t with _ => _ end ] =>
-      case_eq t ; try solve [ intros ; discriminate ]
-    | h : context [ match ?t with _ => _ end ] |- _ =>
-      revert h ;
-      case_eq t ; try solve [ intros ; discriminate ]
-    end.
-
-  Ltac deal_as_sort :=
-    lazymatch goal with
-    | h : type_of_as_sort _ _ _ = _ |- _ =>
-      unfold type_of_as_sort in h ;
-      simpl in h
-    end.
-
-  Ltac deal_reduce_to_sort :=
-    lazymatch goal with
-    | h : reduce_to_sort _ _ _ = Checked _ |- _ =>
-      pose proof (cumul_reduce_to_sort h) ;
-      clear h
-    end.
-
-  Ltac deal_reduce_to_prod :=
-    lazymatch goal with
-    | h : reduce_to_prod _ _ _ = Checked _ |- _ =>
-      let hh := fresh h in
-      pose proof (cumul_reduce_to_prod h) as hh ;
-      clear h ;
-      lazymatch goal with
-      | na : name |- _ => specialize (hh na)
-      | |- _ => specialize (hh nAnon)
-      end
-    end.
-
-  Ltac deal_Checked :=
-    match goal with
-    | h : Checked _ = Checked _ |- _ =>
-      inversion h ; subst ; clear h
-    end.
-
-  Ltac go eq :=
-    simpl in eq ; revert eq ;
-    repeat (case_eq_match ; intros) ;
-    repeat deal_as_sort ;
-    repeat (case_eq_match ; intros) ;
-    repeat deal_Checked ;
-    repeat deal_reduce_to_sort ;
-    repeat deal_reduce_to_prod.
-
-  Ltac one_ih :=
-    lazymatch goal with
-    | h : _ -> _ -> (_ ;;; _ |- ?t : _) * _ |- _ ;;; _ |- ?t : _ =>
-      eapply h
-    | h : _ -> _ -> _ * (_ ;;; _ |- _ <= ?A) |- _ ;;; _ |- _ <= ?A =>
-      eapply h
-    end.
-
-  Ltac ih :=
-    one_ih ; eassumption.
-
-  Ltac cih :=
-    eapply type_Cumul ; [
-      ih
-    | try eassumption
-    | try eassumption
-    ].
-
+  
   Definition map_typing_result {A B} (f : A -> B) (e : typing_result A) : typing_result B :=
     match e with
     | Checked a => Checked (f a)
     | TypeError e => TypeError e
     end.
 
-  Theorem type_of_principal :
-    forall {Γ t B} ,
-      forall (wt : welltyped Σ Γ t) wt',
-      type_of Γ t wt = Checked (B; wt') ->
-      forall A, Σ ;;; Γ |- t : A -> Σ ;;; Γ |- B <= A.
+  Arguments iswelltyped {cf Σ Γ t A}.
+
+  Lemma infer_clause_1_irrel Γ n H wt wt' : infer_clause_1 infer Γ n H wt = infer_clause_1 infer Γ n H wt' :> term.
   Proof.
-    intros Γ t B wt wt' eq. simpl in wt'. revert B wt' eq. simpl in wt.
-    induction t using term_forall_list_ind; intros B wt' eq A wA.
-    - cbn in eq. destruct option_or eqn:Heq.
-      destruct a as [x Hx]. simpl in eq.
-      inversion eq. subst. clear eq. clear Heq.
-  Admitted. (* Just inversion lemmas, as we're inducting on the term *)
+    destruct H as [[b|] eq]; simp infer. simpl. reflexivity. bang.
+  Qed.
 
-  (*     rewrite Hx in Heq. simpl in Heq. rewrite e in Hx. simpl in Hx. noconf Hx. *)
-  (*     + eapply cumul_refl'. *)
-  (*     + simpl in eq. discriminate. *)
-  (*   - cbn in eq. inversion eq. subst. clear eq. *)
-  (*     constructor. red. constructor. simpl. simpl. *)
-  (*     + (* Proving Typeᵢ : Typeᵢ₊₁ shouldn't be hard... *) *)
-  (*       admit. *)
-  (*   - go eq. *)
-  (*     unfold type_of_as_sort. rewrite *)
-  (*     split. *)
-  (*     + econstructor ; try eassumption ; try ih ; try cih. *)
-  (*       (* Again we're missing result on how to type sorts... *) *)
-  (*       left. red. exists [], a. *)
-  (*       unfold app_context; simpl; intuition auto with pcuic. *)
-  (*       eapply typing_wf_local; tea. *)
-  (*       left. red. exists [], a0. unfold app_context; simpl; intuition auto with pcuic. *)
-  (*       eapply typing_wf_local; tea. *)
-  (*     + (* Sorts again *) *)
-  (*       simpl. *)
-  (*       admit. *)
-  (*   - go eq. split. *)
-  (*     + econstructor ; try eassumption ; try ih ; try cih. *)
-  (*     + eapply congr_cumul_prod. *)
-  (*       * eapply conv_alt_refl. reflexivity. *)
-  (*       * ih. *)
-  (*   - go eq. split. *)
-  (*     + econstructor ; try eassumption ; try ih ; try cih. *)
-  (*     + eapply congr_cumul_letin. all: try eapply cumul_refl'. *)
-  (*       ih. *)
-  (*   - go eq. split. *)
-  (*     + econstructor ; try eassumption ; try ih ; try cih. *)
-  (*       all: admit. *)
-  (*     + (* eapply cumul_subst. *) *)
-  (*       admit. *)
-  (*   - simpl in eq. split. *)
-  (*     + admit. *)
-  (*     + admit. *)
-  (*   - admit. *)
-  (*   - admit. *)
-  (*   - admit. *)
-  (*   - admit. *)
-  (*   - admit. *)
-  (*   - admit. *)
-  (*   - split. *)
-  (*     + ih. *)
-  (*     + eapply cumul_trans ; try eassumption. *)
-  (* Admitted. *)
+  (* Lemma infer_irrel {Γ t} (wt wt' : welltyped Σ Γ t) : infer Γ t wt = infer Γ t wt' :> term.
+  Proof.
+    funelim (infer Γ t wt); try solve [simp infer; simpl; try bang; auto].
 
+    simp infer. simpl. f_equal. todo "sorts".
+    simp infer. simpl. f_equal. apply H.
+    simp infer; simpl; f_equal. apply H.
+    simp infer. simpl. todo "prod".
+    simp infer. eapply infer_clause_1_irrel. revert Heqcall. bang.
+  Qed.*)
 
+  Lemma type_of_subtype {Γ t T} (wt : Σ ;;; Γ |- t : T) :
+    ∥ Σ ;;; Γ |- type_of Γ t (iswelltyped wt) <= T ∥.
+  Proof.
+    unfold type_of.
+    destruct infer as [P [[HP Hprinc]]].
+    sq. simpl. now eapply Hprinc.
+  Qed.
+
+  (* Note the careful use of squashing here: the principal type is accessible 
+    computationally but the proof it is principal is squashed (in Prop).
+    One could also easily modify the above function to return non-squashed 
+    principal typing derivations, if there is some use for it. *)
+  Theorem principal_types {Γ t} (wt : welltyped Σ Γ t) : 
+    ∑ P, ∥ forall T, Σ ;;; Γ |- t : T -> (Σ ;;; Γ |- t : P) * (Σ ;;; Γ |- P <= T) ∥.
+  Proof.
+    exists (infer Γ t wt).
+    destruct infer as [T' [[HT' HT]]].
+    sq. intuition eauto.
+  Qed.
 
 End TypeOf.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -5,7 +5,7 @@ From Equations Require Import Equations.
 
 From Coq Require Import Bool String List Program.
 From MetaCoq.Template Require Import config monad_utils utils uGraph.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction PCUICLiftSubst
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction PCUICLiftSubst
      PCUICUnivSubst PCUICTyping PCUICSafeLemmata PCUICSubstitution PCUICValidity
      PCUICGeneration PCUICInversion PCUICValidity PCUICInductives PCUICSR
      PCUICCumulativity PCUICConversion PCUICConfluence PCUICArities
@@ -24,8 +24,6 @@ Add Search Blacklist "_graph_mut".
 
 Require Import ssreflect.
 
-
-Require Import PCUICAstUtils.
 Lemma cumul_Ind_Ind_inv {cf:checker_flags} {Σ : global_env_ext} Γ ind u args ind' u' args' : 
   wf Σ ->
   Σ ;;; Γ |- mkApps (tInd ind u) args <= mkApps (tInd ind' u') args' ->

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -76,7 +76,7 @@ Fixpoint ack (n m:nat) {struct n} : nat :=
   end.
 Definition ack35 := (ack 3 5).
 MetaCoq Quote Recursively Definition cbv_ack35 :=
-  ltac:(let t:=(eval cbv in ack35) in exact t).
+  ltac:(let t:=(eval cbv delta [ack35] in ack35) in exact t).
 
 Time Definition testack35 := Eval lazy in test cbv_ack35.
 
@@ -96,7 +96,7 @@ Arguments fcons {A}.
 Arguments node {A}.
 Definition sf: forest bool := (fcons (node true (leaf false)) (leaf true)).
 MetaCoq Quote Recursively Definition p_sf := sf.
-Time Definition testp_sf := Eval cbv in test p_sf.
+Time Definition testp_sf := Eval lazy in test p_sf.
 
 Fixpoint tree_size (t:tree bool) : nat :=
   match t with
@@ -117,12 +117,11 @@ Definition arden_size := (forest_size arden).
 MetaCoq Quote Recursively Definition cbv_arden_size :=
   ltac:(let t:=(eval cbv in arden_size) in exact t).
 Definition ans_arden_size :=
- Eval cbv in test cbv_arden_size.
+ Eval lazy in test cbv_arden_size.
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_arden_size := arden_size.
 
-Definition P_arden_size := Eval cbv in test p_arden_size.
-
+Definition P_arden_size := Eval lazy in test p_arden_size.
 
 (** SASL tautology function: variable arity **)
 Require Import Bool.
@@ -142,12 +141,12 @@ MetaCoq Quote Recursively Definition cbv_pierce :=
   ltac:(let t:=(eval cbv in pierce) in exact t).
 
 Definition ans_pierce :=
-  Eval cbv in (test cbv_pierce).
+  Eval lazy in (test cbv_pierce).
 
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_pierce := pierce.
 
-Definition P_pierce := Eval cbv in test p_pierce.
+Definition P_pierce := Eval lazy in test p_pierce.
 
 (* Goal
   let env := (env P_pierce) in
@@ -163,12 +162,12 @@ MetaCoq Quote Recursively Definition cbv_Scomb :=
   ltac:(let t:=(eval cbv in Scomb) in exact t).
 
 Definition ans_Scomb :=
-  Eval cbv in (test cbv_Scomb).
+  Eval lazy in (test cbv_Scomb).
 
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_Scomb := Scomb.
 
-Definition P_Scomb := Eval cbv in (test p_Scomb).
+Definition P_Scomb := Eval lazy in (test p_Scomb).
 
 (* Goal
   let env := (env P_Scomb) in
@@ -190,10 +189,10 @@ Definition slowFib3 := (slowFib 3).
 MetaCoq Quote Recursively Definition cbv_slowFib3 :=
   ltac:(let t:=(eval cbv in slowFib3) in exact t).
 Definition ans_slowFib3 :=
- Eval cbv in (test cbv_slowFib3).
+ Eval lazy in (test cbv_slowFib3).
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_slowFib3 := slowFib3.
-Definition P_slowFib3 := Eval cbv in (test p_slowFib3).
+Definition P_slowFib3 := Eval lazy in (test p_slowFib3).
 (* Goal
   let env := (env P_slowFib3) in
   let main := (main P_slowFib3) in
@@ -212,10 +211,10 @@ Definition fib9 := fib 9.
 MetaCoq Quote Recursively Definition cbv_fib9 :=
   ltac:(let t:=(eval cbv in fib9) in exact t).
 Time Definition ans_fib9 :=
-  Eval cbv in (test cbv_fib9).
+  Eval lazy in (test cbv_fib9).
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_fib9 := fib9.
-Definition P_fib9 := Eval cbv in (test p_fib9).
+Definition P_fib9 := Eval lazy in (test p_fib9).
 (* 
 Goal
   let env := (env P_fib9) in
@@ -259,10 +258,10 @@ Definition sumPL_myPL := (sumPList myPList).
 MetaCoq Quote Recursively Definition cbv_sumPL_myPL :=
   ltac:(let t:=(eval cbv in sumPL_myPL) in exact t).
 Definition ans_sumPL_myPL :=
-  Eval cbv in (test cbv_sumPL_myPL).
+  Eval lazy in (test cbv_sumPL_myPL).
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_sumPL_myPL := sumPL_myPL.
-Definition P_sumPL_myPL := Eval cbv in (test p_sumPL_myPL).
+Definition P_sumPL_myPL := Eval lazy in (test p_sumPL_myPL).
 (* Goal
   let env := (env P_sumPL_myPL) in
   let main := (main P_sumPL_myPL) in
@@ -295,10 +294,10 @@ Definition size_myTree := size myTree.
 MetaCoq Quote Recursively Definition cbv_size_myTree :=
   ltac:(let t:=(eval cbv in size_myTree) in exact t).
 Definition ans_size_myTree :=
-  Eval cbv in (test cbv_size_myTree).
+  Eval lazy in (test cbv_size_myTree).
 (* [program] of the program *)
 MetaCoq Quote Recursively Definition p_size_myTree := size_myTree.
-Definition P_size_myTree := Eval cbv in (test p_size_myTree).
+Definition P_size_myTree := Eval lazy in (test p_size_myTree).
 (* Goal
   let env := (env P_size_myTree) in
   let main := (main P_size_myTree) in
@@ -322,9 +321,9 @@ Definition x := 3.
 Definition provedCopyx := provedCopy x.
 (* Compute provedCopyx.  * evals correctly in Coq * *)
 MetaCoq Quote Recursively Definition cbv_provedCopyx :=
-  ltac:(let t:=(eval cbv in provedCopyx) in exact t).
+  ltac:(let t:=(eval cbv delta [provedCopyx provedCopy] in provedCopyx) in exact t).
 Definition ans_provedCopyx :=
-  Eval cbv in (test cbv_provedCopyx).
+  Eval lazy in (test cbv_provedCopyx).
 MetaCoq Quote Recursively Definition p_provedCopyx := provedCopyx. (* program *)
 (* We don't run those every time as they are really expensive *)
 (* Time Definition P_provedCopyx := Eval lazy in (test p_provedCopyx).

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -7,10 +7,7 @@ Local Open Scope string_scope.
 From MetaCoq.Template Require Import utils.
 
 Definition test (p : Ast.program) : string :=
-  match erase_and_print_template_program p with
-  | inl s => s
-  | inr s => s
-  end.
+  erase_and_print_template_program p.
 
 MetaCoq Quote Recursively Definition zero := 0.
 Definition zerocst := Eval lazy in test zero.
@@ -326,10 +323,8 @@ Definition ans_provedCopyx :=
   Eval lazy in (test cbv_provedCopyx).
 MetaCoq Quote Recursively Definition p_provedCopyx := provedCopyx. (* program *)
 (* We don't run those every time as they are really expensive *)
-(* Time Definition P_provedCopyx := Eval lazy in (test p_provedCopyx).
- *)(* 2 min purely inside Coq *)
-(* Time Definition P_provedCopyxvm := Eval vm_compute in (test p_provedCopyx).
- *)
+Time Definition P_provedCopyx := Eval lazy in (test cbv_provedCopyx).
+Time Definition P_provedCopyxvm := Eval vm_compute in (test p_provedCopyx).
 From MetaCoq.Erasure Require Import Loader.
 MetaCoq Erase provedCopyx.
 (* 2m purely in the bytecode VM *)


### PR DESCRIPTION
This completes the proof of "safe" erasure, that should be called on well-typed terms only: it shows that erasure is a total function in this case and that it is correct (w.r.t. the erasure relation), except for the two optimizations that remove match and proj on boxes. The extraction should be a little faster as it avoids any error case and does not use a monad anymore.