### PR TITLE
Erasure optimization correctness

### DIFF
--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -21,4 +21,5 @@ theories/EArities.v
 theories/ErasureCorrectness.v
 theories/ErasureFunction.v
 theories/SafeErasureFunction.v
+theories/EOptimizePropDiscr.v
 theories/SafeTemplateErasure.v

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -118,6 +118,8 @@ src/safeErasureFunction.mli
 src/safeErasureFunction.ml
 src/ePretty.mli
 src/ePretty.ml
+src/eOptimizePropDiscr.mli
+src/eOptimizePropDiscr.ml
 
 src/safeTemplateErasure.mli
 src/safeTemplateErasure.ml

--- a/erasure/src/eOptimizePropDiscr.ml
+++ b/erasure/src/eOptimizePropDiscr.ml
@@ -1,0 +1,62 @@
+open BasicAst
+open Datatypes
+open EAst
+open ETyping
+open Extract
+open List0
+open MCProd
+
+(** val optimize : E.global_context -> E.term -> E.term **)
+
+let rec optimize _UU03a3_ t = match t with
+| E.Coq_tRel i -> E.Coq_tRel i
+| E.Coq_tEvar (ev, args) -> E.Coq_tEvar (ev, (map (optimize _UU03a3_) args))
+| E.Coq_tLambda (na, m) -> E.Coq_tLambda (na, (optimize _UU03a3_ m))
+| E.Coq_tLetIn (na, b, b') ->
+  E.Coq_tLetIn (na, (optimize _UU03a3_ b), (optimize _UU03a3_ b'))
+| E.Coq_tApp (u, v) ->
+  E.Coq_tApp ((optimize _UU03a3_ u), (optimize _UU03a3_ v))
+| E.Coq_tCase (ind, c, brs) ->
+  let brs' = map (on_snd (optimize _UU03a3_)) brs in
+  (match is_propositional _UU03a3_ (fst ind) with
+   | Some b ->
+     if b
+     then (match brs' with
+           | [] -> E.Coq_tCase (ind, (optimize _UU03a3_ c), brs')
+           | p :: l ->
+             let (a, b0) = p in
+             (match l with
+              | [] -> E.mkApps b0 (repeat E.Coq_tBox a)
+              | _ :: _ -> E.Coq_tCase (ind, (optimize _UU03a3_ c), brs')))
+     else E.Coq_tCase (ind, (optimize _UU03a3_ c), brs')
+   | None -> E.Coq_tCase (ind, (optimize _UU03a3_ c), brs'))
+| E.Coq_tProj (p, c) ->
+  (match is_propositional _UU03a3_ (fst (fst p)) with
+   | Some b ->
+     if b then E.Coq_tBox else E.Coq_tProj (p, (optimize _UU03a3_ c))
+   | None -> E.Coq_tProj (p, (optimize _UU03a3_ c)))
+| E.Coq_tFix (mfix, idx) ->
+  let mfix' = map (E.map_def (optimize _UU03a3_)) mfix in
+  E.Coq_tFix (mfix', idx)
+| E.Coq_tCoFix (mfix, idx) ->
+  let mfix' = map (E.map_def (optimize _UU03a3_)) mfix in
+  E.Coq_tCoFix (mfix', idx)
+| _ -> t
+
+(** val optimize_constant_decl :
+    E.global_context -> E.constant_body -> E.constant_body **)
+
+let optimize_constant_decl _UU03a3_ cb =
+  option_map (optimize _UU03a3_) (E.cst_body cb)
+
+(** val optimize_decl : E.global_context -> E.global_decl -> E.global_decl **)
+
+let optimize_decl _UU03a3_ d = match d with
+| E.ConstantDecl cb -> E.ConstantDecl (optimize_constant_decl _UU03a3_ cb)
+| E.InductiveDecl _ -> d
+
+(** val optimize_env :
+    global_declarations -> (kername * E.global_decl) list **)
+
+let optimize_env _UU03a3_ =
+  map (on_snd (optimize_decl _UU03a3_)) _UU03a3_

--- a/erasure/src/eOptimizePropDiscr.mli
+++ b/erasure/src/eOptimizePropDiscr.mli
@@ -1,0 +1,16 @@
+open BasicAst
+open Datatypes
+open EAst
+open ETyping
+open Extract
+open List0
+open MCProd
+
+val optimize : E.global_context -> E.term -> E.term
+
+val optimize_constant_decl :
+  E.global_context -> E.constant_body -> E.constant_body
+
+val optimize_decl : E.global_context -> E.global_decl -> E.global_decl
+
+val optimize_env : global_declarations -> (kername * E.global_decl) list

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -49,6 +49,7 @@ EPretty
 Extract
 ErasureFunction
 SafeErasureFunction
+EOptimizePropDiscr
 SafeTemplateErasure
 
 G_metacoq_erasure

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -604,3 +604,21 @@ Proof.
   reflexivity.
   now eapply it_mkProd_isArity.
 Qed.
+
+Lemma isErasable_any_type {Σ Γ t T} : 
+  wf_ext Σ -> 
+  isErasable Σ Γ t ->
+  Σ ;;; Γ |- t : T ->
+  isErasable_Type Σ Γ T.
+Proof.
+  intros wfΣ [T' [Ht Ha]].
+  intros HT.
+  pose proof (PCUICPrincipality.principal_typing _ (fst wfΣ) Ht HT) as [P [le [le' tC]]].
+  destruct Ha.
+  left. eapply arity_type_inv. 3:exact Ht. all:eauto using typing_wf_local.
+  destruct s as [u [Hu isp]].
+  right.
+  exists u; split; auto.
+  eapply cumul_prop2; eauto. eapply PCUICValidity.validity; eauto.
+  eapply cumul_prop1; eauto. eapply PCUICValidity.validity; eauto.
+Qed.

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -161,8 +161,8 @@ Proof.
     eapply invert_it_Ind_red1 in X1 as (? & ? & ?); eauto.
 Qed.
 
-Lemma it_mkProd_red_Arity Σ  c0 i u l : wf Σ ->
-  ~ Is_conv_to_Arity Σ [] (it_mkProd_or_LetIn c0 (mkApps (tInd i u) l)).
+Lemma it_mkProd_red_Arity Σ Γ c0 i u l : wf Σ ->
+  ~ Is_conv_to_Arity Σ Γ (it_mkProd_or_LetIn c0 (mkApps (tInd i u) l)).
 Proof.
   intros HS (? & [] & ?). eapply invert_it_Ind_red in X as (? & ? & ?). subst.
   eapply it_mkProd_arity in H. eapply isArity_mkApps in H as [[] ]. eauto.
@@ -182,17 +182,17 @@ Qed.
 
 (* if a constructor is a type or proof, it is a proof *)
 
-Lemma tConstruct_no_Type (Σ : global_env_ext) ind c u x1 : wf Σ ->
-  isErasable Σ [] (mkApps (tConstruct ind c u) x1) ->
-  Is_proof Σ [] (mkApps (tConstruct ind c u) x1).
+Lemma tConstruct_no_Type (Σ : global_env_ext) Γ ind c u x1 : wf Σ ->
+  isErasable Σ Γ (mkApps (tConstruct ind c u) x1) ->
+  Is_proof Σ Γ (mkApps (tConstruct ind c u) x1).
 Proof.
   intros wfΣ (? & ? & [ | (? & ? & ?)]).
   - exfalso.
     eapply PCUICValidity.inversion_mkApps in t as (? & ? & ?); eauto.
-    assert(c0 : Σ ;;; [] |- x <= x) by reflexivity.
+    assert(c0 : Σ ;;; Γ |- x <= x) by reflexivity.
     revert c0 t0 i. generalize x at 1 3.
     intros x2 c0 t0 i.
-    assert (HWF : isWfArity_or_Type Σ [] x2).
+    assert (HWF : isWfArity_or_Type Σ Γ x2).
     { eapply PCUICValidity.validity.
       - eauto.
       - eapply type_mkApps. 2:eauto. eauto.
@@ -263,7 +263,7 @@ Proof.
       subst.
       eapply IHt0; eauto.
 
-      eapply (substitution_untyped_cumul Σ [] [_] [] [hd]) in c1.
+      eapply (substitution_untyped_cumul Σ Γ [_] [] [hd]) in c1.
       cbn in c1. 2:eauto. 2:{ repeat econstructor. }
       rewrite subst_it_mkProd_or_LetIn in c1.
       rewrite subst_mkApps in c1. eassumption.
@@ -272,17 +272,17 @@ Qed.
 
 (* if a cofixpoint is a type or proof, it is a proof *)
 
-Lemma tCoFix_no_Type (Σ : global_env_ext) mfix idx x1 : wf Σ ->
-  isErasable Σ [] (mkApps (tCoFix mfix idx) x1) ->
-  Is_proof Σ [] (mkApps (tCoFix mfix idx) x1).
+Lemma tCoFix_no_Type (Σ : global_env_ext) Γ mfix idx x1 : wf Σ ->
+  isErasable Σ Γ (mkApps (tCoFix mfix idx) x1) ->
+  Is_proof Σ Γ (mkApps (tCoFix mfix idx) x1).
 Proof.
   intros wfΣ (? & ? & [ | (? & ? & ?)]).
   - exfalso.
     eapply PCUICValidity.inversion_mkApps in t as (? & ? & ?); eauto.
-    assert(c0 : Σ ;;; [] |- x <= x) by reflexivity.
+    assert(c0 : Σ ;;; Γ |- x <= x) by reflexivity.
     revert c0 t0 i. generalize x at 1 3.
     intros x2 c0 t0 i.
-    assert (HWF : isWfArity_or_Type Σ [] x2).
+    assert (HWF : isWfArity_or_Type Σ Γ x2).
     { eapply PCUICValidity.validity.
       - eauto.
       - eapply type_mkApps. 2:eauto. eauto.

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -605,6 +605,10 @@ Proof.
   now eapply it_mkProd_isArity.
 Qed.
 
+Definition isErasable_Type (Σ : global_env_ext) Γ T := 
+  (Is_conv_to_Arity Σ Γ T +
+    (∑ u : Universe.t, Σ;;; Γ |- T : tSort u × Universe.is_prop u))%type.
+
 Lemma isErasable_any_type {Σ Γ t T} : 
   wf_ext Σ -> 
   isErasable Σ Γ t ->

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -166,9 +166,14 @@ Notation " Γ ,, d " := (snoc Γ d) (at level 20, d at next level).
 
 (** *** Environments *)
 
+Variant informative := 
+  | Computational
+  | Propositional. 
+
 (** See [one_inductive_body] from [declarations.ml]. *)
 Record one_inductive_body : Set := {
   ind_name : ident;
+  ind_informative : informative;
   ind_kelim : sort_family; (* Top allowed elimination sort *)
   ind_ctors : list (ident * nat (* arity, w/o lets, w/o parameters *));
   ind_projs : list (ident) (* names of projections, if any. *) }.

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -166,14 +166,10 @@ Notation " Γ ,, d " := (snoc Γ d) (at level 20, d at next level).
 
 (** *** Environments *)
 
-Variant informative := 
-  | Computational
-  | Propositional. 
-
 (** See [one_inductive_body] from [declarations.ml]. *)
 Record one_inductive_body : Set := {
   ind_name : ident;
-  ind_informative : informative;
+  ind_propositional : bool; (* True iff the inductive lives in Prop *)
   ind_kelim : sort_family; (* Top allowed elimination sort *)
   ind_ctors : list (ident * nat (* arity, w/o lets, w/o parameters *));
   ind_projs : list (ident) (* names of projections, if any. *) }.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -358,6 +358,9 @@ Lemma erases_deps_forall_ind Σ Σ'
         P (Extract.E.tConst kn))
   (Hconstruct : forall (ind : inductive) (c : nat), P (Extract.E.tConstruct ind c))
   (Hcase : forall (p : inductive × nat) (discr : Extract.E.term) (brs : list (nat × Extract.E.term)),
+      (* PCUICTyping.declared_inductive Σ kn cb ->
+      ETyping.declared_inductive Σ' kn cb' ->
+      erases_mutual_inductive_body cb cb' ->  *)
         erases_deps Σ Σ' discr ->
         P discr ->
         Forall (fun br : nat × Extract.E.term => erases_deps Σ Σ' br.2) brs ->

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -584,12 +584,10 @@ Qed.
 
 Lemma Forall2_nth_error_left {A B} {P} {l : list A} {l' : list B} : Forall2 P l l' ->
   forall n x, nth_error l n = Some x ->
-  exists x', nth_error l' n = Some x'.
+  exists x', nth_error l' n = Some x' /\ P x x'.
 Proof.  
   induction 1; destruct n; simpl; auto; try discriminate.
   intros x' [= ->]. eexists; eauto.
-  intros x' Hnth.
-  destruct (IHForall2 _ _ Hnth). eexists; eauto.
 Qed.
 
 Lemma erases_global_all_deps Σ Σ' :

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -253,7 +253,7 @@ Qed.
 
 Notation "Σ ⊢ s ▷ t" := (eval Σ s t) (at level 50, s, t at next level) : type_scope.
 
-Lemma erases_deps_eval Σ t v Σ' :
+Lemma erases_deps_eval {wfl:WcbvFlags} Σ t v Σ' :
   Σ' ⊢ t ▷ v ->
   erases_deps Σ Σ' t ->
   erases_deps Σ Σ' v.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -58,13 +58,13 @@ Proof.
   - depelim er.
     now constructor.
   - depelim er.
-    constructor; [easy|].
+    econstructor; eauto.
     induction X; [easy|].
-    depelim H.
+    depelim H2.
     constructor; [|easy].
     now cbn.
   - depelim er.
-    now constructor.
+    now econstructor.
   - depelim er.
     constructor.
     induction H in k, H, H0 |- *; [easy|].
@@ -106,13 +106,13 @@ Proof.
   - depelim er.
     now constructor.
   - depelim er.
-    constructor; [easy|].
+    econstructor; eauto.
     induction X; [easy|].
-    depelim H.
+    depelim H2.
     constructor; [|easy].
     now cbn.
   - depelim er.
-    now constructor.
+    now econstructor.
   - depelim er.
     constructor.
     induction H in k, H, H0 |- *; [easy|].
@@ -161,13 +161,13 @@ Proof.
   - depelim er.
     now constructor.
   - depelim er.
-    constructor; [easy|].
+    econstructor; [easy|easy|easy|easy|].
     induction X; [easy|].
-    depelim H.
+    depelim H2.
     constructor; [|easy].
     now cbn.
   - depelim er.
-    now constructor.
+    now econstructor.
   - depelim er.
     constructor.
     induction H in k, H, H0 |- *; [easy|].
@@ -277,11 +277,11 @@ Proof.
       eapply nth_error_forall in nth; [|now eauto].
       assumption.
     + intuition auto.
-      apply erases_deps_mkApps_inv in H0.
+      apply erases_deps_mkApps_inv in H3.
       now apply Forall_skipn.
   - depelim er.
     subst brs; cbn in *.
-    depelim H.
+    depelim H2.
     cbn in *.
     apply IHev2.
     apply erases_deps_mkApps; [easy|].
@@ -302,23 +302,23 @@ Proof.
     now apply erases_deps_mkApps.
   - depelim er.
     apply erases_deps_mkApps_inv in er as (? & ?).
-    depelim H0.
+    depelim H3.
     apply IHev.
-    constructor; [|easy].
+    econstructor; [easy|easy|easy| |easy].
     apply erases_deps_mkApps; [|easy].
-    now eapply erases_deps_cunfold_cofix.
+    now eapply erases_deps_cunfold_cofix; eauto.
   - depelim er.
     apply erases_deps_mkApps_inv in er as (? & ?).
-    depelim H.
+    depelim H2.
     apply IHev.
-    constructor.
+    econstructor; eauto.
     apply erases_deps_mkApps; [|easy].
     now eapply erases_deps_cunfold_cofix.
   - depelim er.
     now apply IHev, H2.
   - depelim er.
     intuition auto.
-    apply erases_deps_mkApps_inv in H as (? & ?).
+    apply erases_deps_mkApps_inv in H2 as (? & ?).
     apply IHev2.
     rewrite nth_nth_error.
     destruct nth_error eqn:nth; [|now constructor].
@@ -357,16 +357,19 @@ Lemma erases_deps_forall_ind Σ Σ'
       (forall body : Extract.E.term, Extract.E.cst_body cb' = Some body -> P body) ->
         P (Extract.E.tConst kn))
   (Hconstruct : forall (ind : inductive) (c : nat), P (Extract.E.tConstruct ind c))
-  (Hcase : forall (p : inductive × nat) (discr : Extract.E.term) (brs : list (nat × Extract.E.term)),
-      (* PCUICTyping.declared_inductive Σ kn cb ->
-      ETyping.declared_inductive Σ' kn cb' ->
-      erases_mutual_inductive_body cb cb' ->  *)
+  (Hcase : forall (p : inductive × nat) mdecl idecl mdecl' idecl' (discr : Extract.E.term) (brs : list (nat × Extract.E.term)),
+        PCUICTyping.declared_inductive Σ mdecl (fst p) idecl ->
+        ETyping.declared_inductive Σ' mdecl' (fst p) idecl' ->
+        erases_one_inductive_body idecl idecl' ->
         erases_deps Σ Σ' discr ->
         P discr ->
         Forall (fun br : nat × Extract.E.term => erases_deps Σ Σ' br.2) brs ->
         Forall (fun br => P br.2) brs ->
         P (Extract.E.tCase p discr brs))
-  (Hproj : forall (p : projection) (t : Extract.E.term),
+  (Hproj : forall (p : projection) mdecl idecl mdecl' idecl' (t : Extract.E.term),
+        PCUICTyping.declared_inductive Σ mdecl p.1.1 idecl ->
+        ETyping.declared_inductive Σ' mdecl' p.1.1 idecl' ->
+        erases_one_inductive_body idecl idecl' ->
         erases_deps Σ Σ' t -> P t -> P (Extract.E.tProj p t))
   (Hfix : forall (defs : list (Extract.E.def Extract.E.term)) (i : nat),
          Forall (fun d : Extract.E.def Extract.E.term => erases_deps Σ Σ' (Extract.E.dbody d)) defs ->
@@ -395,13 +398,15 @@ Proof.
     intros.
     apply f.
     now apply H2.
-  - apply Hcase; try assumption.
+  - eapply Hcase; try eassumption.
     + now apply f.
-    + revert brs H.
+    + revert brs H2.
       fix f' 2.
       intros brs []; [now constructor|].
       constructor; [now apply f|now apply f'].
-  - apply Hfix; try assumption.
+  - eapply Hproj; try eassumption.
+    now apply f.
+  - eapply Hfix; try assumption.
     revert defs H.
     fix f' 2.
     intros defs []; [now constructor|].
@@ -458,18 +463,50 @@ Proof.
       apply H.
     + now destruct E.cst_body.
   - easy.
+  - econstructor; eauto.
+    destruct H as [H H'].
+    split; eauto. red in H |- *.
+    inv wfΣ.
+    simpl. unfold eq_kername.
+    destruct (kername_eq_dec (inductive_mind p.1) kn); auto. subst.
+    eapply lookup_env_Some_fresh in H; eauto. contradiction.
+    destruct H0 as [H0 H0'].
+    split; eauto. red in H0 |- *.
+    inv wfΣ. simpl.
+    destruct (kername_eq_dec (inductive_mind p.1) kn); auto. subst.
+    destruct H as [H _].
+    eapply lookup_env_Some_fresh in H. eauto. contradiction.
+  - econstructor; eauto.
+    destruct H as [H H'].
+    split; eauto. red in H |- *.
+    inv wfΣ.
+    simpl. unfold eq_kername.
+    destruct (kername_eq_dec (inductive_mind p.1.1) kn); auto. subst.
+    eapply lookup_env_Some_fresh in H; eauto. contradiction.
+    destruct H0 as [H0 H0'].
+    split; eauto. red in H0 |- *.
+    inv wfΣ. simpl.
+    destruct (kername_eq_dec (inductive_mind p.1.1) kn); auto. subst.
+    destruct H as [H _].
+    eapply lookup_env_Some_fresh in H. eauto. contradiction.
 Qed.
 
 Derive Signature for erases_global_decls.
 Derive Signature for Forall2.
 
 Definition globals_erased_with_deps Σ Σ' :=
-  forall k cst,
+  (forall k cst,
     PCUICTyping.declared_constant Σ k cst ->
     exists cst',
       ETyping.declared_constant Σ' k cst' /\
       erases_constant_body (Σ, cst_universes cst) cst cst' /\
-      (forall body, cst_body cst' = Some body -> erases_deps Σ Σ' body).
+      (forall body, cst_body cst' = Some body -> erases_deps Σ Σ' body)) /\
+  (forall k mdecl idecl,
+      PCUICTyping.declared_inductive Σ mdecl k idecl ->
+      exists mdecl' idecl',
+        ETyping.declared_inductive Σ' mdecl' k idecl' /\
+        erases_mutual_inductive_body mdecl mdecl').
+
 
 Lemma erases_deps_single Σ Σ' t T et :
   wf_ext Σ ->
@@ -493,7 +530,10 @@ Proof.
     now econstructor; eauto.
   - apply inversion_Case in wt
       as (? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
-    constructor; [now eauto|].
+    destruct (proj2 Σer _ _ _ d) as (? & ? & ? & ?).
+    econstructor; eauto.
+    destruct H2. destruct d. destruct H1.
+    eapply Forall2_All2 in H2. eapply All2_nth_error in H2; eauto.
     clear -wf a X H0 Σer.
     revert brs' x5 a X H0 Σer.
     induction brs; intros brs' x5 brtys typ er deps.
@@ -503,11 +543,14 @@ Proof.
     depelim er.
     destruct p as ((? & ?) & ?).
     destruct p0.
-    now constructor; eauto.
+    now constructor; eauto. 
 
   - apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?); eauto.
-    constructor.
-    now eapply IHer; eauto.
+    destruct (proj2 Σer _ _ _ (proj1 d)) as (? & ? & ? & ?).
+    econstructor; eauto. eapply d.
+    destruct d as [[declm decli] _]. destruct H1. destruct H0.
+    eapply Forall2_All2 in H1. eapply All2_nth_error in H1; eauto.
+
   - constructor.
     apply inversion_Fix in wt as (?&?&?&?&?&?&?); eauto.
     clear -wf a0 X H Σer.
@@ -539,6 +582,16 @@ Proof.
     now constructor; eauto.
 Qed.
 
+Lemma Forall2_nth_error_left {A B} {P} {l : list A} {l' : list B} : Forall2 P l l' ->
+  forall n x, nth_error l n = Some x ->
+  exists x', nth_error l' n = Some x'.
+Proof.  
+  induction 1; destruct n; simpl; auto; try discriminate.
+  intros x' [= ->]. eexists; eauto.
+  intros x' Hnth.
+  destruct (IHForall2 _ _ Hnth). eexists; eauto.
+Qed.
+
 Lemma erases_global_all_deps Σ Σ' :
   wf Σ ->
   erases_global Σ Σ' ->
@@ -547,8 +600,10 @@ Proof.
   intros wf erg.
   induction Σ as [|(kn, decl) Σ IH] in Σ', wf, erg |- *; cbn in *.
   - depelim erg.
-    intros ? ? decl; discriminate decl.
-  - intros kn' cst' decl'.
+    split; [intros ? ? decl; discriminate decl|].
+    intros ? ? ? [decl _]; discriminate decl.
+  - split.
+    intros kn' cst' decl'.
     destruct (eq_dec kn kn') as [<-|].
     + unfold PCUICTyping.declared_constant, ETyping.declared_constant in *; cbn in *.
       rewrite eq_kername_refl in *.
@@ -585,7 +640,7 @@ Proof.
       { unfold PCUICTyping.declared_constant in *; cbn in *.
         unfold eq_kername in *.
         now destruct kername_eq_dec; [|congruence]. }
-      specialize (erg' kn' cst' decl_ext) as (cst & decl'' & ? & ?).
+      specialize (proj1 erg' kn' cst' decl_ext) as (cst & decl'' & ? & ?).
       exists cst.
       split; [|split].
       * unfold declared_constant in *; cbn.
@@ -602,7 +657,41 @@ Proof.
       * intros.
         apply H0 in H1.
         now apply erases_deps_cons.
-Qed.
+  + intros k mdecl idecl decli.
+    depelim erg.
+    * inv wf.
+      specialize (IH _ X erg).
+      apply proj2 in IH. specialize (IH k mdecl idecl).
+      forward IH.
+      destruct decli as [decli ?]. split; auto.
+      red in decli |- *. simpl in decli |- *.
+      unfold eq_kername in decli |- *.
+      destruct kername_eq_dec. subst. discriminate. auto.
+      destruct IH as [mdecl' [idecl' [decli' er]]].
+      exists mdecl', idecl'. split; auto.
+      red. destruct decli'; split; auto.
+      red in decli.
+      unfold declared_minductive in *.
+      simpl. destruct kername_eq_dec; subst; auto.
+      unfold PCUICTyping.declared_minductive in decli.
+      simpl in decli. rewrite eq_kername_refl in decli. intuition discriminate.
+    * inv wf.
+      specialize (IH _ X erg).
+      destruct decli as [decli ?]. 
+      simpl in decli |- *.
+      unfold PCUICTyping.declared_minductive in decli.
+      simpl in decli.
+      unfold eq_kername in decli |- *.
+      destruct kername_eq_dec. subst. noconf decli.
+      destruct (Forall2_nth_error_left (proj1 H) _ _ H2); eauto.
+      eexists _, _; intuition eauto. split; eauto. red.
+      simpl. destruct kername_eq_dec; try congruence.
+      destruct (proj2 IH _ _ _ (conj decli H2)) as [m' [i' [decli' ei]]].
+      eexists _, _; intuition eauto.
+      destruct decli'; red; split; eauto.
+      red in d |- *. simpl.
+      destruct kername_eq_dec; subst; try congruence.
+Qed.       
 
 Lemma erases_global_erases_deps Σ t T et Σ' :
   wf_ext Σ ->

--- a/erasure/theories/EInversion.v
+++ b/erasure/theories/EInversion.v
@@ -16,12 +16,12 @@ Notation type_Construct_inv := PCUICInversion.inversion_Construct.
 Notation type_tFix_inv := PCUICInversion.inversion_Fix.
 
 Derive Signature for Forall2.
-Lemma eval_box_apps:
+Lemma eval_box_apps {wfl : WcbvFlags}:
   forall (Σ' : E.global_declarations) (e : E.term) (x x' : list E.term),
     All2 (eval Σ') x x' ->
     eval Σ' e EAst.tBox -> eval Σ' (EAst.mkApps e x) EAst.tBox.
 Proof.
-  intros Σ' e x H2. revert e H2; induction x using rev_ind; cbn; intros; eauto using eval.
+  intros Σ' e x H2. revert e H2; induction x using rev_ind; cbn; intros; eauto using eval; auto.
   eapply All2_app_inv in H as ((l1' & l2') & (-> & H) & H2).
   depelim H2.
   specialize (IHx e _ H H0). simpl.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -1,0 +1,488 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import Utf8 Program.
+From MetaCoq.Template Require Import config utils Kernames.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+     PCUICReflect PCUICWeakeningEnv
+     PCUICTyping PCUICInversion PCUICGeneration
+     PCUICConfluence PCUICConversion 
+     PCUICCumulativity PCUICSR PCUICSafeLemmata
+     PCUICValidity PCUICPrincipality PCUICElimination PCUICSN.
+     
+From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeChecker PCUICSafeRetyping.
+From MetaCoq.Erasure Require Import EAstUtils EArities Extract Prelim ErasureCorrectness EDeps 
+    SafeErasureFunction ELiftSubst.
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Import MonadNotation.
+
+From Equations Require Import Equations.
+Set Equations Transparent.
+Local Set Keyed Unification.
+Require Import ssreflect ssrbool.
+
+(** We assumes [Prop </= Type] and universes are checked correctly in the following. *)
+Local Existing Instance extraction_checker_flags.
+
+Ltac introdep := let H := fresh in intros H; depelim H.
+
+Hint Constructors Ee.eval : core.
+
+Import E.
+
+Section optimize.
+  Context (Σ : global_context).
+
+  Fixpoint optimize (t : term) : term :=
+    match t with
+    | tRel i => tRel i
+    | tEvar ev args => tEvar ev (List.map optimize args)
+    | tLambda na M => tLambda na (optimize M)
+    | tApp u v => tApp (optimize u) (optimize v)
+    | tLetIn na b b' => tLetIn na (optimize b) (optimize b')
+    | tCase ind c brs =>
+      let brs' := List.map (on_snd optimize) brs in
+      match ETyping.is_propositional Σ (fst ind) with
+      | Some true =>
+        match brs' with
+        | [(a, b)] => E.mkApps b (repeat E.tBox a)
+        | _ => E.tCase ind (optimize c) brs'
+        end
+      | _ => E.tCase ind (optimize c) brs'
+      end
+    | tProj p c =>
+      match ETyping.is_propositional Σ p.1.1 with 
+      | Some true => tBox
+      | _ => tProj p (optimize c)
+      end
+    | tFix mfix idx =>
+      let mfix' := List.map (map_def optimize) mfix in
+      tFix mfix' idx
+    | tCoFix mfix idx =>
+      let mfix' := List.map (map_def optimize) mfix in
+      tCoFix mfix' idx
+    | tBox => t
+    | tVar _ => t
+    | tConst _ => t
+    | tConstruct _ _ => t
+    end.
+
+  Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).
+  Proof.
+    induction l using rev_ind; simpl; auto.
+    now rewrite -mkApps_nested /= IHl map_app /= -mkApps_nested /=.
+  Qed.
+  
+  Lemma optimize_iota_red pars n args brs :
+    optimize (ETyping.iota_red pars n args brs) = ETyping.iota_red pars n (map optimize args) (map (on_snd optimize) brs).
+  Proof.
+    unfold ETyping.iota_red.
+    rewrite !nth_nth_error nth_error_map.
+    destruct nth_error eqn:hnth => /=;
+    now rewrite optimize_mkApps map_skipn.
+  Qed.
+  
+  Lemma map_repeat {A B} (f : A -> B) x n : map f (repeat x n) = repeat (f x) n.
+  Proof.
+    now induction n; simpl; auto; rewrite IHn.
+  Qed.
+  
+  Lemma map_optimize_repeat_box n : map optimize (repeat tBox n) = repeat tBox n.
+  Proof. by rewrite map_repeat. Qed.
+
+  Import ECSubst.
+
+  Lemma csubst_mkApps {a k f l} : csubst a k (mkApps f l) = mkApps (csubst a k f) (map (csubst a k) l).
+  Proof.
+    induction l using rev_ind; simpl; auto.
+    rewrite - mkApps_nested /= IHl.
+    now rewrite [EAst.tApp _ _](mkApps_nested _ _ [_]) map_app.
+  Qed.
+
+  Lemma optimize_csubst a k b : 
+    optimize (ECSubst.csubst a k b) = ECSubst.csubst (optimize a) k (optimize b).
+  Proof.
+    induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto; 
+      try solve [f_equal; eauto; ELiftSubst.solve_all].
+    
+    - destruct (k ?= n); auto.
+    - f_equal; eauto. rewrite !map_map_compose; eauto.
+      solve_all.
+    - destruct ETyping.is_propositional as [[|]|] => /= //.
+      destruct l as [|[br n] [|l']] eqn:eql; simpl.
+      * f_equal; auto.
+      * depelim X. simpl in *.
+        rewrite e. rewrite csubst_mkApps.
+        now rewrite map_repeat /=.
+      * depelim X.
+        f_equal; eauto.
+        f_equal; eauto. now rewrite e.
+        f_equal; eauto.
+        f_equal. depelim X.
+        now rewrite e0. depelim X. rewrite !map_map_compose.
+        solve_all.
+      * f_equal; eauto.
+        rewrite !map_map_compose; solve_all.
+      * f_equal; eauto.
+        rewrite !map_map_compose; solve_all.
+    - destruct ETyping.is_propositional as [[|]|]=> //;
+      now rewrite IHb.
+    - rewrite !map_map_compose; f_equal; solve_all.
+      destruct x; unfold EAst.map_def; simpl in *. 
+      autorewrite with len. f_equal; eauto.
+    - rewrite !map_map_compose; f_equal; solve_all.
+      destruct x; unfold EAst.map_def; simpl in *. 
+      autorewrite with len. f_equal; eauto.
+  Qed.
+
+  Lemma optimize_substl s t : optimize (Ee.substl s t) = Ee.substl (map optimize s) (optimize t).
+  Proof.
+    induction s in t |- *; simpl; auto.
+    rewrite IHs. f_equal.
+    now rewrite optimize_csubst.
+  Qed.
+
+  Lemma optimize_fix_subst mfix : ETyping.fix_subst (map (map_def optimize) mfix) = map optimize (ETyping.fix_subst mfix).
+  Proof.
+    unfold ETyping.fix_subst.
+    rewrite map_length.
+    generalize #|mfix|.
+    induction n; simpl; auto.
+    f_equal; auto.
+  Qed.
+
+  Lemma optimize_cofix_subst mfix : ETyping.cofix_subst (map (map_def optimize) mfix) = map optimize (ETyping.cofix_subst mfix).
+  Proof.
+    unfold ETyping.cofix_subst.
+    rewrite map_length.
+    generalize #|mfix|.
+    induction n; simpl; auto.
+    f_equal; auto.
+  Qed.
+
+  Lemma optimize_cunfold_fix mfix idx n f : 
+    Ee.cunfold_fix mfix idx = Some (n, f) ->
+    Ee.cunfold_fix (map (map_def optimize) mfix) idx = Some (n, optimize f).
+  Proof.
+    unfold Ee.cunfold_fix.
+    rewrite nth_error_map.
+    destruct nth_error.
+    intros [= <- <-] => /=. f_equal.
+    now rewrite optimize_substl optimize_fix_subst.
+    discriminate.
+  Qed.
+
+  Lemma optimize_cunfold_cofix mfix idx n f : 
+    Ee.cunfold_cofix mfix idx = Some (n, f) ->
+    Ee.cunfold_cofix (map (map_def optimize) mfix) idx = Some (n, optimize f).
+  Proof.
+    unfold Ee.cunfold_cofix.
+    rewrite nth_error_map.
+    destruct nth_error.
+    intros [= <- <-] => /=. f_equal.
+    now rewrite optimize_substl optimize_cofix_subst.
+    discriminate.
+  Qed.
+
+  Lemma optimize_nth {n l d} : 
+    optimize (nth n l d) = nth n (map optimize l) (optimize d).
+  Proof.
+    induction l in n |- *; destruct n; simpl; auto.
+  Qed.
+
+End optimize.
+
+
+Lemma is_box_inv b : is_box b -> ∑ args, b = mkApps tBox args.
+Proof.
+  unfold is_box, EAstUtils.head.
+  destruct decompose_app eqn:da.
+  simpl. destruct t => //.
+  eapply decompose_app_inv in da. subst.
+  eexists; eauto.
+Qed.
+
+Lemma eval_is_box {wfl:Ee.WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
+Proof.
+  intros ev; induction ev => //.
+  - rewrite is_box_tApp.
+    intros isb. intuition congruence.
+  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst => //.
+  - destruct t => //.
+Qed. 
+
+Lemma isType_tSort {cf:checker_flags} {Σ : global_env_ext} {Γ l A} {wfΣ : wf Σ} : Σ ;;; Γ |- tSort (Universe.make l) : A -> isType Σ Γ (tSort (Universe.make l)).
+Proof.
+  intros HT.
+  eapply inversion_Sort in HT as [l' [wfΓ [inl [eq Hs]]]]; auto.
+  eexists; econstructor; eauto.
+  now eapply Universe.make_inj in eq as ->.
+Qed.
+
+Lemma isType_it_mkProd {cf:checker_flags} {Σ : global_env_ext} {Γ na dom codom A} {wfΣ : wf Σ} :   
+  Σ ;;; Γ |- tProd na dom codom : A -> 
+  isType Σ Γ (tProd na dom codom).
+Proof.
+  intros HT.
+  eapply inversion_Prod in HT as (? & ? & ? & ? & ?); auto.
+  eexists; econstructor; eauto.
+Qed.
+
+Lemma erasable_tBox_value (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) t T v :
+  axiom_free Σ.1 ->
+  forall wt : Σ ;;; [] |- t : T,
+  Σ |-p t ▷ v -> erases Σ [] v tBox -> ∥ isErasable Σ [] t ∥.
+Proof.
+  intros.
+  depind H0.
+  eapply Is_type_eval_inv; eauto. eexists; eauto.
+Qed.
+
+Lemma erase_eval_to_box (wfl := Ee.default_wcbv_flags) {Σ : global_env_ext}  {wfΣ : wf_ext Σ} {t v Σ' t' deps} :
+  axiom_free Σ.1 ->
+  forall wt : welltyped Σ [] t,
+  erase Σ (sq wfΣ) [] t wt = t' ->
+  KernameSet.subset (term_global_deps t') deps ->
+  erase_global deps Σ (sq wfΣ.1) = Σ' ->
+  PCUICWcbvEval.eval Σ t v ->
+  @Ee.eval Ee.default_wcbv_flags Σ' t' tBox -> ∥ isErasable Σ [] t ∥.
+Proof.
+  intros axiomfree [T wt].
+  intros.
+  destruct (erase_correct Σ wfΣ _ _ _ _ _ axiomfree _ H H0 H1 X) as [ev [eg [eg']]].
+  pose proof (Ee.eval_deterministic _ H2 eg'). subst.
+  eapply erasable_tBox_value; eauto.
+Qed.
+
+Definition optimize_constant_decl Σ cb := 
+  {| cst_body := option_map (optimize Σ) cb.(cst_body) |}.
+  
+Definition optimize_decl Σ d :=
+  match d with
+  | ConstantDecl cb => ConstantDecl (optimize_constant_decl Σ cb)
+  | InductiveDecl idecl => d
+  end.
+
+Definition optimize_env (Σ : EAst.global_declarations) := 
+  map (on_snd (optimize_decl Σ)) Σ.
+
+Import ETyping.
+
+(* Lemma optimize_extends Σ Σ' : extends Σ Σ' ->
+  optimize Σ t = optimize Σ' t. *)
+
+Lemma lookup_env_optimize Σ kn : 
+  lookup_env (optimize_env Σ) kn = 
+  option_map (optimize_decl Σ) (lookup_env Σ kn).
+Proof.
+  unfold optimize_env.
+  induction Σ at 2 4; simpl; auto.
+  destruct kername_eq_dec => //.
+Qed.
+
+Lemma is_propositional_optimize Σ ind : 
+  is_propositional Σ ind = is_propositional (optimize_env Σ) ind.
+Proof.
+  rewrite /is_propositional.
+  rewrite lookup_env_optimize.
+  destruct lookup_env; simpl; auto.
+  destruct g; simpl; auto.
+Qed.
+
+Lemma isLambda_mkApps f l : ~~ isLambda f -> ~~ EAst.isLambda (mkApps f l).
+Proof.
+  induction l using rev_ind; simpl; auto => //.
+  intros isf; specialize (IHl isf).
+  now rewrite -mkApps_nested.
+Qed.
+ 
+Lemma isFixApp_mkApps f l : ~~ Ee.isFixApp f -> ~~ Ee.isFixApp (mkApps f l).
+Proof.
+  unfold Ee.isFixApp.
+  erewrite <- (fst_decompose_app_rec _ l).
+  now rewrite /decompose_app decompose_app_rec_mkApps app_nil_r.
+Qed.
+
+Lemma isBox_mkApps f l : ~~ isBox f -> ~~ isBox (mkApps f l).
+Proof.
+  induction l using rev_ind; simpl; auto => //.
+  intros isf; specialize (IHl isf).
+  now rewrite -mkApps_nested.
+Qed.
+
+Definition extends (Σ Σ' : global_declarations) := ∑ Σ'', Σ' = Σ'' ++ Σ.
+
+Definition fresh_global kn (Σ : global_declarations) :=
+  Forall (fun x => x.1 <> kn) Σ.
+
+Inductive wf_glob : global_declarations -> Type :=
+| wf_glob_nil : wf_glob []
+| wf_glob_cons kn d Σ : 
+  wf_glob Σ ->
+  fresh_global kn Σ ->
+  wf_glob ((kn, d) :: Σ).
+Derive Signature for wf_glob.
+
+Lemma lookup_env_Some_fresh {Σ c decl} :
+  lookup_env Σ c = Some decl -> ~ (fresh_global c Σ).
+Proof.
+  induction Σ; cbn. 1: congruence.
+  unfold eq_kername; destruct kername_eq_dec; subst.
+  - intros [= <-] H2. inv H2.
+    contradiction.
+  - intros H1 H2. apply IHΣ; tas.
+    now inv H2.
+Qed.
+
+Lemma extends_lookup {Σ Σ' c decl} :
+  wf_glob Σ' ->
+  extends Σ Σ' ->
+  lookup_env Σ c = Some decl ->
+  lookup_env Σ' c = Some decl.
+Proof.
+  intros wfΣ' [Σ'' ->]. simpl.
+  induction Σ'' in wfΣ', c, decl |- *.
+  - simpl. auto.
+  - specialize (IHΣ'' c decl). forward IHΣ''.
+    + now inv wfΣ'.
+    + intros HΣ. specialize (IHΣ'' HΣ).
+      inv wfΣ'. simpl in *.
+      unfold eq_kername; destruct kername_eq_dec; subst; auto.
+      apply lookup_env_Some_fresh in IHΣ''; contradiction.
+Qed.
+
+Lemma extends_is_propositional {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind b, is_propositional Σ ind = Some b -> is_propositional Σ' ind = Some b.
+Proof.
+  intros wf ex ind b.
+  rewrite /is_propositional.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+Qed.
+
+Lemma weakening_eval_env (wfl : Ee.WcbvFlags) {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  ∀ v t, Ee.eval Σ v t -> Ee.eval Σ' v t.
+Proof.
+  intros wf ex t v ev.
+  induction ev; try solve [econstructor; eauto using (extends_is_propositional wf ex)].
+  econstructor; eauto.
+  red in isdecl |- *. eauto using extends_lookup.
+Qed.
+
+Lemma optimize_correct Σ t v :
+  @Ee.eval Ee.default_wcbv_flags Σ t v ->
+  @Ee.eval Ee.opt_wcbv_flags (optimize_env Σ) (optimize Σ t) (optimize Σ v).
+Proof.
+  intros ev.
+  induction ev; simpl in *; try solve [econstructor; eauto].
+
+  - econstructor; eauto.
+    now rewrite optimize_csubst in IHev3.
+
+  - rewrite optimize_csubst in IHev2.
+    econstructor; eauto.
+
+  - rewrite optimize_mkApps in IHev1.
+    rewrite optimize_iota_red in IHev2.
+    destruct ETyping.is_propositional as [[]|]eqn:isp => //.
+    eapply Ee.eval_iota; eauto.
+    now rewrite -is_propositional_optimize.
+  
+  - rewrite e e0 /=.
+    now rewrite optimize_mkApps map_optimize_repeat_box in IHev2.
+
+  - rewrite optimize_mkApps in IHev1.
+    simpl in *. eapply Ee.eval_fix; eauto.
+    rewrite map_length. now eapply optimize_cunfold_fix. 
+    now rewrite optimize_mkApps in IHev3.
+
+  - rewrite optimize_mkApps in IHev1 |- *.
+    simpl in *. eapply Ee.eval_fix_value. auto. auto.
+    eapply optimize_cunfold_fix; eauto. now rewrite map_length. 
+
+  - destruct ETyping.is_propositional as [[]|] eqn:isp => //.
+    destruct brs as [|[a b] []]; simpl in *; auto.
+    rewrite -> optimize_mkApps in IHev |- *. simpl.
+    econstructor; eauto.
+    now apply optimize_cunfold_cofix.
+    rewrite -> optimize_mkApps in IHev |- *. simpl.
+    econstructor; eauto.
+    now apply optimize_cunfold_cofix.
+    rewrite -> optimize_mkApps in IHev |- *. simpl.
+    econstructor; eauto.
+    now apply optimize_cunfold_cofix.
+    rewrite -> optimize_mkApps in IHev |- *. simpl.
+    econstructor; eauto.
+    now apply optimize_cunfold_cofix.
+
+  - destruct ETyping.is_propositional as [[]|] eqn:isp; auto.
+    rewrite -> optimize_mkApps in IHev |- *. simpl.
+    econstructor; eauto.
+    now apply optimize_cunfold_cofix.
+    rewrite -> optimize_mkApps in IHev |- *. simpl.
+    econstructor; eauto.
+    now apply optimize_cunfold_cofix.
+  
+  - econstructor. red in isdecl |- *.
+    rewrite lookup_env_optimize isdecl //.
+    now rewrite /optimize_constant_decl e.
+    apply IHev.
+  
+  - destruct ETyping.is_propositional as [[]|] eqn:isp => //.
+    rewrite optimize_mkApps in IHev1.
+    rewrite optimize_nth in IHev2.
+    econstructor; eauto. now rewrite -is_propositional_optimize.
+  
+  - now rewrite e.
+
+  - eapply Ee.eval_app_cong; eauto.
+    eapply Ee.eval_to_value in ev1.
+    destruct ev1; simpl in *; eauto.
+    * destruct t => //; rewrite optimize_mkApps /=.
+    * destruct t => /= //; rewrite optimize_mkApps /=;
+      rewrite (negbTE (isLambda_mkApps _ _ _)) // (negbTE (isBox_mkApps _ _ _)) 
+        // (negbTE (isFixApp_mkApps _ _ _)) //.
+    * destruct f0 => //.
+      rewrite optimize_mkApps /=.
+      unfold Ee.isFixApp in i.
+      rewrite decompose_app_mkApps /= in i => //.
+      rewrite orb_true_r /= // in i.
+  - destruct t => //.
+    all:constructor; eauto.
+Qed.
+
+Lemma erase_opt_correct (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) t v Σ' t' :
+  axiom_free Σ.1 ->
+  forall wt : welltyped Σ [] t,
+  erase Σ (sq wfΣ) [] t wt = t' ->
+  erase_global (term_global_deps t') Σ (sq wfΣ.1) = Σ' ->
+  PCUICWcbvEval.eval Σ t v ->
+  ∃ v' : term, Σ;;; [] |- v ⇝ℇ v' ∧ 
+  ∥ @Ee.eval Ee.opt_wcbv_flags (optimize_env Σ') (optimize Σ' t') (optimize Σ' v') ∥.
+Proof.
+  intros axiomfree wt.
+  generalize (sq wfΣ.1) as swfΣ.
+  intros swfΣ HΣ' Ht' ev.
+  assert (extraction_pre Σ) by now constructor.
+  pose proof (erases_erase (wfΣ := sq wfΣ) wt); eauto.
+  rewrite HΣ' in H.
+  destruct wt as [T wt].
+  unshelve epose proof (erase_global_erases_deps wfΣ wt H _); cycle 2.
+  eapply erases_correct in ev; eauto.
+  destruct ev as [v' [ev evv]].
+  exists v'. split.
+  2:{ sq. now apply optimize_correct. }
+  auto. 
+  rewrite <- Ht'.
+  eapply erase_global_includes.
+  intros.
+  eapply term_global_deps_spec in H; eauto.
+  eapply KernameSet.subset_spec.
+  intros x hin; auto.
+Qed.
+
+Print Assumptions erase_opt_correct.

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -117,10 +117,23 @@ Proof.
   finish_reflect.
 Defined.
 
+Definition eqb_informative (x y : informative) :=
+  match x, y with
+  | Computational, Computational => true
+  | Propositional, Propositional => true
+  | _, _ => false
+  end.
+
+Instance reflect_informative : ReflectEq informative.
+Proof.
+  refine {| eqb := eqb_informative |}.
+  intros [] []; finish_reflect.
+Defined.
+
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
-  let (n, k, c, p) := x in
-  let (n', k', c', p') := y in
-  eqb n n' && eqb k k' && eqb c c' && eqb p p'.
+  let (n, i, k, c, p) := x in
+  let (n', i', k', c', p') := y in
+  eqb n n' && eqb i i' && eqb k k' && eqb c c' && eqb p p'.
 
 Instance reflect_one_inductive_body : ReflectEq one_inductive_body.
 Proof.

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -117,19 +117,6 @@ Proof.
   finish_reflect.
 Defined.
 
-Definition eqb_informative (x y : informative) :=
-  match x, y with
-  | Computational, Computational => true
-  | Propositional, Propositional => true
-  | _, _ => false
-  end.
-
-Instance reflect_informative : ReflectEq informative.
-Proof.
-  refine {| eqb := eqb_informative |}.
-  intros [] []; finish_reflect.
-Defined.
-
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
   let (n, i, k, c, p) := x in
   let (n', i', k', c', p') := y in

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -78,6 +78,8 @@ Proof.
   split. eauto. econstructor. eauto.
 Qed.
 
+Require Import ssrbool.
+
 Lemma erases_extends :
   env_prop (fun Σ Γ t T =>
               forall Σ', wf Σ' -> extends Σ Σ' -> forall t', erases Σ Γ t t' -> erases (Σ', Σ.2) Γ t t')
@@ -87,6 +89,11 @@ Proof.
   all: match goal with [ H : erases _ _ ?a _ |- _ ] => tryif is_var a then idtac else inv H end.
   all: try now (econstructor; eauto).
   all: try now (econstructor; eapply Is_type_extends; eauto).
+  - econstructor.
+    red.
+    destruct isdecl as [[? ?] ?]. red in H0.
+    red in H5. rewrite H0 in H5.
+    eapply extends_lookup in H0; eauto. now rewrite H0.
   - econstructor. all:eauto.
     2:{ eauto. eapply All2_All_left in X3.
         2:{ intros ? ? [[[? ?] ?] ?]. exact e. }
@@ -403,7 +410,7 @@ Proof.
   - inv H0. econstructor.
     eapply is_type_subst; eauto.
   - inv H0.
-    + cbn. econstructor.
+    + cbn. econstructor; auto.
     + econstructor.
       eapply is_type_subst; eauto.
   - depelim H6.

--- a/erasure/theories/ETyping.v
+++ b/erasure/theories/ETyping.v
@@ -50,7 +50,7 @@ Definition is_propositional Σ ind :=
   match lookup_env Σ (inductive_mind ind) with
   | Some (InductiveDecl mdecl) =>
     match nth_error mdecl.(ind_bodies) (inductive_ind ind) with 
-    | Some idecl => Some (Reflect.eqb idecl.(ind_informative) Propositional)
+    | Some idecl => Some (idecl.(ind_propositional))
     | None => None
     end
   | _ => None

--- a/erasure/theories/ETyping.v
+++ b/erasure/theories/ETyping.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Program.
-From MetaCoq.Template Require Import config utils.
-From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst.
+From MetaCoq.Template Require Import config utils Reflect.
+From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst EReflect.
 Require Import ssreflect.
 
 (** * Typing derivations
@@ -44,6 +44,17 @@ Proof.
   simpl. destruct kername_eq_dec. subst => //. auto. 
 Qed.
 
+(** Knowledge of propositionality status oof an inductive type *)
+
+Definition is_propositional Σ ind :=
+  match lookup_env Σ (inductive_mind ind) with
+  | Some (InductiveDecl mdecl) =>
+    match nth_error mdecl.(ind_bodies) (inductive_ind ind) with 
+    | Some idecl => Some (Reflect.eqb idecl.(ind_informative) Propositional)
+    | None => None
+    end
+  | _ => None
+  end.
 
 (** ** Reduction *)
 

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -74,7 +74,14 @@ Definition cunfold_cofix (mfix : mfixpoint term) (idx : nat) :=
   | None => None
   end.
 
+(* Tells if the evaluation relation should include match-box and proj-box reduction rules. *)
+Class WcbvFlags := { with_box_case : bool }.
+
+Definition default_wcbv_flags := {| with_box_case := true |}.
+Definition opt_wcbv_flags := {| with_box_case := false |}.
+
 Section Wcbv.
+  Context {wfl : WcbvFlags}.
   Context (Σ : global_declarations).
   (* The local context is fixed: we are only doing weak reductions *)
 
@@ -106,6 +113,7 @@ Section Wcbv.
 
   (** Singleton case on a proof *)
   | eval_iota_sing ind pars discr brs n f res :
+      with_box_case ->
       eval discr tBox ->
       brs = [ (n,f) ] ->
       eval (mkApps f (repeat tBox n)) res ->
@@ -153,6 +161,7 @@ Section Wcbv.
 
   (** Proj *)
   | eval_proj_box i pars arg discr :
+      with_box_case ->
       eval discr tBox ->
       eval (tProj (i, pars, arg) discr) tBox
 
@@ -372,285 +381,288 @@ Section Wcbv.
     now rewrite (closed_cofix_substl_subst_eq cl).
   Qed.
 
-Lemma eval_mkApps_tCoFix mfix idx args v :
-  eval (mkApps (tCoFix mfix idx) args) v ->
-  exists args', v = mkApps (tCoFix mfix idx) args'.
-Proof.
-  revert v.
-  induction args using List.rev_ind; intros v ev.
-  + exists [].
-    now depelim ev.
-  + rewrite mkApps_app in ev.
-    cbn in *.
-    depelim ev;
-      try (apply IHargs in ev1 as (? & ?); solve_discr).
-    * apply IHargs in ev1 as (argsv & ->).
-      exists (argsv ++ [a']).
-      now rewrite mkApps_app.
-    * easy.
-Qed.
-
-Derive NoConfusionHom for EAst.global_decl.
-
-
-Lemma Forall_Forall2_refl :
-  forall (A : Type) (R : A -> A -> Prop) (l : list A),
-  Forall (fun x : A => R x x) l -> Forall2 R l l.
-Proof.
-  induction 1; constructor; auto.
-Qed.
-
-Lemma value_head_spec_impl t :
-  implb (value_head t) (~~ (isLambda t || isFixApp t || isBox t)).
-Proof.
-  destruct t; simpl; intuition auto; eapply implybT.
-Qed.
-
-Derive Signature for Forall.
-
-Lemma eval_stuck_fix args argsv mfix idx :
-  All2 eval args argsv ->
-  isStuckFix (tFix mfix idx) argsv ->
-  eval (mkApps (tFix mfix idx) args) (mkApps (tFix mfix idx) argsv).
-Proof.
-  revert argsv.
-  induction args as [|a args IH] using MCList.rev_ind;
-  intros argsv all stuck.
-  - apply All2_length in all.
-    destruct argsv; [|easy].
-    now apply eval_atom.
-  - destruct argsv as [|? ? _] using MCList.rev_ind;
-      [apply All2_length in all; rewrite app_length in all; now cbn in *|].
-    apply All2_app_r in all as (all & ev_a).
-    rewrite <- !mkApps_nested.
-    cbn in *.
-    destruct (cunfold_fix mfix idx) as [(? & ?)|] eqn:cuf; [|easy].
-    eapply eval_fix_value.
-    + apply IH; [easy|].
-      destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
-      rewrite app_length /= in stuck.
-      eapply Nat.leb_le in stuck. eapply Nat.leb_le. lia.
-    + easy.
-    + easy.
-    + rewrite app_length /= in stuck.
-      eapply Nat.leb_le in stuck; lia.
-Qed.
-
-Lemma stuck_fix_value_inv argsv mfix idx narg fn :
-  value (mkApps (tFix mfix idx) argsv) -> 
-  cunfold_fix mfix idx = Some (narg, fn) ->
-  (All value argsv × isStuckFix (tFix mfix idx) argsv).
-Proof.
-  remember (mkApps (tFix mfix idx) argsv) as tfix.
-  intros hv; revert Heqtfix.
-  induction hv using value_values_ind; intros eq; subst.
-  unfold atom in H. destruct argsv using rev_case => //.
-  split; auto. simpl. simpl in H. rewrite H0 //.
-  rewrite -mkApps_nested /= in H. depelim H.
-  solve_discr => //.
-  solve_discr.
-Qed.
-  
-Lemma stuck_fix_value_args argsv mfix idx narg fn :
-  value (mkApps (tFix mfix idx) argsv) ->
-  cunfold_fix mfix idx = Some (narg, fn) ->
-  #|argsv| <= narg.
-Proof.
-  intros val unf.
-  eapply stuck_fix_value_inv in val; eauto.
-  destruct val.
-  simpl in i. rewrite unf in i.
-  now eapply Nat.leb_le in i.
-Qed.
-
-Lemma value_final e : value e -> eval e e.
-Proof.
-  induction 1 using value_values_ind; simpl; auto using value.
-  - apply All_All2_refl in H1 as H2.
-    move/implyP: (value_head_spec_impl t).
-    move/(_ H) => Ht.
-    induction l using rev_ind. simpl.
-    destruct t; try discriminate.
-    * repeat constructor.
-    * repeat constructor.
-    * rewrite -mkApps_nested.
-      eapply All_app in H0 as [Hl Hx]. depelim Hx.
-      eapply All_app in H1 as [Hl' Hx']. depelim Hx'.
-      eapply All2_app_inv_r in H2 as [Hl'' [Hx'' [? [? ?]]]].
-      depelim a0.
-      eapply eval_app_cong; auto.
-      eapply IHl; auto.
-      now eapply All_All2.
-      destruct l using rev_ind; auto.
-      eapply value_head_nApp in H.
-      rewrite isFixApp_mkApps => //.
-      rewrite -mkApps_nested; simpl.
-      rewrite orb_false_r.
-      destruct t; auto.
-  - destruct f; try discriminate.
-    apply All_All2_refl in H0.
-    now apply eval_stuck_fix.
-Qed.
-
-Set Equations With UIP.
-
-Unset SsrRewrite.
-Lemma eval_unique_sig {t v v'} :
-  forall (ev1 : eval t v) (ev2 : eval t v'),
-    {| pr1 := v; pr2 := ev1 |} = {| pr1 := v'; pr2 := ev2 |}.
-Proof.
-  Local Ltac go :=
-    solve [
-        repeat
-          match goal with
-          | [H: _, H' : _ |- _] =>
-            specialize (H _ H');
-            try solve [apply (f_equal pr1) in H; cbn in *; solve_discr];
-            noconf H
-          end; easy].
-  intros ev.
-  revert v'.
-  depind ev; intros v' ev'.
-  - depelim ev'; go.
-  - depelim ev'; go.
-  - depelim ev'; go.
-  - depelim ev'; try go.
-    + specialize (IHev1 _ ev'1); noconf IHev1.
-      apply (f_equal pr1) in IHev1 as apps_eq; cbn in *.
-      apply mkApps_eq_inj in apps_eq as (eq1 & eq2); try easy.
-      noconf eq1.
-      noconf eq2.
-      noconf IHev1.
-      now specialize (IHev2 _ ev'2); noconf IHev2.
-    + apply eval_mkApps_tCoFix in ev1 as H.
-      destruct H as (? & ?); solve_discr.
-  - depelim ev'; try go.
-    + subst.
-      noconf e0.
-      specialize (IHev1 _ ev'1); noconf IHev1.
-      now specialize (IHev2 _ ev'2); noconf IHev2.
-    + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
-  - depelim ev'; try go.
-    + specialize (IHev1 _ ev'1).
-      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
-      noconf H.
-      noconf IHev1.
-      specialize (IHev2 _ ev'2); noconf IHev2.
-      assert (fn0 = fn) as -> by congruence.
-      assert (e0 = e) as -> by now apply uip.
-      now specialize (IHev3 _ ev'3); noconf IHev3.
-    + specialize (IHev1 _ ev'1).
-      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
-      noconf H.
-      exfalso; rewrite e0 in e.
-      noconf e.
-      lia.
-    + specialize (IHev1 _ ev'1).
-      noconf IHev1.
-      exfalso.
-      rewrite isFixApp_mkApps in i by easy.
+  Lemma eval_mkApps_tCoFix mfix idx args v :
+    eval (mkApps (tCoFix mfix idx) args) v ->
+    exists args', v = mkApps (tCoFix mfix idx) args'.
+  Proof.
+    revert v.
+    induction args using List.rev_ind; intros v ev.
+    + exists [].
+      now depelim ev.
+    + rewrite mkApps_app in ev.
       cbn in *.
-      now rewrite Bool.orb_true_r in i.
-  - depelim ev'; try go.
-    + specialize (IHev1 _ ev'1).
-      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
-      noconf H.
-      exfalso; rewrite e0 in e.
-      noconf e.
-      lia.
-    + specialize (IHev1 _ ev'1).
-      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
-      noconf H.
-      noconf IHev1.
-      specialize (IHev2 _ ev'2); noconf IHev2.
-      assert (narg0 = narg) as -> by congruence.
-      assert (fn0 = fn) as -> by congruence.
-      assert (e0 = e) as -> by now apply uip.
-      now assert (l0 = l) as -> by now apply PCUICWcbvEval.le_irrel.
-    + specialize (IHev1 _ ev'1).
-      noconf IHev1.
-      exfalso.
-      rewrite isFixApp_mkApps in i by easy.
+      depelim ev;
+        try (apply IHargs in ev1 as (? & ?); solve_discr).
+      * apply IHargs in ev1 as (argsv & ->).
+        exists (argsv ++ [a']).
+        now rewrite mkApps_app.
+      * easy.
+  Qed.
+
+  Derive NoConfusionHom for EAst.global_decl.
+
+  Lemma Forall_Forall2_refl :
+    forall (A : Type) (R : A -> A -> Prop) (l : list A),
+    Forall (fun x : A => R x x) l -> Forall2 R l l.
+  Proof.
+    induction 1; constructor; auto.
+  Qed.
+
+  Lemma value_head_spec_impl t :
+    implb (value_head t) (~~ (isLambda t || isFixApp t || isBox t)).
+  Proof.
+    destruct t; simpl; intuition auto; eapply implybT.
+  Qed.
+
+  Derive Signature for Forall.
+
+  Lemma eval_stuck_fix args argsv mfix idx :
+    All2 eval args argsv ->
+    isStuckFix (tFix mfix idx) argsv ->
+    eval (mkApps (tFix mfix idx) args) (mkApps (tFix mfix idx) argsv).
+  Proof.
+    revert argsv.
+    induction args as [|a args IH] using MCList.rev_ind;
+    intros argsv all stuck.
+    - apply All2_length in all.
+      destruct argsv; [|easy].
+      now apply eval_atom.
+    - destruct argsv as [|? ? _] using MCList.rev_ind;
+        [apply All2_length in all; rewrite app_length in all; now cbn in *|].
+      apply All2_app_r in all as (all & ev_a).
+      rewrite <- !mkApps_nested.
       cbn in *.
-      now rewrite Bool.orb_true_r in i.
-  - depelim ev'; try go.
-    + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
-    + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
-    + apply mkApps_eq_inj in e' as H'; auto.
-      destruct H' as (H' & <-).
-      noconf H'.
-      assert (narg0 = narg) as -> by congruence.
-      assert (fn0 = fn) as -> by congruence.
-      assert (e' = eq_refl) as -> by now apply uip.
+      destruct (cunfold_fix mfix idx) as [(? & ?)|] eqn:cuf; [|easy].
+      eapply eval_fix_value.
+      + apply IH; [easy|].
+        destruct (cunfold_fix mfix idx) as [(? & ?)|]; [|easy].
+        rewrite app_length /= in stuck.
+        eapply Nat.leb_le in stuck. eapply Nat.leb_le. lia.
+      + easy.
+      + easy.
+      + rewrite app_length /= in stuck.
+        eapply Nat.leb_le in stuck; lia.
+  Qed.
+
+  Lemma stuck_fix_value_inv argsv mfix idx narg fn :
+    value (mkApps (tFix mfix idx) argsv) -> 
+    cunfold_fix mfix idx = Some (narg, fn) ->
+    (All value argsv × isStuckFix (tFix mfix idx) argsv).
+  Proof.
+    remember (mkApps (tFix mfix idx) argsv) as tfix.
+    intros hv; revert Heqtfix.
+    induction hv using value_values_ind; intros eq; subst.
+    unfold atom in H. destruct argsv using rev_case => //.
+    split; auto. simpl. simpl in H. rewrite H0 //.
+    rewrite -mkApps_nested /= in H. depelim H.
+    solve_discr => //.
+    solve_discr.
+  Qed.
+    
+  Lemma stuck_fix_value_args argsv mfix idx narg fn :
+    value (mkApps (tFix mfix idx) argsv) ->
+    cunfold_fix mfix idx = Some (narg, fn) ->
+    #|argsv| <= narg.
+  Proof.
+    intros val unf.
+    eapply stuck_fix_value_inv in val; eauto.
+    destruct val.
+    simpl in i. rewrite unf in i.
+    now eapply Nat.leb_le in i.
+  Qed.
+
+  Lemma value_final e : value e -> eval e e.
+  Proof.
+    induction 1 using value_values_ind; simpl; auto using value.
+    - apply All_All2_refl in H1 as H2.
+      move/implyP: (value_head_spec_impl t).
+      move/(_ H) => Ht.
+      induction l using rev_ind. simpl.
+      destruct t; try discriminate.
+      * repeat constructor.
+      * repeat constructor.
+      * rewrite -mkApps_nested.
+        eapply All_app in H0 as [Hl Hx]. depelim Hx.
+        eapply All_app in H1 as [Hl' Hx']. depelim Hx'.
+        eapply All2_app_inv_r in H2 as [Hl'' [Hx'' [? [? ?]]]].
+        depelim a0.
+        eapply eval_app_cong; auto.
+        eapply IHl; auto.
+        now eapply All_All2.
+        destruct l using rev_ind; auto.
+        eapply value_head_nApp in H.
+        rewrite isFixApp_mkApps => //.
+        rewrite -mkApps_nested; simpl.
+        rewrite orb_false_r.
+        destruct t; auto.
+    - destruct f; try discriminate.
+      apply All_All2_refl in H0.
+      now apply eval_stuck_fix.
+  Qed.
+
+  Set Equations With UIP.
+
+  Unset SsrRewrite.
+  Lemma eval_unique_sig {t v v'} :
+    forall (ev1 : eval t v) (ev2 : eval t v'),
+      {| pr1 := v; pr2 := ev1 |} = {| pr1 := v'; pr2 := ev2 |}.
+  Proof.
+    Local Ltac go :=
+      solve [
+          repeat
+            match goal with
+            | [H: _, H' : _ |- _] =>
+              specialize (H _ H');
+              try solve [apply (f_equal pr1) in H; cbn in *; solve_discr];
+              noconf H
+            end; easy].
+    intros ev.
+    revert v'.
+    depind ev; intros v' ev'.
+    - depelim ev'; go.
+    - depelim ev'; go.
+    - depelim ev'; go.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        apply (f_equal pr1) in IHev1 as apps_eq; cbn in *.
+        apply mkApps_eq_inj in apps_eq as (eq1 & eq2); try easy.
+        noconf eq1.
+        noconf eq2.
+        noconf IHev1.
+        now specialize (IHev2 _ ev'2); noconf IHev2.
+      + apply eval_mkApps_tCoFix in ev1 as H.
+        destruct H as (? & ?); solve_discr.
+    - depelim ev'; try go.
+      + subst.
+        noconf e0.
+        simpl.
+        specialize (IHev1 _ ev'1); noconf IHev1. simpl.
+        pose proof (uip i i0). subst i0.
+        now specialize (IHev2 _ ev'2); noconf IHev2.
+      + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        noconf IHev1.
+        specialize (IHev2 _ ev'2); noconf IHev2.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e0 = e) as -> by now apply uip.
+        now specialize (IHev3 _ ev'3); noconf IHev3.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        exfalso; rewrite e0 in e.
+        noconf e.
+        lia.
+      + specialize (IHev1 _ ev'1).
+        noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        exfalso; rewrite e0 in e.
+        noconf e.
+        lia.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        noconf IHev1.
+        specialize (IHev2 _ ev'2); noconf IHev2.
+        assert (narg0 = narg) as -> by congruence.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e0 = e) as -> by now apply uip.
+        now assert (l0 = l) as -> by now apply PCUICWcbvEval.le_irrel.
+      + specialize (IHev1 _ ev'1).
+        noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+    - depelim ev'; try go.
+      + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
+      + apply eval_mkApps_tCoFix in ev'1 as H; destruct H; solve_discr.
+      + apply mkApps_eq_inj in e' as H'; auto.
+        destruct H' as (H' & <-).
+        noconf H'.
+        assert (narg0 = narg) as -> by congruence.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e' = eq_refl) as -> by now apply uip.
+        assert (e0 = e) as -> by now apply uip.
+        cbn in *; subst.
+        now specialize (IHev _ ev'); noconf IHev.
+    - depelim ev'; try go.
+      + apply mkApps_eq_inj in e1 as H'; auto.
+        destruct H' as (H' & <-).
+        noconf H'.
+        assert (narg0 = narg) as -> by congruence.
+        assert (fn0 = fn) as -> by congruence.
+        assert (e1 = eq_refl) as -> by now apply uip.
+        assert (e0 = e) as -> by now apply uip.
+        cbn in *; subst.
+        now specialize (IHev _ ev'); noconf IHev.
+      + exfalso; apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
+      + exfalso; apply eval_mkApps_tCoFix in ev' as (? & ?); solve_discr.
+    - depelim ev'; try go.
+      unfold ETyping.declared_constant in *.
+      assert (decl0 = decl) as -> by congruence.
+      assert (body0 = body) as -> by congruence.
       assert (e0 = e) as -> by now apply uip.
-      cbn in *; subst.
+      assert (isdecl0 = isdecl) as -> by now apply uip.
       now specialize (IHev _ ev'); noconf IHev.
-  - depelim ev'; try go.
-    + apply mkApps_eq_inj in e1 as H'; auto.
-      destruct H' as (H' & <-).
-      noconf H'.
-      assert (narg0 = narg) as -> by congruence.
-      assert (fn0 = fn) as -> by congruence.
-      assert (e1 = eq_refl) as -> by now apply uip.
-      assert (e0 = e) as -> by now apply uip.
-      cbn in *; subst.
+    - depelim ev'; try go.
+      + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
+      + specialize (IHev1 _ ev'1).
+        pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
+        noconf H.
+        noconf IHev1.
+        now specialize (IHev2 _ ev'2); noconf IHev2.
+    - depelim ev'; try go.
+      apply eval_mkApps_tCoFix in ev as H; destruct H; solve_discr.
+      rewrite (uip i0 i2).
       now specialize (IHev _ ev'); noconf IHev.
-    + exfalso; apply eval_mkApps_tCoFix in ev'1 as (? & ?); solve_discr.
-    + exfalso; apply eval_mkApps_tCoFix in ev' as (? & ?); solve_discr.
-  - depelim ev'; try go.
-    unfold ETyping.declared_constant in *.
-    assert (decl0 = decl) as -> by congruence.
-    assert (body0 = body) as -> by congruence.
-    assert (e0 = e) as -> by now apply uip.
-    assert (isdecl0 = isdecl) as -> by now apply uip.
-    now specialize (IHev _ ev'); noconf IHev.
-  - depelim ev'; try go.
-    + apply eval_mkApps_tCoFix in ev1 as H; destruct H; solve_discr.
-    + specialize (IHev1 _ ev'1).
-      pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
-      noconf H.
-      noconf IHev1.
-      now specialize (IHev2 _ ev'2); noconf IHev2.
-  - depelim ev'; try go.
-    apply eval_mkApps_tCoFix in ev as H; destruct H; solve_discr.
-  - depelim ev'; try go.
-    + specialize (IHev1 _ ev'1); noconf IHev1.
-      exfalso.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite Bool.orb_true_r in i.
-    + specialize (IHev1 _ ev'1); noconf IHev1.
-      exfalso.
-      rewrite isFixApp_mkApps in i by easy.
-      cbn in *.
-      now rewrite Bool.orb_true_r in i.
-    + specialize (IHev1 _ ev'1); noconf IHev1.
-      specialize (IHev2 _ ev'2); noconf IHev2.
+    - depelim ev'; try go.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        exfalso.
+        rewrite isFixApp_mkApps in i by easy.
+        cbn in *.
+        now rewrite Bool.orb_true_r in i.
+      + specialize (IHev1 _ ev'1); noconf IHev1.
+        specialize (IHev2 _ ev'2); noconf IHev2.
+        now assert (i0 = i) as -> by now apply uip.
+    - depelim ev'; try go.
       now assert (i0 = i) as -> by now apply uip.
-  - depelim ev'; try go.
-    now assert (i0 = i) as -> by now apply uip.
-Qed.
+  Qed.
 
-Lemma eval_deterministic {t v v'} :
-  eval t v ->
-  eval t v' ->
-  v = v'.
-Proof.
-  intros ev ev'.
-  pose proof (eval_unique_sig ev ev').
-  now noconf H.
-Qed.
+  Lemma eval_deterministic {t v v'} :
+    eval t v ->
+    eval t v' ->
+    v = v'.
+  Proof.
+    intros ev ev'.
+    pose proof (eval_unique_sig ev ev').
+    now noconf H.
+  Qed.
 
-Lemma eval_unique {t v} :
-  forall (ev1 : eval t v) (ev2 : eval t v),
-    ev1 = ev2.
-Proof.
-  intros ev ev'.
-  pose proof (eval_unique_sig ev ev').
-  now noconf H.
-Qed.
+  Lemma eval_unique {t v} :
+    forall (ev1 : eval t v) (ev2 : eval t v),
+      ev1 = ev2.
+  Proof.
+    intros ev ev'.
+    pose proof (eval_unique_sig ev ev').
+    now noconf H.
+  Qed.
 
-Set SsrRewrite.
+  Set SsrRewrite.
 
 End Wcbv.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -509,7 +509,7 @@ Proof.
     eapply b0. eauto. now rewrite app_length fix_context_length.
 Qed.
 
-Lemma eval_to_mkApps_tBox_inv Σ t argsv :
+Lemma eval_to_mkApps_tBox_inv {wfl:WcbvFlags} Σ t argsv :
   Σ ⊢ t ▷ E.mkApps E.tBox argsv ->
   argsv = [].
 Proof.
@@ -583,13 +583,13 @@ Qed.
 
 Transparent PCUICParallelReductionConfluence.construct_cofix_discr.
 
-Lemma erases_correct Σ t T t' v Σ' :
+Lemma erases_correct (wfl := default_wcbv_flags) Σ t T t' v Σ' :
   extraction_pre Σ ->
   Σ;;; [] |- t : T ->
   Σ;;; [] |- t ⇝ℇ t' ->  
   erases_deps Σ Σ' t' ->
   Σ |-p t ▷ v ->
-  exists v', Σ;;; [] |- v ⇝ℇ v' /\ ∥Σ' ⊢ t' ▷ v'∥.
+  exists v', Σ;;; [] |- v ⇝ℇ v' /\ ∥ Σ' ⊢ t' ▷ v' ∥.
 Proof.
   intros pre Hty He Hed H.
   revert T Hty t' He Hed.
@@ -774,7 +774,7 @@ Proof.
         now constructor.
 
         (* destruct x4; cbn in e2; subst. destruct X2. destruct p0; cbn in e2; subst. cbn in *.  destruct y.  *)
-        exists x3. split; eauto. constructor. eapply eval_iota_sing.  2:eauto.
+        exists x3. split; eauto. constructor. eapply eval_iota_sing => //. 2:eauto.
         pose proof (Ee.eval_to_value _ _ _ He_v').
         eapply value_app_inv in H5. subst. eassumption.
 
@@ -862,7 +862,7 @@ Proof.
            now constructor.
 
            exists x0. split; eauto.
-           constructor. eapply eval_iota_sing.
+           constructor. eapply eval_iota_sing => //.
            pose proof (Ee.eval_to_value _ _ _ He_v').
            2:eauto. auto.
            apply value_app_inv in H9; subst x1.
@@ -906,7 +906,7 @@ Proof.
         eassumption.
         eapply isErasable_Proof. constructor. eauto.
 
-        eapply eval_proj_box.
+        eapply eval_proj_box => //.
         pose proof (Ee.eval_to_value _ _ _ Hty_vc').
         eapply value_app_inv in H1. subst. eassumption.
       * rename H3 into Hinf.
@@ -935,7 +935,7 @@ Proof.
            eassumption.
            eapply isErasable_Proof. eauto.
 
-           constructor. eapply eval_proj_box.
+           constructor. eapply eval_proj_box => //.
            pose proof (Ee.eval_to_value _ _ _ Hty_vc').
            eapply value_app_inv in H2. subst. eassumption.
         -- eapply erases_deps_eval in Hty_vc'; [|now eauto].
@@ -972,7 +972,8 @@ Proof.
       { exists E.tBox.
         eapply eval_to_mkApps_tBox_inv in ev_stuck as ?; subst.
         cbn in *.
-        split; [|now constructor; eauto using Ee.eval].
+        split; [|constructor; eauto using Ee.eval].
+        2:{ eapply (eval_box_apps _ _ [_]); eauto. }
         destruct H2.
         eapply (Is_type_app _ _ _ (x5 ++ [av])) in X as []; eauto; first last.
         - rewrite mkApps_nested app_assoc mkApps_snoc.
@@ -1115,7 +1116,7 @@ Proof.
     eapply erases_App in He as He'; [|eauto].
     destruct He' as [(-> & [])|(? & ? & -> & ? & ?)].
     + exists E.tBox.
-      split; [|now constructor; eauto using Ee.eval].
+      split; [|now constructor; eauto using @Ee.eval].
       constructor.
       eapply Is_type_red.
       * eauto.
@@ -1136,7 +1137,7 @@ Proof.
         rewrite -> !app_nil_r in *.
         cbn in *.
         exists E.tBox.
-        split; [|now constructor; eauto using Ee.eval].
+        split; [|now constructor; eauto using @Ee.eval].
         eapply (Is_type_app _ _ _ [av]) in X as [].
         -- constructor.
            apply X.
@@ -1160,7 +1161,7 @@ Proof.
               
         -- exists E.tBox.
            apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
-           split; [|now constructor; eauto using Ee.eval].
+           split; [|now constructor; eauto using @Ee.eval].
            eapply Is_type_app in X as [].
            ++ constructor.
               rewrite <- mkApps_snoc.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -620,7 +620,6 @@ Lemma erases_correct (wfl := default_wcbv_flags) Σ t T t' v Σ' :
   Σ;;; [] |- t : T ->
   Σ;;; [] |- t ⇝ℇ t' ->  
   erases_deps Σ Σ' t' ->
-  (forall ind b, isPropositional Σ ind b -> is_propositional Σ' ind = Some b) ->
   Σ |-p t ▷ v ->
   exists v', Σ;;; [] |- v ⇝ℇ v' /\ ∥ Σ' ⊢ t' ▷ v' ∥.
 Proof.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -22,69 +22,6 @@ Require Import ssreflect.
 
 Derive Signature for on_global_env.
 
-Reserved Notation "Σ ;;; Γ |- s ⇝⧈ t" (at level 50, Γ, s, t at next level).
-Reserved Notation "Σ ;;; Γ |- s ⇝⧆ t" (at level 50, Γ, s, t at next level).
-(* 
-Section ErasesAll.
-  Context {cf:checker_flags}.
-
-  Inductive erases_comp (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :=
-    erases_tRel : forall i : nat, Σ;;; Γ |- tRel i ⇝⧆ E.tRel i
-  | erases_tVar : forall n : ident, Σ;;; Γ |- tVar n ⇝⧆ E.tVar n
-  | erases_tEvar : forall (m m' : nat) (l : list term) (l' : list E.term),
-                   All2 (erases Σ Γ) l l' -> Σ;;; Γ |- tEvar m l ⇝⧆ E.tEvar m' l'
-  | erases_tLambda : forall (na : name) (b t : term) (t' : E.term),
-                     Σ;;; (vass na b :: Γ) |- t ⇝⧆ t' ->
-                     Σ;;; Γ |- tLambda na b t ⇝⧆ E.tLambda na t'
-  | erases_tLetIn : forall (na : name) (t1 : term) (t1' : E.term)
-                      (T t2 : term) (t2' : E.term),
-                    Σ;;; Γ |- t1 ⇝⧈ t1' ->
-                    Σ;;; (vdef na t1 T :: Γ) |- t2 ⇝⧆ t2' ->
-                    Σ;;; Γ |- tLetIn na t1 T t2 ⇝⧆ E.tLetIn na t1' t2'
-  | erases_tApp : forall (f u : term) (f' u' : E.term),
-                  Σ;;; Γ |- f ⇝⧆ f' ->
-                  Σ;;; Γ |- u ⇝⧈ u' -> Σ;;; Γ |- tApp f u ⇝⧆ E.tApp f' u'
-  | erases_tConst : forall (kn : kername) (u : Instance.t),
-                    Σ;;; Γ |- tConst kn u ⇝⧆ E.tConst kn
-  | erases_tConstruct : forall (kn : inductive) (k : nat) (n : Instance.t),
-                        Σ;;; Γ |- tConstruct kn k n ⇝⧆ E.tConstruct kn k
-  | erases_tCase1 : forall (ind : inductive) (npar : nat) (T c : term)
-                      (brs : list (nat × term)) (c' : E.term)
-                      (brs' : list (nat × E.term)),
-                    Informative Σ ind ->
-                    Σ;;; Γ |- c ⇝⧈ c' ->
-                    All2
-                      (fun (x : nat × term) (x' : nat × E.term) =>
-                       Σ;;; Γ |- snd x ⇝⧆ snd x' × fst x = fst x') brs brs' ->
-                    Σ;;; Γ |- tCase (ind, npar) T c brs ⇝⧆ E.tCase (ind, npar) c' brs'
-  | erases_tProj : forall (p : (inductive × nat) × nat) (c : term) (c' : E.term),
-                   let ind := fst (fst p) in
-                   Informative Σ ind ->
-                   Σ;;; Γ |- c ⇝⧆ c' -> Σ;;; Γ |- tProj p c ⇝⧆ E.tProj p c'
-  | erases_tFix : forall (mfix : mfixpoint term) (n : nat) (mfix' : list (E.def E.term)),
-                  All2
-                    (fun (d : def term) (d' : E.def E.term) =>
-                     dname d = E.dname d'
-                     × rarg d = E.rarg d'
-                       × Σ;;; Γ ,,, PCUICLiftSubst.fix_context mfix |-
-                         dbody d ⇝⧆ E.dbody d') mfix mfix' ->
-                  Σ;;; Γ |- tFix mfix n ⇝⧆ E.tFix mfix' n
-  | erases_tCoFix : forall (mfix : mfixpoint term) (n : nat) (mfix' : list (E.def E.term)),
-                    All2
-                      (fun (d : def term) (d' : E.def E.term) =>
-                       dname d = E.dname d'
-                       × rarg d = E.rarg d'
-                         × Σ;;; Γ ,,, PCUICLiftSubst.fix_context mfix |-
-                           dbody d ⇝⧆ E.dbody d') mfix mfix' ->
-                    Σ;;; Γ |- tCoFix mfix n ⇝⧆ E.tCoFix mfix' n
-  with erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :=
-  | erases_nonbox t u : (isErasable Σ Γ t -> False) -> Σ ;;; Γ |- t ⇝⧆ u -> Σ ;;; Γ |- t ⇝⧈ u
-  | erases_box t : isErasable Σ Γ t -> Σ;;; Γ |- t ⇝⧈ E.tBox 
-  
-  where "Σ ;;; Γ |- s ⇝⧈ t" := (erases Σ Γ s t)
-  and "Σ ;;; Γ |- s ⇝⧆ t" := (erases_comp Σ Γ s t).
-End ErasesAll. *)
-
 (* To debug performance issues *)
 (* 
 Axiom time : forall {A}, string -> (unit -> A) -> A.
@@ -615,8 +552,6 @@ Proof.
     eapply isArity_ind_type; eauto.
 Defined.
 
-Require Import ssrbool.
-
 Lemma erases_erase {Σ : global_env_ext} {wfΣ : ∥wf_ext Σ∥} {Γ t} (wt : welltyped Σ Γ t) :
   erases Σ Γ t (erase Σ wfΣ Γ t wt).
 Proof.
@@ -673,7 +608,8 @@ Proof.
     eapply isArity_ind_type; eauto.
 
   - constructor. clear E.
-    todo "not erasable not propositional".
+    eapply nisErasable_Propositional in f; auto.
+    now exists A.
 
   - constructor. clear E.
     eapply inversion_Proj in t as (? & ? & ? & ? & ? & ? & ? & ? & ?) ; auto.
@@ -728,16 +664,15 @@ Definition erase_one_inductive_body (oib : one_inductive_body) : E.one_inductive
   (* Projection and constructor types are types, hence always erased *)
   let ctors := map (A:=(ident * term) * nat) (fun '((x, y), z) => (x, z)) oib.(ind_ctors) in
   let projs := map (fun '(x, y) => x) oib.(ind_projs) in
-  let is_informative := 
+  let is_propositional := 
     match destArity [] oib.(ind_type) with
-    | Some (_, u) => if Universe.is_prop u then E.Propositional
-      else E.Computational
-    | None => E.Computational (* dummy, impossible case *)
+    | Some (_, u) => Universe.is_prop u
+    | None => false (* dummy, impossible case *)
     end
   in
   {| E.ind_name := oib.(ind_name);
      E.ind_kelim := oib.(ind_kelim);
-     E.ind_informative := is_informative;
+     E.ind_propositional := is_propositional;
      E.ind_ctors := ctors;
      E.ind_projs := projs |}.
 
@@ -800,7 +735,9 @@ Definition global_erased_with_deps Σ Σ' kn :=
     erases_constant_body (Σ, cst_universes cst) cst cst' /\
     (forall body : EAst.term,
      EAst.cst_body cst' = Some body -> erases_deps Σ Σ' body)) \/
-  (exists mib, declared_minductive Σ kn mib).
+  (exists mib mib', declared_minductive Σ kn mib /\ 
+    ETyping.declared_minductive Σ' kn mib' /\
+    erases_mutual_inductive_body mib mib').
 
 Definition includes_deps Σ Σ' deps :=  
   forall kn, 
@@ -940,13 +877,24 @@ Proof.
     destruct Σer as [[c' [declc' (? & ? & ? & ?)]]|].
     pose proof (PCUICWeakeningEnv.declared_constant_inj _ _ d declc'). subst x.
     now econstructor; eauto.
-    destruct H as [mib declm].
+    destruct H as [mib [mib' [declm declm']]].
     red in declm, d. rewrite d in declm. noconf declm.
   - apply inversion_Case in wt
       as (? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
     destruct ind as [kn i']; simpl in *.
     apply includes_deps_fold in H2 as [? ?].
+
+    specialize (H1 kn). forward H1.
+    now rewrite KernameSet.singleton_spec. red in H1. destruct H1.
+    elimtype False. destruct H1 as [cst [declc _]].
+    { red in declc. destruct d as [d _]. red in d. rewrite d in declc. noconf declc. }
+    destruct H1 as [mib [mib' [declm [declm' em]]]].
+    destruct em.
+    pose proof d as [].
+    eapply Forall2_nth_error_left in H1; eauto. destruct H1 as [? [? ?]].
     eapply erases_deps_tCase; eauto.
+    split; eauto.
+    destruct H1.
     eapply In_Forall in H3.
     eapply All_Forall. eapply Forall_All in H3.
     eapply Forall2_All2 in H0.
@@ -955,10 +903,21 @@ Proof.
     eapply All2_All_left. eapply a.
     simpl. intuition auto. eexists ; eauto.
     ELiftSubst.solve_all. destruct a2 as [T' HT]. eauto.
+    simpl.
+    destruct d. red in H7, declm. rewrite H7 in declm. now noconf declm.
 
   - apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?); eauto.
-    constructor.
-    now eapply IHer; eauto.
+    destruct (proj1 d).
+    specialize (H0 (inductive_mind p.1.1)). forward H0.
+    now rewrite KernameSet.singleton_spec. red in H0. destruct H0.
+    elimtype False. destruct H0 as [cst [declc _]].
+    { red in declc. destruct d as [[d _] _]. red in d. rewrite d in declc. noconf declc. }
+    destruct H0 as [mib [mib' [declm [declm' em]]]].
+    destruct d. destruct em.
+    eapply Forall2_nth_error_left in H5 as (x' & ? & ?); eauto.
+    econstructor; eauto. split; eauto.
+    destruct H0. red in H0, declm. rewrite H0 in declm. now noconf declm.
+
   - constructor.
     apply inversion_Fix in wt as (?&?&?&?&?&?&?); eauto.
     eapply All_Forall. eapply includes_deps_fold in Σer as [_ Σer].
@@ -1008,6 +967,45 @@ Proof.
      (Σ' := (((kn, d) :: Σ), cst_universes cb))); eauto.
   simpl. now inv wfΣ.
   eexists [(kn, d)]; intuition eauto.
+  econstructor; eauto.
+  red. destruct H. split; eauto.
+  inv wfΣ.
+  red in d0 |- *.
+  rewrite -d0. simpl. unfold eq_kername. destruct kername_eq_dec; try congruence.
+  eapply lookup_env_Some_fresh in d0. subst kn; contradiction.
+  econstructor; eauto.
+  red. destruct H. split; eauto.
+  inv wfΣ.
+  red in d0 |- *.
+  rewrite -d0. simpl. unfold eq_kername. destruct kername_eq_dec; try congruence.
+  eapply lookup_env_Some_fresh in d0. subst kn; contradiction.
+Qed.
+
+Lemma lookup_env_ext {Σ kn kn' d d'} : 
+  wf ((kn', d') :: Σ) ->
+  lookup_env Σ kn = Some d ->
+  kn <> kn'.
+Proof.
+  intros wf hl.
+  eapply lookup_env_Some_fresh in hl.
+  inv wf.
+  destruct (kername_eq_dec kn kn'); subst; congruence.
+Qed.
+
+Lemma lookup_env_cons_disc {Σ kn kn' d} : 
+  kn <> kn' ->
+  lookup_env ((kn', d) :: Σ) kn = lookup_env Σ kn.
+Proof.
+  intros Hk. simpl; unfold eq_kername.
+  destruct kername_eq_dec; congruence.
+Qed.
+
+Lemma elookup_env_cons_disc {Σ kn kn' d} : 
+  kn <> kn' ->
+  ETyping.lookup_env ((kn', d) :: Σ) kn = ETyping.lookup_env Σ kn.
+Proof.
+  intros Hk. simpl; unfold eq_kername.
+  destruct kername_eq_dec; congruence.
 Qed.
 
 Lemma global_erases_with_deps_cons kn kn' d d' Σ Σ' : 
@@ -1038,13 +1036,12 @@ Proof.
   eapply erases_deps_cons; eauto.
   constructor; auto.
 
-  right. destruct H as [mib Hm].
-  exists mib.
-  red.
-  rewrite lookup_env_cons_fresh //.
-  inv wf.
-  { eapply lookup_env_Some_fresh in Hm.
-    intros <-; contradiction. }
+  right. destruct H as [mib [mib' [? [? ?]]]].
+  exists mib, mib'. intuition eauto.
+  * red. red in H. pose proof (lookup_env_ext wf H).
+    now rewrite lookup_env_cons_disc.
+  * red. pose proof (lookup_env_ext wf H).
+    now rewrite elookup_env_cons_disc.
 Qed.
 
 Lemma global_erases_with_deps_weaken kn kn' d Σ Σ' : 
@@ -1072,13 +1069,11 @@ Proof.
   noconf H.
   eapply erases_deps_weaken; eauto. constructor; eauto.
 
-  right. destruct H as [mib Hm].
-  exists mib.
+  right. destruct H as [mib [mib' [Hm [? ?]]]].
+  exists mib, mib'; intuition auto.
   red.
   rewrite lookup_env_cons_fresh //.
-  inv wf.
-  { eapply lookup_env_Some_fresh in Hm.
-    intros <-; contradiction. }
+  now epose proof (lookup_env_ext wf Hm).
 Qed.
 
 Lemma erase_constant_body_correct Σ Σ' cb (wfΣ : ∥  wf_ext Σ ∥) (onc : ∥ on_constant_decl (lift_typing typing) Σ cb ∥) :
@@ -1106,6 +1101,30 @@ Proof.
   destruct obl. sq.
   exists bod, A; intuition auto. simpl.
   eapply erases_erase. now simpl in H.
+Qed.
+
+Lemma erases_mutual {Σ mdecl m} : 
+  wf Σ ->
+  declared_minductive Σ mdecl m ->
+  erases_mutual_inductive_body m (erase_mutual_inductive_body m).
+Proof.
+  destruct m; constructor; simpl; auto.
+  eapply on_declared_minductive in H; auto. simpl in H. clear X.
+  eapply onInductives in H; simpl in *.
+  assert (Alli (fun i oib => match destArity [] oib.(ind_type) with Some _ => True | None => False end) 0 ind_bodies).
+  { eapply Alli_impl; eauto.
+    simpl. intros n x []. simpl in *. rewrite ind_arity_eq.
+    rewrite !destArity_it_mkProd_or_LetIn /= //. } clear H.
+  induction X; constructor; auto.
+  destruct hd; constructor; simpl; auto.
+  clear.
+  induction ind_ctors; constructor; auto.
+  destruct a as [[? ?] ?]; constructor; auto.
+  intuition auto.
+  induction ind_projs; constructor; auto.
+  destruct a; auto.
+  unfold isPropositionalArity.
+  destruct destArity as [[? ?]|] eqn:da; auto.
 Qed.
 
 Lemma erase_global_includes Σ deps deps' wfΣ :
@@ -1148,8 +1167,16 @@ Proof.
       eapply KernameSet.subset_spec.
       intros x hin'. eapply KernameSet.union_spec. right; auto.
       congruence. congruence.
-      eexists; red; intuition eauto.
-      simpl. rewrite eq_kername_refl.  reflexivity.
+      eexists m, _; intuition eauto.
+      simpl. unfold declared_minductive.
+      simpl. rewrite eq_kername_refl. reflexivity.
+      specialize (sub _ hin).
+      eapply KernameSet.mem_spec in sub. rewrite sub.
+      red. cbn. destruct kername_eq_dec; try congruence.
+      reflexivity.
+      eapply erases_mutual; eauto.
+      rewrite /declared_minductive /=; rewrite -> eq_kername_refl => //. 
+
     * intros ikn Hi.
       destruct d as [|].
       ++ destruct (KernameSet.mem kn deps) eqn:eqkn.
@@ -1213,653 +1240,9 @@ Proof.
   unshelve epose proof (erase_global_erases_deps wfΣ wt H _); cycle 2.
   eapply erases_correct; eauto.
   intros.
-  rewrite <- Ht'. todo "ispropo".
   rewrite <- Ht'.
   eapply erase_global_includes.
   intros.
   eapply term_global_deps_spec in H; eauto.
   assumption.
-Qed.
-
-
-Require Import ELiftSubst.
-
-Import E.
-
-Section optimize.
-  Context (Σ : global_context).
-
-Fixpoint optimize (t : term) : term :=
-  match t with
-  | tRel i => tRel i
-  | tEvar ev args => tEvar ev (List.map optimize args)
-  | tLambda na M => tLambda na (optimize M)
-  | tApp u v => tApp (optimize u) (optimize v)
-  | tLetIn na b b' => tLetIn na (optimize b) (optimize b')
-  | tCase ind c brs =>
-    let brs' := List.map (on_snd optimize) brs in
-    match ETyping.is_propositional Σ (fst ind) with
-    | Some true =>
-      match brs' with
-      | [(a, b)] => E.mkApps b (repeat E.tBox a)
-      | _ => E.tCase ind (optimize c) brs'
-      end
-    | _ => E.tCase ind (optimize c) brs'
-    end
-  | tProj p c =>
-    match ETyping.is_propositional Σ p.1.1 with 
-    | Some true => tBox
-    | _ => tProj p (optimize c)
-    end
-  | tFix mfix idx =>
-    let mfix' := List.map (map_def optimize) mfix in
-    tFix mfix' idx
-  | tCoFix mfix idx =>
-    let mfix' := List.map (map_def optimize) mfix in
-    tCoFix mfix' idx
-  | tBox => t
-  | tVar _ => t
-  | tConst _ => t
-  | tConstruct _ _ => t
-  end.
-
-  Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).
-  Proof.
-    induction l using rev_ind; simpl; auto.
-    now rewrite -mkApps_nested /= IHl map_app /= -mkApps_nested /=.
-  Qed.
-  
-  Lemma optimize_iota_red pars n args brs :
-    optimize (ETyping.iota_red pars n args brs) = ETyping.iota_red pars n (map optimize args) (map (on_snd optimize) brs).
-  Proof.
-    unfold ETyping.iota_red.
-    rewrite !nth_nth_error nth_error_map.
-    destruct nth_error eqn:hnth => /=;
-    now rewrite optimize_mkApps map_skipn.
-  Qed.
-  
-  Lemma map_repeat {A B} (f : A -> B) x n : map f (repeat x n) = repeat (f x) n.
-  Proof.
-    now induction n; simpl; auto; rewrite IHn.
-  Qed.
-  
-  Lemma map_optimize_repeat_box n : map optimize (repeat tBox n) = repeat tBox n.
-  Proof. by rewrite map_repeat. Qed.
-
-  Import ECSubst.
-
-  Lemma csubst_mkApps {a k f l} : csubst a k (mkApps f l) = mkApps (csubst a k f) (map (csubst a k) l).
-  Proof.
-    induction l using rev_ind; simpl; auto.
-    rewrite - mkApps_nested /= IHl.
-    now rewrite [EAst.tApp _ _](mkApps_nested _ _ [_]) map_app.
-  Qed.
-
-  Lemma optimize_csubst a k b : 
-    optimize (ECSubst.csubst a k b) = ECSubst.csubst (optimize a) k (optimize b).
-  Proof.
-    induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto; 
-      try solve [f_equal; eauto; ELiftSubst.solve_all].
-    
-    - destruct (k ?= n); auto.
-    - f_equal; eauto. rewrite !map_map_compose; eauto.
-      solve_all.
-    - destruct ETyping.is_propositional as [[|]|] => /= //.
-      destruct l as [|[br n] [|l']] eqn:eql; simpl.
-      * f_equal; auto.
-      * depelim X. simpl in *.
-        rewrite e. rewrite csubst_mkApps.
-        now rewrite map_repeat /=.
-      * depelim X.
-        f_equal; eauto.
-        f_equal; eauto. now rewrite e.
-        f_equal; eauto.
-        f_equal. depelim X.
-        now rewrite e0. depelim X. rewrite !map_map_compose.
-        solve_all.
-      * f_equal; eauto.
-        rewrite !map_map_compose; solve_all.
-      * f_equal; eauto.
-        rewrite !map_map_compose; solve_all.
-    - destruct ETyping.is_propositional as [[|]|]=> //;
-      now rewrite IHb.
-    - rewrite !map_map_compose; f_equal; solve_all.
-      destruct x; unfold EAst.map_def; simpl in *. 
-      autorewrite with len. f_equal; eauto.
-    - rewrite !map_map_compose; f_equal; solve_all.
-      destruct x; unfold EAst.map_def; simpl in *. 
-      autorewrite with len. f_equal; eauto.
-  Qed.
-
-  Lemma optimize_substl s t : optimize (Ee.substl s t) = Ee.substl (map optimize s) (optimize t).
-  Proof.
-    induction s in t |- *; simpl; auto.
-    rewrite IHs. f_equal.
-    now rewrite optimize_csubst.
-  Qed.
-
-  Lemma optimize_fix_subst mfix : ETyping.fix_subst (map (map_def optimize) mfix) = map optimize (ETyping.fix_subst mfix).
-  Proof.
-    unfold ETyping.fix_subst.
-    rewrite map_length.
-    generalize #|mfix|.
-    induction n; simpl; auto.
-    f_equal; auto.
-  Qed.
-
-  Lemma optimize_cofix_subst mfix : ETyping.cofix_subst (map (map_def optimize) mfix) = map optimize (ETyping.cofix_subst mfix).
-  Proof.
-    unfold ETyping.cofix_subst.
-    rewrite map_length.
-    generalize #|mfix|.
-    induction n; simpl; auto.
-    f_equal; auto.
-  Qed.
-
-  Lemma optimize_cunfold_fix mfix idx n f : 
-    Ee.cunfold_fix mfix idx = Some (n, f) ->
-    Ee.cunfold_fix (map (map_def optimize) mfix) idx = Some (n, optimize f).
-  Proof.
-    unfold Ee.cunfold_fix.
-    rewrite nth_error_map.
-    destruct nth_error.
-    intros [= <- <-] => /=. f_equal.
-    now rewrite optimize_substl optimize_fix_subst.
-    discriminate.
-  Qed.
-
-  Lemma optimize_cunfold_cofix mfix idx n f : 
-    Ee.cunfold_cofix mfix idx = Some (n, f) ->
-    Ee.cunfold_cofix (map (map_def optimize) mfix) idx = Some (n, optimize f).
-  Proof.
-    unfold Ee.cunfold_cofix.
-    rewrite nth_error_map.
-    destruct nth_error.
-    intros [= <- <-] => /=. f_equal.
-    now rewrite optimize_substl optimize_cofix_subst.
-    discriminate.
-  Qed.
-
-  Lemma optimize_nth {n l d} : 
-    optimize (nth n l d) = nth n (map optimize l) (optimize d).
-  Proof.
-    induction l in n |- *; destruct n; simpl; auto.
-  Qed.
-
-End optimize.
-
-
-Lemma is_box_inv b : is_box b -> ∑ args, b = mkApps tBox args.
-Proof.
-  unfold is_box, EAstUtils.head.
-  destruct decompose_app eqn:da.
-  simpl. destruct t => //.
-  eapply decompose_app_inv in da. subst.
-  eexists; eauto.
-Qed.
-
-Lemma eval_is_box {wfl:Ee.WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
-Proof.
-  intros ev; induction ev => //.
-  - rewrite is_box_tApp.
-    intros isb. intuition congruence.
-  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
-  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
-  - rewrite is_box_tApp. move/IHev1 => ?. subst => //.
-  - destruct t => //.
-Qed. 
-
-
-
-(* 
-Lemma nisErasable_eval_tBox  (wfl := Ee.default_wcbv_flags) Σ Σ' Γ t t' deps (wfΣ : wf_ext Σ) : ∥ isErasable Σ Γ t -> False ∥ -> 
-  forall wt : welltyped Σ Γ t,
-  erase Σ (sq wfΣ) Γ t wt = t' ->
-  erase_global_decls deps Σ (sq wfΣ.1) = Σ' -> 
-  Σ' ⊢ t' ▷ tBox -> False.
-Proof.
-  intros [ise]. *)
-
-  
-  
-(*
-
-Lemma eval_to_tbox (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) deps Γ t Σ' t' :
-  forall wt : welltyped Σ Γ t,
-  erase Σ (sq wfΣ) Γ t wt = t' ->
-  erase_global_decls deps Σ (sq wfΣ.1) = Σ' -> 
-  Σ' ⊢ t' ▷ tBox -> ∥ isErasable Σ Γ t ∥.
-Proof.
-  induction t in Γ, t', Σ' |- * using PCUICInduction.term_forall_list_ind; simpl; intros [T wt].
-  all:try solve [try destruct is_erasable; auto; simpl; intros <-; auto; intros eg ev; try solve[depelim ev]].
-  - intros <-.
-    intros. sq. admit.
-  - admit.
-  - destruct is_erasable; auto; move=> <- Hg ev.
-    depelim ev.
-
-
-
-  
-  
-  destruct is_erasable; simpl. intros <-; auto.
-  
-
-  simpl.
-  intros.
-  intros wt et eg.
-
-Lemma erase_opt_correct (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) Σ' t' v :
-  axiom_free Σ.1 ->
-  @Ee.eval Ee.default_wcbv_flags Σ' t' v -> 
-  @Ee.eval Ee.opt_wcbv_flags Σ' (optimize t') (optimize v).
-Proof.
-  intros axiomfree ev.
-  induction ev; simpl in *; try econstructor; eauto.
-  - now rewrite -csubst_optimize.
-  - now rewrite -csubst_optimize.
-  - destruct (is_box discr) eqn:isb.
-    eapply eval_is_box in ev1; eauto. solve_discr.
-    econstructor; eauto.
-    now rewrite optimize_mkApps in IHev1.
-    now rewrite optimize_iota_red in IHev2.
-  - destruct (is_box discr) eqn:isb.
-    rewrite optimize_mkApps in IHev2.
-    subst brs => /=. now rewrite map_optimize_repeat_box in IHev2.
-    eapply econstructor; eauto.
-    now rewrite optimize_mkApps in IHev1.
-    now rewrite optimize_iota_red in IHev2.
-  -
-    rewrite 
-    
-  admit.
-
-Lemma erase_opt_correct (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) Γ t Σ' t' v :
-  axiom_free Σ.1 ->
-  forall wt : welltyped Σ Γ t,
-  @Ee.eval Ee.default_wcbv_flags Σ' t' v -> 
-  erase Σ (sq wfΣ) Γ t wt = t' ->
-  @Ee.eval Ee.opt_wcbv_flags Σ' (optimize t') (optimize v).
-Proof.
-  intros axiomfree wt ev. revert t wt.
-  induction ev; simpl in *; intros ot wt et.
-
-*)
-
-Lemma isType_tSort {Σ : global_env_ext} {Γ l A} {wfΣ : wf Σ} : Σ ;;; Γ |- tSort (Universe.make l) : A -> isType Σ Γ (tSort (Universe.make l)).
-Proof.
-  intros HT.
-  eapply inversion_Sort in HT as [l' [wfΓ [inl [eq Hs]]]]; auto.
-  eexists; econstructor; eauto.
-  now eapply Universe.make_inj in eq as ->.
-Qed.
-
-Lemma isType_it_mkProd {Σ : global_env_ext} {Γ na dom codom A} {wfΣ : wf Σ} :   
-  Σ ;;; Γ |- tProd na dom codom : A -> 
-  isType Σ Γ (tProd na dom codom).
-Proof.
-  intros HT.
-  eapply inversion_Prod in HT as (? & ? & ? & ? & ?); auto.
-  eexists; econstructor; eauto.
-Qed.
-
-Lemma erasable_tBox_value (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) t T v :
-  axiom_free Σ.1 ->
-  forall wt : Σ ;;; [] |- t : T,
-  Σ |-p t ▷ v -> erases Σ [] v tBox -> ∥ isErasable Σ [] t ∥.
-Proof.
-  intros.
-  depind H0.
-  eapply Is_type_eval_inv; eauto. eexists; eauto.
-Qed.
-
-Lemma erase_eval_to_box (wfl := Ee.default_wcbv_flags) {Σ : global_env_ext}  {wfΣ : wf_ext Σ} {t v Σ' t' deps} :
-  axiom_free Σ.1 ->
-  forall wt : welltyped Σ [] t,
-  erase Σ (sq wfΣ) [] t wt = t' ->
-  KernameSet.subset (term_global_deps t') deps ->
-  erase_global deps Σ (sq wfΣ.1) = Σ' ->
-  PCUICWcbvEval.eval Σ t v ->
-  @Ee.eval Ee.default_wcbv_flags Σ' t' tBox -> ∥ isErasable Σ [] t ∥.
-Proof.
-  intros axiomfree [T wt].
-  intros.
-  destruct (erase_correct Σ wfΣ _ _ _ _ _ axiomfree _ H H0 H1 X) as [ev [eg [eg']]].
-  pose proof (Ee.eval_deterministic _ H2 eg'). subst.
-  eapply erasable_tBox_value; eauto.
-Qed.
-
-(* Lemma csubst_reduce Σ t k v u : Σ |- ECSubst.csubst t k v ▷ tBox -> 
-  s *)
-(*
-Lemma erase_opt_correct (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) Γ t T Σ' t' :
-  axiom_free Σ.1 ->
-  forall wt : Σ ;;; Γ |- t : T,
-  erase Σ (sq wfΣ) Γ t (iswelltyped wt) = t' ->
-  Σ ⊢p t ▷ v -> 
-  Σ' ⊢ t' ▷ tBox -> ∥ isErasable Σ Γ t ∥.
-Proof.
-  intros axiomfree wt.
-  generalize (iswelltyped wt).
-  intros wt'.
-  set (wfΣ' := sq _).
-  clearbody wfΣ'.
-  revert Γ t T wt wt' wfΣ' t' Σ'.
-  eapply(typing_ind_env (fun Σ Γ t T =>
-  forall (wt' : welltyped Σ Γ t) (wfΣ' : ∥ wf_ext Σ ∥) t' Σ',
-  erase Σ wfΣ' Γ t wt' = t' ->
-  Σ' ⊢ t' ▷ tBox -> ∥ isErasable Σ Γ t ∥
-         )
-         (fun Σ Γ wfΓ => wf_local Σ Γ)); try intros Σ0 wfΣ' Γ wfΓ; auto; clear Σ wfΣ axiomfree; rename Σ0 into Σ;
-         intros.
-
-  all:try match goal with
-    [ H : erase _ _ _ _ _ = _ |- _ ] => simpl in H; try destruct is_erasable; simpl in *; subst; simpl
-  end; auto.
-    
-  all:intros; try match goal with
-    [ H : _ ⊢ _ ▷ _ |- _ ] => try solve[depelim H; constructor; simpl; auto]
-  end; auto; try solve [constructor; auto].
-  
-  - destruct wt'. sq. eapply isType_isErasable. now eapply isType_tSort.
-
-  - destruct wt'. sq. eapply isType_isErasable.
-    now eapply isType_it_mkProd.
-
-  - depelim H3.
-    
-
-    
-
-
-  depelim H2.
-  2:{ simpl in H0. subst. simpl.  }
-*)
-
-Require Import Utf8.
-
-Inductive obs_eq : EAst.term -> EAst.term -> Type :=
-| obs_eq_atom t : Ee.atom t -> obs_eq t t
-| obs_eq_tconstr h args args' : Ee.value_head h -> 
-  All2 obs_eq args args' ->
-  obs_eq (mkApps h args) (mkApps h args')
-| obs_eq_stuckfix f args : Ee.isStuckFix f args -> obs_eq (mkApps f args) (mkApps f args)
-| obs_eq_tlam na na' b b' :
-  (∀ v, obs_eq (ECSubst.csubst v 0 b) (ECSubst.csubst v 0 b')) -> obs_eq (tLambda na b) (tLambda na' b').
-
-Ltac introdep := let H := fresh in intros H; depelim H.
-
-Hint Constructors Ee.eval obs_eq : core.
-
-Lemma value_obs_eq v : Ee.value v -> obs_eq v v.
-Proof.
-  intros val; induction val using Ee.value_values_ind.
-  - constructor; auto.
-  - constructor 2; auto. now eapply All_All2_refl.
-  - constructor 3; auto.
-Qed.
-
-Definition optimize_constant_decl Σ cb := 
-  {| cst_body := option_map (optimize Σ) cb.(cst_body) |}.
-  
-Definition optimize_decl Σ d :=
-  match d with
-  | ConstantDecl cb => ConstantDecl (optimize_constant_decl Σ cb)
-  | InductiveDecl idecl => d
-  end.
-
-Definition optimize_env (Σ : EAst.global_declarations) := 
-  map (on_snd (optimize_decl Σ)) Σ.
-
-Import ETyping.
-
-(* Lemma optimize_extends Σ Σ' : extends Σ Σ' ->
-  optimize Σ t = optimize Σ' t. *)
-
-Lemma lookup_env_optimize Σ kn : 
-  lookup_env (optimize_env Σ) kn = 
-  option_map (optimize_decl Σ) (lookup_env Σ kn).
-Proof.
-  unfold optimize_env.
-  induction Σ at 2 4; simpl; auto.
-  destruct kername_eq_dec => //.
-Qed.
-
-Lemma is_propositional_optimize Σ ind : 
-  is_propositional Σ ind = is_propositional (optimize_env Σ) ind.
-Proof.
-  rewrite /is_propositional.
-  rewrite lookup_env_optimize.
-  destruct lookup_env; simpl; auto.
-  destruct g; simpl; auto.
-Qed.
-
-Lemma isLambda_mkApps f l : ~~ isLambda f -> ~~ EAst.isLambda (mkApps f l).
-Proof.
-  induction l using rev_ind; simpl; auto => //.
-  intros isf; specialize (IHl isf).
-  now rewrite -mkApps_nested.
-Qed.
- 
-Lemma isFixApp_mkApps f l : ~~ Ee.isFixApp f -> ~~ Ee.isFixApp (mkApps f l).
-Proof.
-  unfold Ee.isFixApp.
-  erewrite <- (fst_decompose_app_rec _ l).
-  now rewrite /decompose_app decompose_app_rec_mkApps app_nil_r.
-Qed.
-
-Lemma isBox_mkApps f l : ~~ isBox f -> ~~ isBox (mkApps f l).
-Proof.
-  induction l using rev_ind; simpl; auto => //.
-  intros isf; specialize (IHl isf).
-  now rewrite -mkApps_nested.
-Qed.
-
-
-Inductive optimized_env : global_declarations -> Type :=
-| optimized_env_nil : optimized_env []
-| optimized_env_cons Σ kn d : optimized_env Σ -> 
-  (match d with  
-  | ConstantDecl d =>
-    match d.(cst_body) with
-    | Some b =>
-      forall v,
-      @Ee.eval Ee.default_wcbv_flags Σ b v ->
-      @Ee.eval Ee.opt_wcbv_flags (optimize_env Σ) (optimize Σ b) (optimize Σ v)
-    | None => True
-    end
-  | InductiveDecl d => True
-  end) -> optimized_env ((kn, d) :: Σ).
-
-Definition extends (Σ Σ' : global_declarations) := ∑ Σ'', Σ' = Σ'' ++ Σ.
-
-Definition fresh_global kn (Σ : global_declarations) :=
-  Forall (fun x => x.1 <> kn) Σ.
- 
-Inductive wf_glob : global_declarations -> Type :=
-| wf_glob_nil : wf_glob []
-| wf_glob_cons kn d Σ : 
-  wf_glob Σ ->
-  fresh_global kn Σ ->
-  wf_glob ((kn, d) :: Σ).
-Derive Signature for wf_glob.
-
-Lemma lookup_env_optimized Σ : optimized_env Σ -> 
-  forall kn d b, lookup_env Σ kn = Some (ConstantDecl d) ->
-  cst_body d = Some b ->
-  ∑ Σ', (extends Σ' Σ) *
-  (forall v, 
-  @Ee.eval Ee.default_wcbv_flags Σ' b v ->
-  @Ee.eval Ee.opt_wcbv_flags (optimize_env Σ') (optimize Σ' b) (optimize Σ' v)).
-Proof.
-  induction 1; simpl; intros => //.
-  destruct kername_eq_dec. subst.
-  noconf H; simpl in *. rewrite H0 in y.
-  exists Σ.
-  split; simpl. eexists [_] => //. auto.
-  specialize (IHX _ _ _ H H0) as [Σ' [ext ev]].
-  exists Σ'. split. destruct ext.
-  subst Σ. exists ((kn, d) :: x) => //.
-  auto.
-Qed.
-
-Lemma lookup_env_Some_fresh {Σ c decl} :
-  lookup_env Σ c = Some decl -> ~ (fresh_global c Σ).
-Proof.
-  induction Σ; cbn. 1: congruence.
-  unfold eq_kername; destruct kername_eq_dec; subst.
-  - intros [= <-] H2. inv H2.
-    contradiction.
-  - intros H1 H2. apply IHΣ; tas.
-    now inv H2.
-Qed.
-
-Lemma extends_lookup {Σ Σ' c decl} :
-  wf_glob Σ' ->
-  extends Σ Σ' ->
-  lookup_env Σ c = Some decl ->
-  lookup_env Σ' c = Some decl.
-Proof.
-  intros wfΣ' [Σ'' ->]. simpl.
-  induction Σ'' in wfΣ', c, decl |- *.
-  - simpl. auto.
-  - specialize (IHΣ'' c decl). forward IHΣ''.
-    + now inv wfΣ'.
-    + intros HΣ. specialize (IHΣ'' HΣ).
-      inv wfΣ'. simpl in *.
-      unfold eq_kername; destruct kername_eq_dec; subst; auto.
-      apply lookup_env_Some_fresh in IHΣ''; contradiction.
-Qed.
-
-Lemma extends_is_propositional {Σ Σ'} : 
-  wf_glob Σ' -> extends Σ Σ' ->
-  forall ind b, is_propositional Σ ind = Some b -> is_propositional Σ' ind = Some b.
-Proof.
-  intros wf ex ind b.
-  rewrite /is_propositional.
-  destruct lookup_env eqn:lookup => //.
-  now rewrite (extends_lookup wf ex lookup).
-Qed.
-
-Lemma weakening_eval_env (wfl : Ee.WcbvFlags) {Σ Σ'} : 
-  wf_glob Σ' -> extends Σ Σ' ->
-  ∀ v t, Ee.eval Σ v t -> Ee.eval Σ' v t.
-Proof.
-  intros wf ex t v ev.
-  induction ev; try solve [econstructor; eauto using (extends_is_propositional wf ex)].
-  econstructor; eauto.
-  red in isdecl |- *. eauto using extends_lookup.
-Qed.
-
-Lemma optimize_correct Σ t v :
-  @Ee.eval Ee.default_wcbv_flags Σ t v ->
-  @Ee.eval Ee.opt_wcbv_flags (optimize_env Σ) (optimize Σ t) (optimize Σ v).
-Proof.
-  intros ev.
-  induction ev; simpl in *; try solve [econstructor; eauto].
-
-  - econstructor; eauto.
-    now rewrite optimize_csubst in IHev3.
-
-  - rewrite optimize_csubst in IHev2.
-    econstructor; eauto.
-
-  - rewrite optimize_mkApps in IHev1.
-    rewrite optimize_iota_red in IHev2.
-    destruct ETyping.is_propositional as [[]|]eqn:isp => //.
-    eapply Ee.eval_iota; eauto.
-    now rewrite -is_propositional_optimize.
-  
-  - rewrite e e0 /=.
-    now rewrite optimize_mkApps map_optimize_repeat_box in IHev2.
-
-  - rewrite optimize_mkApps in IHev1.
-    simpl in *. eapply Ee.eval_fix; eauto.
-    rewrite map_length. now eapply optimize_cunfold_fix. 
-    now rewrite optimize_mkApps in IHev3.
-
-  - rewrite optimize_mkApps in IHev1 |- *.
-    simpl in *. eapply Ee.eval_fix_value. auto. auto.
-    eapply optimize_cunfold_fix; eauto. now rewrite map_length. 
-
-  - destruct ETyping.is_propositional as [[]|] eqn:isp => //.
-    destruct brs as [|[a b] []]; simpl in *; auto.
-    rewrite -> optimize_mkApps in IHev |- *. simpl.
-    econstructor; eauto.
-    now apply optimize_cunfold_cofix.
-    rewrite -> optimize_mkApps in IHev |- *. simpl.
-    econstructor; eauto.
-    now apply optimize_cunfold_cofix.
-    rewrite -> optimize_mkApps in IHev |- *. simpl.
-    econstructor; eauto.
-    now apply optimize_cunfold_cofix.
-    rewrite -> optimize_mkApps in IHev |- *. simpl.
-    econstructor; eauto.
-    now apply optimize_cunfold_cofix.
-
-  - destruct ETyping.is_propositional as [[]|] eqn:isp; auto.
-    rewrite -> optimize_mkApps in IHev |- *. simpl.
-    econstructor; eauto.
-    now apply optimize_cunfold_cofix.
-    rewrite -> optimize_mkApps in IHev |- *. simpl.
-    econstructor; eauto.
-    now apply optimize_cunfold_cofix.
-  
-  - econstructor. red in isdecl |- *.
-    rewrite lookup_env_optimize isdecl //.
-    now rewrite /optimize_constant_decl e.
-    apply IHev.
-  
-  - destruct ETyping.is_propositional as [[]|] eqn:isp => //.
-    rewrite optimize_mkApps in IHev1.
-    rewrite optimize_nth in IHev2.
-    econstructor; eauto. now rewrite -is_propositional_optimize.
-  
-  - now rewrite e.
-
-  - eapply Ee.eval_app_cong; eauto.
-    eapply Ee.eval_to_value in ev1.
-    destruct ev1; simpl in *; eauto.
-    * destruct t => //; rewrite optimize_mkApps /=.
-    * destruct t => /= //; rewrite optimize_mkApps /=;
-      rewrite (negbTE (isLambda_mkApps _ _ _)) // (negbTE (isBox_mkApps _ _ _)) 
-        // (negbTE (isFixApp_mkApps _ _ _)) //.
-    * destruct f0 => //.
-      rewrite optimize_mkApps /=.
-      unfold Ee.isFixApp in i.
-      rewrite decompose_app_mkApps /= in i => //.
-      rewrite orb_true_r /= // in i.
-  - destruct t => //.
-    all:constructor; eauto.
-Qed.
-
-Lemma erase_opt_correct (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) t v Σ' t' :
-  axiom_free Σ.1 ->
-  forall wt : welltyped Σ [] t,
-  erase Σ (sq wfΣ) [] t wt = t' ->
-  erase_global (term_global_deps t') Σ (sq wfΣ.1) = Σ' ->
-  PCUICWcbvEval.eval Σ t v ->
-  ∃ v' : term, Σ;;; [] |- v ⇝ℇ v' ∧ 
-  ∥ @Ee.eval Ee.opt_wcbv_flags (optimize_env Σ') (optimize Σ' t') (optimize Σ' v') ∥.
-Proof.
-  intros axiomfree wt.
-  generalize (sq wfΣ.1) as swfΣ.
-  intros swfΣ HΣ' Ht' ev.
-  assert (extraction_pre Σ) by now constructor.
-  pose proof (erases_erase (wfΣ := sq wfΣ) wt); eauto.
-  rewrite HΣ' in H.
-  destruct wt as [T wt].
-  unshelve epose proof (erase_global_erases_deps wfΣ wt H _); cycle 2.
-  eapply erases_correct in ev; eauto.
-  destruct ev as [v' [ev evv]].
-  exists v'. split.
-  2:{ sq. now apply optimize_correct. }
-  auto. 
-  rewrite <- Ht'. todo "ispropo".
-  rewrite <- Ht'.
-  eapply erase_global_includes.
-  intros.
-  eapply term_global_deps_spec in H; eauto.
-  eapply KernameSet.subset_spec.
-  intros x hin; auto.
 Qed.

--- a/erasure/theories/SafeErasureFunction.v
+++ b/erasure/theories/SafeErasureFunction.v
@@ -1513,7 +1513,7 @@ Fixpoint noccur_between k n (t : term) : bool :=
     List.forallb (test_def (noccur_between k' n)) mfix
   | x => true
   end.
-
+(*
 Lemma erases_erasable_vars Σ Γ t u : 
   Σ ;;; Γ |- t ⇝ℇ u ->
   forall n decl, nth_error Γ n = Some decl ->
@@ -1522,7 +1522,7 @@ Lemma erases_erasable_vars Σ Γ t u :
 Proof.
   induction 1.
   - intros n decl hnth ise.
-    admit.
+    admit.*)
 
 
 Lemma erase_opt_correct (wfl := Ee.default_wcbv_flags) (Σ : global_env_ext) (wfΣ : wf_ext Σ) t v T Σ' t' v' deps :
@@ -1569,10 +1569,9 @@ Proof.
       eapply erase_eval_to_box in H0; eauto.
       2:{ eapply KernameSet.subset_spec. intros x hin. eapply sub.
           rewrite KernameSet.union_spec; auto. }
-      assert (optimize (ECSubst.csubst tBox 0 b0) = ECSubst.csubst tBox 0 (optimize b0)).
       epose proof (erase_correct _ _ _ _ _ _ deps axiomfree (erase_obligation_5 Σ (sq wfΣ) [] f a w s) eq_refl) as ec. 
       forward ec. admit.
-      specialize (ec eq_refl ev1) as [lamv [erv' [ev']]].
+      specialize (ec eq_refl ev1) as [lamv [erv' ev']].
       pose proof (Ee.eval_deterministic _ H ev'). subst lamv.
       depelim erv'.
       destruct w as [appT app].


### PR DESCRIPTION
Add an optimization pass that removes pattern-matches on propositional inductive types. This results in a simpler evaluation relation on optimized terms: no more case/box and proj/box reductions are needed and this guarantees that we're not doing any computation on propositional content *at all* on the optimized erased terms. For the typical example of singleton elimination of an equality, it disappears, and this is now proven correct:

```coq
singelim_test = 
"Environment is well-formed and fun X : [Set] => fun x : X => fun e : eq X x x => match e as x' in eq return fun e0 : eq UnboundRel(3) X e => bool with 
eq_refl => true
end
 erases to: 
fun X => fun x => fun e => true"
	 : string
```

The correctness theorem just states that to each evaluation on erased terms `\Sigma |- t -> v` corresponds an evaluation on optimized terms: `opt \Sigma |- opt \Sigma t -> opt \Sigma v`. As the optimization only transforms redexes (and preserves values, which is also proven), I don't think this will be a problem for any observational equivalence we might want to preserve.
