### PR TITLE
Fix implicitness of proofs about eval

### DIFF
--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -252,7 +252,7 @@ Proof.
   intros axiomfree [T wt].
   intros.
   destruct (erase_correct Σ wfΣ _ _ _ _ _ axiomfree _ H H0 H1 X) as [ev [eg [eg']]].
-  pose proof (Ee.eval_deterministic _ H2 eg'). subst.
+  pose proof (Ee.eval_deterministic H2 eg'). subst.
   eapply erasable_tBox_value; eauto.
 Qed.
 

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -674,6 +674,6 @@ Section Wcbv.
 
 End Wcbv.
 
-Arguments eval_unique_sig {_ _ _ _}.
-Arguments eval_deterministic {_ _ _ _}.
-Arguments eval_unique {_ _ _}.
+Arguments eval_unique_sig {_ _ _ _ _}.
+Arguments eval_deterministic {_ _ _ _ _}.
+Arguments eval_unique {_ _ _ _}.


### PR DESCRIPTION
Tiny fix for something I noticed when updating our stuff for #498.