### PR TITLE
Safechecker cases correct

### DIFF
--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -96,7 +96,7 @@ Proof.
     eapply extends_lookup in H0; eauto. now rewrite H0.
   - econstructor. all:eauto.
     2:{ eauto. eapply All2_All_left in X3.
-        2:{ intros ? ? [[[? ?] ?] ?]. exact e. }
+        2:{ intros ? ? [[[? ?] ?] ?]. exact e0. }
         eapply All2_All_mix_left in X3; eauto.
         eapply All2_impl. exact X3.
         intros. destruct H as [? []].
@@ -198,7 +198,7 @@ Proof.
     + eapply H4; eauto.
     + eapply All2_map.
       eapply All2_All_left in X3.
-      2:{ idtac. intros ? ? [[[[? ?] e0] ?] e']. exact e0. }
+      2:{ idtac. intros ? ? [[[? ?] ?] [? [? ?]]]. exact e0. }
       eapply All2_impl. eapply All2_All_mix_left.
       eassumption. eassumption. intros.
       destruct H. destruct p0.
@@ -421,7 +421,7 @@ Proof.
         eapply All2_impl_In; eauto.
         intros. destruct H10, x, y. cbn in *. subst. split; eauto.
         eapply All2_All_left in X3.
-        2:{ intros ? ? [[[[? ?] e1] ?] ?]. exact e1. }
+        2:{ intros ? ? [[[? ?] e1]]. exact e1. }
 
         eapply In_nth_error in H8 as [].
         eapply nth_error_all in X3; eauto.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -128,7 +128,7 @@ Proof.
     eapply PCUICContextConversion.context_conversion with Γ; eauto.
     eassumption.
   - econstructor. eauto. eauto.
-    eapply All2_All_left in X3. 2:{ idtac. intros ? ? [[[? e] ?] ?]. exact e. }
+    eapply All2_All_left in X3. 2:{ idtac. intros ? ? [[? e] ?]. exact e. }
 
     eapply All2_impl. eapply All2_All_mix_left.
     all: firstorder.
@@ -254,7 +254,7 @@ Proof.
   - cbn. econstructor; eauto.
     eapply All2_map_left.
     eapply All2_impl. eapply All2_All_mix_left.
-    eapply All2_All_left. exact X3. intros ? ? [[[? e] ?] ?].
+    eapply All2_All_left. exact X3. intros ? ? [[? e] ?].
     exact e. exact X6.
     intros; cbn in *. destruct H. destruct p0. split; eauto.
   - assert (Hw :  wf_local (Σ.1, univs) (subst_instance_context u (Γ ,,, types))).

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -490,7 +490,7 @@ Proof.
 
     pose proof (Prelim.monad_map_All2 _ _ _ brs a2 E2).
 
-    eapply All2_All_left in X3. 2:{ intros. destruct X5. destruct p0. destruct p0. exact e0. }
+    eapply All2_All_left in X3. 2:{ intros. destruct X5. destruct p0. destruct p0. exact e. }
 
     eapply All2_impl.
     eapply All2_All_mix_left. eassumption. eassumption.

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -382,10 +382,6 @@ Section Alpha.
       econstructor ; eauto.
     - intros ind u npar p c brs args mdecl idecl isdecl X X0 H pars ps pty
              Hcpt X1 X2 H1 H2 X3 X4 btys Hbbt Hbrs v e; invs e.
-      (* intros ind u npar p c brs args mdecl idecl isdecl X X0 H pars pty X1 *)
-      (*        indctx pctx ps btys htc H1 H2 ihp hc ihc ihbrs v e. *)
-      (* eapply types_of_case_eq_term in htc as htc' ; eauto. *)
-      (* destruct htc' as [btys' [ebtys' he]]. *)
       econstructor.
       + eapply build_branches_type_eq_term in Hbbt; tea.
         destruct Hbbt as [btys' [Hbbt1 Hbbt2]].
@@ -393,25 +389,26 @@ Section Alpha.
         unshelve eapply All2_trans'; [..|eassumption].
         * exact (fun br bty : nat × term =>
                    (((br.1 = bty.1 × Σ;;; Γ |- br.2 : bty.2)
-                       × (forall v : term, upto_names' br.2 v -> Σ;;; Γ |- v : bty.2))
-                      × Σ;;; Γ |- bty.2 : tSort ps)
-                     × (forall v : term, upto_names' bty.2 v -> Σ;;; Γ |- v : tSort ps)).
-        * clear. intros x y z X; rdest; cbn in *.
-          congruence. 2: eauto. econstructor; tea. 
-          right. exists ps. eauto. constructor.
+                       × (forall v : term, upto_names' br.2 v -> Σ;;; Γ |- v : bty.2))) × 
+                    (∑ s, (Σ ;;; Γ |- bty.2 : tSort s) × 
+                    (forall v : term, upto_names' bty.2 v -> Σ ;;; Γ |- v : tSort s))).
+        * clear. intros x y z X; intuition auto; cbn in *.
+          congruence.
+          destruct b0 as [s [Hs IH]]; eauto.
+          specialize (IH _ a).
+          econstructor; eauto. constructor.
           now eapply upto_names_impl_leq_term.
+          destruct b0 as [s [Hs IH]]; eauto.
         * eapply All2_trans'; [..|eassumption].
           2: apply All2_sym; tea.
           clear. intros x y z X; rdest; cbn in *; eauto. congruence.
           intros v H. unshelve eapply (upto_names_trans _ _ _ _) in H; tea.
           eauto.
+
       + eapply validity_term ; eauto.
         instantiate (1 := tCase (ind, ind_npars mdecl) p c brs).
         econstructor ; eauto.
-        apply All2_prod_inv in Hbrs as [a1 a4].
-        apply All2_prod_inv in a1 as [a1 a3].
-        apply All2_prod_inv in a1 as [a1 a2].
-        apply All2_prod. all: assumption.
+        solve_all. destruct b0 as [s [Hs IH]]; eauto.
       + constructor.
         eapply eq_term_leq_term.
         apply eq_term_sym.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -9,8 +9,6 @@ From MetaCoq.PCUIC Require Import PCUICAst
 From Coq Require Import CRelationClasses ssreflect.
 From Equations Require Import Equations.
 
-
-
 Arguments red_ctx : clear implicits.
 
 Ltac my_rename_hyp h th :=
@@ -832,6 +830,7 @@ Proof.
     eapply forall_Γ'1; repeat (constructor; pcuic).
   - econstructor; pcuic. intuition auto. eapply isdecl. eapply isdecl.
     eauto. solve_all.
+    destruct b0 as [? [? ?]]; eauto.
   - econstructor; pcuic.
     eapply (All_impl X0).
     intros x [s [Hs IH]].

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -190,14 +190,13 @@ Proof.
 Qed.
 
 Lemma map_subst_instance_constr_to_extended_list_k u ctx k :
-  map (subst_instance_constr u) (to_extended_list_k (subst_instance_context u ctx) k)
-  = to_extended_list_k (subst_instance_context u ctx) k.
+  map (subst_instance_constr u) (to_extended_list_k ctx k)
+  = to_extended_list_k ctx k.
 Proof.
-  pose proof (to_extended_list_k_spec (subst_instance_context u ctx) k).
+  pose proof (to_extended_list_k_spec ctx k).
   solve_all.
   now destruct H as [n [-> _]].
 Qed.
-
 
 Lemma subst_instance_to_extended_list_k u l k
   : map (subst_instance_constr u) (to_extended_list_k l k)

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -115,9 +115,6 @@ Proof.
     subst npar.
     now rewrite firstn_skipn. }
   - constructor.
-    * left; eexists _, _; intuition eauto. simpl.
-      eapply typing_wf_local; eauto.
-    * reflexivity.
   - unfold universe_family in Huf.
     destruct (Universe.is_prop ps); auto.
     destruct (Universe.is_small ps); discriminate.

--- a/pcuic/theories/PCUICGeneration.v
+++ b/pcuic/theories/PCUICGeneration.v
@@ -5,7 +5,6 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
 
-
 Derive NoConfusion NoConfusionHom for term.
 Derive NoConfusion NoConfusionHom for context_decl.
 Derive NoConfusion NoConfusionHom for list.
@@ -13,8 +12,6 @@ Derive NoConfusion NoConfusionHom for option.
 
 Section Generation.
   Context `{cf : config.checker_flags}.
-
-  Definition isWfArity_or_Type Σ Γ T : Type := (isWfArity typing Σ Γ T + isType Σ Γ T).
 
   Inductive typing_spine (Σ : global_env_ext) (Γ : context) :
     term -> list term -> term -> Type :=

--- a/pcuic/theories/PCUICInduction.v
+++ b/pcuic/theories/PCUICInduction.v
@@ -115,7 +115,14 @@ Qed.
 Lemma decompose_app_size_tApp2 t1 t2 :
   Forall (fun t => size t < size (tApp t1 t2)) (decompose_app (tApp t1 t2)).2.
 Proof.
-  todo String.EmptyString.
+  destruct decompose_app eqn:da.
+  eapply decompose_app_inv in da. rewrite da. simpl. clear da.
+  induction l using rev_ind; try constructor.
+  eapply app_Forall; [|constructor].
+  eapply Forall_impl; eauto; simpl; intros.
+  rewrite <- mkApps_nested; simpl. lia.
+  rewrite <- mkApps_nested; simpl. lia.
+  constructor.
 Qed.
 
 Definition mkApps_decompose_app_rec t l :

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -1033,9 +1033,7 @@ Proof.
   eapply isWAT_it_mkProd_or_LetIn; auto. now rewrite app_context_nil_l.
   rewrite -(app_nil_r (to_extended_list (smash_context [] (subst_instance_context u Δ)))).
   eapply arity_spine_it_mkProd_or_LetIn; auto.
-  2:{ simpl; constructor; [|reflexivity].
-      eapply isWAT_tSort; auto.
-      now apply wf_local_smash_context. }
+  2:{ simpl; constructor. }
   eapply spine_subst_smash_inv; eauto.
 Qed.
 

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -186,7 +186,7 @@ Section Inversion.
         map_option_out (build_branches_type ind mdecl idecl params u p)
                      = Some btys ×
         All2 (fun br bty => (br.1 = bty.1 × Σ ;;; Γ |- br.2 : bty.2)
-                           × Σ ;;; Γ |- bty.2 : tSort ps) brs btys ×
+                           × isType Σ Γ bty.2) brs btys ×
         Σ ;;; Γ |- mkApps p (skipn npar args ++ [c]) <= T.
   Proof.
     intros Γ indnpar p c brs T h. invtac h.

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -1235,6 +1235,7 @@ Proof.
     + exact (todo "build_branches_type Nameless").
     + clear -X5. eapply All2_map, All2_impl; tea. cbn.
       clear. intros x y [[[? ?] ?] ?]. intuition eauto.
+      destruct s as [s [Hs IH]] ; exists s; eauto.
   - destruct pdecl as [pdecl1 pdecl2]; simpl.
     rewrite map_rev.
     eapply type_Proj with (mdecl0:=nl_mutual_inductive_body mdecl)

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -367,8 +367,7 @@ Proof.
          simpl in sp. rewrite !map_map_compose in sp. eapply sp.
          autorewrite with len.
          simpl. constructor.
-         2:{ simpl; constructor; auto. left; eexists _, _; intuition eauto.
-             reflexivity. }
+         2:{ simpl; constructor; auto. }
          rewrite lift_mkApps subst_mkApps.
          simpl. eapply type_mkApps. econstructor; eauto.
          split; eauto.
@@ -533,7 +532,7 @@ Proof.
       split. eapply validity; eauto.
       eapply arity_spine_it_mkProd_or_LetIn; eauto.
       simpl. constructor. 
-      2:{ constructor; pcuic. left; eexists _, _; intuition eauto. }
+      2:{ constructor; pcuic. }
       rewrite subst_mkApps /= map_app. unfold to_extended_list.
       generalize (spine_subst_subst_to_extended_list_k subsidx).
       rewrite to_extended_list_k_subst 
@@ -690,8 +689,6 @@ Proof.
       split. apply (env_prop_typing _ _ validity) in typep as ?; eauto.
       eapply arity_spine_it_mkProd_or_LetIn; eauto.
       simpl. constructor; [ |constructor].
-      2:{ left; eexists _, _; split. simpl; eauto. auto. }
-      2:reflexivity.
       rewrite subst_mkApps. simpl.
       rewrite map_app. rewrite map_map_compose.
       rewrite map_subst_lift_id_eq. now rewrite (subslet_length sargs); autorewrite with len.
@@ -720,8 +717,6 @@ Proof.
       split. apply (env_prop_typing _ _ validity) in typep; eauto.
       eapply arity_spine_it_mkProd_or_LetIn; eauto.
       simpl. constructor; [ |constructor].
-      2:{ left; eexists _, _; split. simpl; eauto. auto. }
-      2:reflexivity.
       rewrite subst_mkApps. simpl.
       rewrite map_app. rewrite map_map_compose.
       rewrite map_subst_lift_id_eq. now rewrite (subslet_length sargs); autorewrite with len.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -670,7 +670,9 @@ Proof.
       intros.
       intuition auto. now transitivity y.1.
       eapply type_Cumul; eauto.
-      now eapply conv_cumul, red_conv, red1_red.
+      2:now eapply conv_cumul, red_conv, red1_red.
+      destruct b0 as [s [Hs IH]]; eauto.
+      destruct b0 as [s [Hs IH]]; eauto.
     * right.
       pose proof typec as typec'.
       eapply (env_prop_typing _ _ validity) in typec' as wat; auto.
@@ -700,7 +702,7 @@ Proof.
 
   - (* Case congruence on discriminee *) 
     eapply type_Cumul. eapply type_Case; eauto.
-    * solve_all.
+    * solve_all. destruct b0 as [s [Hs IH]]; eauto.
     * right.
       pose proof typec as typec'.
       eapply (env_prop_typing _ _ validity) in typec' as wat; auto.
@@ -733,10 +735,11 @@ Proof.
     eapply type_Case; eauto.
     eapply (OnOne2_All2_All2 o X5).
     intros [] []; simpl. intros.
-    intuition auto. subst.
+    intuition auto. destruct b as [s [Hs IH]]; eauto. subst.
     intros [] [] []; simpl. intros.
     intuition auto. subst.    
     reflexivity.
+    destruct b0 as [s [Hs IH]]; eauto.
 
   - (* Proj CoFix congruence *)
     assert(typecofix : Σ ;;; Γ |- tProj p (mkApps (tCoFix mfix idx) args0) : subst0 (mkApps (tCoFix mfix idx) args0 :: List.rev args)

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -220,10 +220,10 @@ Qed.
 
 Inductive arity_spine {cf : checker_flags} (Σ : PCUICAst.global_env_ext) (Γ : PCUICAst.context) : 
   term -> list term -> term -> Type :=
-| arity_spine_nil ty ty' :
-  isWfArity_or_Type Σ Γ ty' ->
-  Σ ;;; Γ |- ty <= ty' ->
-  arity_spine Σ Γ ty [] ty'
+| arity_spine_nil ty : arity_spine Σ Γ ty [] ty
+| arity_spine_conv ty ty' : isWfArity_or_Type Σ Γ ty' ->
+  Σ ;;; Γ |- ty <= ty' -> arity_spine Σ Γ ty [] ty'
+  
 | arity_spine_def : forall (tl : list term) 
                       (na : name) (A a B B' : term),                      
                     arity_spine Σ Γ (B {0 := a}) tl B' ->
@@ -247,7 +247,7 @@ Lemma wf_arity_spine_typing_spine {cf:checker_flags} Σ Γ T args T' :
 Proof.
   intros wfΣ [wf sp].
   have wfΓ := isWAT_wf_local wf.
-  induction sp; try constructor; auto.
+  induction sp; try constructor; auto. reflexivity.
   eapply isWAT_tLetIn_red in wf; auto.
   specialize (IHsp wf).
   eapply typing_spine_strengthen; eauto.
@@ -869,8 +869,7 @@ Lemma arity_spine_it_mkProd_or_LetIn_Sort {cf:checker_flags} Σ Γ ctx s args in
 Proof.
   intros wfΣ sp. rewrite -(app_nil_r args).
   eapply arity_spine_it_mkProd_or_LetIn => //.
-  eauto. constructor. left. eexists _, _; intuition eauto.
-  eapply sp. simpl. reflexivity.
+  eauto. constructor.
 Qed.
 
 Lemma ctx_inst_app {cf:checker_flags} {Σ Γ} {Δ : context} {Δ' args} (c : ctx_inst Σ Γ args (Δ ++ Δ')) :
@@ -1625,30 +1624,19 @@ Qed.
 Lemma arity_spine_eq {cf:checker_flags} Σ Γ T T' :
   isWfArity_or_Type Σ Γ T' ->
   T = T' -> arity_spine Σ Γ T [] T'.
-Proof. intros H  ->; constructor;auto. reflexivity. Qed.
-(* 
-Lemma typing_spine_isWAT {cf : checker_flags} {Σ : global_env × universes_decl}
-  {Γ T args T'} :
-  wf Σ.1 ->
-  wf_local Σ Γ ->
-  typing_spine Σ Γ T args T' ->
-  isWfArity_or_Type Σ Γ T.
-Proof.
-  intros wfΣ wfΓ.
-  induction 1. *)
+Proof. intros H ->; constructor;auto. Qed.
 
-
-Lemma arity_spine_letin_inv {cf:checker_flags} {Σ Γ na b B T args S} : 
+(* Lemma arity_spine_letin_inv {cf:checker_flags} {Σ Γ na b B T args S} : 
   wf Σ.1 ->
   arity_spine Σ Γ (tLetIn na b B T) args S ->
   arity_spine Σ Γ (T {0 := b}) args S.
 Proof.
   intros wfΣ Hsp.
   depelim Hsp.
-  constructor. auto.
+  econstructor. auto.
   now eapply invert_cumul_letin_l in c.
   auto.
-Qed.
+Qed. *)
 
 Lemma typing_spine_inv {cf : checker_flags} {Σ : global_env × universes_decl}
   {Γ Δ : context} {T args args' T'} :

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -10,7 +10,6 @@ From Equations Require Import Equations.
 
 (** * Substitution lemmas for typing derivations. *)
 
-
 Local Set Keyed Unification.
 
 Set Default Goal Selector "!".
@@ -2590,6 +2589,7 @@ Proof.
       * subst params. rewrite firstn_map. exact H3.
       * now rewrite closedn_subst_instance_context.
     + solve_all.
+      destruct b0 as [s' [Hs IH]]; eexists; eauto.
 
   - specialize (X2 Γ Γ' Δ s sub eq_refl).
     eapply refine_type.

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -938,7 +938,7 @@ in All (for wf_local assumptions)
       apply X4.
     + admit. (* map_option_out build branche type *)
     (* this should be similar to trans_build_case_predicate_type *)
-    + now apply trans_branches.
+    + admit. (* now apply trans_branches.*)
   - rewrite trans_subst.
     rewrite trans_subst_instance_constr.
     cbn.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -22,7 +22,6 @@ Create HintDb univ_subst.
 
 Local Ltac aa := rdest; eauto with univ_subst.
 
-
 Lemma subst_instance_level_val u l v v'
       (H1 : forall s, valuation_mono v s = valuation_mono v' s)
       (H2 : forall n, val v (nth n u Level.lSet) = Z.of_nat (valuation_poly v' n))
@@ -1540,7 +1539,7 @@ Proof.
       * cbn. eauto.
       * cbn.
         destruct x, y; cbn in *; subst.
-        eapply t1; assumption.
+        destruct s as [s [Hs IH]]. eexists; eauto.
 
   - intros p c u mdecl idecl pdecl isdecl args X X0 X1 X2 H u0 univs wfΣ' HSub H0.
     rewrite <- subst_subst_instance_constr. cbn.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -239,8 +239,7 @@ Section Validity.
       pose proof (context_subst_fun cs sparsubst). subst pars.
       eapply sargsubst.
       simpl. constructor; first last.
-      constructor; auto. left; eexists _, _; intuition eauto.
-      reflexivity.
+      constructor; auto.
       rewrite subst_mkApps.
       simpl.
       rewrite map_app. subst params.

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -1015,6 +1015,7 @@ Proof.
     -- destruct idecl; simpl in *; auto.
     -- now rewrite -> !lift_mkApps in IHc.
     -- solve_all.
+      destruct b0 as [s [Hs IH]]; eauto.
 
   - simpl.
     erewrite (distr_lift_subst_rec _ _ _ 0 #|Γ'|).

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -414,6 +414,7 @@ Proof.
     + eapply p; eauto.
   - econstructor; eauto 2 with extends.
     close_Forall. intros; intuition eauto with extends.
+    destruct b as [s [Hs IH]]; eauto.
   - econstructor; eauto with extends.
     + eapply (All_impl X0); simpl; intuition eauto with extends.
       destruct X as [s Hs]; exists s. intuition eauto with extends.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -8,10 +8,9 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
 From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeConversion.
 
 From Equations Require Import Equations.
+Require Import ssreflect.
 
 Local Set Keyed Unification.
-
-
 
 Lemma weakening_sq `{cf : checker_flags} {Σ Γ} Γ' {t T} :
   ∥ wf Σ.1 ∥ -> ∥ wf_local Σ (Γ ,,, Γ') ∥ ->
@@ -344,55 +343,6 @@ Lemma map_squash {A B} (f : A -> B) : ∥ A ∥ -> ∥ B ∥.
 Proof.
   intros []; constructor; auto.
 Qed.
-
-(* From valid_btys *)
-Lemma inversion_WAT_indapp {cf:checker_flags} Σ Γ ind u args :
-    forall mdecl idecl (isdecl : declared_inductive Σ.1 mdecl ind idecl),
-    wf Σ.1 ->
-    isType Σ Γ (mkApps (tInd ind u) args) ->
-    mdecl.(ind_npars) <= #|args| /\ inductive_ind ind < #|ind_bodies mdecl| /\
-    consistent_instance_ext Σ (ind_universes mdecl) u.
-Proof.
-Admitted.
-
-
-Lemma wf_local_vass {cf:checker_flags} Σ {Γ na A} s :
-  Σ ;;; Γ |- A : tSort s -> wf_local Σ (Γ ,, vass na A).
-Proof.
-  intro X; apply typing_wf_local in X as Y.
-  constructor; tea. eexists; eassumption.
-Qed.
-
-Lemma WfArity_build_case_predicate_type {cf:checker_flags} Σ
-      Γ ind u args mdecl idecl ps pty :
-  wf Σ.1 ->
-  declared_inductive Σ.1 mdecl ind idecl ->
-  isType Σ Γ (mkApps (tInd ind u) args) ->
-  let params := firstn (ind_npars mdecl) args in
-  build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
-  isWfArity typing Σ Γ pty.
-Proof.
-  intros wfΣ isdecl X params XX. unfold build_case_predicate_type in XX.
-  case_eq (instantiate_params
-             (subst_instance_context u (ind_params mdecl))
-             params (subst_instance_constr u (ind_type idecl)));
-    [|intro e; rewrite e in XX; discriminate].
-  intros ipars Hipars; rewrite Hipars in XX; simpl in XX.
-  case_eq (destArity [] ipars);
-    [|intro e; rewrite e in XX; discriminate].
-  intros [ictx is] Hictxs; rewrite Hictxs in XX; apply some_inj in XX.
-  subst pty. eexists _, _.
-  rewrite destArity_it_mkProd_or_LetIn. split. reflexivity.
-  simpl. eapply wf_local_vass.
-  eapply type_mkApps. econstructor; tea.
-  * admit.
-  * eapply inversion_WAT_indapp with (mdecl0:=mdecl) in X; tea.
-    apply X.
-  * eapply PCUICWeakeningEnv.on_declared_inductive in isdecl as oind; tea.
-    rewrite oind.2.(ind_arity_eq). cbn.
-    admit.
-Admitted.
-
 Lemma destArity_mkApps_None ctx t l :
   destArity ctx t = None -> destArity ctx (mkApps t l) = None.
 Proof.
@@ -405,7 +355,6 @@ Lemma destArity_mkApps_Ind ctx ind u l :
 Proof.
     apply destArity_mkApps_None. reflexivity.
 Qed.
-
 
 Section Typecheck.
   Context {cf : checker_flags} {Σ : global_env_ext} (HΣ : ∥ wf Σ ∥)
@@ -615,7 +564,7 @@ Section Typecheck.
   Proof.
     unfold is_graph_of_uctx in HG.
     case_eq (gc_of_uctx (global_ext_uctx Σ)); [intros [lvs cts] XX|intro XX];
-      rewrite XX in *; simpl in *; [|contradiction].
+      rewrite -> XX in *; simpl in *; [|contradiction].
     unfold gc_of_uctx in XX; simpl in XX.
     destruct (gc_of_constraints Σ); [|discriminate].
     inversion XX; subst. generalize (global_ext_levels Σ); intros lvs; cbn.
@@ -708,7 +657,6 @@ Section Typecheck.
     cbn. apply eqb_decl_spec.
   Qed.
 
-
   Obligation Tactic := Program.Tactics.program_simplify ; eauto 2.
 
   Program Fixpoint infer (Γ : context) (HΓ : ∥ wf_local Σ Γ ∥) (t : term) {struct t}
@@ -787,6 +735,8 @@ Section Typecheck.
                     (NotConvertible G Γ (tInd ind u) (tInd ind' u)) ;;
       d <- lookup_ind_decl ind' ;;
       let '(decl; d') := d in let '(body; HH) := d' in
+      check_coind <- check_eq_true (negb (isCoFinite (ind_finite decl)))
+            (Msg "Case on coinductives disallowed") ;;
       check_eq_true (ind_npars decl =? par)
                     (Msg "not the right number of parameters") ;;
       pty <- infer Γ HΓ p ;;
@@ -808,8 +758,9 @@ Section Typecheck.
             match map_option_out (build_branches_type ind decl body params u p) with
             | None => raise (Msg "failure in build_branches_type")
             | Some btys => 
+              let btyswf : ∥ All (isType Σ Γ ∘ snd) btys ∥ := _ in
               (fix check_branches (brs btys : list (nat * term))
-                (HH : Forall (squash ∘ (isType Σ Γ) ∘ snd) btys) {struct brs}
+                (HH : ∥ All (isType Σ Γ ∘ snd) btys ∥) {struct brs}
                   : typing_result
                     (All2 (fun br bty => br.1 = bty.1 /\ ∥ Σ ;;; Γ |- br.2 : bty.2 ∥) brs btys)
                           := match brs, btys with
@@ -822,7 +773,7 @@ Section Typecheck.
                                ret (All2_cons (conj _ _) X)
                              | [], _ :: _
                              | _ :: _, [] => raise (Msg "wrong number of branches")
-                             end) brs btys _ ;;
+                             end) brs btys btyswf ;;
                 ret (mkApps p (List.skipn par args ++ [c]); _)
             end
           end
@@ -1009,12 +960,39 @@ Section Typecheck.
     change (eqb (ind_npars d) par = true) in H1.
     destruct (eqb_spec (ind_npars d) par) as [e|e]; [|discriminate].
     rename Heq_anonymous into HH. symmetry in HH.
-    eapply WfArity_build_case_predicate_type; eauto. simpl in *.
+    eapply PCUICInductiveInversion.WfArity_build_case_predicate_type; eauto. simpl in *.
     2:rewrite e; eauto.
     eapply type_reduction in t0; eauto. eapply validity in t0; eauto.
     now eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in t0.
   Qed.
-  
+
+  Next Obligation.
+    symmetry in Heq_anonymous2.
+    unfold iscumul in Heq_anonymous2. simpl in Heq_anonymous2. destruct wildcard'.
+    apply isconv_term_sound in Heq_anonymous2.
+    red in Heq_anonymous2.
+    noconf Heq_I''.
+    noconf Heq_I'. noconf Heq_I.
+    noconf Heq_d. noconf Heq_d'.
+    simpl in *; sq.
+    change (eqb ind I = true) in H0.
+    destruct (eqb_spec ind I) as [e|e]; [destruct e|discriminate H0].
+    change (eqb (ind_npars d) par = true) in H1.
+    destruct (eqb_spec (ind_npars d) par) as [e|e]; [|discriminate]; subst.
+    assert (wfΣ : wf_ext Σ) by (split; auto).
+    eapply type_reduction in X9; eauto.
+    have val:= validity_term wfΣ X9.
+    eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in val; eauto.
+    eapply type_Cumul in X; [| |eassumption].
+    2:{ left. eapply PCUICInductiveInversion.WfArity_build_case_predicate_type; eauto. }
+    have [pctx' da] : (∑ pctx', destArity [] pty' =  Some (pctx', ps)).
+    { symmetry in Heq_anonymous1.
+      unshelve eapply (PCUICInductives.build_case_predicate_type_spec (Σ.1, ind_universes d)) in Heq_anonymous1 as [parsubst [_ ->]].
+      eauto. eapply (PCUICWeakeningEnv.on_declared_inductive wfΣ) in HH as [? ?]. eauto.
+      eexists. rewrite !destArity_it_mkProd_or_LetIn; simpl. reflexivity. }
+    eapply PCUICInductiveInversion.build_branches_type_wt. 6:eapply X. all:eauto.
+  Defined.
+    
   Next Obligation.
     rename Heq_anonymous2 into XX2. destruct wildcard'.
     symmetry in XX2. simpl in *. eapply isconv_sound in XX2.
@@ -1022,57 +1000,50 @@ Section Typecheck.
     destruct (eqb_spec ind ind') as [e|e]; [destruct e|discriminate H0].
     change (eqb (ind_npars decl) par = true) in H1.
     destruct (eqb_spec (ind_npars decl) par) as [e|e]; [|discriminate]; subst.
-    depelim HH.
-    sq. right; auto.
+    sq. depelim HH. now right.
   Defined.
   Next Obligation.
-    now depelim HH.
+    sq. now depelim HH.
   Defined.
+
+  (* The obligation tactic removes a useful let here. *)
+  Obligation Tactic := idtac.
   Next Obligation.
+    intros. clearbody btyswf. idtac; Program.Tactics.program_simplify.
     symmetry in Heq_anonymous2.
     unfold iscumul in Heq_anonymous2. simpl in Heq_anonymous2. destruct wildcard'.
     apply isconv_term_sound in Heq_anonymous2.
-    red in Heq_anonymous2. sq. destruct X.
-    noconf Heq_I''.
-    noconf Heq_I'. noconf Heq_I.
-    noconf Heq_d. noconf Heq_d'.
-    simpl in *. destruct H, X9.
+    noconf Heq_I''. noconf Heq_I'. noconf Heq_I.
+    noconf Heq_d. noconf Heq_d'. simpl in *.
+    assert (∥ All2 (fun x y  => ((fst x = fst y) *
+                              (Σ;;; Γ |- snd x : snd y) * isType Σ Γ y.2)%type) brs btys ∥). {
+      solve_all. simpl in *.
+      destruct btyswf. eapply All2_sq. solve_all. simpl in *; intuition (sq; auto). }
+    clear H3. sq.
     change (eqb ind I = true) in H0.
     destruct (eqb_spec ind I) as [e|e]; [destruct e|discriminate H0].
     change (eqb (ind_npars d) par = true) in H1.
     destruct (eqb_spec (ind_npars d) par) as [e|e]; [|discriminate]; subst.
-    eapply type_Cumul in t; eauto.
-    2:{ left. eapply WfArity_build_case_predicate_type; eauto. simpl in *.
-        eapply type_reduction in X0; eauto. eapply validity in X0; eauto.
-        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in X0; eauto. }
-    eapply type_reduction in X0; eauto.
-    
-
-   assert (∥ All2 (fun x y  => ((fst x = fst y) *
-                              (Σ;;; Γ |- snd x : snd y))%type) brs btys ∥). {
-      depelim HH.
-      eapply All2_sq. eapply All2_impl.
-      specialize (check_branches brs _ HH).
-      eassumption.
-      cbn; intros ? ? []. now sq. }
-    destruct H as [H], X9, XX2 as [XX2]. sq.
-    eapply type_Case' with (pty0:=pty'); tea.
+    assert (wfΣ : wf_ext Σ) by (split; auto).
+    eapply type_reduction in X9; eauto.
+    eapply type_Cumul in X; eauto.
+    2:{ left. eapply PCUICInductiveInversion.WfArity_build_case_predicate_type; eauto. simpl in *.
+        eapply validity in X9; eauto.
+        eapply PCUICInductiveInversion.isWAT_mkApps_Ind_isType in X9; eauto. }
+    have [pctx' da] : (∑ pctx', destArity [] pty' =  Some (pctx', ps)).
+    { symmetry in Heq_anonymous1.
+      unshelve eapply (PCUICInductives.build_case_predicate_type_spec (Σ.1, ind_universes d)) in Heq_anonymous1 as [parsubst [_ ->]].
+      eauto. eapply (PCUICWeakeningEnv.on_declared_inductive wfΣ) in HH as [? ?]. eauto.
+      eexists. rewrite !destArity_it_mkProd_or_LetIn; simpl. reflexivity. }
+    eapply type_Case with (pty0:=pty'); tea.
     - reflexivity.
     - symmetry; eassumption.
-    - econstructor; tea.
-      rename Heq_anonymous1 into XX. left.
-      eapply WfArity_build_case_predicate_type; tea.
-      2: symmetry; eassumption.
-      simpl in *. apply validity_term in X9; tea.
-      eapply isWfArity_or_Type_red in X9; tea.
-      destruct X9; [|assumption].
-      destruct i as [ctx [s [HH1 _]]]. cbn in HH1.
-      rewrite destArity_mkApps_Ind in HH1; discriminate.
-    - eapply type_reduction; tea.
-    - symmetry; eassumption.*)
+    - destruct isCoFinite; auto.
+    - symmetry; eauto.
   Defined.
-  Next Obligation. todo "type_Case". Qed.
   
+  Obligation Tactic := Program.Tactics.program_simplify ; eauto 2.
+
   (* tProj *)
   Next Obligation. simpl; eauto using validity_wf. Qed.
   Next Obligation.
@@ -1518,7 +1489,7 @@ Section CheckEnv.
       unfold is_consistent, global_ext_uctx, gc_of_uctx, global_ext_constraints.
       simpl.
       rewrite gc_of_constraints_union.
-      rewrite HΣctrs, Hctrs.
+      rewrite HΣctrs Hctrs.
       inversion Huctx; subst; clear Huctx.
       clear -H2 cf. rewrite add_uctx_make_graph in H2.
       refine (eq_rect _ (fun G => wGraph.is_acyclic G = true) H2 _ _).
@@ -1554,14 +1525,14 @@ Section CheckEnv.
     unfold gc_of_uctx in e. simpl in e.
     case_eq (gc_of_constraints (constraints_of_udecl (universes_decl_of_decl g)));
       [|intro HH; rewrite HH in e; discriminate e].
-    intros ctrs' Hctrs'. rewrite Hctrs' in *.
+    intros ctrs' Hctrs'. rewrite Hctrs' in e.
     cbn in e. inversion e; subst; clear e.
     unfold global_ext_constraints; simpl.
     rewrite gc_of_constraints_union. rewrite Hctrs'.
     red in i. unfold gc_of_uctx in i; simpl in i.
     case_eq (gc_of_constraints (global_constraints Σ));
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
-    intros Σctrs HΣctrs; rewrite HΣctrs in *; simpl in *.
+    intros Σctrs HΣctrs; rewrite HΣctrs in i; simpl in *.
     subst G. unfold global_ext_levels; simpl. rewrite no_prop_levels_union.
     symmetry; apply add_uctx_make_graph.
   Qed.
@@ -1571,7 +1542,7 @@ Section CheckEnv.
     unfold gc_of_uctx in e. simpl in e.
     case_eq (gc_of_constraints (constraints_of_udecl (universes_decl_of_decl g)));
       [|intro HH; rewrite HH in e; discriminate e].
-    intros ctrs' Hctrs'. rewrite Hctrs' in *.
+    intros ctrs' Hctrs'. rewrite Hctrs' in e.
     cbn in e. inversion e; subst; clear e.
     unfold global_ext_constraints; simpl.
     rewrite gc_of_constraints_union.
@@ -1583,7 +1554,7 @@ Section CheckEnv.
     red in i. unfold gc_of_uctx in i; simpl in i.
     case_eq (gc_of_constraints (global_constraints Σ));
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
-    intros Σctrs HΣctrs; rewrite HΣctrs in *; simpl in *.
+    intros Σctrs HΣctrs; rewrite HΣctrs in i; simpl in *.
     subst G. unfold global_ext_levels; simpl. rewrite no_prop_levels_union.
     assert (eq: monomorphic_levels_decl g
                 = levels_of_udecl (universes_decl_of_decl g)). {
@@ -1638,14 +1609,14 @@ Section CheckEnv.
     unfold gc_of_uctx in e. simpl in e.
     case_eq (gc_of_constraints (constraints_of_udecl φ));
       [|intro HH; rewrite HH in e; discriminate e].
-    intros ctrs' Hctrs'. rewrite Hctrs' in *.
+    intros ctrs' Hctrs'. rewrite Hctrs' in e.
     cbn in e. inversion e; subst; clear e.
     unfold global_ext_constraints; simpl.
     rewrite gc_of_constraints_union. rewrite Hctrs'.
     red in i. unfold gc_of_uctx in i; simpl in i.
     case_eq (gc_of_constraints (global_constraints p.1));
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
-    intros Σctrs HΣctrs; rewrite HΣctrs in *; simpl in *.
+    intros Σctrs HΣctrs; rewrite HΣctrs in i; simpl in *.
     subst G. unfold global_ext_levels; simpl. rewrite no_prop_levels_union.
     symmetry; apply add_uctx_make_graph.
   Qed.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -469,8 +469,7 @@ Section TypeOf.
             rewrite subst_instance_constr_it_mkProd_or_LetIn subst_it_mkProd_or_LetIn.
             simpl. rewrite -(app_nil_r (skipn _ _)).
             eapply arity_spine_it_mkProd_or_LetIn_smash; eauto.
-            2:{ simpl. constructor; auto. left; eexists _, _; intuition eauto. pcuic.
-                constructor. reflexivity. }
+            2:{ simpl. constructor; auto. }
             eapply validity_term in Hty; eauto.
             unshelve epose proof (isWAT_mkApps_Ind w decli _ Hty) as [parsubst' [argsubst' [[spars' spargs'] ?]]]; pcuic.
             eapply (subslet_cumul _ _ _ (smash_context [] (subst_context parsubst' 0 

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -157,7 +157,7 @@ Section TypeOf.
     Qed.
     Next Obligation.
       simpl. intros.
-      todo "sort"%string.
+      todo "completeness of reduce_to_sort"%string.
     Qed.
   End SortOf.
 
@@ -694,10 +694,10 @@ Section TypeOf.
   Proof.
     funelim (infer Γ t wt); try solve [simp infer; simpl; try bang; auto].
 
-    simp infer. simpl. f_equal. todo "sorts".
+    simp infer. simpl. f_equal. 
     simp infer. simpl. f_equal. apply H.
     simp infer; simpl; f_equal. apply H.
-    simp infer. simpl. todo "prod".
+    simp infer. simpl. 
     simp infer. eapply infer_clause_1_irrel. revert Heqcall. bang.
   Qed.*)
 


### PR DESCRIPTION
This fills the holes in the safe checker that ensure that we check enough conditions to ensure a case is type-correct. This used to rely on SafeLemmatas that were never proven, up to now :) The last big remaining hole in the safe checker (and all around actually) is checking individual inductive bodies and constructors and showing this corresponds to the wf env conditions, in particular checking cumulativity conditions. 