### PR TITLE
Complete principality and retyping

### DIFF
--- a/checker/theories/Closed.v
+++ b/checker/theories/Closed.v
@@ -389,8 +389,8 @@ Proof.
   pose proof (declared_projection_inv weaken_env_prop_closed wfΣ X0 isdecl) as onp.
   set (declared_inductive_inv _ wfΣ X0 isdecl.p1) as oib in *.
   clearbody oib.
-  have onpars := onParams _ _ _ _ (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
-  have parslen := onNpars _ _ _ _ (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
+  have onpars := onParams (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
+  have parslen := onNpars (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
   simpl in onp. destruct (ind_cshapes oib) as [|? []] eqn:Heq; try contradiction.
   red in onp.
   destruct (nth_error (smash_context [] _) _) eqn:Heq'; try contradiction.

--- a/checker/theories/WeakeningEnv.v
+++ b/checker/theories/WeakeningEnv.v
@@ -394,7 +394,7 @@ Proof.
       simpl.
       intros v indv. specialize (on_ctype_variance v indv).
       simpl in *. move: on_ctype_variance.
-      unfold respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
+      unfold cstr_respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
       intros [args idxs]. split.
       eapply (All2_local_env_impl args); intros.
       eapply weakening_env_cumul; eauto.
@@ -415,6 +415,11 @@ Proof.
           destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ' Hext.
           induction ind_indices; simpl in *; auto.
           destruct a as [na [b|] ty]; simpl in *; intuition eauto.
+      -- intros v onv.
+          move: (onIndices v onv). unfold ind_respects_variance.
+         destruct variance_universes as [[[univs u] u']|] => //.
+         intros idx; eapply (All2_local_env_impl idx); simpl.
+         intros par par' t t'. eapply weakening_env_cumul; eauto.
   - red in onP |- *. eapply All_local_env_impl; eauto.
 Qed.
 

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -4,8 +4,8 @@
 
 src/init.mli
 src/init.ml
-src/classes0.mli
-src/classes0.ml
+# src/classes0.mli
+# src/classes0.ml
 
 # From Coq's stdlib
 src/mSetWeakList.mli

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -4,8 +4,8 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
   PCUICClosed PCUICTyping PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICArities
   PCUICSR PCUICGeneration PCUICSubstitution PCUICElimination
   PCUICContextConversion PCUICConversion PCUICCanonicity
-  PCUICSpine PCUICInductives PCUICInductiveInversion PCUICConfluence.
-From MetaCoq.SafeChecker Require Import PCUICPrincipality.
+  PCUICSpine PCUICInductives PCUICInductiveInversion PCUICConfluence PCUICPrincipality.
+
 Require Import ssreflect.
 From MetaCoq.Erasure Require Import Extract.
   
@@ -468,7 +468,7 @@ Lemma arity_type_inv (Σ : global_env_ext) Γ t T1 T2 : wf_ext Σ -> wf_local Σ
   Σ ;;; Γ |- t : T1 -> isArity T1 -> Σ ;;; Γ |- t : T2 -> Is_conv_to_Arity Σ Γ T2.
 Proof.
   intros wfΣ wfΓ. intros. 
-  eapply principal_typing in X as (? & [(? & ? & ?)]). 2:eauto. 2:exact X0.
+  eapply common_typing in X as (? & ? & ? & ?). 2:eauto. 2:exact X0.
 
   eapply invert_cumul_arity_r in c0 as (? & X & ?); eauto. sq.
   eapply PCUICCumulativity.red_cumul_inv in X.
@@ -489,7 +489,7 @@ Proof.
   assert (HW : isWfArity_or_Type Σ Γ T). eapply PCUICValidity.validity; eauto.
   eapply PCUICValidity.inversion_mkApps in X as (? & ? & ?); auto.
   destruct X0 as (? & ? & [ | [u]]).
-  - eapply principal_typing in t2 as (? & [(? & ? & ?)]). 2:eauto. 2:exact t0.
+  - eapply common_typing in t2 as (? & ? & ? & ?). 2:eauto. 2:exact t0.
     eapply invert_cumul_arity_r in c0; eauto.
     destruct c0 as (? & ? & ?). destruct H as [].
     eapply PCUICCumulativity.red_cumul_inv in X.
@@ -511,7 +511,7 @@ Proof.
 
     eapply isWfArity_or_Type_red; eauto. exists x3; split; sq; eauto.
   - destruct p.
-    eapply PCUICPrincipality.principal_typing in t2 as (? & [(? & ? & ?)]). 2:eauto. 2:exact t0.
+    eapply PCUICPrincipality.common_typing in t2 as (? & ? & ? & ?). 2:eauto. 2:exact t0.
     eapply cumul_prop1 in c0; eauto.
     eapply cumul_prop2 in c; eauto.
     econstructor. exists T. split. eapply type_mkApps. 2:eassumption. eassumption. right.
@@ -581,7 +581,7 @@ Proof.
   intros wfΣ axfree [T HT] ev [vt [Ht Hp]].
   eapply wcbeval_red in ev; eauto.
   pose proof (subject_reduction _ _ _ _ _ wfΣ.1 HT ev).
-  pose proof (principal_typing _ wfΣ Ht X) as [P [[Pvt [Pt vP]]]].
+  pose proof (common_typing _ wfΣ Ht X) as [P [Pvt [Pt vP]]].
   destruct Hp.
   eapply arity_type_inv in X. 5:eauto. all:eauto.
   red in X. destruct X as [T' [[red] isA]].
@@ -615,11 +615,11 @@ Lemma isErasable_any_type {Σ Γ t T} :
   wf_ext Σ -> 
   isErasable Σ Γ t ->
   Σ ;;; Γ |- t : T ->
-  ∥ isErasable_Type Σ Γ T ∥.
+  isErasable_Type Σ Γ T.
 Proof.
   intros wfΣ [T' [Ht Ha]].
   intros HT.
-  destruct (PCUICPrincipality.principal_typing _ wfΣ Ht HT) as [P [[le [le' tC]]]]. sq.
+  destruct (PCUICPrincipality.common_typing _ wfΣ Ht HT) as [P [le [le' tC]]]. sq.
   destruct Ha.
   left. eapply arity_type_inv. 3:exact Ht. all:eauto using typing_wf_local.
   destruct s as [u [Hu isp]].

--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -2,9 +2,10 @@
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils 
   PCUICClosed PCUICTyping PCUICWcbvEval PCUICLiftSubst PCUICInversion PCUICArities
-  PCUICSR PCUICPrincipality PCUICGeneration PCUICSubstitution PCUICElimination
+  PCUICSR PCUICGeneration PCUICSubstitution PCUICElimination
   PCUICContextConversion PCUICConversion PCUICCanonicity
   PCUICSpine PCUICInductives PCUICInductiveInversion PCUICConfluence.
+From MetaCoq.SafeChecker Require Import PCUICPrincipality.
 Require Import ssreflect.
 From MetaCoq.Erasure Require Import Extract.
   
@@ -463,10 +464,11 @@ Proof.
     eapply substitution0; eauto.
 Qed.
 
-Lemma arity_type_inv (Σ : global_env_ext) Γ t T1 T2 : wf Σ -> wf_local Σ Γ ->
+Lemma arity_type_inv (Σ : global_env_ext) Γ t T1 T2 : wf_ext Σ -> wf_local Σ Γ ->
   Σ ;;; Γ |- t : T1 -> isArity T1 -> Σ ;;; Γ |- t : T2 -> Is_conv_to_Arity Σ Γ T2.
 Proof.
-  intros wfΣ wfΓ. intros. eapply principal_typing in X as (? & ? & ? & ?). 2:eauto. 2:exact X0.
+  intros wfΣ wfΓ. intros. 
+  eapply principal_typing in X as (? & [(? & ? & ?)]). 2:eauto. 2:exact X0.
 
   eapply invert_cumul_arity_r in c0 as (? & X & ?); eauto. sq.
   eapply PCUICCumulativity.red_cumul_inv in X.
@@ -487,7 +489,7 @@ Proof.
   assert (HW : isWfArity_or_Type Σ Γ T). eapply PCUICValidity.validity; eauto.
   eapply PCUICValidity.inversion_mkApps in X as (? & ? & ?); auto.
   destruct X0 as (? & ? & [ | [u]]).
-  - eapply principal_typing in t2 as (? & ? & ? & ?). 2:eauto. 2:exact t0.
+  - eapply principal_typing in t2 as (? & [(? & ? & ?)]). 2:eauto. 2:exact t0.
     eapply invert_cumul_arity_r in c0; eauto.
     destruct c0 as (? & ? & ?). destruct H as [].
     eapply PCUICCumulativity.red_cumul_inv in X.
@@ -509,7 +511,7 @@ Proof.
 
     eapply isWfArity_or_Type_red; eauto. exists x3; split; sq; eauto.
   - destruct p.
-    eapply PCUICPrincipality.principal_typing in t2 as (? & ? & ? & ?). 2:eauto. 2:exact t0.
+    eapply PCUICPrincipality.principal_typing in t2 as (? & [(? & ? & ?)]). 2:eauto. 2:exact t0.
     eapply cumul_prop1 in c0; eauto.
     eapply cumul_prop2 in c; eauto.
     econstructor. exists T. split. eapply type_mkApps. 2:eassumption. eassumption. right.
@@ -579,7 +581,7 @@ Proof.
   intros wfΣ axfree [T HT] ev [vt [Ht Hp]].
   eapply wcbeval_red in ev; eauto.
   pose proof (subject_reduction _ _ _ _ _ wfΣ.1 HT ev).
-  pose proof (principal_typing _ wfΣ.1 Ht X) as [P [Pvt [Pt vP]]].
+  pose proof (principal_typing _ wfΣ Ht X) as [P [[Pvt [Pt vP]]]].
   destruct Hp.
   eapply arity_type_inv in X. 5:eauto. all:eauto.
   red in X. destruct X as [T' [[red] isA]].
@@ -613,11 +615,11 @@ Lemma isErasable_any_type {Σ Γ t T} :
   wf_ext Σ -> 
   isErasable Σ Γ t ->
   Σ ;;; Γ |- t : T ->
-  isErasable_Type Σ Γ T.
+  ∥ isErasable_Type Σ Γ T ∥.
 Proof.
   intros wfΣ [T' [Ht Ha]].
   intros HT.
-  pose proof (PCUICPrincipality.principal_typing _ (fst wfΣ) Ht HT) as [P [le [le' tC]]].
+  destruct (PCUICPrincipality.principal_typing _ wfΣ Ht HT) as [P [[le [le' tC]]]]. sq.
   destruct Ha.
   left. eapply arity_type_inv. 3:exact Ht. all:eauto using typing_wf_local.
   destruct s as [u [Hu isp]].

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -50,7 +50,7 @@ Proof.
   - depelim er.
     constructor.
     induction H; cbn in *; [easy|].
-    now depelim H0.
+    now depelim X.
   - depelim er.
     now constructor.
   - depelim er.
@@ -67,20 +67,20 @@ Proof.
     now econstructor.
   - depelim er.
     constructor.
-    induction H in k, H, H0 |- *; [easy|].
+    induction H in k, X |- *; [simpl; easy|].
     cbn in *.
     rewrite <- !Nat.add_succ_r.
-    depelim H0.
+    depelim X.
     constructor; [|easy].
-    now apply p.
+    now apply e.
   - depelim er.
     constructor.
-    induction H in k, H, H0 |- *; [easy|].
+    induction H in k, H, X |- *; [simpl; easy|].
     cbn in *.
     rewrite <- !Nat.add_succ_r.
-    depelim H0.
+    depelim X.
     constructor; [|easy].
-    now apply p.
+    now apply e.
 Qed.
 
 Lemma erases_deps_subst Σ Σ' s k t :
@@ -96,8 +96,8 @@ Proof.
     now apply erases_deps_lift.
   - depelim er.
     constructor.
-    induction H; [easy|].
-    depelim H0.
+    induction H; [simpl; easy|].
+    depelim X.
     now constructor.
   - depelim er.
     now constructor.
@@ -115,20 +115,20 @@ Proof.
     now econstructor.
   - depelim er.
     constructor.
-    induction H in k, H, H0 |- *; [easy|].
+    induction H in k, H, X |- *; [simpl; easy|].
     cbn in *.
     rewrite <- !Nat.add_succ_r.
-    depelim H0.
+    depelim X.
     constructor; [|easy].
-    now apply p.
+    now apply e.
   - depelim er.
     constructor.
-    induction H in k, H, H0 |- *; [easy|].
+    induction H in k, H, X |- *; [simpl; easy|].
     cbn in *.
     rewrite <- !Nat.add_succ_r.
-    depelim H0.
+    depelim X.
     constructor; [|easy].
-    now apply p.
+    now apply e.
 Qed.
 
 Lemma erases_deps_subst1 Σ Σ' t k u :
@@ -151,8 +151,8 @@ Proof.
   - destruct (_ ?= _); try constructor; easy.
   - depelim er.
     constructor.
-    induction H; [easy|].
-    depelim H0.
+    induction H; [simpl; easy|].
+    depelim X.
     now constructor.
   - depelim er.
     now constructor.
@@ -170,20 +170,20 @@ Proof.
     now econstructor.
   - depelim er.
     constructor.
-    induction H in k, H, H0 |- *; [easy|].
+    induction H in k, H, X |- *; [simpl;easy|].
     cbn in *.
     rewrite <- !Nat.add_succ_r.
-    depelim H0.
+    depelim X.
     constructor; [|easy].
-    now apply p.
+    now apply e.
   - depelim er.
     constructor.
-    induction H in k, H, H0 |- *; [easy|].
+    induction H in k, H, X |- *; [simpl; easy|].
     cbn in *.
     rewrite <- !Nat.add_succ_r.
-    depelim H0.
+    depelim X.
     constructor; [|easy].
-    now apply p.
+    now apply e.
 Qed.
 
 Lemma erases_deps_substl Σ Σ' s t :

--- a/erasure/theories/EInversion.v
+++ b/erasure/theories/EInversion.v
@@ -11,7 +11,6 @@ From Equations Require Import Equations.
 
 (** * Inversion on eval *)
 
-
 Notation type_Construct_inv := PCUICInversion.inversion_Construct.
 Notation type_tFix_inv := PCUICInversion.inversion_Fix.
 
@@ -22,8 +21,8 @@ Lemma eval_box_apps {wfl : WcbvFlags}:
     eval Σ' e EAst.tBox -> eval Σ' (EAst.mkApps e x) EAst.tBox.
 Proof.
   intros Σ' e x H2. revert e H2; induction x using rev_ind; cbn; intros; eauto using eval; auto.
-  eapply All2_app_inv in H as ((l1' & l2') & (-> & H) & H2).
+  eapply All2_app_inv in X as ((l1' & l2') & (-> & H') & H2).
   depelim H2.
-  specialize (IHx e _ H H0). simpl.
+  specialize (IHx e _ H' H). simpl.
   rewrite mkApps_app. simpl. econstructor; eauto.
 Qed.

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -41,13 +41,13 @@ Proof.
     destruct t ; try (right ; discriminate).
   all: term_dec_tac term_dec.
   - left; reflexivity.
-  - revert l0. induction H ; intro l0.
+  - revert l0. induction X ; intro l0.
     + destruct l0.
       * left. reflexivity.
       * right. discriminate.
     + destruct l0.
       * right. discriminate.
-      * destruct (IHAll l0) ; nodec.
+      * destruct (IHX l0) ; nodec.
         destruct (p t) ; nodec.
         subst. left. inversion e. reflexivity.
   - destruct (IHx t) ; nodec.
@@ -74,27 +74,27 @@ Proof.
         cbn in *. subst. inversion e. reflexivity.
   - destruct (IHx t) ; nodec.
     left. subst. reflexivity.
-  - revert m0. induction H ; intro m0.
+  - revert m0. induction X ; intro m0.
     + destruct m0.
       * left. reflexivity.
       * right. discriminate.
     + destruct m0.
       * right. discriminate.
       * destruct (p (dbody d)) ; nodec.
-        destruct (IHAll m0) ; nodec.
+        destruct (IHX m0) ; nodec.
         destruct x, d ; subst. cbn in *.
         destruct (eq_dec dname dname0) ; nodec.
         subst. inversion e0. subst.
         destruct (eq_dec rarg rarg0) ; nodec.
         subst. left. reflexivity.
-  - revert m0. induction H ; intro m0.
+  - revert m0. induction X ; intro m0.
     + destruct m0.
       * left. reflexivity.
       * right. discriminate.
     + destruct m0.
       * right. discriminate.
       * destruct (p (dbody d)) ; nodec.
-        destruct (IHAll m0) ; nodec.
+        destruct (IHX m0) ; nodec.
         destruct x, d ; subst. cbn in *.
         destruct (eq_dec dname dname0) ; nodec.
         subst. inversion e0. subst.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -258,7 +258,7 @@ Section Wcbv.
     - now eapply atom_mkApps in H.
     - intros * isapp appeq. move: (value_head_nApp H) => Ht.
       apply mkApps_eq_inj in appeq; intuition subst; auto.
-    - intros * isapp appeq. move: (isStuckfix_nApp H1) => Hf.
+    - intros * isapp appeq. move: (isStuckfix_nApp H) => Hf.
       apply mkApps_eq_inj in appeq; intuition subst; auto.
   Qed.
 
@@ -478,7 +478,7 @@ Section Wcbv.
   Lemma value_final e : value e -> eval e e.
   Proof.
     induction 1 using value_values_ind; simpl; auto using value.
-    - apply All_All2_refl in H1 as H2.
+    - apply All_All2_refl in X0 as H2.
       move/implyP: (value_head_spec_impl t).
       move/(_ H) => Ht.
       induction l using rev_ind. simpl.
@@ -486,8 +486,8 @@ Section Wcbv.
       * repeat constructor.
       * repeat constructor.
       * rewrite -mkApps_nested.
-        eapply All_app in H0 as [Hl Hx]. depelim Hx.
-        eapply All_app in H1 as [Hl' Hx']. depelim Hx'.
+        eapply All_app in X as [Hl Hx]. depelim Hx.
+        eapply All_app in X0 as [Hl' Hx']. depelim Hx'.
         eapply All2_app_inv_r in H2 as [Hl'' [Hx'' [? [? ?]]]].
         depelim a0.
         eapply eval_app_cong; auto.
@@ -500,7 +500,7 @@ Section Wcbv.
         rewrite orb_false_r.
         destruct t; auto.
     - destruct f; try discriminate.
-      apply All_All2_refl in H0.
+      apply All_All2_refl in X0.
       now apply eval_stuck_fix.
   Qed.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -528,7 +528,7 @@ Lemma Is_proof_ty Σ Γ t :
 Proof.
   intros wfΣ [ty [u [Hty isp]]].
   intros t' ty' Hty'.
-  epose proof (PCUICPrincipality.principal_typing _ wfΣ Hty Hty') as [C [Cty [Cty' Ht'']]].
+  epose proof (PCUICPrincipality.principal_typing _ wfΣ Hty Hty') as [C [[Cty [Cty' Ht'']]]].
   intros Ht'.
   exists ty', u; intuition auto.
   eapply PCUICValidity.validity in Hty; eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -528,7 +528,7 @@ Lemma Is_proof_ty Σ Γ t :
 Proof.
   intros wfΣ [ty [u [Hty isp]]].
   intros t' ty' Hty'.
-  epose proof (PCUICPrincipality.principal_typing _ wfΣ Hty Hty') as [C [[Cty [Cty' Ht'']]]].
+  epose proof (PCUICPrincipality.common_typing _ wfΣ Hty Hty') as [C [Cty [Cty' Ht'']]].
   intros Ht'.
   exists ty', u; intuition auto.
   eapply PCUICValidity.validity in Hty; eauto.
@@ -547,7 +547,7 @@ Proof.
   eapply PCUICValidity.inversion_mkApps in Htargs as [A [Ht sp]].
   pose proof (PCUICValidity.validity_term wfΣ Hty).  
   pose proof (PCUICValidity.validity_term wfΣ Ht).  
-  epose proof (PCUICPrincipality.principal_typing _ wfΣ Hty Ht) as [C [Cty [Cty' Ht'']]].
+  epose proof (PCUICPrincipality.common_typing _ wfΣ Hty Ht) as [C [Cty [Cty' Ht'']]].
   eapply PCUICSpine.typing_spine_strengthen in sp; eauto.
   edestruct (sort_typing_spine _ _ _ u _ _ _ pu sp) as [u' [Hty' isp']].
   eapply PCUICElimination.cumul_prop1; eauto.
@@ -881,7 +881,7 @@ Proof.
         (* destruct x4; cbn in e2; subst. destruct X2. destruct p0; cbn in e2; subst. csbn in *.  destruct y.  *)
         exists x3. split; eauto. constructor. eapply eval_iota_sing => //. 3:eauto.
         pose proof (Ee.eval_to_value _ _ _ He_v').
-        eapply value_app_inv in H8. subst. eassumption.
+        eapply value_app_inv in X0. subst. eassumption.
         depelim H2.
         eapply isErasable_Propositional in X0; eauto.
         eapply isPropositional_propositional; eauto.
@@ -977,7 +977,7 @@ Proof.
            constructor. eapply eval_iota_sing => //.
            pose proof (Ee.eval_to_value _ _ _ He_v').
            2:eauto. auto.
-           apply value_app_inv in H9; subst x1.
+           apply value_app_inv in X0; subst x1.
            apply He_v'.
 
            
@@ -1028,7 +1028,7 @@ Proof.
 
         eapply eval_proj_prop => //.
         pose proof (Ee.eval_to_value _ _ _ Hty_vc').
-        eapply value_app_inv in H1. subst. eassumption.
+        eapply value_app_inv in X0. subst. eassumption.
       * rename H3 into Hinf.
         eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
         assert (Σ ;;; [] |- mkApps (tConstruct i 0 u) args : mkApps (tInd i x) x2).
@@ -1061,7 +1061,7 @@ Proof.
 
            constructor. eapply eval_proj_prop => //.
            pose proof (Ee.eval_to_value _ _ _ Hty_vc').
-           eapply value_app_inv in H2. subst. eassumption.
+           eapply value_app_inv in X0. subst. eassumption.
         -- eapply erases_deps_eval in Hty_vc'; [|now eauto].
            eapply erases_deps_mkApps_inv in Hty_vc' as (? & ?).
            now eapply nth_error_forall in H1; eauto.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -298,14 +298,14 @@ Next Obligation.
   - intros (? & ? & ?). sq.
      destruct s as [ | (? & ? & ?)].
      + destruct H. eapply arity_type_inv; eauto.
-     + eapply principal_typing in X2 as (? & ? & ? &?). 2:eauto. 2:exact t0.
+     + eapply common_typing in X2 as (? & ? & ? &?). 2:eauto. 2:exact t0.
 
        eapply cumul_prop1 in c; eauto.
        eapply cumul_prop2 in c0; eauto.
 
        eapply type_reduction in X0; eauto.
 
-       eapply principal_typing in c0 as (? & ? & ? & ?). 2:eauto. 2:{ exact X0. }
+       eapply common_typing in c0 as (? & ? & ? & ?). 2:eauto. 2:{ exact X0. }
 
        eapply cumul_prop1 in c; eauto.
 

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -12,7 +12,7 @@ Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
    https://github.com/coq/coq/issues/7017. *)
 Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
-Extraction Blacklist config uGraph Universes Ast String List Nat Int
+Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
            UnivSubst Typing Checker Retyping OrderedType Logic Common Equality Classes.
 Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -16,8 +16,6 @@ Module P := PCUICWcbvEval.
 
 Ltac inv H := inversion H; subst; clear H.
 
-Coercion wf_ext_wf : wf_ext >-> wf.
-Existing Instance wf_ext_wf.
 Existing Class axiom_free.
 
 Lemma nth_error_app_inv X (x : X) n l1 l2 :
@@ -263,7 +261,7 @@ Lemma value_app_inv L :
   Ee.value (EAst.mkApps EAst.tBox L) ->
   L = nil.
 Proof.
-  intros. depelim H.
+  intros. depelim X.
   - destruct L using rev_ind.
     reflexivity.
     rewrite emkApps_snoc in i. inv i.

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -29,7 +29,6 @@ theories/PCUICContextConversion.v
 theories/PCUICConversion.v
 theories/PCUICGeneration.v
 theories/PCUICAlpha.v
-theories/PCUICPrincipality.v
 theories/PCUICCtxShape.v
 theories/PCUICContexts.v
 theories/PCUICArities.v

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -48,7 +48,7 @@ theories/PCUICRetyping.v
 theories/PCUICCumulProp.v
 theories/PCUICElimination.v
 theories/PCUICSN.v
-
+theories/PCUICPrincipality.v
 theories/PCUICSigmaCalculus.v
 
 theories/PCUICSafeLemmata.v

--- a/pcuic/theories/Extraction.v
+++ b/pcuic/theories/Extraction.v
@@ -13,7 +13,7 @@ Require Import FSets ssreflect ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
    https://github.com/coq/coq/issues/7017. *)
 Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
-Extraction Blacklist config uGraph universes Ast String List Logic Logic0 Nat Int
+Extraction Blacklist Classes config uGraph universes Ast String List Logic Logic0 Nat Int
            UnivSubst Typing Checker Retyping OrderedType Classes equality.
 Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -146,3 +146,5 @@ Include PCUICEnvironment.
 
 Module PCUICLookup := Lookup PCUICTerm PCUICEnvironment.
 Include PCUICLookup.
+
+Derive NoConfusion for global_decl context_decl.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -1137,7 +1137,7 @@ Section WeakNormalization.
       Σ ;;; [] |- t : mkApps (tInd i u) args -> 
       wh_normal Σ [] t -> 
       construct_cofix_discr (head t).
-  Proof. Admitted. (* intros. eapply wh_normal_empty_gen. Qed.  *)
+  Proof. intros. eapply wh_normal_empty_gen; eauto. Qed.
 
   Lemma whnf_ind_finite t ind u indargs : 
     axiom_free Σ ->

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -601,8 +601,8 @@ Proof.
   pose proof (declared_projection_inv weaken_env_prop_closed wfΣ X0 isdecl) as onp.
   set (declared_inductive_inv _ wfΣ X0 _) as oib in *.
   clearbody oib.
-  have onpars := onParams _ _ _ _ (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
-  have parslen := onNpars _ _ _ _ (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
+  have onpars := onParams (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
+  have parslen := onNpars (declared_minductive_inv weaken_env_prop_closed wfΣ X0 isdecl.p1.p1).
   simpl in onp. destruct (ind_cshapes oib) as [|? []] eqn:Heq; try contradiction.
   destruct onp as [_ onp].
   red in onp.
@@ -812,6 +812,7 @@ Proof.
            eapply Forall_impl; tea. auto.
            destruct indices_matter; [|trivial].
            eapply type_local_ctx_impl; tea. eauto.
+      --- eapply onIndices.
     -- red in onP. red.
        eapply All_local_env_impl. eauto.
        intros. now apply X.

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -80,10 +80,12 @@ Proof.
   clear -H. induction H; simpl; auto. constructor. constructor.
   constructor. auto.
 Qed.
+Hint Resolve smash_context_assumption_context : pcuic.
 
 Lemma assumption_context_length ctx : assumption_context ctx ->
   context_assumptions ctx = #|ctx|.
 Proof. induction 1; simpl; auto. Qed.
+Hint Resolve assumption_context_length : pcuic.
 
 Lemma context_subst_length2 {ctx args s} : context_subst ctx args s -> #|args| = context_assumptions ctx.
 Proof.
@@ -138,7 +140,7 @@ Proof.
     pose proof (context_subst_length2 Hc).
     rewrite context_assumptions_app in H.
     destruct IHctx as [IHctx _].
-    pose proof (context_subst_length _ _ _ IHctx).
+    pose proof (context_subst_length IHctx).
     rewrite subst_context_snoc. rewrite !skipn_S.
     rewrite /subst_decl /map_decl /= Nat.add_0_r.
     rewrite -{4}(firstn_skipn #|ctx| s0).
@@ -217,7 +219,7 @@ Proof.
   rewrite lift_context_snoc map_app /=; constructor; auto.
   rewrite lift_context_snoc /= /lift_decl /map_decl /=.
   rewrite Nat.add_0_r.
-  rewrite (context_subst_length _ _ _ X).
+  rewrite (context_subst_length X).
   rewrite distr_lift_subst Nat.add_0_r.
   now constructor.
 Qed.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -23,9 +23,6 @@ Hint Resolve eq_universe_leq_universe' : pcuic.
 Derive Signature for conv cumul assumption_context.
 Derive Signature for clos_refl_trans_1n. 
 
-(* So that we can use [conv_trans]... *)
-Existing Class wf.
-
 (* todo move *)
 Lemma All2_refl {A} {P : A -> A -> Type} l : 
   (forall x, P x x) ->

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -406,7 +406,6 @@ Qed.
 
 Instance cumul_prop_transitive Σ Γ : wf_ext Σ -> CRelationClasses.Transitive (cumul_prop Σ Γ).
 Proof. intros. red. intros. now eapply cumul_prop_trans. Qed.
-Existing Class wf_ext.
 
 Lemma cumul_prop_cum_l Σ Γ A T B : 
   wf_ext Σ ->

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -5,7 +5,7 @@ From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils
      PCUICSubstitution PCUICUnivSubst PCUICUnivSubstitution
      PCUICCtxShape PCUICConversion PCUICCumulativity PCUICConfluence PCUICContexts
      PCUICSR PCUICInversion PCUICValidity PCUICSafeLemmata PCUICContextConversion
-     PCUICPrincipality PCUICEquality PCUICReduction.
+     PCUICEquality PCUICReduction.
 
 Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
 Require Equations.Prop.DepElim.
@@ -23,6 +23,49 @@ Section no_prop_leq_type.
 Context `{cf : checker_flags}.
 Variable Hcf : prop_sub_type = false.
 Variable Hcf' : check_univs = true.
+
+Lemma cumul_sort_confluence {Σ : global_env_ext} {wfΣ : wf Σ} {Γ A u v} :
+  Σ ;;; Γ |- A <= tSort u ->
+  Σ ;;; Γ |- A <= tSort v ->
+  ∑ v', (Σ ;;; Γ |- A = tSort v') *
+        (leq_universe (global_ext_constraints Σ) v' u /\
+          leq_universe (global_ext_constraints Σ) v' v).
+Proof.
+  move=> H H'.
+  eapply invert_cumul_sort_r in H as [u'u ?].
+  eapply invert_cumul_sort_r in H' as [vu ?].
+  destruct p, p0.
+  destruct (red_confluence wfΣ r r0).
+  destruct p.
+  eapply invert_red_sort in r1.
+  eapply invert_red_sort in r2. subst. noconf r2.
+  exists u'u. split; auto.
+Qed.
+
+Lemma cumul_ind_confluence {Σ : global_env_ext} {wfΣ : wf Σ} {Γ A ind u v l l'} :
+  Σ ;;; Γ |- A <= mkApps (tInd ind u) l  ->
+  Σ ;;; Γ |- A <= mkApps (tInd ind v) l' ->
+  ∑ v' l'', (red Σ Γ A (mkApps (tInd ind v') l'')) *
+        All2 (conv Σ Γ) l l'' *
+        All2 (conv Σ Γ) l' l'' *          
+        (R_global_instance Σ (eq_universe Σ) (leq_universe Σ) (IndRef ind) #|l| v' u /\
+          R_global_instance Σ (eq_universe Σ) (leq_universe Σ) (IndRef ind) #|l'| v' v).
+Proof.
+  move=> H H'.
+  eapply invert_cumul_ind_r in H as [u'u [l'u [redl [ru ?]]]].
+  eapply invert_cumul_ind_r in H' as [vu [l''u [redr [ru' ?]]]].
+  destruct (red_confluence wfΣ redl redr) as [nf [redl' redr']].
+  eapply red_mkApps_tInd in redl'  as [args' [eqnf conv]].
+  eapply red_mkApps_tInd in redr'  as [args'' [eqnf' conv']].
+  rewrite eqnf in eqnf'. solve_discr. subst nf.
+  all:auto. exists u'u, args'; intuition auto.
+  transitivity (mkApps (tInd ind u'u) l'u).
+  auto. eapply red_mkApps. reflexivity. auto.
+  - apply All2_trans with l'u => //. typeclasses eauto.
+    eapply (All2_impl conv). intros. now apply red_conv.
+  - apply All2_trans with l''u => //. typeclasses eauto.
+    eapply (All2_impl conv'). intros. now apply red_conv.
+Qed.
 
 Lemma invert_conv_letin_l_alt {Σ Γ C na d ty b} :
   wf Σ.1 -> wf_local Σ (Γ ,, vdef na d ty) ->
@@ -43,7 +86,7 @@ Lemma is_prop_bottom {Σ Γ T s s'} :
   Universe.is_prop s -> Universe.is_prop s'.
 Proof.
   intros wfΣ hs hs'.
-  destruct (cumul_sort_confluence _ wfΣ.1 hs hs') as [x' [conv [leq leq']]].
+  destruct (cumul_sort_confluence hs hs') as [x' [conv [leq leq']]].
   intros isp.
   unshelve eapply (leq_prop_is_prop _ _ _ _ leq'); auto.
   now unshelve eapply (leq_prop_is_prop _ _ _ _ leq).
@@ -805,6 +848,19 @@ Qed.
 Instance cumul_prop_sym' Σ Γ : wf Σ.1 -> CRelationClasses.Symmetric (cumul_prop Σ Γ).
 Proof.
   now intros wf x y; eapply cumul_prop_sym.
+Qed.
+
+Notation eq_term_napp Σ n x y :=
+  (eq_term_upto_univ_napp Σ (eq_universe Σ) (eq_universe Σ) n x y).
+
+Notation leq_term_napp Σ n x y :=
+    (eq_term_upto_univ_napp Σ (eq_universe Σ) (leq_universe Σ) n x y).
+    
+Lemma eq_term_upto_univ_napp_leq {Σ : global_env_ext} {n x y} :
+  eq_term_napp Σ n x y -> 
+  leq_term_napp Σ n x y.
+Proof.
+  eapply eq_term_upto_univ_impl; auto; typeclasses eauto.
 Qed.
 
 Lemma typing_leq_term_prop (Σ : global_env_ext) Γ t t' T T' :

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -5,7 +5,7 @@ From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils
      PCUICSubstitution PCUICUnivSubst PCUICUnivSubstitution
      PCUICCtxShape PCUICConversion PCUICCumulativity PCUICConfluence PCUICContexts
      PCUICSR PCUICInversion PCUICValidity PCUICSafeLemmata PCUICContextConversion
-     PCUICPrincipality PCUICCumulProp.
+     PCUICCumulProp.
 
 Require Equations.Prop.DepElim.
 From Equations Require Import Equations.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -106,7 +106,7 @@ Proof.
   rewrite PCUICLiftSubst.subst_mkApps. simpl.
   rewrite map_app map_map_compose.
   rewrite PCUICLiftSubst.map_subst_lift_id_eq. 
-  { rewrite - (PCUICSubstitution.context_subst_length _ _ _ spa).
+  { rewrite - (PCUICSubstitution.context_subst_length spa).
       now autorewrite with len. }
   { unfold to_extended_list. 
     rewrite (spine_subst_subst_to_extended_list_k_gen spa).
@@ -456,7 +456,7 @@ Proof.
 
     apply s.
     rewrite subst_app_context in X0.
-    rewrite -(context_subst_length _ _ _ sub) in X0.
+    rewrite -(context_subst_length sub) in X0.
     autorewrite with len in X0.
     eapply (type_local_ctx_All_local_assum_impl Σ 
       (fun Γ Γ' t => 

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -145,14 +145,14 @@ Lemma branch_type_spec {cf:checker_flags} Σ ind mdecl idecl cdecl pars u p c na
          (map (lift0 nargs') pars ++         
           to_extended_list substargs)])).
 Proof.
-  move=> decli onmib [] indices ps aeq onAr indsorts onC onP inds.
-  intros cs onc brty.
+  move=> decli onmib [] indices ps aeq onAr indsorts onC onP inds onIndices.
+  intros cs onc brty. simpl in *.
   simpl in onc.
   clear onP.
   assert(lenbodies: inductive_ind ind < #|ind_bodies mdecl|).
   { destruct decli as [_ Hnth]. now apply nth_error_Some_length in Hnth. }
   clear decli.
-  destruct onc.
+  destruct onc. simpl in *.
   destruct cs as [args indi csort] => /=. simpl in *. 
   rewrite cstr_eq in on_ctype.
   unfold branch_type in brty.
@@ -195,7 +195,7 @@ Proof.
   rewrite !map_map_compose map_app.
   rewrite chop_n_app.
   rewrite map_length to_extended_list_k_length.
-  by rewrite (onmib.(onNpars _ _ _ _)).
+  by rewrite (onmib.(onNpars)).
 
   move=> [=] Hargs Hbty. subst nargs. split;auto. rewrite -Hbty.
   clear Hbty bty.
@@ -524,10 +524,8 @@ Proof.
   set (declared_inductive_inv _ _ _ _) as oib' in onp.
   change oib' with oib in *. clear oib'.
   simpl in oib.
-  have onpars := onParams _ _ _ _ 
-    (declared_minductive_inv weaken_env_prop_typing wfΣ wfΣ decli.p1).
-  have parslen := onNpars _ _ _ _ 
-    (declared_minductive_inv weaken_env_prop_typing wfΣ wfΣ decli.p1).
+  have onpars := onParams (declared_minductive_inv weaken_env_prop_typing wfΣ wfΣ decli.p1).
+  have parslen := onNpars (declared_minductive_inv weaken_env_prop_typing wfΣ wfΣ decli.p1).
   simpl in onp. rewrite Heq in onp. 
   destruct onp as [[[wfargs onProjs] Hp2] onp].
   red in onp.
@@ -1129,7 +1127,7 @@ Proof.
   apply context_subst_app in cs as [parsubst argsubst].
   eexists _, _. move=> lk parctx argctx. subst lk.
   rewrite subst_instance_context_assumptions in argsubst, parsubst.
-  rewrite declm.(onNpars _ _ _ _) in argsubst, parsubst.
+  rewrite declm.(onNpars) in argsubst, parsubst.
   eapply subslet_app_inv in subs as [subp suba].
   rewrite subst_instance_context_length in subp, suba.
   subst parctx argctx.
@@ -1160,7 +1158,7 @@ Proof.
   simpl in y. destruct (ind_cshapes oib) as [|cs []]; try contradiction.
   destruct y as [[[_ onps] ?] ?].
   pose proof (on_projs_noidx _ _ _ _ _ _ onps).
-  pose proof (onNpars _ _ _ _ o).
+  pose proof (onNpars o).
   pose proof (context_subst_length2 spargs).
   rewrite context_assumptions_fold in H1.
   autorewrite with len in H1.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -868,7 +868,6 @@ Lemma declared_projection_type_and_eq {cf:checker_flags} {Σ : global_env_ext} {
   forall (wfΣ : wf Σ.1) (Hdecl : declared_projection Σ mdecl idecl p pdecl),
   let u := PCUICLookup.abstract_instance (ind_universes mdecl) in
   let oib := declared_inductive_inv weaken_env_prop_typing wfΣ wfΣ (let (x, _) := Hdecl in x) in
-  let u := PCUICLookup.abstract_instance (ind_universes mdecl) in
   match ind_cshapes oib return Type with
   | [cs] => 
     isType (Σ.1, ind_universes mdecl)
@@ -1040,20 +1039,18 @@ Proof.
   eapply spine_subst_smash_inv; eauto.
 Qed.
 
-Lemma wf_projection_context {cf:checker_flags} (Σ : global_env_ext) Γ mdecl idecl p pdecl u : 
+Lemma wf_projection_context {cf:checker_flags} (Σ : global_env_ext) {mdecl idecl p pdecl u} : 
   wf Σ.1 ->
   declared_projection Σ mdecl idecl p pdecl ->
   consistent_instance_ext Σ (PCUICAst.ind_universes mdecl) u ->
-  wf_local Σ Γ ->
-  wf_local Σ (Γ ,,, projection_context mdecl idecl p.1.1 u).
+  wf_local Σ (projection_context mdecl idecl p.1.1 u).
 Proof.
   move=> wfΣ decli.
   pose proof (on_declared_projection wfΣ decli) as [onmind onind].
   set (oib := declared_inductive_inv _ _ _ _) in *. clearbody oib.
   simpl in onind; destruct ind_cshapes as [|? []]; try contradiction.
   destruct onind as [[[_ onps] Hpe] onp].
-  move=> cu wfΓ.
-  apply weaken_wf_local; auto.
+  move=> cu.
   assert(wfparams : wf_local Σ (subst_instance_context u (ind_params mdecl))).
   { eapply on_minductive_wf_params; eauto. eapply decli. }
   assert(wfsmash : wf_local Σ (smash_context [] (subst_instance_context u (ind_params mdecl)))).

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -40,6 +40,8 @@ Section Normal.
   (* Relative to reduction flags *)
   Inductive whnf (Γ : context) : term -> Prop :=
   | whnf_ne t : whne Γ t -> whnf Γ t
+  | whnf_sort s : whnf Γ (tSort s)
+  | whnf_prod na A B : whnf Γ (tProd na A B)
   | whnf_lam na A B : whnf Γ (tLambda na A B)
   | whnf_cstrapp i n u v : whnf Γ (mkApps (tConstruct i n u) v)
   | whnf_indapp i u v : whnf Γ (mkApps (tInd i u) v)
@@ -65,10 +67,6 @@ Section Normal.
 
   | whne_evar n l :
       whne Γ (tEvar n l)
-
-  | whne_sort s : whne Γ (tSort s)
-
-  | whne_prod na A B : whne Γ (tProd na A B)
 
   | whne_letin_nozeta na B b t :
       RedFlags.zeta flags = false ->
@@ -266,6 +264,18 @@ Proof.
            eapply whne_mkApps_inv in H0 as []; eauto.
            ++ depelim H0. help.
            ++ firstorder congruence.
+      * destruct v as [ | ? v].
+        -- eauto.
+        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
+            eapply whne_mkApps_inv in H0 as []; eauto.
+            ++ depelim H0. help.
+            ++ firstorder congruence.
+      * destruct v as [ | ? v].
+        -- eauto.
+        -- right. intros ?. depelim H0. depelim H0. all:help. clear IHl.
+            eapply whne_mkApps_inv in H0 as []; eauto.
+            ++ depelim H0. help.
+            ++ firstorder congruence.
       * destruct (unfold_fix mfix idx) as [(narg, body) |] eqn:E1.
         -- destruct (nth_error v narg) as [a  | ] eqn:E2.
            ++ destruct (nth_error_all E2 X Γ) as [_ []].

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -486,7 +486,7 @@ Section Pred1_inversion.
     revert c. induction args using rev_ind; intros; simpl in *.
     depelim X...
     - red in H, isdecl. rewrite isdecl in H; noconf H.
-      simpl in H. injection H. intros. subst. congruence.
+      congruence.
     - exists []. intuition auto.
     - rewrite <- mkApps_nested in X.
       depelim X...

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -12,11 +12,10 @@ Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
 Set Equations With UIP.
 
-(** We show a weak version of principal typing, close to uniqueness of types.
-  Given two typings of the same terms, we can always find a typing that is
-  smaller that both. It follows trivially from the later definition of 
-  [PCUICSafeRetyping.type_of] which computes the principal type of a terrm
-  but whose correctness proof also requires completeness of weak-head-reduction. *)
+(** We show that principal types are derivable, without relying on normalization.
+  The principal type is burried in the proof here, but [PCUICSafeRetyping.type_of]
+  gives an explicit computation, but its definition and correctness proof requires
+  completeness of weak-head-reduction. *)
 
 Section Principality.
   Context {cf : checker_flags}.
@@ -31,7 +30,6 @@ Section Principality.
     |- _ =>
   specialize (ih _ _ _ h1 h2)
   end.
-
 
   Ltac insum :=
     match goal with
@@ -432,25 +430,6 @@ Lemma eq_term_upto_univ_napp_leq {cf:checker_flags} {Σ : global_env_ext} {n x y
 Proof.
   eapply eq_term_upto_univ_impl; auto; typeclasses eauto.
 Qed.
-(* 
-Lemma typing_leq_term_app {cf:checker_flags} (Σ : global_env_ext) Γ t t' l l' T T' : 
-  wf Σ.1 ->
-  Σ ;;; Γ |- mkApps t l : T ->
-  Σ ;;; Γ |- mkApps t' l' : T' ->
-  All2 (eq_term Σ Σ) l l' ->
-  leq_term_napp Σ #|l| t' t ->
-  Σ ;;; Γ |- mkApps t' l' : T.
-Proof.
-  intros wfΣ Ht Ht' Hl Heq.
-  depind Heq.        *)
-(* 
-Lemma typing_leq_term_gen {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' : 
-  wf Σ.1 ->
-  Σ ;;; Γ |- t : T ->
-  Σ ;;; Γ |- t' : T' ->
-  leq_term Σ Σ t' t ->
-  Σ ;;; Γ |- t' : T.
-Proof. *)
 
 Lemma R_global_instance_empty_universe_instance Re Rle ref napp u u' :
   R_global_instance [] Re Rle ref napp u u' ->

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -391,7 +391,7 @@ Proof.
          rewrite {6}/pargctxu in X0.
          rewrite distr_lift_subst_context in X0.
          rewrite closed_ctx_lift in X0.
-         { rewrite /argctxu. rewrite -(context_subst_length _ _ _ csubst).
+         { rewrite /argctxu. rewrite -(context_subst_length csubst).
            rewrite subst_instance_context_length. rewrite Nat.add_comm. eapply closedn_ctx_subst.
           2:eapply declared_minductive_closed_inds; eauto.
           rewrite /argctx. autorewrite with len. simpl.
@@ -447,7 +447,7 @@ Proof.
            simpl in sp. instantiate (1:=inst).
            eapply spine_subst_eq; [eapply sp|].
            rewrite distr_lift_subst_context -H. f_equal.
-           rewrite -(context_subst_length _ _ _ iparsubst0).
+           rewrite -(context_subst_length iparsubst0).
            autorewrite with len. rewrite closed_ctx_lift //.
            epose proof (on_minductive_wf_params_indices_inst _ _ u _ _ _ (proj1 decli) oib cu).
            rewrite subst_instance_context_app in X1. eapply closed_wf_local in X1; eauto.
@@ -487,7 +487,7 @@ Proof.
              eapply (closedn_expand_lets 0) in cl.
              rewrite subst_closedn closedn_subst_instance_constr.
              now len in cl.
-             rewrite -(context_subst_length _ _ _ iparsubst0).
+             rewrite -(context_subst_length iparsubst0).
              autorewrite with len. now rewrite Nat.add_comm; len in cl. }  
            rewrite !map_map_compose. apply (All_All2 X1).
            intros x cl.
@@ -799,7 +799,7 @@ Proof.
       eapply (All2_impl (P:=fun x y => red Σ.1 Γ x y)).
       2:{ intros x' y' hred. rewrite heq_length.
           eapply weakening_red_0; auto. autorewrite with len.
-          pose proof (onNpars _ _ _ _ oi). simpl; lia. }
+          pose proof (onNpars oi). simpl; lia. }
       elim: p.2. simpl. constructor.
       intros n Hn. constructor; auto.
       eapply red1_red. eapply red_cofix_proj. eauto.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
-     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICPrincipality PCUICConfluence
+     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICConfluence
      PCUICCumulativity PCUICSR PCUICPosition PCUICEquality PCUICNameless
      PCUICAlpha PCUICNormal PCUICInversion PCUICReduction PCUICSubstitution
      PCUICConversion PCUICContextConversion PCUICValidity PCUICCtxShape

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -104,10 +104,10 @@ Proof.
   rewrite -(firstn_skipn (context_assumptions ctx') args).
   assert (lenctx' : context_assumptions ctx' + context_assumptions ctx = #|args|).
   { assert (lenctx'' : context_assumptions ctx' <= #|args|).
-    move: (context_subst_assumptions_length _ _ _ Hr).
+    move: (context_subst_assumptions_length Hr).
     rewrite firstn_length; lia.
-    move: (context_subst_assumptions_length _ _ _ Hr).
-    move: (context_subst_assumptions_length _ _ _ Hl).
+    move: (context_subst_assumptions_length Hr).
+    move: (context_subst_assumptions_length Hl).
     rewrite firstn_length skipn_length; try lia.
     intros H1 H2. rewrite context_assumptions_subst in H1. lia. }
   move: args s ctx' lenctx' Hl Hr.
@@ -133,7 +133,7 @@ Proof.
       now econstructor.
     * destruct a as [na' [b'|] ty']; simpl in *; noconf H.
       rewrite skipn_S in Hl, Hr, H. subst b.
-      pose proof (context_subst_length _ _ _ Hl). rewrite subst_context_length in H.
+      pose proof (context_subst_length Hl). rewrite subst_context_length in H.
       rewrite {3}H -subst_app_simpl [firstn #|ctx| _ ++ _]firstn_skipn. constructor.
       apply IHctx => //.
 Qed.
@@ -313,7 +313,7 @@ Proof.
           rewrite !skipn_0 {1}subst_empty.
           assert(#|l| <= n) by lia.
           rewrite context_assumptions_subst in instlen.
-          pose proof (context_subst_length _ _ _ cs). rewrite subst_context_length in H0.
+          pose proof (context_subst_length cs). rewrite subst_context_length in H0.
           rewrite !(firstn_app_left _ 0). lia. simpl. rewrite !app_nil_r.
           split. now rewrite H0 skipn_all_app.
           rewrite H0 skipn_all_app. repeat constructor.
@@ -352,7 +352,7 @@ Proof.
         * apply context_subst_app_inv. cbn.
           rewrite !skipn_S skipn_0.
           assert(#|l| <= n) by lia.
-          pose proof (context_subst_length _ _ _ cs). rewrite subst_context_length in H0.
+          pose proof (context_subst_length cs). rewrite subst_context_length in H0.
           rewrite !(firstn_app_left _ 0). lia. simpl. rewrite !app_nil_r.
           split. now rewrite H0 skipn_all_app.
           rewrite H0 skipn_all_app. apply (context_subst_ass _ []). constructor.
@@ -555,7 +555,7 @@ Proof.
   epose proof (context_subst_def _ _ _ na (subst sub (#|Γ1| + #|Γ'|) b) (subst sub (#|Γ1| + #|Γ'|) t) IHcs).
   rewrite /subst_decl /map_decl /=.
   rewrite distr_subst. 
-  now rewrite (context_subst_length _ _ _ cs) in X |- *.
+  now rewrite (context_subst_length cs) in X |- *.
   clear cs wfΔ.
   induction subl; rewrite ?subst_context_snoc ?map_app; simpl; try constructor; auto.
   - eapply substitution in t0; eauto. simpl.
@@ -1685,7 +1685,7 @@ Proof.
       exists (args_sub ++ [b]); split; [split;[constructor|]|]; auto.
       * eapply context_subst_app_inv.
         simpl. rewrite skipn_0.
-        move: (context_subst_length _ _ _ sps).
+        move: (context_subst_length sps).
         autorewrite with len.
         move=> eq'. rewrite eq'.
         rewrite skipn_all_app (firstn_app_left _ 0) //.
@@ -1699,10 +1699,10 @@ Proof.
         eapply All_local_env_app in wf as [wfd _].
         depelim wfd. apply l0.
       * rewrite subst_app_simpl.
-        move: (context_subst_length _ _ _ sps).
+        move: (context_subst_length sps).
         now  autorewrite with len => <-.
       * rewrite subst_app_simpl.
-        move: (context_subst_length _ _ _ sps).
+        move: (context_subst_length sps).
         now  autorewrite with len => <-.
 
     + rewrite /mkProd_or_LetIn /= in sp, wat.
@@ -1730,7 +1730,7 @@ Proof.
       exists (args_sub ++ [a]); split; [split;[constructor|]|]; auto.
       * eapply context_subst_app_inv.
         simpl. rewrite skipn_S skipn_0.
-        move: (context_subst_length _ _ _ sps).
+        move: (context_subst_length sps).
         autorewrite with len.
         move=> eq'. rewrite eq'.
         rewrite skipn_all_app (firstn_app_left _ 0) //.
@@ -1741,10 +1741,10 @@ Proof.
         rewrite -{1}(subst_empty 0 a).
         repeat constructor. now rewrite !subst_empty.
       * rewrite subst_app_simpl.
-        move: (context_subst_length _ _ _ sps).
+        move: (context_subst_length sps).
         now autorewrite with len => <-.
       * rewrite subst_app_simpl.
-        move: (context_subst_length _ _ _ sps).
+        move: (context_subst_length sps).
         now autorewrite with len => <-.
       * apply conv_cumul. now symmetry.
 Qed.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -623,10 +623,10 @@ Proof.
   - simpl. now rewrite -> inds_length, closedn_subst_instance_constr.
 Qed.
 
-Lemma context_subst_length Γ a s : context_subst Γ a s -> #|Γ| = #|s|.
+Lemma context_subst_length {Γ a s} : context_subst Γ a s -> #|Γ| = #|s|.
 Proof. induction 1; simpl; congruence. Qed.
 
-Lemma context_subst_assumptions_length Γ a s : context_subst Γ a s -> context_assumptions Γ = #|a|.
+Lemma context_subst_assumptions_length {Γ a s} : context_subst Γ a s -> context_assumptions Γ = #|a|.
 Proof. induction 1; simpl; try congruence. rewrite app_length /=. lia. Qed.
 
 (* Lemma context_subst_app {cf:checker_flags} Γ Γ' a s : *)
@@ -939,7 +939,7 @@ Proof.
   rewrite !XX; clear XX.
   apply make_context_subst_spec in Hsubst as Hsubst'.
   rewrite rev_involutive in Hsubst'.
-  pose proof (context_subst_assumptions_length _ _ _ Hsubst') as H1.
+  pose proof (context_subst_assumptions_length Hsubst') as H1.
   case E: chop => [l l'].
   have chopm := (chop_map _ _ _ _ _ E).
   move: E chopm.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -906,6 +906,7 @@ Proof.
              destruct X14 as [u Hu]. exists u.
              specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Hu)))))).
              apply IH. simpl. constructor 1. simpl. auto with arith.
+      ++ apply onIndices.
       ++ red in onP |- *.
          eapply All_local_env_impl; eauto.
          intros. destruct T; simpl in X14.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -470,7 +470,7 @@ Proof.
       * simpl.
         intros v indv. specialize (on_ctype_variance v indv).
         simpl in *. move: on_ctype_variance.
-        unfold respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
+        unfold cstr_respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
         intros [args idxs]. split.
         ** eapply (All2_local_env_impl args); intros.
            eapply weakening_env_cumul; eauto.
@@ -491,6 +491,12 @@ Proof.
         -- destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ' Hext.
            induction ind_indices; simpl in *; auto.
            destruct a as [na [b|] ty]; simpl in *; intuition eauto.
+    + intros v onv.
+      move: (onIndices v onv). unfold ind_respects_variance.
+      destruct variance_universes as [[[univs u] u']|] => //.
+      intros idx; eapply (All2_local_env_impl idx); simpl.
+      intros par par' t t'. eapply weakening_env_cumul; eauto.
+
   - red in onP |- *. eapply All_local_env_impl; eauto.
 Qed.
 

--- a/safechecker/_CoqProject.in
+++ b/safechecker/_CoqProject.in
@@ -5,5 +5,6 @@ theories/PCUICSafeConversion.v
 theories/PCUICSafeChecker.v
 theories/SafeTemplateChecker.v
 theories/PCUICSafeRetyping.v
+theories/PCUICPrincipality.v
 
 theories/Extraction.v

--- a/safechecker/_CoqProject.in
+++ b/safechecker/_CoqProject.in
@@ -5,6 +5,5 @@ theories/PCUICSafeConversion.v
 theories/PCUICSafeChecker.v
 theories/SafeTemplateChecker.v
 theories/PCUICSafeRetyping.v
-theories/PCUICPrincipality.v
 
 theories/Extraction.v

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -2,8 +2,8 @@
 -Q src MetaCoq.SafeChecker
 -R theories MetaCoq.SafeChecker
 
-src/classes0.mli
-src/classes0.ml
+# src/classes0.mli
+# src/classes0.ml
 
 # From Coq's stdlib
 src/mSetWeakList.mli

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -18,7 +18,7 @@ Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun 
 Extract Constant ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt".
 
-Extraction Blacklist config uGraph Universes Ast String List Nat Int
+Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
            UnivSubst Typing Checker Retyping OrderedType Logic Common Equality Classes.
 Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".

--- a/safechecker/theories/PCUICPrincipality.v
+++ b/safechecker/theories/PCUICPrincipality.v
@@ -2,17 +2,15 @@
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICInduction
      PCUICLiftSubst PCUICTyping PCUICSubstitution PCUICEquality
-     PCUICReduction PCUICCumulativity PCUICConfluence
+     PCUICReduction PCUICCumulativity PCUICConfluence PCUICClosed
      PCUICContextConversion PCUICConversion PCUICInversion PCUICUnivSubst
-     PCUICArities PCUICValidity PCUICInductives PCUICSR.
-From MetaCoq.SafeChecker Require Import PCUICSafeRetyping.
+     PCUICArities PCUICValidity PCUICInductives PCUICInductiveInversion 
+     PCUICSR PCUICCumulProp. 
 
 Require Import ssreflect.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
 Set Equations With UIP.
-
-Derive NoConfusion for global_decl.
 
 (** We show a weak version of principal typing, close to uniqueness of types.
   Given two typings of the same terms, we can always find a typing that is
@@ -67,326 +65,303 @@ Section Principality.
   Qed.
   Hint Extern 10 (isWfArity _ _ _ (tSort _)) => apply isWfArity_sort : pcuic.
 
-  Theorem principal_typing {Γ u A B} : Σ ;;; Γ |- u : A -> Σ ;;; Γ |- u : B ->
-    ∑ C, ∥ Σ ;;; Γ |- C <= A  ×  Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C ∥.
-  Proof.
-    intros hA hB.
-    destruct (principal_types Σ (sq wfΣ) (sq wfΣ.2) (PCUICSafeLemmata.welltyped hA)) as [P [pty Hp]].
-    exists P; split; auto.
+  Ltac int inv := intros B hB; eapply inv in hB; auto; split; [|econstructor; eauto].
+  Hint Resolve wf_ext_wf : core.
 
-    induction u in Γ, A, B, hA, hB |- * using term_forall_list_ind.
+  Theorem principal_type {Γ u A} : Σ ;;; Γ |- u : A ->
+    ∑ C, (forall B, Σ ;;; Γ |- u : B -> Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C).
+  Proof.
+    intros hA.
+    induction u in Γ, A, hA |- * using term_forall_list_ind.
     - apply inversion_Rel in hA as iA. 2: auto.
       destruct iA as [decl [? [e ?]]].
-      apply inversion_Rel in hB as iB. 2: auto.
-      destruct iB as [decl' [? [e' ?]]].
+      eexists; int inversion_Rel.
+      destruct hB as [decl' [? [e' ?]]].
       rewrite e' in e. inversion e. subst. clear e.
       repeat insum. repeat intimes.
       all: try eassumption.
-      constructor ; assumption.
     - apply inversion_Var in hA. destruct hA.
     - apply inversion_Evar in hA. destruct hA.
     - apply inversion_Sort in hA as iA. 2: auto.
-      apply inversion_Sort in hB as iB. 2: auto.
+      repeat outsum. repeat outtimes. subst.
+      exists (tSort (Universe.super x)).
+      int inversion_Sort.
       repeat outsum. repeat outtimes. subst.
       assert (x0 = x) as ee. {
         clear -e. destruct x, x0; cbnr; invs e; reflexivity. }
       subst. repeat insum. repeat intimes; tea.
-      constructor ; assumption.
     - apply inversion_Prod in hA as [dom1 [codom1 iA]]; auto.
-      apply inversion_Prod in hB as [dom2 [codom2 iB]]=> //.
-      repeat outsum. repeat outtimes.
-      repeat pih.
-      destruct IHu1 as [dom Hdom].
-      destruct IHu2 as [codom Hcodom].
-      repeat outsum. repeat outtimes.
-      destruct (cumul_sort_confluence c3 c4) as [dom' [dom'dom [leq0 leq1]]].
-      destruct (cumul_sort_confluence c1 c2) as [codom' [codom'dom [leq0' leq1']]].
-      exists (tSort (Universe.sort_of_product dom' codom')).
-      repeat split.
+      repeat outtimes.
+      specialize (IHu1 _ _ t) as [dom Hdom].
+      specialize (IHu2 _ _ t0) as [codom Hcodom].
+      destruct (Hdom _ t).
+      eapply invert_cumul_sort_r in c0 as [domu [red leq]].
+      destruct (Hcodom _ t0).
+      eapply invert_cumul_sort_r in c0 as [codomu [cored coleq]].
+      exists (tSort (Universe.sort_of_product domu codomu)).
+      int inversion_Prod.
+      repeat outsum; repeat outtimes.
       + eapply cumul_trans. 1: auto. 2:eapply c0.
+        destruct (Hdom _ t3) as [le' u1'].
+        eapply invert_cumul_sort_r in le' as [u' [redu' leu']].
+        destruct (Hcodom _ t4) as [le'' u2'].
+        eapply invert_cumul_sort_r in le'' as [u'' [redu'' leu'']].
         constructor. constructor.
         apply leq_universe_product_mon; auto.
-      + eapply cumul_trans. 1: auto. 2:eapply c.
-        constructor. constructor.
-        apply leq_universe_product_mon; auto.
-      + eapply type_Prod.
-        * eapply type_Cumul; eauto.
-          -- left; eapply isWfArity_sort. now eapply typing_wf_local in t1.
-          -- eapply conv_cumul; auto.
-        * eapply type_Cumul; eauto.
-          -- left; eapply isWfArity_sort. now eapply typing_wf_local in t3.
-          -- eapply conv_cumul; auto.
+        pose proof (red_confluence wfΣ red redu') as [v' [redl redr]].
+        eapply invert_red_sort in redl.
+        eapply invert_red_sort in redr. subst. now noconf redr.
+        pose proof (red_confluence wfΣ cored redu'') as [v' [redl redr]].
+        eapply invert_red_sort in redl.
+        eapply invert_red_sort in redr. subst. now noconf redr.
+      + eapply type_reduction; eauto.
+      + eapply type_reduction; eauto.
 
-    - apply inversion_Lambda in hA => //.
-      apply inversion_Lambda in hB => //.
+    - apply inversion_Lambda in hA => //; eauto.
       repeat outsum. repeat outtimes.
-      repeat pih.
+      destruct (IHu1 _ _ t) as [? ?].
+      destruct (IHu2 _ _ t0) as [? ?].
+      destruct (p _ t).
+      destruct (p0 _ t0).
+      exists (tProd n u1 x2).
+      int inversion_Lambda.
       repeat outsum. repeat outtimes.
-      apply invert_cumul_prod_l in c0 as [na' [A' [B' [[redA u1eq] ?]]]] => //.
-      apply invert_cumul_prod_l in c as [na'' [A'' [B'' [[redA' u1eq'] ?]]]] => //.
-      exists (tProd n u1 x3).
-      repeat split; auto.
-      + eapply cumul_trans with (tProd na' A' B'); auto.
-        * eapply congr_cumul_prod => //.
-          eapply cumul_trans with x2 => //.
-        * now eapply red_cumul_inv.
-      + eapply cumul_trans with (tProd na'' A'' B''); auto.
-        * eapply congr_cumul_prod => //.
-          eapply cumul_trans with x0 => //.
-        * now eapply red_cumul_inv.
-      + eapply type_Lambda; eauto.
+      etransitivity; eauto.
+      apply invert_cumul_prod_l in c2 as [na' [A' [B' [[redA u1eq] ?]]]] => //; auto.
+      destruct (p0 _ t4).
+      eapply congr_cumul_prod => //; auto.
 
-    - eapply inversion_LetIn in hA; auto.
-      eapply inversion_LetIn in hB; auto.
-      destruct hA as [tty [bty ?]].
-      destruct hB as [tty' [bty' ?]].
-      repeat outtimes.
-      specialize (IHu3 _ _ _ t4 t1) as [C' ?].
-      repeat outtimes.
-      exists (tLetIn n u1 u2 C'). repeat split.
-      + clear IHu1 IHu2.
-        eapply invert_cumul_letin_l in c0 => //.
-        eapply invert_cumul_letin_l in c => //.
-        eapply cumul_trans with (C' {0 := u1}). 1: auto.
-        * eapply red_cumul. eapply red_step.
-          -- econstructor.
-          -- auto.
-        * eapply cumul_trans with (bty {0 := u1}) => //.
-          eapply (substitution_cumul Σ Γ [vdef n u1 u2] []) => //.
-          -- constructor; auto.
-             ++ now eapply typing_wf_local in t3.
-             ++ red. exists tty' => //.
-          -- pose proof (cons_let_def Σ Γ [] [] n u1 u2).
-             rewrite !subst_empty in X. apply X. 1: constructor.
-             auto.
-      + clear IHu1 IHu2.
-        eapply invert_cumul_letin_l in c0 => //.
-        eapply invert_cumul_letin_l in c => //.
-        eapply cumul_trans with (C' {0 := u1}). 1: auto.
-        * eapply red_cumul. eapply red_step.
-          -- econstructor.
-          -- auto.
-        * eapply cumul_trans with (bty' {0 := u1}) => //.
-          eapply (substitution_cumul Σ Γ [vdef n u1 u2] []) => //.
-          -- constructor; auto.
-             ++ now eapply typing_wf_local in t3.
-             ++ red. exists tty' => //.
-          -- pose proof (cons_let_def Σ Γ [] [] n u1 u2).
-             rewrite !subst_empty in X. apply X. 1: constructor.
-             auto.
-      + eapply type_LetIn; eauto.
+    - eapply inversion_LetIn in hA as (s1 & bty & Hu2 & Hu1 & Hu3 & Hcum); auto.
+      destruct (IHu1 _ _ Hu1) as [? p].
+      destruct (p _ Hu1).
+      destruct (IHu2 _ _ Hu2) as [? p'].
+      destruct (p' _ Hu2).
+      destruct (IHu3 _ _ Hu3) as [? p''].
+      destruct (p'' _ Hu3).
+      exists (tLetIn n u1 u2 x1).
+      int inversion_LetIn.
+      destruct hB as (s1' & bty' & Hu2' & Hu1' & Hu3' & Hcum'); eauto.
+      etransitivity; eauto.
+      eapply cum_LetIn; eauto.
+      now specialize (p'' _ Hu3') as [? ?].
 
-    - eapply inversion_App in hA as [na [dom [codom [tydom [tyarg tycodom]]]]] => //.
-      eapply inversion_App in hB as [na' [dom' [codom' [tydom' [tyarg' tycodom']]]]] => //.
-      specialize (IHu2 _ _ _ tyarg tyarg').
-      specialize (IHu1 _ _ _ tydom tydom').
-      destruct IHu1, IHu2.
-      repeat outtimes.
-      apply invert_cumul_prod_r in c1 as [? [A' [B' [[redA u1eq] ?]]]] => //.
-      apply invert_cumul_prod_r in c2 as [? [A'' [B'' [[redA' u1eq'] ?]]]] => //.
+    - eapply inversion_App in hA as [na [dom [codom [tydom [tyarg tycodom]]]]] => //; auto.
+      destruct (IHu2 _ _ tyarg).
+      destruct (IHu1 _ _ tydom).
+      destruct (p _ tyarg). destruct (p0 _ tydom).
+      apply invert_cumul_prod_r in c0 as [? [A' [B' [[redA u1eq] ?]]]] => //; auto.
+      exists (subst [u2] 0 B').
+      intros ? hB.
+      eapply inversion_App in hB as [na' [dom' [codom' [tydom' [tyarg' tycodom']]]]] => //; auto.
+      destruct (p0 _ tydom').
+      destruct (p _ tyarg').
+      apply invert_cumul_prod_r in c1 as [? [A'' [B'' [[redA' u1eq'] ?]]]] => //; auto.
       destruct (red_confluence wfΣ redA redA') as [nfprod [redl redr]].
       eapply invert_red_prod in redl as [? [? [[? ?] ?]]] => //. subst.
       eapply invert_red_prod in redr as [? [? [[? ?] ?]]] => //. noconf e.
+      all:auto.
       assert(Σ ;;; Γ |- A' = A'').
-      { apply conv_trans with x3 => //.
-        - now eapply red_conv.
-        - apply conv_sym; auto.
-      }
+      { apply conv_trans with x3 => //; auto.
+        - apply conv_sym; auto. }
       assert(Σ ;;; Γ ,, vass x1 A' |- B' = B'').
-      { apply conv_trans with x4 => //.
+      { apply conv_trans with x4 => //. auto.
         - now eapply red_conv.
         - apply conv_sym; auto.
           eapply conv_conv_ctx; eauto.
           constructor; auto. 1: eapply conv_ctx_refl.
-          constructor. now eapply conv_sym.
-      }
-      exists (B' {0 := u2}).
-      repeat split.
-      + eapply cumul_trans with (codom {0 := u2}) => //.
-        eapply substitution_cumul0 => //. eapply c1.
-      + eapply cumul_trans with (B'' {0 := u2}); eauto.
-        * eapply substitution_cumul0 => //. eapply conv_cumul in X0; eauto.
-        * eapply cumul_trans with (codom' {0 := u2}) => //.
-          eapply substitution_cumul0 => //. eauto.
-      + eapply (type_App _ _ _ x1 A').
-        eapply type_Cumul.
-        * eapply t0.
-        * have v := validity_term wfΣ t0; auto.
-          eapply isWfArity_or_Type_red in v.
-          3:eapply redA. now apply v. auto.
-        * apply red_cumul; eauto.
-        * eapply type_Cumul. eauto.
-          have v := validity_term wfΣ t0; auto.
-          eapply isWfArity_or_Type_red in v.
-          3:eapply redA.
-          eapply isWAT_tProd in v as [HA' _].
-          right; apply HA'. all:auto. now apply typing_wf_local in tydom'.
-          transitivity A''; eauto. now apply conv_cumul.
-          apply conv_cumul. now symmetry.
+          constructor. now eapply conv_sym. }
+      split.
+      etransitivity; eauto.
+      eapply substitution_cumul0 => //. auto.
+      transitivity x4; eauto. now eapply red_cumul.
+      transitivity B''.
+      eapply cumul_conv_ctx; eauto. eapply red_cumul_inv; eauto.
+      constructor. apply conv_ctx_refl. constructor. now apply conv_sym.
+      eapply cumul_conv_ctx; eauto.
+      constructor. apply conv_ctx_refl. constructor. 
+      eapply conv_trans; eauto. now apply conv_sym.
+      econstructor. eapply type_reduction; eauto.
+      eapply type_Cumul; eauto.
+      2:transitivity dom; auto; now apply conv_cumul.
+      eapply type_reduction in t0. 3:eapply redA. 2:auto.
+      eapply validity in t0; auto.
+      eapply isWAT_tProd in t0 as [? ?]; eauto.
+      eapply typing_wf_local; eauto.
 
-    - eapply inversion_Const in hA as [decl ?] => //.
-      eapply inversion_Const in hB as [decl' ?] => //.
+    - eapply inversion_Const in hA as [decl ?] => //; eauto.
       repeat outtimes.
-      exists (subst_instance_constr u (cst_type decl)).
-      red in d0, d. rewrite d0 in d.
-      change PCUICEnvironment.ConstantDecl with ConstantDecl in d.
-      noconf d.
-      repeat intimes; eauto.
-      eapply type_Const; eauto.
-
-    - eapply inversion_Ind in hA as [mdecl [idecl [? [Hdecl ?]]]] => //.
-      eapply inversion_Ind in hB as [mdecl' [idecl' [? [Hdecl' ?]]]] => //.
+      eexists; int inversion_Const.
+      destruct hB as [decl' [wf [declc' [cu cum]]]].
+      now rewrite -(PCUICWeakeningEnv.declared_constant_inj _ _ d declc') in cum.
+      
+    - eapply inversion_Ind in hA as [mdecl [idecl [? [Hdecl ?]]]] => //; auto.
       repeat outtimes.
       exists (subst_instance_constr u (ind_type idecl)).
+      int inversion_Ind. destruct hB as [mdecl' [idecl' [? [Hdecl' ?]]]] => //.
       red in Hdecl, Hdecl'. destruct Hdecl as [? ?].
       destruct Hdecl' as [? ?]. red in H, H1.
       rewrite H1 in H; noconf H.
       rewrite H2 in H0; noconf H0.
-      repeat intimes; eauto.
-      eapply type_Ind; eauto.
-      split; eauto.
+      repeat intimes; eauto. now destruct p.
 
-    - eapply inversion_Construct in hA as [mdecl [idecl [? [? [Hdecl ?]]]]] => //.
-      eapply inversion_Construct in hB as [mdecl' [idecl' [? [? [Hdecl' ?]]]]] => //.
+    - eapply inversion_Construct in hA as [mdecl [idecl [? [? [Hdecl ?]]]]] => //; auto.
       repeat outtimes.
+      exists (type_of_constructor mdecl (i0, t, n0) (i, n) u).
+      int inversion_Construct. destruct hB as [mdecl' [idecl' [? [? [Hdecl' [? ?]]]]]] => //.
       red in Hdecl, Hdecl'.
       destruct Hdecl as [[? ?] ?].
       destruct Hdecl' as [[? ?] ?].
       red in H, H2. rewrite H2 in H. noconf H.
       rewrite H3 in H0. noconf H0.
-      rewrite H4 in H1. noconf H1.
-      exists (type_of_constructor mdecl (i1, t0, n1) (i, n) u).
-      repeat split; eauto.
-      eapply type_Construct; eauto. repeat split; eauto.
+      rewrite H4 in H1. now noconf H1.
 
     - destruct p as [ind n].
+      assert (wf Σ) by auto.
       eapply inversion_Case in hA=>//.
-      eapply inversion_Case in hB=>//.
       repeat outsum. repeat outtimes. simpl in *.
       repeat outtimes.
       subst.
-      destruct d, d0. red in H, H1.
-      rewrite H in H1. noconf H1. rewrite H0 in H2. noconf H2.
-      specialize (IHu1 _ _ _ t t1). clear t. eapply PCUICValidity.validity in t1.
-      specialize (IHu2 _ _ _ t0 t2).
-      repeat outsum. repeat outtimes.
+      destruct (IHu1 _ _ t) as [? p].
+      destruct (IHu2 _ _ t0) as [? p0].
+      destruct (p _ t). destruct (p0 _ t0).
       eapply invert_cumul_ind_r in c1 as [u' [x0' [redr [redu ?]]]]; auto.
+      exists (mkApps u1 (skipn (ind_npars x1) x0 ++ [u2])); intros b hB; repeat split; auto.
+      2:econstructor; eauto.
+      eapply inversion_Case in hB=>//; auto.
+      repeat outsum. repeat outtimes. simpl in *.
+      repeat outtimes.
+      destruct (PCUICWeakeningEnv.declared_inductive_inj d d0) as [-> ->].
+      destruct (p0 _ t4).
       eapply invert_cumul_ind_r in c2 as [u'' [x9' [redr' [redu' ?]]]]; auto.
-      assert (All2 (fun a a' => Σ ;;; Γ |- a = a') x0 x7).
+      assert (All2 (fun a a' => Σ ;;; Γ |- a = a') x0 x9).
       { destruct (red_confluence wfΣ redr redr').
-        destruct p.
+        destruct p1.
         eapply red_mkApps_tInd in r as [args' [? ?]]; auto.
         eapply red_mkApps_tInd in r0 as [args'' [? ?]]; auto.
         subst. solve_discr.
-        clear -wfΣ a1 a2 a3 a4.
+        clear -wfΣ a0 a1 a2 a3 a4.
+        eapply All2_trans with x0'; eauto. eapply conv_trans; eauto.
         eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- x = y)) in a3; auto using red_conv.
-        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- y = x)) in a4;
-          [|intros; symmetry; now apply red_conv].
-        pose proof (All2_trans _ (conv_trans _ _) _ _ _ a1 a3).
-        apply All2_sym in a4.
-        pose proof (All2_trans _ (conv_trans _ _) _ _ _ X a4).
-        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- y = x)) in a2;
-          [|intros; now symmetry].
-        - apply All2_sym in a2.
-          apply (All2_trans _ (conv_trans _ _) _ _ _ X0 a2).
+        eapply (All2_impl (Q:=fun x y => Σ ;;; Γ |- x = y)) in a4; auto using red_conv.
+        eapply All2_trans with args'; eauto. eapply conv_trans; eauto.
+        eapply All2_trans with x9'; eauto. eapply conv_trans; eauto.
+        eapply All2_symmetry; eauto. eapply conv_sym.
+        eapply All2_symmetry; eauto. eapply conv_sym.
       }
       clear redr redr' a1 a2.
-      exists (mkApps u1 (skipn (ind_npars x8) x7 ++ [u2])); repeat split; auto.
-      transitivity (mkApps u1 (skipn (ind_npars x8) x0 ++ [u2])); auto.
+      etransitivity. 2:eapply c1.
       eapply conv_cumul, mkApps_conv_args; auto.
       eapply All2_app. 2:constructor; auto.
-      eapply All2_skipn. eapply All2_sym, (All2_impl X0); firstorder.
-      econstructor;  eauto. simpl. split; auto.
-      eapply type_Cumul; eauto. auto. 
+      now eapply All2_skipn.
 
     - destruct s as [[ind k] pars]; simpl in *.
-      eapply inversion_Proj in hA=>//.
-      eapply inversion_Proj in hB=>//.
+      eapply inversion_Proj in hA=>//; auto.
       repeat outsum. repeat outtimes.
       simpl in *.
-      assert(declp := d0).
-      destruct d0, d. destruct H, H1. red in H, H1.
-      rewrite H1 in H; noconf H.
-      rewrite H4 in H3; noconf H3.
-      destruct H0, H2.
-      rewrite H2 in H; noconf H.
-      rewrite -e in e0.
-      specialize (IHu _ _ _ t t1) as [C' [? [? ?]]].
-      destruct (cumul_ind_confluence c1 c2) as [nfu [nfargs [[[conv convargs] convargs'] [ru ru']]]].
-      exists (subst0 (u :: List.rev nfargs) (subst_instance_constr nfu t2)).
-      assert(wfnf : PCUICGeneration.isWfArity_or_Type Σ Γ (mkApps (tInd ind nfu) nfargs)).
-      { eapply validity; eauto. eapply type_reduction; eauto. }
-      repeat split; auto.
-      + etransitivity; [|eapply c0].
-        eapply conv_cumul.
-        eapply (subst_conv _ (projection_context x5 x6 ind nfu)
-          (projection_context x5 x6 ind x4) []); auto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        eapply type_reduction; eauto. simpl.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        simpl; auto.
-        eapply validity; eauto.
-        constructor; auto. apply All2_rev. eapply All2_sym.
-        eapply (All2_impl convargs'). apply conv_sym.
-        eapply (wf_projection_context _ _ _ _ (ind, k, pars)); eauto.
-        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in wfnf.
-        destruct wfnf as [s Hs].
-        eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto.
-        eapply declp. now apply typing_wf_local in t0.
-        constructor.
-        apply PCUICUnivSubstitution.eq_term_upto_univ_subst_instance_constr;
-           try typeclasses eauto; auto.
-        todo "univs"%string.
-      + etransitivity; [|eapply c].
-        transitivity (subst0 (u :: List.rev nfargs) (subst_instance_constr x t2)).
-        todo "univs"%string.
-        eapply conv_cumul.
-        eapply (subst_conv _ (projection_context x5 x6 ind nfu)
-          (projection_context x5 x6 ind x) []); auto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        eapply type_reduction; eauto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
-        simpl; auto.
-        eapply validity; eauto.
-        constructor; auto. apply All2_rev. eapply All2_sym.
-        eapply (All2_impl convargs). apply conv_sym.
-        eapply (wf_projection_context _ _ _ _ (ind, k, pars)); eauto.
-        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in wfnf.
-        destruct wfnf as [s Hs].
-        eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto.
-        eapply declp. now apply typing_wf_local in t0.
-      + eapply refine_type.
-        * eapply type_Proj.
-          -- repeat split; eauto.
-          -- simpl. eapply type_Cumul.
-             1: eapply t0.
-             1: right.
-             2:eapply conv_cumul; eauto.
-             eapply type_reduction in t0; [|auto|apply conv].
-             eapply validity_term in t0; eauto. 
-             now apply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in t0.
-          -- rewrite H3. simpl. simpl in H0.
-             rewrite -H0. rewrite -(All2_length _ _ convargs). congruence.
-        * simpl. reflexivity.
-
+      specialize (IHu _ _ t) as [C HP].
+      destruct (HP _ t).
+      eapply invert_cumul_ind_r in c0 as [u' [x0' [redr [redu ?]]]]; auto.
+      exists (subst0 (u :: List.rev x0') (subst_instance_constr u' t0)).
+      intros B hB.
+      eapply inversion_Proj in hB=>//; auto.
+      repeat outsum. repeat outtimes.
+      simpl in *.
+      destruct (PCUICWeakeningEnv.declared_projection_inj d d0) as [-> [-> [= -> ->]]].
+      destruct (HP _ t2).
+      split; cycle 1.
+      eapply type_reduction in t0; eauto.
+      eapply invert_cumul_ind_r in c1 as [u'' [x0'' [redr' [redu' ?]]]]; auto.
+      eapply (type_Proj _ _ _ _ _ _ _ _ d0); simpl; auto.
+      now rewrite -(All2_length _ _ a).
+      eapply invert_cumul_ind_r in c1 as [u'' [x0'' [redr' [redu' ?]]]]; auto.
+      destruct (red_confluence wfΣ redr redr') as [nf [redl redr'']].
+      eapply red_mkApps_tInd in redl as [? [-> conv]]; auto.
+      eapply red_mkApps_tInd in redr'' as [? [[=] conv']]; auto.
+      solve_discr.
+      etransitivity; eauto.
+      assert (consistent_instance_ext Σ (ind_universes x0) u').
+      { eapply type_reduction in t1. 3:eapply redr. all:pcuic. 
+        eapply validity in t1; eauto.
+        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in t1; auto.
+        destruct t1 as [s Hs].
+        eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto. eapply d. }
+      assert (consistent_instance_ext Σ (ind_universes x0) x2).
+        { eapply validity in t2; eauto.
+          eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in t2; auto.
+          destruct t2 as [s Hs].
+          eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto. eapply d. }
+        transitivity (subst0 (u :: List.rev x0') (subst_instance_constr x2 t3)); cycle 1.
+      eapply conv_cumul.
+      assert (conv_terms Σ Γ x0' x7).
+      { transitivity x4. eapply (All2_impl conv); auto using red_conv.
+        transitivity x0''. symmetry. eapply (All2_impl conv'); auto using red_conv.
+        now symmetry. }
+      eapply (subst_conv _ (projection_context x0 x1 ind u')
+      (projection_context x0 x1 ind x2) []); auto.
+      eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
+      simpl. eapply type_reduction; eauto. simpl.
+      eapply type_reduction in t0. 3:eapply redr. eapply validity; eauto. auto.
+      eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
+      simpl. eapply validity; eauto.
+      constructor; auto. now apply All2_rev.
+      eapply PCUICWeakening.weaken_wf_local; eauto.
+      eapply PCUICWeakening.weaken_wf_local; pcuic.
+      eapply (wf_projection_context _ (p:= (ind, k, pars))); pcuic.
+      eapply (substitution_cumul _ Γ (projection_context x0 x1 ind u') []); auto.
+      eapply PCUICWeakening.weaken_wf_local; pcuic.
+      eapply PCUICWeakening.weaken_wf_local; pcuic.
+      eapply (wf_projection_context _ (p:=(ind, k, pars))); pcuic.
+      eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
+      simpl. eapply type_reduction; eauto. simpl.
+      eapply type_reduction in t0. 3:eapply redr. all:eauto.
+      eapply validity; eauto.
+      rewrite e0 in redu'.
+      unshelve epose proof (projection_cumulative_indices wfΣ d _ H H0 redu').
+      { eapply (PCUICWeakeningEnv.weaken_lookup_on_global_env' _ _ _ wfΣ (proj1 (proj1 d))). }
+      eapply PCUICWeakeningEnv.on_declared_projection in d0; eauto.
+      eapply weaken_cumul in X; eauto.
+      eapply closed_wf_local; eauto.
+      eapply (wf_projection_context _ (p:= (ind, k, pars))); pcuic.
+      len. simpl. len. simpl.
+      rewrite d0.(onNpars).
+      rewrite closedn_subst_instance_constr.
+      now apply (declared_projection_closed wfΣ d).
+      simpl; len. rewrite d0.(onNpars).
+      rewrite closedn_subst_instance_constr.
+      now apply (declared_projection_closed wfΣ d).
+      
     - pose proof (typing_wf_local hA).
-      apply inversion_Fix in hA as [decl [hguard [nthe [wfΓ [? [? ?]]]]]]=>//.
-      eapply inversion_Fix in hB as [decl' [hguard' [nthe' [wfΓ' [? [? ?]]]]]]=>//.
+      apply inversion_Fix in hA as [decl [hguard [nthe [wfΓ [? [? ?]]]]]]=>//; auto.
+      exists (dtype decl).
+      intros B hB.
+      eapply inversion_Fix in hB as [decl' [hguard' [nthe' [wfΓ' [? [? ?]]]]]]=>//; auto.
       rewrite nthe' in nthe; noconf nthe.
-      exists (dtype decl); repeat split; eauto.
+      repeat split; eauto.
       eapply type_Fix; eauto.
 
     - pose proof (typing_wf_local hA).
-      eapply inversion_CoFix in hA as [decl [allow [nthe [wfΓ [? [? ?]]]]]]=>//.
-      eapply inversion_CoFix in hB as [decl' [allpw [nthe' [wfΓ' [? [? ?]]]]]]=>//.
+      apply inversion_CoFix in hA as [decl [hguard [nthe [wfΓ [? [? ?]]]]]]=>//; auto.
+      exists (dtype decl).
+      intros B hB.
+      eapply inversion_CoFix in hB as [decl' [hguard' [nthe' [wfΓ' [? [? ?]]]]]]=>//; auto.
       rewrite nthe' in nthe; noconf nthe.
-      exists (dtype decl); repeat split; eauto.
+      repeat split; eauto.
       eapply type_CoFix; eauto.
+  Qed.
+
+  (** A weaker version that is often convenient to use. *)
+  Lemma common_typing {Γ u A B} : Σ ;;; Γ |- u : A -> Σ ;;; Γ |- u : B ->
+    ∑ C, Σ ;;; Γ |- C <= A × Σ ;;; Γ |- C <= B × Σ ;;; Γ |- u : C.
+  Proof.
+    intros hA hB.
+    destruct (principal_type hA) as [P HP]; eauto.
+    exists P; split; eauto.
+    eapply HP; eauto.
   Qed.
 
 End Principality.
 
-Lemma principal_type_ind {cf:checker_flags} {Σ Γ c ind u u' args args'} {wfΣ: wf Σ.1} :
+Lemma principal_type_ind {cf:checker_flags} {Σ Γ c ind u u' args args'} {wfΣ: wf_ext Σ} :
   Σ ;;; Γ |- c : mkApps (tInd ind u) args ->
   Σ ;;; Γ |- c : mkApps (tInd ind u') args' ->
   (∑ ui', 
@@ -397,7 +372,7 @@ Lemma principal_type_ind {cf:checker_flags} {Σ Γ c ind u u' args args'} {wfΣ:
   All2 (conv Σ Γ) args args'.
 Proof.
   intros h h'.
-  destruct (principal_typing _ wfΣ h h') as [C [l [r ty]]].
+  destruct (common_typing _ wfΣ h h') as [C [l [r ty]]].
   eapply invert_cumul_ind_r in l as [ui' [l' [red [Ru eqargs]]]]; auto.
   eapply invert_cumul_ind_r in r as [ui'' [l'' [red' [Ru' eqargs']]]]; auto.
   destruct (red_confluence wfΣ red red') as [nf [redl redr]].
@@ -477,8 +452,6 @@ Lemma typing_leq_term_gen {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' 
   Σ ;;; Γ |- t' : T.
 Proof. *)
 
-
-
 Lemma R_global_instance_empty_universe_instance Re Rle ref napp u u' :
   R_global_instance [] Re Rle ref napp u u' ->
   R_universe_instance Re u u'.
@@ -489,6 +462,7 @@ Qed.
 
 Lemma typing_leq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' : 
   wf Σ.1 ->
+  on_udecl Σ.1 Σ.2 ->
   Σ ;;; Γ |- t : T ->
   Σ ;;; Γ |- t' : T' ->
   leq_term [] Σ t' t -> 
@@ -496,10 +470,11 @@ Lemma typing_leq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' :
     inductives in different sorts. *)
   Σ ;;; Γ |- t' : T.
 Proof.
-  intros wfΣ Ht.
-  revert Σ wfΣ Γ t T Ht t' T'.
+  intros wfΣ onu Ht.
+  revert Σ wfΣ Γ t T Ht onu t' T'.
   eapply (typing_ind_env 
   (fun Σ Γ t T =>
+    forall (onu : on_udecl Σ.1 Σ.2),
     forall t' T' : term, Σ ;;; Γ |- t' : T' -> leq_term [] Σ t' t -> Σ;;; Γ |- t' : T)
   (fun Σ Γ wfΓ => wf_local Σ Γ)); auto;intros Σ wfΣ Γ wfΓ; intros.
     1-13:match goal with
@@ -507,7 +482,7 @@ Proof.
     end.
   all:try solve [econstructor; eauto].
   13:{ eapply type_Cumul.
-       eapply X1. eauto. eauto. 
+       eapply X1. eauto. eauto. auto.
        destruct X2; [left|right].
        red in i. apply i.
        exists s.π1. apply s.π2. auto.
@@ -519,14 +494,14 @@ Proof.
     apply x. auto.
 
   - eapply inversion_Prod in X4 as [s1' [s2' [Ha [Hb Hs]]]]; auto.
-    specialize (X1 _ _ Ha). 
+    specialize (X1 onu _ _ Ha). 
     specialize (X1 (eq_term_empty_leq_term X5_1)).
     apply eq_term_empty_eq_term in X5_1.
     eapply context_conversion in Hb. 3:{ constructor. apply conv_ctx_refl. constructor.
       constructor. eauto. }
     all:eauto.
     2:{ constructor; eauto. now exists s1. }
-    specialize (X3 _ _ Hb X5_2).
+    specialize (X3 onu _ _ Hb X5_2).
     econstructor; eauto.
     apply leq_term_empty_leq_term in X5_2.
     eapply context_conversion; eauto.
@@ -534,11 +509,11 @@ Proof.
     constructor; pcuic.
 
   - eapply inversion_Lambda in X4 as (s & B & dom & codom & cum); auto.
-    specialize (X1 _ _ dom (eq_term_empty_leq_term X5_1)).
+    specialize (X1 onu _ _ dom (eq_term_empty_leq_term X5_1)).
     apply eq_term_empty_eq_term in X5_1.
     assert(conv_context Σ (Γ ,, vass na ty) (Γ ,, vass n t)).
     { repeat constructor; pcuic. }
-    specialize (X3 t0 B).
+    specialize (X3 onu t0 B).
     forward X3 by eapply context_conversion; eauto; pcuic.
     econstructor.
     econstructor. eauto. instantiate (1 := bty).
@@ -550,13 +525,13 @@ Proof.
     constructor; auto. reflexivity.
     
   - eapply inversion_LetIn in X6 as (s1' & A & dom & bod & codom & cum); auto.
-    specialize (X1 _ _ dom (eq_term_empty_leq_term X7_2)).
-    specialize (X3 _ _ bod (eq_term_empty_leq_term X7_1)).
+    specialize (X1 onu _ _ dom (eq_term_empty_leq_term X7_2)).
+    specialize (X3 onu _ _ bod (eq_term_empty_leq_term X7_1)).
     apply eq_term_empty_eq_term in X7_1.
     apply eq_term_empty_eq_term in X7_2.
     assert(conv_context Σ (Γ ,, vdef na t ty) (Γ ,, vdef n b b_ty)).
     { repeat constructor; pcuic. }
-    specialize (X5 u A).
+    specialize (X5 onu u A).
     forward X5 by eapply context_conversion; eauto; pcuic.
     specialize (X5 X7_3).
     eapply leq_term_empty_leq_term in X7_3.
@@ -572,8 +547,8 @@ Proof.
   - eapply inversion_App in X4 as (na' & A' & B' & hf & ha & cum); auto.
     unfold leq_term in X1.
     eapply eq_term_upto_univ_empty_impl in X5_1.
-    specialize (X1 _ _ hf X5_1). all:try typeclasses eauto.
-    specialize (X3 _ _ ha (eq_term_empty_leq_term X5_2)).
+    specialize (X1 onu _ _ hf X5_1). all:try typeclasses eauto.
+    specialize (X3 onu _ _ ha (eq_term_empty_leq_term X5_2)).
     eapply leq_term_empty_leq_term in X5_1.
     eapply eq_term_empty_eq_term in X5_2.
     econstructor.
@@ -635,7 +610,7 @@ Proof.
   - eapply inversion_Case in X6 as (u' & args' & mdecl' & idecl' & ps' & pty' & btys' & inv); auto.
     intuition auto.
     intuition auto.
-    specialize (X4 _ _ a6 (eq_term_empty_leq_term X7_2)).
+    pose proof (X2 _ _ a6 (eq_term_empty_leq_term X7_2)).
     eapply eq_term_empty_eq_term in X7_1.
     eapply eq_term_empty_eq_term in X7_2.
     eapply type_Cumul.
@@ -649,17 +624,19 @@ Proof.
     eapply All2_app. simpl in *.
     2:constructor; pcuic.
     eapply All2_skipn.
-    clear -wfΣ a6 X4 X7_2.
-    eapply (principal_type_ind a6 X4).
+    clear -onu wfΣ a6 X4 X6.
+    unshelve eapply (principal_type_ind a6 X4).
+    split; auto.
     
   - eapply inversion_Proj in X3 as (u' & mdecl' & idecl' & pdecl' & args' & inv); auto.
     intuition auto.
-    specialize (X2 _ _ a0 (eq_term_empty_leq_term X4)).
+    specialize (X3 _ _ a0 (eq_term_empty_leq_term X4)).
     eapply eq_term_empty_eq_term in X4.
-    pose proof (principal_type_ind X2 a0) as [Ruu' X3].
+    assert (wf_ext Σ) by (split; assumption).
+    pose proof (principal_type_ind X3 a0) as [Ruu' X3'].
     eapply type_Cumul. clear a0.
     econstructor; eauto.
-    now rewrite (All2_length _ _ X3).
+    now rewrite (All2_length _ _ X3').
     eapply PCUICValidity.validity; eauto.
     eapply type_Proj; eauto.
     transitivity (subst0 (c :: List.rev args) (subst_instance_constr u pdecl'.2)).
@@ -671,10 +648,10 @@ Proof.
     eapply All2_rev. eapply All2_refl. intros; apply conv_refl'.
     eapply subslet_untyped_subslet; eauto.
     eapply PCUICInductives.projection_subslet; eauto.
-    eapply validity in X2; auto.
+    eapply validity in X3; auto.
     eapply subslet_untyped_subslet; eauto.
     eapply PCUICInductives.projection_subslet; eauto.
-    eapply validity in X2; auto.
+    eapply validity in X3; auto.
     constructor. eapply PCUICEquality.subst_leq_term.
     destruct (PCUICWeakeningEnv.declared_projection_inj a isdecl) as [<- [<- <-]].
     subst ty. reflexivity.
@@ -705,15 +682,15 @@ Proof.
 Qed.
 
 Lemma typing_eq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' : 
-  wf Σ.1 ->
+  wf_ext Σ ->
   Σ ;;; Γ |- t : T ->
   Σ ;;; Γ |- t' : T' ->
   eq_term [] Σ t t' ->
   Σ ;;; Γ |- t' : T.
 Proof.
   intros wfΣ ht ht' eq.
-  eapply typing_leq_term; eauto.
+  eapply typing_leq_term; eauto. apply wfΣ.
   now eapply eq_term_empty_leq_term.
 Qed.
 
-Print Assumptions principal_typing.
+Print Assumptions principal_type.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -197,9 +197,6 @@ Section TypeOf.
     congruence.
   Qed.
 
-
-    
-
   Obligation Tactic := idtac.
 
   Equations? infer (Γ : context) (t : term) (wt : welltyped Σ Γ t) : principal_type Σ Γ t 

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -170,9 +170,9 @@ Section TypeOf.
 
     infer Γ (tProd n ty b) wt :=
       let ty1 := infer Γ ty _ in
-      let s1 := infer_as_sort (todo "wt") ty1 in
+      let s1 := infer_as_sort _ ty1 in
       let ty2 := infer (Γ ,, vass n ty) b _  in
-      let s2 := infer_as_sort (todo "wt2") ty2 in
+      let s2 := infer_as_sort _ ty2 in
       ret (tSort (Universe.sort_of_product s1 s2));
 
     infer Γ (tLambda n t b) wt :=
@@ -332,7 +332,7 @@ Section TypeOf.
         now rewrite subst_empty.
 
     - eapply inversion_Const in HT as [decl ?] => //.
-      intuition auto. red in a0. rewrite a0 in wildcard. noconf wildcard.
+      intuition auto. rewrite a0 in wildcard. noconf wildcard.
       sq. split.
       * constructor; eauto.
       * intros T' [decl [wf [lookup [cu cum]]]]%inversion_Const; auto.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -22,16 +22,17 @@ Set Equations Transparent.
 
 Add Search Blacklist "_graph_mut".
 
+Add Search Blacklist "obligation".
+
 Require Import ssreflect.
 
-Lemma cumul_Ind_Ind_inv {cf:checker_flags} {Σ : global_env_ext} Γ ind u args ind' u' args' : 
-  wf Σ ->
+Lemma cumul_Ind_Ind_inv {cf:checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} {Γ ind u args ind' u' args'} : 
   Σ ;;; Γ |- mkApps (tInd ind u) args <= mkApps (tInd ind' u') args' ->
   eq_inductive ind ind' *
   PCUICEquality.R_global_instance Σ (eq_universe Σ) (leq_universe Σ) (IndRef ind) #|args| u u' *
   All2 (conv Σ Γ) args args'.
 Proof.
-  intros wfΣ cum.
+  intros cum.
   eapply invert_cumul_ind_l in cum as [ui' [l' [redl [ru conv]]]]; auto.
   eapply red_mkApps_tInd in redl as [args'' [eqind red']]; auto.
   apply mkApps_eq_inj in eqind as [eq ->]=> //; auto. noconf eq.
@@ -46,6 +47,12 @@ Qed.
 Definition well_sorted {cf:checker_flags} Σ Γ T := 
   ∥ ∑ s, Σ ;;; Γ |- T : tSort s ∥.
 
+Lemma well_sorted_well_typed {cf:checker_flags} {Σ Γ T} : well_sorted Σ Γ T -> welltyped Σ Γ T.
+Proof.
+  intros [[s Hs]]; now exists (tSort s).
+Qed.
+
+Coercion well_sorted_well_typed : well_sorted >-> welltyped.
 
 (** * Retyping
 
@@ -84,6 +91,40 @@ Lemma reduce_to_ind_complete {cf:checker_flags} {Σ : global_env_ext} (wfΣ : wf
   (∑ ind u args, red Σ Γ ty (mkApps (tInd ind u) args)) -> False.
 Proof.
 Admitted.
+
+From MetaCoq.PCUIC Require Import PCUICInductives PCUICInductiveInversion PCUICSpine PCUICArities.
+
+Lemma isWAT_mkApps_Ind_conv_args  {cf:checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} {Γ ind mdecl idecl u args args'} :
+  declared_inductive Σ mdecl ind idecl ->
+  wf_local Σ Γ ->
+  isWfArity_or_Type Σ Γ (mkApps (tInd ind u) args) ->
+  conv_terms Σ Γ args args' ->
+  isWfArity_or_Type Σ Γ (mkApps (tInd ind u) args').
+Proof.
+  move=> decli wf; move/(isWAT_mkApps_Ind_isType _ _ _ _ _ wfΣ) => [s Hs] convargs.
+  right; exists s.
+  eapply invert_type_mkApps_ind in Hs as [sp cu]; eauto.
+  eapply type_mkApps; eauto.
+  econstructor; eauto.
+Admitted.
+
+Definition on_subterm P Pty Γ t : Type := 
+  match t with
+  | tProd na t b => Pty Γ t * Pty (Γ ,, vass na t) b
+  | tLetIn na d t t' => 
+    Pty Γ t * P Γ d * P (Γ ,, vdef na d t) t'
+  | tLambda na t b => Pty Γ t * P (Γ ,, vass na t) b
+  | _ => True
+  end.
+
+Lemma welltyped_subterm {cf:checker_flags} {Σ : global_env_ext} (wfΣ : ∥ wf Σ ∥) {Γ t} :
+  welltyped Σ Γ t -> on_subterm (welltyped Σ) (well_sorted Σ) Γ t.
+Proof.
+  destruct t; simpl; auto; intros [T HT]; sq.
+  eapply inversion_Prod in HT as (? & ? & ? & ? & ?); auto; split; try econstructor; eauto.
+  eapply inversion_Lambda in HT as (? & ? & ? & ? & ?); auto; split; try econstructor; eauto.
+  eapply inversion_LetIn in HT as (? & ? & ? & ? & ? & ?); auto; split; [split|]; try econstructor; eauto.
+Qed.
 
 Section TypeOf.
   Context {cf : checker_flags}.
@@ -154,6 +195,9 @@ Section TypeOf.
     congruence.
   Qed.
 
+
+    
+
   Obligation Tactic := idtac.
 
   Equations? infer (Γ : context) (t : term) (wt : welltyped Σ Γ t) : principal_type Σ Γ t 
@@ -169,18 +213,18 @@ Section TypeOf.
     infer Γ (tSort s) _ := ret (tSort (Universe.try_suc s));
 
     infer Γ (tProd n ty b) wt :=
-      let ty1 := infer Γ ty _ in
-      let s1 := infer_as_sort _ ty1 in
-      let ty2 := infer (Γ ,, vass n ty) b _  in
-      let s2 := infer_as_sort _ ty2 in
+      let ty1 := infer Γ ty (welltyped_subterm hΣ wt).1 in
+      let s1 := infer_as_sort (welltyped_subterm hΣ wt).1 ty1 in
+      let ty2 := infer (Γ ,, vass n ty) b (welltyped_subterm hΣ wt).2 in
+      let s2 := infer_as_sort (welltyped_subterm hΣ wt).2 ty2 in
       ret (tSort (Universe.sort_of_product s1 s2));
 
     infer Γ (tLambda n t b) wt :=
-      let t2 := infer (Γ ,, vass n t) b _ in
+      let t2 := infer (Γ ,, vass n t) b (welltyped_subterm hΣ wt).2 in
       ret (tProd n t t2);
 
     infer Γ (tLetIn n b b_ty b') wt :=
-      let b'_ty := infer (Γ ,, vdef n b b_ty) b' _ in
+      let b'_ty := infer (Γ ,, vdef n b b_ty) b' (welltyped_subterm hΣ wt).2 in
       ret (tLetIn n b b_ty b'_ty);
 
     infer Γ (tApp t a) wt :=
@@ -260,24 +304,21 @@ Section TypeOf.
       destruct (NoPropLevel.of_level l); simpl; auto;
       try destruct t; simpl; auto; reflexivity.
             
-    - eapply inversion_Prod in HT as (? & ? & ? & ? & ?); try econstructor; eauto.
-    - destruct hΣ. destruct Hφ. destruct (inversion_Prod Σ w HT) as (? & ? & ? & ? & ?); try econstructor; eauto.
     - simpl in *.
       destruct (inversion_Prod Σ w HT) as (? & ? & ? & ? & ?).
-      subst ty1 ty2.
+      subst ty1 s1.
       destruct infer_as_sort as [x1 [[Hx1 Hx1p]]]; simpl.
       destruct infer_as_sort as [x2 [[Hx2 Hx2p]]]; simpl.
-      subst s1 s2; simpl in *. sq.
+      subst s2; simpl in *. sq.
       split.
-      * specialize (Hx1p _ t).
-        specialize (Hx2p _ t0).
+      * specialize (Hx1p _ t0).
+        specialize (Hx2p _ t).
         econstructor; eauto.
       * intros T' Ht'.
         eapply inversion_Prod in Ht' as (? & ? & ? & ? & ?); auto.
         etransitivity; eauto. constructor. constructor.
         eapply leq_universe_product_mon; eauto.
 
-    - eapply inversion_Lambda in HT as (? & ? & ? & ? & ?); try econstructor; eauto.
     - simpl in t2. destruct (inversion_Lambda Σ w HT) as (? & ? & ? & ? & ?).
       destruct infer as [bty' [[Hbty pbty]]]; subst t2; simpl in *.
       sq. split.
@@ -287,8 +328,6 @@ Section TypeOf.
         transitivity (tProd n t x2); eauto.
         eapply congr_cumul_prod; auto.
 
-    - eapply inversion_LetIn in HT as (? & ? & ? & ? & ? & ?); auto.
-      eexists; eauto.
     - simpl in b'_ty.
       destruct (inversion_LetIn Σ w HT) as (? & ? & ? & ? & ? & ?).
       destruct infer as [bty' [[Hbty pbty]]]; subst b'_ty; simpl in *.
@@ -394,7 +433,7 @@ Section TypeOf.
       destruct infer as [cty [[Hty Hp]]]. simpl.
       eapply validity in Hty.
       eapply wat_wellformed; auto. sq; auto. auto.
-    - simpl in *. 
+    - simpl in *.
       destruct inversion_Case as (u & args & mdecl & idecl & ps & pty & btys & decli & indp & bcp & Hpty & lebs
         & isco & Hc & Hbtys & all & cum).
       destruct infer as [cty [[Hty Hp]]].
@@ -408,12 +447,84 @@ Section TypeOf.
       { eapply cumul_red_l_inv; eauto. }
       eapply cumul_Ind_Ind_inv in X0 as [[eqi Ru] cl]; auto.
       sq; split; simpl.
-      * eapply type_Cumul. econstructor. 3:eauto. all:eauto.
-        todo "cumulativity here"%string.
-        eapply conv_cumul.
-        eapply mkApps_conv_args; auto.
-        eapply All2_app. 2:repeat (constructor; auto).
-        eapply All2_skipn. now symmetry in cl.
+      * pose proof (Reflect.eqb_eq i ind eqi) as ->.
+        simpl in *. subst par.
+        pose proof (validity_term _ Hc).
+        eapply (isWAT_mkApps_Ind w decli) in X0 as [parsubst [argsubst [[sppars spargs] cu]]]; pcuic.
+        pose proof (PCUICContexts.context_subst_length2 sppars).
+        len in H.
+        set (oib := (on_declared_inductive w decli).2) in *.
+        eapply type_Cumul. econstructor; eauto.
+        assert (Σ ;;; Γ |- c : mkApps (tInd ind u) (firstn (ind_npars mdecl) args ++  skipn (ind_npars mdecl) l)).
+        { eapply type_Cumul. eauto.
+          + right. exists (subst_instance_univ u (ind_sort oib)).
+            eapply type_mkApps. econstructor; pcuic.
+            eapply wf_arity_spine_typing_spine; eauto.
+            constructor. 
+            epose proof (on_inductive_inst _ _ _ _ _ _ w ltac:(pcuic) _ _ oib cu).
+            rewrite oib.(ind_arity_eq) -it_mkProd_or_LetIn_app subst_instance_constr_it_mkProd_or_LetIn.
+            eapply isWAT_weaken; eauto. pcuic.
+            rewrite oib.(ind_arity_eq) subst_instance_constr_it_mkProd_or_LetIn.
+            eapply arity_spine_it_mkProd_or_LetIn; eauto.
+            rewrite subst_instance_constr_it_mkProd_or_LetIn subst_it_mkProd_or_LetIn.
+            simpl. rewrite -(app_nil_r (skipn _ _)).
+            eapply arity_spine_it_mkProd_or_LetIn_smash; eauto.
+            2:{ simpl. constructor; auto. left; eexists _, _; intuition eauto. pcuic.
+                constructor. reflexivity. }
+            eapply validity_term in Hty; eauto.
+            unshelve epose proof (isWAT_mkApps_Ind w decli _ Hty) as [parsubst' [argsubst' [[spars' spargs'] ?]]]; pcuic.
+            eapply (subslet_cumul _ _ _ (smash_context [] (subst_context parsubst' 0 
+              (subst_instance_context u' (ind_indices oib))))); pcuic.
+
+
+            eapply arity_spine_it_mkProd_or_LetIn_Sort; eauto.
+            
+            
+
+          + transitivity (mkApps (tInd ind u) l).
+            constructor. eapply PCUICEquality.eq_term_upto_univ_napp_mkApps.
+            now rewrite Nat.add_0_r; constructor.
+            eapply All2_refl. intros. reflexivity. 
+            rewrite -{1}(firstn_skipn (ind_npars mdecl) l). eapply conv_cumul, mkApps_conv_args; auto.
+            eapply All2_app. now eapply All2_firstn. eapply All2_refl; eauto. }
+        right. exists ps.
+        eapply type_mkApps; eauto.
+        pose proof (validity_term w X0) as vt; auto.
+        eapply (build_case_predicate_type_spec _ _ _ _ _ _ _ _ oib) in bcp as [parsubst' [csubst ->]]; auto.
+        pose proof (PCUICContexts.context_subst_fun sppars csubst). subst parsubst'.
+        unshelve epose proof (isWAT_mkApps_Ind w decli _ vt) as [parsubst' [argsubst' [[spars' spargs'] ?]]]; pcuic.
+        change (ind_indices (on_declared_inductive w decli).2) with (ind_indices oib) in spargs'.
+        subst oib; destruct on_declared_inductive as [onmind oib].
+        rewrite onmind.(onNpars _ _ _ _) in H.
+        pose proof (firstn_length_le_inv _ _ H).
+        pose proof (subslet_length spargs'). len in H1.
+        rewrite skipn_all_app_eq in spargs'. now rewrite H.
+        rewrite (firstn_app_left _ 0) in spars'; try lia.
+        simpl in spars'. rewrite app_nil_r in spars'.
+        pose proof (PCUICContexts.context_subst_fun spars' csubst). subst parsubst'.
+        eapply PCUICSpine.typing_spine_it_mkProd_or_LetIn'; eauto.
+        + simpl. econstructor. 2:reflexivity. 3:{ constructor; eauto. 
+          left; eexists _, _; intuition eauto with pcuic.
+          reflexivity. }
+          left; eexists _, _; intuition eauto. simpl. constructor; eauto with pcuic.
+          red. rewrite subst_mkApps /= map_app.
+          rewrite -H1.
+          rewrite map_map_compose map_subst_lift_id.
+          relativize (to_extended_list _).
+          erewrite (spine_subst_subst_to_extended_list_k spargs').
+          2:{ rewrite to_extended_list_k_subst. eapply map_subst_instance_constr_to_extended_list_k. }
+          eapply isWAT_mkApps_Ind_isType in vt; eauto.
+          rewrite subst_mkApps. rewrite -H1 map_app map_map_compose map_subst_lift_id.
+          relativize (to_extended_list _).
+          erewrite (spine_subst_subst_to_extended_list_k spargs').
+          2:{ rewrite to_extended_list_k_subst. eapply map_subst_instance_constr_to_extended_list_k. }
+          assumption.
+        + simpl. now eapply validity in Hpty.
+        + simpl.
+          eapply conv_cumul.
+          eapply mkApps_conv_args; auto.
+          eapply All2_app. 2:repeat (constructor; auto).
+          eapply All2_skipn. now symmetry in cl.
       * intros T'' Hc'.
         eapply inversion_Case in Hc' as (u'' & args' & mdecl' & idecl' & ps' & pty'
            & btys' & decli' & indp' & bcp' & Hpty' & lebs' & isco' & Hc' & Hbtys' & all' & cum'); auto.

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -3,6 +3,10 @@
 -R theories MetaCoq.Template
 
 # Generated Code by `ls -1 *.ml *.mli` in `template-coq/gen-src` after having compiled `Extraction.v`
+gen-src/signature.mli
+gen-src/signature.ml
+gen-src/classes0.mli
+gen-src/classes0.ml
 gen-src/all_Forall.ml
 gen-src/all_Forall.mli
 gen-src/ascii.ml

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -32,6 +32,8 @@ MCOption
 MCProd
 MCCompare
 MCString
+Signature
+Classes0
 All_Forall
 Config0
 Universes0

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -16,7 +16,7 @@ Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun 
 Extract Constant ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt".
 
-Extraction Blacklist config uGraph Universes Ast String List Nat Int
+Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
            UnivSubst Typing Checker Retyping OrderedType Logic Common Equality UnivSubst.
 Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -1318,6 +1318,7 @@ Proof.
              pose proof (typing_wf_local Hu).
              specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ X14 (existT _ _ (existT _ _ Hu))))))).
              apply IH. simpl. constructor 1. simpl. auto with arith.
+        -- apply (onIndices Xg).
       * red in onP |- *.
         eapply All_local_env_impl; eauto.
         intros. destruct T; simpl in X14.

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -650,6 +650,7 @@ Proof.
            eapply Forall_impl; tea. auto.
            destruct indices_matter; [|trivial].
            eapply type_local_ctx_impl; tea. eauto.
+       --- apply (onIndices X1).
     -- red in onP. red.
        eapply All_local_env_impl. eauto.
        intros. now apply X.

--- a/template-coq/theories/utils/All_Forall.v
+++ b/template-coq/theories/utils/All_Forall.v
@@ -6,6 +6,7 @@ Import ListNotations.
 Local Ltac inv H := inversion_clear H.
 Local Coercion is_true : bool >-> Sortclass.
 
+Derive Signature for Forall.
 
 (** Combinators *)
 

--- a/template-coq/theories/utils/All_Forall.v
+++ b/template-coq/theories/utils/All_Forall.v
@@ -1,6 +1,6 @@
 From Coq Require Import List Bool Arith ssreflect Lia.
 From MetaCoq.Template Require Import MCPrelude MCList MCRelations MCProd MCOption.
-
+From Equations Require Import Equations.
 Import ListNotations.
 
 Local Ltac inv H := inversion_clear H.
@@ -16,12 +16,15 @@ Inductive All {A} (P : A -> Type) : list A -> Type :=
                   P x -> All P l -> All P (x :: l).
 Arguments All_nil {_ _}.
 Arguments All_cons {_ _ _ _}.
+Derive Signature NoConfusion for All.
 
 Inductive Alli {A} (P : nat -> A -> Type) (n : nat) : list A -> Type :=
 | Alli_nil : Alli P n []
 | Alli_cons hd tl : P n hd -> Alli P (S n) tl -> Alli P n (hd :: tl).
 Arguments Alli_nil {_ _ _}.
 Arguments Alli_cons {_ _ _ _ _}.
+Derive Signature for Alli.
+Derive NoConfusionHom for Alli.
 
 Inductive All2 {A B : Type} (R : A -> B -> Type) : list A -> list B -> Type :=
   All2_nil : All2 R [] []
@@ -29,6 +32,8 @@ Inductive All2 {A B : Type} (R : A -> B -> Type) : list A -> list B -> Type :=
     R x y -> All2 R l l' -> All2 R (x :: l) (y :: l').
 Arguments All2_nil {_ _ _}.
 Arguments All2_cons {_ _ _ _ _ _ _}.
+Derive Signature for All2.
+Derive NoConfusionHom for All2.
 
 Fixpoint alli {A} (p : nat -> A -> bool) (l : list A) (n : nat) : bool :=
   match l with
@@ -496,6 +501,7 @@ Qed.
 Inductive OnOne2 {A : Type} (P : A -> A -> Type) : list A -> list A -> Type :=
 | OnOne2_hd hd hd' tl : P hd hd' -> OnOne2 P (hd :: tl) (hd' :: tl)
 | OnOne2_tl hd tl tl' : OnOne2 P tl tl' -> OnOne2 P (hd :: tl) (hd :: tl').
+Derive Signature NoConfusion for OnOne2.
 
 Lemma OnOne2_All_mix_left {A} {P : A -> A -> Type} {Q : A -> Type} {l l'} :
   All Q l -> OnOne2 P l l' -> OnOne2 (fun x y => (P x y * Q x)%type) l l'.
@@ -1694,6 +1700,7 @@ Inductive All2i {A B : Type} (R : nat -> A -> B -> Type) (n : nat)
       R n x y ->
       All2i R (S n) l r ->
       All2i R n (x :: l) (y :: r).
+Derive Signature NoConfusionHom for All2i.
 
 Lemma All2i_impl :
   forall A B R R' n l l',

--- a/translations/param_cheap_packed.v
+++ b/translations/param_cheap_packed.v
@@ -155,7 +155,10 @@ Definition tsl_mind_body (ΣE : tsl_context) (mp : modpath)
                  bodies <- _ ;;
                  ret (_, [{| ind_npars := mind.(ind_npars);
                              ind_bodies := bodies ;
-                 ind_universes := mind.(ind_universes);
+                 ind_universes := match mind.(ind_universes) with 
+                  | Monomorphic_ctx _ => Monomorphic_ctx ContextSet.empty (* Don't redeclare universes *)
+                  | Polymorphic_ctx ctx => Polymorphic_ctx ctx
+                 end;
                  ind_variance := mind.(ind_variance) |}])).  (* FIXME always ok? *)
   (* L is [(tInd n, tRel 0); ... ; (tInd 0, tRel n)] *)
   simple refine (let L : list term := _ in _).
@@ -194,9 +197,8 @@ Definition tsl_mind_body (ΣE : tsl_context) (mp : modpath)
     + (* ind *)
       refine (IndRef (mkInd kn i), pair ind.(ind_type) a2 (tInd (mkInd kn i) []) (tInd (mkInd kn' i) [])).
     + (* ctors *)
-      (* refine (fold_left_i (fun E k _ => _ :: E) ind.(ind_ctors) []). *)
-      (* exact (ConstructRef (mkInd id i) k, tConstruct (mkInd id' i) k []). *)
-      refine [].
+      refine (fold_left_i (fun E k _ => _ :: E) ind.(ind_ctors) []).
+      exact (ConstructRef (mkInd kn i) k, tConstruct (mkInd kn' i) k []). 
   - exact mind.(ind_finite).
   - (* FIXME don't know what to do *) refine (mind.(ind_params)).
 Defined.

--- a/translations/sigma.v
+++ b/translations/sigma.v
@@ -3,6 +3,7 @@ From MetaCoq.Template Require Import utils All.
 
 Local Set Primitive Projections.
 
+#[universes(template)]
 Record sigma A B :=
   mk_sig { π1 : A ; π2 : B π1 }.
 


### PR DESCRIPTION
Finally finish principality for case and proj: this required interesting new invariants on inductives: the indices must be in cumulativity relation and we must use the cumulativity property for primitive projections too. This is now all closed. SafeRetyping (and hence SafeErasure) now only relies on todos for reduction completeness.