### PR TITLE
Remove Export utils in EAst

### DIFF
--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Export utils BasicAst Universes.
+From MetaCoq.Template Require Export BasicAst Universes.
+From MetaCoq.Template Require Import utils.
 
 (** * Extracted terms
 

--- a/erasure/theories/EInduction.v
+++ b/erasure/theories/EInduction.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 Require Import List.
+From MetaCoq Require Import utils.
 From MetaCoq.Erasure Require Import EAst.
 
 (** * Deriving a compact induction principle for terms


### PR DESCRIPTION
I'd like to turn this Export into an Import. Otherwise we're running into trouble in CertiCoq: utils export the monad notation globally, which clashes with the monad notation used in `coq-ext-lib`. That's something which should be fixed anyways, but until then this PR fixes the problem.