### PR TITLE
make translations Makefile delegating

### DIFF
--- a/translations/Makefile
+++ b/translations/Makefile
@@ -11,11 +11,12 @@ Makefile.coq: _CoqProject
 clean: Makefile.coq
 	$(MAKE) -f Makefile.coq clean
 
-install: all
-	$(MAKE) -f Makefile.coq install
-
-uninstall: all
-	$(MAKE) -f Makefile.coq uninstall
-
 mrproper:
 	rm -f Makefile.coq
+
+force Makefile _CoqProject.in metacoq-config: ;
+
+%: Makefile.coq force
+	+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean mrproper force


### PR DESCRIPTION
This PR makes the `translations` Makefile delegating, meaning that tasks like `install`, `uninstall`, `pretty-timed` are implicitly delegated to `Makefile.coq`. To avoid depending on the `time` command in the standard build of `translations`, the default task is `all` rather than `pretty-timed`. To get timed builds, just run `make pretty-timed`. I also mark all non-file tasks as `PHONY`.