### PR TITLE
Try to make conversion of projections complete

### DIFF
--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -380,6 +380,19 @@ Section Lemmata.
       + econstructor. assumption.
   Qed.
 
+  Lemma cored_proj :
+    forall Γ p c c',
+      cored Σ Γ c c' ->
+      cored Σ Γ (tProj p c) (tProj p c').
+  Proof.
+    intros Γ p c c' h.
+    induction h in p |- *.
+    - constructor. constructor. assumption.
+    - eapply cored_trans.
+      + eapply IHh.
+      + econstructor. assumption.
+  Qed.
+
   Lemma welltyped_context :
     forall Γ t,
       welltyped Σ Γ (zip t) ->

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -2100,20 +2100,6 @@ Section Conversion.
     intuition eauto.
   Qed.
 
-  (* TODO MOVE to SafeLemmata *)
-  Lemma cored_proj :
-    forall Γ p c c',
-      cored Σ Γ c c' ->
-      cored Σ Γ (tProj p c) (tProj p c').
-  Proof.
-    intros Γ p c c' h.
-    induction h in p |- *.
-    - constructor. constructor. assumption.
-    - eapply cored_trans.
-      + eapply IHh.
-      + econstructor. assumption.
-  Qed.
-
   Opaque reduce_stack.
   Equations(noeqns) _isconv_prog (Γ : context) (leq : conv_pb)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)


### PR DESCRIPTION
@jakobbotsch noticed that the conversion for projection might have been incomplete.
Somehow I think I was confused for a moment why stuck projections wouldn't be handled by the "fallback" but that's not how it works.

So with the new version I tried to stick with what we do for pattern-matching:
- If the two projections are the same, then we compare the bodies, if not we fail (!!! This seems wrong, they could be different bodies but have the same projection right?)
- Otherwise, we reduce both bodies (with δ):
  - If none of them made progress, we fail
  - If at least one of them progressed, we start over comparison with the reduced bodies (using `isconv_red` so that projections might be reduced).

So this seems definitely better, but still not enough. I could of course, add another fallback in the first case, after comparing the bodies, but I don't know what's best really.
I should have a look at the ocaml implementation (or hope that someone who knows tells me hehe).