### PR TITLE
Bidirectional Typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,3 +418,7 @@ erasure/src/pCUICTypeChecker.ml
 erasure/src/pCUICTypeChecker.mli
 erasure/src/pCUICPrimitive.ml
 erasure/src/pCUICPrimitive.mli
+
+bidirectional/CoqMakefile
+
+bidirectional/CoqMakefile.conf

--- a/bidirectional/_CoqProject
+++ b/bidirectional/_CoqProject
@@ -1,6 +1,5 @@
 -R ../template-coq/theories MetaCoq.Template
 -R ../pcuic/theories MetaCoq.PCUIC
--R ../safechecker/theories MetaCoq.SafeChecker
 
 -R theories MetaCoq.Bidirectional
 

--- a/bidirectional/_CoqProject
+++ b/bidirectional/_CoqProject
@@ -1,0 +1,8 @@
+-R ../template-coq/theories MetaCoq.Template
+-R ../pcuic/theories MetaCoq.PCUIC
+-R ../safechecker/theories MetaCoq.SafeChecker
+
+-R theories MetaCoq.Bidirectional
+
+theories/BDEnvironmentTyping.v
+theories/BDTyping.v

--- a/bidirectional/_CoqProject
+++ b/bidirectional/_CoqProject
@@ -6,3 +6,4 @@
 
 theories/BDEnvironmentTyping.v
 theories/BDTyping.v
+theories/BDToPCUIC.v

--- a/bidirectional/_CoqProject
+++ b/bidirectional/_CoqProject
@@ -6,4 +6,4 @@
 theories/BDEnvironmentTyping.v
 theories/BDTyping.v
 theories/BDMinimalTyping.v
-theories/BDToPCUIC.v
+theories/BDMinimalToPCUIC.v

--- a/bidirectional/_CoqProject
+++ b/bidirectional/_CoqProject
@@ -4,6 +4,5 @@
 -R theories MetaCoq.Bidirectional
 
 theories/BDEnvironmentTyping.v
-theories/BDTyping.v
 theories/BDMinimalTyping.v
 theories/BDMinimalToPCUIC.v

--- a/bidirectional/_CoqProject
+++ b/bidirectional/_CoqProject
@@ -5,4 +5,5 @@
 
 theories/BDEnvironmentTyping.v
 theories/BDTyping.v
+theories/BDMinimalTyping.v
 theories/BDToPCUIC.v

--- a/bidirectional/theories/BDEnvironmentTyping.v
+++ b/bidirectional/theories/BDEnvironmentTyping.v
@@ -1,9 +1,6 @@
 From Coq Require Import Ascii String OrderedType Lia.
 From MetaCoq.Template Require Import config utils BasicAst AstUtils.
 From MetaCoq.Template Require Import Universes Environment.
-Import List.ListNotations.
-
-Set Asymmetric Patterns.
 
 Module Lookup (T : Term) (E : EnvironmentSig T).
 
@@ -416,12 +413,17 @@ Module Type Typing (T : Term) (E : EnvironmentSig T) (ET : EnvTypingSig T E).
 
   Parameter Inline smash_context : context -> context -> context.
   Parameter Inline lift_context : nat -> nat -> context -> context.
+  Parameter Inline subst_context : list term -> nat ->  context -> context.
+  Parameter Inline expand_lets : context -> term -> term.
+  Parameter Inline expand_lets_ctx : context -> context -> context.
   Parameter Inline subst_telescope : list term -> nat -> context -> context.
   Parameter Inline subst_instance_context : Instance.t -> context -> context.
   Parameter Inline subst_instance_constr : Instance.t -> term  -> term.
   Parameter Inline lift : nat -> nat -> term -> term.
   Parameter Inline subst : list term -> nat -> term -> term.
   Parameter Inline inds : kername -> Instance.t -> list one_inductive_body -> list term.
+  Parameter Inline extended_subst : context -> nat -> list term. (* Let expansion substitution *)
+  Parameter destArity : term -> option (context * Universe.t).
   
   (* [noccur_between n k t] Checks that deBruijn indices between n and n+k do not appear in t (even under binders).  *)
   Parameter Inline noccur_between : nat -> nat -> term -> bool.
@@ -467,7 +469,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
     Inductive ctx_inst Σ (Γ : context) : list term -> context -> Type :=
     | ctx_inst_nil : ctx_inst Σ Γ [] []
     | ctx_inst_ass na t i inst Δ : 
-      (lift_sorting checking sorting) Σ Γ i (Some t) ->
+      lift_sorting checking sorting Σ Γ i (Some t) ->
       ctx_inst Σ Γ inst (subst_telescope [i] 0 Δ) ->
       ctx_inst Σ Γ (i :: inst) (vass na t :: Δ)
     | ctx_inst_def na b t inst Δ :
@@ -538,30 +540,38 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
         - None of the variable assumptions in Δ refer to any inductive in the block, 
           but the conclusion [concl] is of the form [mkApps (tRel k) args] for k 
           refering to an inductive in the block, and none of the arguments [args]
-          refer to the inductive.          
+          refer to the inductive. #|args| must be the length of the full inductive application.         
       
       Let-in assumptions in Δ are systematically unfolded, i.e. we really consider:
       the zeta-reduction of [t]. *)
     
-    Inductive positive_cstr_arg mdecl i ctx : term -> Type :=
+    Definition ind_realargs (o : one_inductive_body) := 
+      match destArity o.(ind_type) with
+      | Some (ctx, _) => #|smash_context [] ctx|
+      | _ => 0
+      end.
+
+    Inductive positive_cstr_arg mdecl ctx : term -> Type :=
     | positive_cstr_arg_closed t : 
       closedn #|ctx| t ->
-      positive_cstr_arg mdecl i ctx t
+      positive_cstr_arg mdecl ctx t
 
-    | positive_cstr_arg_concl l k : 
+    | positive_cstr_arg_concl l k i : 
       (** Mutual inductive references in the conclusion are ok *)
-      #|ctx| <= i -> i < #|ctx| + #|mdecl.(ind_bodies)| ->
+      #|ctx| <= k -> k < #|ctx| + #|mdecl.(ind_bodies)| ->
       All (closedn #|ctx|) l ->
-      positive_cstr_arg mdecl i ctx (mkApps (tRel k) l)
+      nth_error (List.rev mdecl.(ind_bodies)) (k - #|ctx|) = Some i ->
+      #|l| = ind_realargs i ->
+      positive_cstr_arg mdecl ctx (mkApps (tRel k) l)
 
     | positive_cstr_arg_let na b ty t :
-      positive_cstr_arg mdecl i ctx (subst [b] 0 ty) ->
-      positive_cstr_arg mdecl i ctx (tLetIn na b ty t) 
+      positive_cstr_arg mdecl ctx (subst [b] 0 t) ->
+      positive_cstr_arg mdecl ctx (tLetIn na b ty t) 
 
     | positive_cstr_arg_ass na ty t :
       closedn #|ctx| ty ->
-      positive_cstr_arg mdecl i (vass na ty :: ctx) t ->
-      positive_cstr_arg mdecl i ctx (tProd na ty t).
+      positive_cstr_arg mdecl (vass na ty :: ctx) t ->
+      positive_cstr_arg mdecl ctx (tProd na ty t).
 
     (** A constructor type [t] is positive w.r.t. an inductive block [mdecl]
       and inductive [i] when it's zeta normal-form is of the shape Π Δ. concl and: 
@@ -583,7 +593,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
       positive_cstr mdecl i ctx (tLetIn na b ty t) 
 
     | positive_cstr_ass na ty t :
-      positive_cstr_arg mdecl i ctx ty ->
+      positive_cstr_arg mdecl ctx ty ->
       positive_cstr mdecl i (vass na ty :: ctx) t ->
       positive_cstr mdecl i ctx (tProd na ty t).
 
@@ -592,6 +602,9 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
       | Level.lProp | Level.lSet | Level.Level _ => l
       | Level.Var k => Level.Var (n + k)
       end.
+
+    Definition lift_instance n l :=
+      map (lift_level n) l.
 
     Definition lift_constraint n (c : Level.t * ConstraintType.t * Level.t) :=
       let '((l, r), l') := c in
@@ -604,16 +617,16 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
     Definition level_var_instance n (inst : list name) :=
       mapi_rec (fun i _ => Level.Var i) inst n.
 
-    Fixpoint add_variance (v : list Variance.t) (u u' : Instance.t) cstrs :=
+    Fixpoint variance_cstrs (v : list Variance.t) (u u' : Instance.t) :=
       match v, u, u' with
-      | _, [], [] => cstrs
+      | _, [], [] => ConstraintSet.empty
       | v :: vs, u :: us, u' :: us' => 
         match v with
-        | Variance.Irrelevant => add_variance vs us us' cstrs
-        | Variance.Covariant => add_variance vs us us' (ConstraintSet.add (u, ConstraintType.Le, u') cstrs)
-        | Variance.Invariant => add_variance vs us us' (ConstraintSet.add (u, ConstraintType.Eq, u') cstrs)
+        | Variance.Irrelevant => variance_cstrs vs us us'
+        | Variance.Covariant => ConstraintSet.add (u, ConstraintType.Le, u') (variance_cstrs vs us us')
+        | Variance.Invariant => ConstraintSet.add (u, ConstraintType.Eq, u') (variance_cstrs vs us us')
         end
-      | _, _, _ => (* Impossible *) cstrs
+      | _, _, _ => (* Impossible due to on_variance invariant *) ConstraintSet.empty
       end.
 
     (** This constructs a duplication of the polymorphic universe context of the inductive,  
@@ -622,15 +635,15 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Definition variance_universes univs v :=
       match univs with
-      | Monomorphic_ctx ctx => (univs, [], []) (* Dummy value: impossible case *)
+      | Monomorphic_ctx ctx => None
       | Polymorphic_ctx auctx =>
         let (inst, cstrs) := auctx in
-        let u := level_var_instance #|inst| inst in
         let u' := level_var_instance 0 inst in
+        let u := lift_instance #|inst| u' in
         let cstrs := ConstraintSet.union cstrs (lift_constraints #|inst| cstrs) in
-        let cstra := add_variance v u u' cstrs in
-        let auctx' := (inst ++ inst, cstrs) in
-        (Polymorphic_ctx auctx', u, u')
+        let cstrv := variance_cstrs v u u' in
+        let auctx' := (inst ++ inst, ConstraintSet.union cstrs cstrv) in
+        Some (Polymorphic_ctx auctx', u, u')
       end.
 
     (** A constructor type respects the given variance [v] if each constructor 
@@ -641,17 +654,33 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Definition ind_arities mdecl := arities_context (ind_bodies mdecl).
 
-    Definition respects_variance Σ mdecl v cs :=
+    Definition ind_respects_variance Σ mdecl v indices :=
       let univs := ind_universes mdecl in
-      let '(univs, u, u') := variance_universes univs v in
-      All2_local_env 
-        (on_decl (fun Γ Γ' t t' => cumul (Σ, univs) (ind_arities mdecl ,,, ind_params mdecl ,,, Γ) t t'))
-        (subst_instance_context u (cshape_args cs))
-        (subst_instance_context u' (cshape_args cs)) *
-      All2 
-        (conv (Σ, univs) (ind_arities mdecl ,,, ind_params mdecl ,,, cshape_args cs))
-        (map (subst_instance_constr u) (cshape_indices cs))
-        (map (subst_instance_constr u') (cshape_indices cs)).
+      match variance_universes univs v with
+      | Some (univs, u, u') =>
+        All2_local_env 
+          (on_decl (fun Γ Γ' t t' => 
+            cumul (Σ, univs) (subst_instance_context u (smash_context [] (ind_params mdecl)) ,,, Γ) t t'))
+          (subst_instance_context u (expand_lets_ctx (ind_params mdecl) (smash_context [] indices)))
+          (subst_instance_context u' (expand_lets_ctx (ind_params mdecl) (smash_context [] indices)))
+      | None => False
+      end.
+
+    Definition cstr_respects_variance Σ mdecl v cs :=
+      let univs := ind_universes mdecl in
+      match variance_universes univs v with
+      | Some (univs, u, u') =>
+        All2_local_env 
+          (on_decl (fun Γ Γ' t t' => 
+            cumul (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl)) ,,, Γ) t t'))
+          (subst_instance_context u (expand_lets_ctx (ind_params mdecl) (smash_context [] (cshape_args cs))))
+          (subst_instance_context u' (expand_lets_ctx (ind_params mdecl) (smash_context [] (cshape_args cs)))) *
+        All2 
+          (conv (Σ, univs) (subst_instance_context u (ind_arities mdecl ,,, smash_context [] (ind_params mdecl ,,, cshape_args cs))))
+          (map (subst_instance_constr u ∘ expand_lets (ind_params mdecl ,,, cshape_args cs)) (cshape_indices cs))
+          (map (subst_instance_constr u' ∘ expand_lets (ind_params mdecl ,,, cshape_args cs)) (cshape_indices cs))
+      | None => False (* Monomorphic inductives have no variance attached *)
+      end.
 
     Record on_constructor Σ mdecl i idecl ind_indices cdecl (cshape : constructor_shape) := {
       (* cdecl.1 fresh ?? *)
@@ -689,7 +718,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
       on_ctype_variance : (* The constructor type respect the variance annotation 
         on polymorphic universes, if any. *)
         forall v, ind_variance mdecl = Some v -> 
-        respects_variance Σ mdecl v cshape
+        cstr_respects_variance Σ mdecl v cshape
     }.
 
     Arguments on_ctype {Σ mdecl i idecl ind_indices cdecl cshape}.
@@ -826,6 +855,11 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
         ind_sorts :
           check_ind_sorts Σ mdecl.(ind_params) idecl.(ind_kelim)
                           ind_indices ind_cshapes ind_sort;
+
+        onIndices : 
+          (* The inductive type respect the variance annotation  on polymorphic universes, if any. *)
+          forall v, ind_variance mdecl = Some v -> 
+          ind_respects_variance Σ mdecl v ind_indices
       }.
 
     Definition on_variance univs (variances : option (list Variance.t)) :=
@@ -928,6 +962,13 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
   Arguments onConstructors {_ checking sorting Σ mind mdecl i idecl}.
   Arguments onProjections {_ checking sorting Σ mind mdecl i idecl}.
   Arguments ind_sorts {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments onIndices {_ checking sorting Σ mind mdecl i idecl}.
+
+  Arguments onInductives {_ checking sorting Σ mind mdecl}.
+  Arguments onParams {_ checking sorting Σ mind mdecl}.
+  Arguments onNpars {_ checking sorting Σ mind mdecl}.
+  Arguments onVariance {_ checking sorting Σ mind mdecl}.
+  Arguments onGuard {_ checking sorting Σ mind mdecl}.
 
   Lemma Alli_impl_trans : forall (A : Type) (P Q : nat -> A -> Type) (l : list A) (n : nat),
   Alli P n l -> (forall (n0 : nat) (x : A), P n0 x -> Q n0 x) -> Alli Q n l.

--- a/bidirectional/theories/BDEnvironmentTyping.v
+++ b/bidirectional/theories/BDEnvironmentTyping.v
@@ -1,0 +1,962 @@
+From Coq Require Import Ascii String OrderedType.
+From MetaCoq.Template Require Import config utils BasicAst AstUtils.
+From MetaCoq.Template Require Import Universes Environment.
+Import List.ListNotations.
+
+Set Asymmetric Patterns.
+
+Module Lookup (T : Term) (E : EnvironmentSig T).
+
+  Import T E.
+
+  (** ** Environment lookup *)
+
+  Definition declared_constant (Σ : global_env) (id : kername) decl : Prop :=
+    lookup_env Σ id = Some (ConstantDecl decl).
+
+  Definition declared_minductive Σ mind decl :=
+    lookup_env Σ mind = Some (InductiveDecl decl).
+
+  Definition declared_inductive Σ mdecl ind decl :=
+    declared_minductive Σ (inductive_mind ind) mdecl /\
+    List.nth_error mdecl.(ind_bodies) (inductive_ind ind) = Some decl.
+
+  Definition declared_constructor Σ mdecl idecl cstr cdecl : Prop :=
+    declared_inductive Σ mdecl (fst cstr) idecl /\
+    List.nth_error idecl.(ind_ctors) (snd cstr) = Some cdecl.
+
+  Definition declared_projection Σ mdecl idecl (proj : projection) pdecl
+  : Prop :=
+    declared_inductive Σ mdecl (fst (fst proj)) idecl /\
+    List.nth_error idecl.(ind_projs) (snd proj) = Some pdecl /\
+    mdecl.(ind_npars) = snd (fst proj).
+
+  Definition on_udecl_decl {A} (F : universes_decl -> A) d : A :=
+  match d with
+  | ConstantDecl cb => F cb.(cst_universes)
+  | InductiveDecl mb => F mb.(ind_universes)
+  end.
+
+  Definition monomorphic_udecl_decl := on_udecl_decl monomorphic_udecl.
+
+  Definition monomorphic_levels_decl := fst ∘ monomorphic_udecl_decl.
+
+  Definition monomorphic_constraints_decl := snd ∘ monomorphic_udecl_decl.
+
+  Definition universes_decl_of_decl := on_udecl_decl (fun x => x).
+
+  Definition abstract_instance decl :=
+    match decl with
+    | Monomorphic_ctx _ => Instance.empty
+    | Polymorphic_ctx auctx => UContext.instance (AUContext.repr auctx)
+    end.
+
+  (* Definition LevelSet_add_list l := LevelSet.union (LevelSetProp.of_list l). *)
+
+  Definition global_levels (Σ : global_env) : LevelSet.t :=
+    fold_right
+      (fun decl lvls => LevelSet.union (monomorphic_levels_decl decl.2) lvls)
+      (LevelSet_pair Level.lSet Level.lProp) Σ.
+
+  Lemma global_levels_Set Σ :
+    LevelSet.mem Level.lSet (global_levels Σ) = true.
+  Proof.
+    induction Σ; simpl. reflexivity.
+    apply LevelSet.mem_spec, LevelSet.union_spec; right.
+    now apply LevelSet.mem_spec in IHΣ.
+  Qed.
+
+  Lemma global_levels_Prop Σ :
+    LevelSet.mem Level.lProp (global_levels Σ) = true.
+  Proof.
+    induction Σ; simpl. reflexivity.
+    apply LevelSet.mem_spec, LevelSet.union_spec; right.
+    now apply LevelSet.mem_spec in IHΣ.
+  Qed.
+
+  (** One can compute the constraints associated to a global environment or its
+      extension by folding over its constituent definitions.
+
+      We make *only* the second of these computations an implicit coercion
+      for more readability. Note that [fst_ctx] is also a coercion which goes
+      from a [global_env_ext] to a [global_env]: coercion coherence would *not*
+      be ensured if we added [global_constraints] as well as a coercion, as it
+      would forget the extension's constraints. *)
+
+  Definition global_constraints (Σ : global_env) : ConstraintSet.t :=
+    fold_right (fun decl ctrs =>
+        ConstraintSet.union (monomorphic_constraints_decl decl.2) ctrs
+      ) ConstraintSet.empty Σ.
+
+  Definition global_uctx (Σ : global_env) : ContextSet.t :=
+    (global_levels Σ, global_constraints Σ).
+
+  Definition global_ext_levels (Σ : global_env_ext) : LevelSet.t :=
+    LevelSet.union (levels_of_udecl (snd Σ)) (global_levels Σ.1).
+
+  Definition global_ext_constraints (Σ : global_env_ext) : ConstraintSet.t :=
+    ConstraintSet.union
+      (constraints_of_udecl (snd Σ))
+      (global_constraints Σ.1).
+
+  Coercion global_ext_constraints : global_env_ext >-> ConstraintSet.t.
+
+  Definition global_ext_uctx (Σ : global_env_ext) : ContextSet.t :=
+    (global_ext_levels Σ, global_ext_constraints Σ).
+
+
+  Lemma prop_global_ext_levels Σ : LevelSet.In Level.lProp (global_ext_levels Σ).
+  Proof.
+    destruct Σ as [Σ φ]; cbn.
+    apply LevelSetFact.union_3. cbn -[global_levels]; clear φ.
+    induction Σ.
+    - cbn. now apply LevelSetFact.add_1.
+    - simpl. now apply LevelSetFact.union_3.
+  Qed.
+
+  (** Check that [uctx] instantiated at [u] is consistent with
+    the current universe graph. *)
+
+  Definition consistent_instance `{checker_flags} (lvs : LevelSet.t) (φ : ConstraintSet.t) uctx (u : Instance.t) :=
+    match uctx with
+    | Monomorphic_ctx c => List.length u = 0
+    | Polymorphic_ctx c =>
+      (* no prop levels in instances *)
+      forallb (negb ∘ Level.is_prop) u /\
+      (* levels of the instance already declared *)
+      forallb (fun l => LevelSet.mem l lvs) u /\
+      List.length u = List.length c.1 /\
+      valid_constraints φ (subst_instance_cstrs u c.2)
+    end.
+
+  Definition consistent_instance_ext `{checker_flags} Σ :=
+    consistent_instance (global_ext_levels Σ) (global_ext_constraints Σ).
+
+End Lookup.
+
+Module Type LookupSig (T : Term) (E : EnvironmentSig T).
+  Include Lookup T E.
+End LookupSig.
+
+Module EnvTyping (T : Term) (E : EnvironmentSig T).
+
+  Import T E.
+
+  Section TypeLocal.
+
+    Context (typing : forall (Γ : context), term -> option term -> Type).
+
+    Definition type_local_decl Γ d :=
+      match d.(decl_body) with
+      | Some b => (typing Γ d.(decl_type) None) × (typing Γ b (Some d.(decl_type)))
+      | None => typing Γ d.(decl_type) None
+      end.
+
+    Inductive All_local_env : context -> Type :=
+    | localenv_nil :
+        All_local_env []
+
+    | localenv_cons_abs Γ na t :
+        All_local_env Γ ->
+        type_local_decl Γ (vass na t) ->
+        All_local_env (Γ ,, vass na t)
+
+    | localenv_cons_def Γ na b t :
+        All_local_env Γ ->
+        type_local_decl Γ (vdef na b t) ->
+        All_local_env (Γ ,, vdef na b t).
+
+(*     Inductive All_local_env : context -> Type :=
+    | localenv_nil :
+        All_local_env []
+
+    | localenv_cons Γ d :
+        All_local_env Γ ->
+        type_local_decl Γ d ->
+        All_local_env (Γ ,, d).
+
+    Definition localenv_cons_abs Γ na t HΓ Hd :=
+      localenv_cons Γ (vass na t) HΓ Hd.
+
+    Definition localenv_cons_def Γ na b t HΓ Hd :=
+      localenv_cons Γ (vdef na b t) HΓ Hd. *)
+
+  End TypeLocal.
+
+  Lemma type_local_decl_impl (P Q : context -> term -> option term -> Type) Γ d :
+  type_local_decl P Γ d ->
+  (forall Γ t T, P Γ t T -> Q Γ t T) ->
+  type_local_decl Q Γ d.
+    Proof.
+      destruct d as [? [] ?] ; unfold type_local_decl ; simpl ; intuition.
+    Qed.
+
+  Lemma All_local_env_impl_wf (P Q : context -> term -> option term -> Type) l :
+    All_local_env P l ->
+    (forall Γ t T, All_local_env P Γ -> P Γ t T -> Q Γ t T) ->
+    All_local_env Q l.
+    Proof.
+      induction 1 ; intros; simpl ; econstructor ; cbn in *; intuition eauto.
+    Qed.
+
+  Lemma All_local_env_impl (P Q : context -> term -> option term -> Type) l :
+    All_local_env P l ->
+    (forall Γ t T, P Γ t T -> Q Γ t T) ->
+    All_local_env Q l.
+    Proof.
+      intros ; eapply All_local_env_impl_wf ; eauto.
+    Qed.
+
+  Lemma All_local_env_skipn P Γ : All_local_env P Γ -> forall n, All_local_env P (skipn n Γ).
+    Proof.
+      induction 1; simpl; intros; destruct n; simpl; try econstructor; eauto.
+    Qed.
+    Hint Resolve All_local_env_skipn : wf.
+
+  Arguments localenv_nil {_}.
+(*   Arguments localenv_cons {_ _ _} _ _. *)
+  Arguments localenv_cons_def {_ _ _ _ _} _ _.
+  Arguments localenv_cons_abs {_ _ _ _} _ _.
+
+  Section All2_local_env.
+
+  Definition on_decl (P : context -> context -> term -> term -> Type)
+             (Γ Γ' : context) (b : option (term * term)) (t t' : term) :=
+    match b with
+    | Some (b, b') => (P Γ Γ' b b' * P Γ Γ' t t')%type
+    | None => P Γ Γ' t t'
+    end.
+
+  Section All_local_2.
+    Context (P : forall (Γ Γ' : context), option (term * term) -> term -> term -> Type).
+
+    Inductive All2_local_env : context -> context -> Type :=
+    | localenv2_nil : All2_local_env [] []
+    | localenv2_cons_abs Γ Γ' na na' t t' :
+        All2_local_env Γ Γ' ->
+        P Γ Γ' None t t' ->
+        All2_local_env (Γ ,, vass na t) (Γ' ,, vass na' t')
+    | localenv2_cons_def Γ Γ' na na' b b' t t' :
+        All2_local_env Γ Γ' ->
+        P Γ Γ' (Some (b, b')) t t' ->
+        All2_local_env (Γ ,, vdef na b t) (Γ' ,, vdef na' b' t').
+  End All_local_2.
+
+  Definition on_decl_over (P : context -> context -> term -> term -> Type) Γ Γ' :=
+    fun Δ Δ' => P (Γ ,,, Δ) (Γ' ,,, Δ').
+
+  Definition All2_local_env_over P Γ Γ' := All2_local_env (on_decl (on_decl_over P Γ Γ')).
+
+  Lemma All2_local_env_length {P l l'} : @All2_local_env P l l' -> #|l| = #|l'|.
+  Proof. induction 1; simpl; auto. Qed.
+
+
+  Lemma All2_local_env_impl {P Q : context -> context -> term -> term -> Type} {par par'} :
+    All2_local_env (on_decl P) par par' ->
+    (forall par par' x y, P par par' x y -> Q par par' x y) ->
+    All2_local_env (on_decl Q) par par'.
+  Proof.
+    intros H aux.
+    induction H; constructor. auto. red in p. apply aux, p.
+    apply IHAll2_local_env. red. split.
+    apply aux. apply p. apply aux. apply p.
+  Defined.
+
+  Lemma All2_local_env_app_inv :
+    forall P (Γ Γ' Γl Γr : context),
+      All2_local_env (on_decl P) Γ Γl ->
+      All2_local_env (on_decl (on_decl_over P Γ Γl)) Γ' Γr ->
+      All2_local_env (on_decl P) (Γ ,,, Γ') (Γl ,,, Γr).
+  Proof.
+    induction 2; auto.
+    - simpl. constructor; auto.
+    - simpl. constructor; auto.
+  Qed.
+
+  End All2_local_env.
+
+  (** Well-formedness of local environments embeds a sorting for each variable *)
+
+  Definition lift_sorting
+  (checking : global_env_ext -> context -> term -> term -> Type)
+  (sorting : global_env_ext -> context -> term -> Universe.t -> Type) :
+  (global_env_ext -> context -> term -> option term -> Type) :=
+    fun Σ Γ t T =>
+    match T with
+    | Some T => checking Σ Γ t T
+    | None => { s : Universe.t & sorting Σ Γ t s }
+    end.   
+
+  Definition lift_typing P :=
+    lift_sorting P (fun Σ Γ t s => P Σ Γ t (tSort s)).
+
+  Section TypeLocalOver.
+    Context (checking : global_env_ext -> context -> term -> term -> Type).
+    Context (sorting : global_env_ext -> context -> term -> Universe.t -> Type).
+    Context (cproperty : forall (Σ : global_env_ext) (Γ : context),
+                All_local_env (lift_sorting checking sorting Σ) Γ ->
+                forall (t T : term), checking Σ Γ t T -> Type).
+    Context (sproperty : forall (Σ : global_env_ext) (Γ : context),
+                All_local_env (lift_sorting checking sorting Σ) Γ ->
+                forall (t : term) (s : Universe.t), sorting Σ Γ t s -> Type).
+
+    Inductive type_local_decl_over {Σ Γ} (wfΓ : All_local_env (lift_sorting checking sorting Σ) Γ) :
+    forall (d : context_decl), type_local_decl (lift_sorting checking sorting Σ) Γ d -> Type :=
+    | decl_abs na t : forall H : type_local_decl (lift_sorting checking sorting Σ) Γ (vass na t),
+      sproperty Σ Γ wfΓ _ _ H.π2 -> type_local_decl_over wfΓ (vass na t) H
+    | decl_def na b t : forall H : type_local_decl (lift_sorting checking sorting Σ) Γ (vdef na b t),
+      sproperty Σ Γ wfΓ _ _ H.1.π2 -> cproperty Σ Γ wfΓ _ _ H.2 -> type_local_decl_over wfΓ (vdef na b t) H.
+          
+
+    Inductive All_local_env_over (Σ : global_env_ext) :
+      forall (Γ : context), All_local_env (lift_sorting checking sorting Σ) Γ -> Type :=
+    | localenv_over_nil :
+        All_local_env_over Σ [] localenv_nil
+
+    | localenv_over_cons_abs Γ na t
+        (all : All_local_env (lift_sorting checking sorting Σ) Γ) :
+        All_local_env_over Σ Γ all ->
+        forall (tu : type_local_decl (lift_sorting checking sorting Σ) Γ (vass na t)),
+          type_local_decl_over all (vass na t) tu ->
+          All_local_env_over Σ (Γ ,, vass na t)
+                            (localenv_cons_abs all tu)
+
+    | localenv_over_cons_def Γ na b t
+        (all : All_local_env (lift_sorting checking sorting Σ) Γ) :
+        All_local_env_over Σ Γ all ->
+        forall (tu : type_local_decl (lift_sorting checking sorting Σ) Γ (vdef na b t)),
+          type_local_decl_over all (vdef na b t) tu ->
+          All_local_env_over Σ (Γ ,, vdef na b t)
+                            (localenv_cons_def all tu).
+  End TypeLocalOver.
+
+End EnvTyping.
+
+Module Type EnvTypingSig (T : Term) (E : EnvironmentSig T).
+  Include EnvTyping T E.
+End EnvTypingSig.
+
+Module Type Typing (T : Term) (E : EnvironmentSig T) (ET : EnvTypingSig T E).
+
+  Import T E ET.
+
+  Parameter (ind_guard : mutual_inductive_body -> bool).
+
+  Parameter (conv : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type).
+  Parameter (cumul : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type).
+
+  Parameter (checking : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type).
+  Parameter (sorting : forall `{checker_flags}, global_env_ext -> context -> term -> Universe.t -> Type).
+
+  Notation " Σ ;;; Γ |- t ◃ T " :=
+    (checking Σ Γ t T) (at level 50, Γ, t, T at next level) : type_scope.
+  Notation " Σ ;;; Γ |- t ▸□ u " :=
+      (sorting Σ Γ t u) (at level 50, Γ, t, u at next level) : type_scope.
+
+  Parameter Inline smash_context : context -> context -> context.
+  Parameter Inline lift_context : nat -> nat -> context -> context.
+  Parameter Inline subst_telescope : list term -> nat -> context -> context.
+  Parameter Inline subst_instance_context : Instance.t -> context -> context.
+  Parameter Inline subst_instance_constr : Instance.t -> term  -> term.
+  Parameter Inline lift : nat -> nat -> term -> term.
+  Parameter Inline subst : list term -> nat -> term -> term.
+  Parameter Inline inds : kername -> Instance.t -> list one_inductive_body -> list term.
+  
+  (* [noccur_between n k t] Checks that deBruijn indices between n and n+k do not appear in t (even under binders).  *)
+  Parameter Inline noccur_between : nat -> nat -> term -> bool.
+  Parameter Inline closedn : nat -> term -> bool.
+  
+  Notation wf_local Σ Γ := (All_local_env (lift_sorting checking sorting Σ) Γ).
+
+End Typing.
+
+Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
+  (ET : EnvTypingSig T E) (Ty : Typing T E ET) (L : LookupSig T E).
+
+  Import T E Ty L ET.
+
+  Definition isType `{checker_flags} (Σ : global_env_ext) (Γ : context) (t : term) :=
+    { s : _ & Σ ;;; Γ |- t ▸□ s }.
+
+  (** *** Typing of inductive declarations *)
+
+  Section GlobalMaps.
+
+    Context {cf: checker_flags}.
+    Context (checking : global_env_ext -> context -> term -> term -> Type).
+    Context (sorting : global_env_ext -> context -> term -> Universe.t -> Type).
+
+    Definition on_context Σ ctx :=
+      All_local_env (lift_sorting checking sorting Σ) ctx.
+
+    (** For well-formedness of inductive declarations we need a way to check that a assumptions
+      of a given context is typable in a sort [u]. We also force well-typing of the let-ins
+      in any universe to imply wf_local. *)
+    Fixpoint type_local_ctx Σ (Γ Δ : context) (u : Universe.t) : Type :=
+      match Δ with
+      | [] => True
+      | {| decl_body := None; decl_type := t |} :: Δ =>
+        (type_local_ctx Σ Γ Δ u × (checking Σ (Γ ,,, Δ) t (tSort u)))
+      | {| decl_body := Some b; decl_type := t |} :: Δ =>
+        (type_local_ctx Σ Γ Δ u × (lift_sorting checking sorting Σ (Γ ,,, Δ) b (Some t)))
+      end.
+
+    (* Delta telescope *)
+    Inductive ctx_inst Σ (Γ : context) : list term -> context -> Type :=
+    | ctx_inst_nil : ctx_inst Σ Γ [] []
+    | ctx_inst_ass na t i inst Δ : 
+      (lift_sorting checking sorting) Σ Γ i (Some t) ->
+      ctx_inst Σ Γ inst (subst_telescope [i] 0 Δ) ->
+      ctx_inst Σ Γ (i :: inst) (vass na t :: Δ)
+    | ctx_inst_def na b t inst Δ :
+      ctx_inst Σ Γ inst (subst_telescope [b] 0 Δ) ->
+      ctx_inst Σ Γ inst (vdef na b t :: Δ).
+
+    Implicit Types (mdecl : mutual_inductive_body) (idecl : one_inductive_body) (cdecl : ident * term * nat).
+
+    Definition on_type Σ Γ T := lift_sorting checking sorting Σ Γ T None.
+
+    Definition cdecl_type cdecl := cdecl.1.2.
+    Definition cdecl_args cdecl := cdecl.2.
+
+    (* A constructor shape is a decomposition of a constructor's type *)
+    Record constructor_shape :=
+      { cshape_args : context;
+        (* Arguments (with lets) *)
+
+        cshape_indices : list term;
+        (* Indices of the constructor, whose length should be the real arguments
+        length of the inductive *)
+
+        cshape_sort : Universe.t;
+        (* The sort bounding the arguments context (without lets) *)
+      }.
+
+    Open Scope type_scope.
+
+    (** Positivity checking of the inductive, ensuring that the inductive itself 
+      can only appear at the right of an arrow in each argument's types. *)
+    (*
+    Definition positive_cstr_arg ninds npars narg (arg : term) : bool :=
+      (* We decompose the constructor's arguments' type and verify the inductive references
+        only appear in the conclusion, if any. *)
+      let (ctx, concl) := decompose_prod_assum [] arg in
+      (* Again, we smash the context, as Coq does *)
+      let ctx := smash_context [] ctx in
+      alli (fun i d => noccur_between (npars + narg + i) ninds d.(decl_type)) 0 (List.rev ctx) &&
+      let (hd, args) := decompose_app concl in
+      match hd with
+      | tRel i => 
+        if noccur_between (npars + narg + #|ctx|) ninds (tRel i) then 
+          (* Call to an unrelated variable *)
+          true
+        else (* Recursive call to the inductive *)
+          (* Coq disallows the inductive to be applied to another inductive in the block *)
+          forallb (noccur_between (npars + narg + #|ctx|) ninds) args
+      | tInd ind u => 
+        if forallb (noccur_between (npars + narg + #|ctx|) ninds) args then
+          (* Unrelated inductive *)
+          true
+        else (* Nested inductive *)
+          true
+      end.
+
+    Definition positive_cstr_args ninds npars (args : context) : bool :=
+      alli (fun i decl => positive_cstr_arg nind npars i decl.(decl_type))
+      (* We smash the context, just as Coq's kernel computes positivity on 
+        weak-head normalized types *)
+      (List.rev (smash_context [] args))
+    *)
+
+    (** A constructor argument type [t] is positive w.r.t. an inductive block [mdecl]
+      when it's zeta-normal form is of the shape Π Δ. concl and: 
+        - [t] does not refer to any inductive in the block.
+          In that case [t] must be a closed type under the context of parameters and
+          previous arguments.
+        - None of the variable assumptions in Δ refer to any inductive in the block, 
+          but the conclusion [concl] is of the form [mkApps (tRel k) args] for k 
+          refering to an inductive in the block, and none of the arguments [args]
+          refer to the inductive.          
+      
+      Let-in assumptions in Δ are systematically unfolded, i.e. we really consider:
+      the zeta-reduction of [t]. *)
+    
+    Inductive positive_cstr_arg mdecl i ctx : term -> Type :=
+    | positive_cstr_arg_closed t : 
+      closedn #|ctx| t ->
+      positive_cstr_arg mdecl i ctx t
+
+    | positive_cstr_arg_concl l k : 
+      (** Mutual inductive references in the conclusion are ok *)
+      #|ctx| <= i -> i < #|ctx| + #|mdecl.(ind_bodies)| ->
+      All (closedn #|ctx|) l ->
+      positive_cstr_arg mdecl i ctx (mkApps (tRel k) l)
+
+    | positive_cstr_arg_let na b ty t :
+      positive_cstr_arg mdecl i ctx (subst [b] 0 ty) ->
+      positive_cstr_arg mdecl i ctx (tLetIn na b ty t) 
+
+    | positive_cstr_arg_ass na ty t :
+      closedn #|ctx| ty ->
+      positive_cstr_arg mdecl i (vass na ty :: ctx) t ->
+      positive_cstr_arg mdecl i ctx (tProd na ty t).
+
+    (** A constructor type [t] is positive w.r.t. an inductive block [mdecl]
+      and inductive [i] when it's zeta normal-form is of the shape Π Δ. concl and: 
+        - All of the arguments in Δ are positive.
+        - The conclusion is of the shape [mkApps (tRel k) indices] 
+          where [k] refers to the current inductive [i] and [indices] does not mention
+          any of the inductive types in the block. I.e. [indices] are closed terms
+          in [params ,,, args]. *)
+          
+    Inductive positive_cstr mdecl i (ctx : context) : term -> Type :=
+    | positive_cstr_concl indices :
+      let headrel : nat := 
+        (#|mdecl.(ind_bodies)| - S i + #|ctx|)%nat in
+      All (closedn #|ctx|) indices ->
+      positive_cstr mdecl i ctx (mkApps (tRel headrel) indices)
+
+    | positive_cstr_let na b ty t :
+      positive_cstr mdecl i ctx (subst [b] 0 t) ->
+      positive_cstr mdecl i ctx (tLetIn na b ty t) 
+
+    | positive_cstr_ass na ty t :
+      positive_cstr_arg mdecl i ctx ty ->
+      positive_cstr mdecl i (vass na ty :: ctx) t ->
+      positive_cstr mdecl i ctx (tProd na ty t).
+
+    Definition lift_level n l :=
+      match l with 
+      | Level.lProp | Level.lSet | Level.Level _ => l
+      | Level.Var k => Level.Var (n + k)
+      end.
+
+    Definition lift_constraint n (c : Level.t * ConstraintType.t * Level.t) :=
+      let '((l, r), l') := c in
+      ((lift_level n l, r), lift_level n l').
+
+    Definition lift_constraints n cstrs :=
+      ConstraintSet.fold (fun elt acc => ConstraintSet.add (lift_constraint n elt) acc)
+        cstrs ConstraintSet.empty.
+
+    Definition level_var_instance n (inst : list name) :=
+      mapi_rec (fun i _ => Level.Var i) inst n.
+
+    Fixpoint add_variance (v : list Variance.t) (u u' : Instance.t) cstrs :=
+      match v, u, u' with
+      | _, [], [] => cstrs
+      | v :: vs, u :: us, u' :: us' => 
+        match v with
+        | Variance.Irrelevant => add_variance vs us us' cstrs
+        | Variance.Covariant => add_variance vs us us' (ConstraintSet.add (u, ConstraintType.Le, u') cstrs)
+        | Variance.Invariant => add_variance vs us us' (ConstraintSet.add (u, ConstraintType.Eq, u') cstrs)
+        end
+      | _, _, _ => (* Impossible *) cstrs
+      end.
+
+    (** This constructs a duplication of the polymorphic universe context of the inductive,  
+      where the two instances are additionally related according to the variance information.
+    *)
+
+    Definition variance_universes univs v :=
+      match univs with
+      | Monomorphic_ctx ctx => (univs, [], []) (* Dummy value: impossible case *)
+      | Polymorphic_ctx auctx =>
+        let (inst, cstrs) := auctx in
+        let u := level_var_instance #|inst| inst in
+        let u' := level_var_instance 0 inst in
+        let cstrs := ConstraintSet.union cstrs (lift_constraints #|inst| cstrs) in
+        let cstra := add_variance v u u' cstrs in
+        let auctx' := (inst ++ inst, cstrs) in
+        (Polymorphic_ctx auctx', u, u')
+      end.
+
+    (** A constructor type respects the given variance [v] if each constructor 
+        argument respects it and each index (in the conclusion) does as well.
+        We formalize this by asking for a cumulativity relation between the contexts
+        of arguments and conversion of the lists of indices instanciated with [u] and 
+        [u'] where [u `v` u']. *)
+
+    Definition ind_arities mdecl := arities_context (ind_bodies mdecl).
+
+    Definition respects_variance Σ mdecl v cs :=
+      let univs := ind_universes mdecl in
+      let '(univs, u, u') := variance_universes univs v in
+      All2_local_env 
+        (on_decl (fun Γ Γ' t t' => cumul (Σ, univs) (ind_arities mdecl ,,, ind_params mdecl ,,, Γ) t t'))
+        (subst_instance_context u (cshape_args cs))
+        (subst_instance_context u' (cshape_args cs)) *
+      All2 
+        (conv (Σ, univs) (ind_arities mdecl ,,, ind_params mdecl ,,, cshape_args cs))
+        (map (subst_instance_constr u) (cshape_indices cs))
+        (map (subst_instance_constr u') (cshape_indices cs)).
+
+    Record on_constructor Σ mdecl i idecl ind_indices cdecl (cshape : constructor_shape) := {
+      (* cdecl.1 fresh ?? *)
+      cstr_args_length : context_assumptions (cshape_args cshape) = cdecl_args cdecl;
+      
+      (* Real (non-let) arguments bound by the constructor *)
+      cstr_concl_head := tRel (#|mdecl.(ind_bodies)|
+      - S i
+      + #|mdecl.(ind_params)|
+      + #|cshape_args cshape|);
+      (* Conclusion head: reference to the current inductive in the block *)
+
+      cstr_eq : cdecl_type cdecl =
+       it_mkProd_or_LetIn mdecl.(ind_params)
+                          (it_mkProd_or_LetIn (cshape_args cshape)
+                              (mkApps cstr_concl_head
+                              (to_extended_list_k mdecl.(ind_params) #|cshape_args cshape|
+                                ++ cshape_indices cshape)));
+      (* The type of the constructor canonically has this shape: parameters, real
+        arguments ending with a reference to the inductive applied to the
+        (non-lets) parameters and arguments *)
+
+      on_ctype : on_type Σ (arities_context mdecl.(ind_bodies)) (cdecl_type cdecl);
+      on_cargs : (* FIXME: there is some redundancy with the type_local_ctx *)
+        type_local_ctx Σ (arities_context mdecl.(ind_bodies) ,,, mdecl.(ind_params))
+                      cshape.(cshape_args) cshape.(cshape_sort);
+      on_cindices : 
+        ctx_inst Σ (arities_context mdecl.(ind_bodies) ,,, mdecl.(ind_params) ,,, cshape.(cshape_args))
+                      cshape.(cshape_indices)
+                      (List.rev (lift_context #|cshape.(cshape_args)| 0 ind_indices));
+
+      on_ctype_positive : (* The constructor type is positive *)
+        positive_cstr mdecl i [] (cdecl_type cdecl);
+
+      on_ctype_variance : (* The constructor type respect the variance annotation 
+        on polymorphic universes, if any. *)
+        forall v, ind_variance mdecl = Some v -> 
+        respects_variance Σ mdecl v cshape
+    }.
+
+    Arguments on_ctype {Σ mdecl i idecl ind_indices cdecl cshape}.
+    Arguments on_cargs {Σ mdecl i idecl ind_indices cdecl cshape}.
+    Arguments on_cindices {Σ mdecl i idecl ind_indices cdecl cshape}.
+    Arguments cstr_args_length {Σ mdecl i idecl ind_indices cdecl cshape}.
+    Arguments cstr_eq {Σ mdecl i idecl ind_indices cdecl cshape}.
+
+    Definition on_constructors Σ mdecl i idecl ind_indices :=
+      All2 (on_constructor Σ mdecl i idecl ind_indices).
+
+    (** Each projection type corresponds to a non-let argument of the 
+        corresponding constructor. It is parameterized over the 
+        parameters of the inductive type and all the preceding arguments
+        of the constructor. When computing the type of a projection for argument
+        [n] at a given instance of the parameters and a given term [t] in the inductive
+        type, we instantiate the argument context by corresponsping projections
+        [t.π1 ... t.πn-1]. This is essential for subject reduction to hold: each
+        projections type can only refer to the record object through projections.
+    
+      Projection types have their parameter and argument contexts smashed to avoid
+      costly computations during type-checking and reduction: we can just substitute
+      the instances of parameters and the inductive value without considering the 
+      presence of let bindings. *)
+
+    Fixpoint projs ind npars k :=
+      match k with
+      | 0 => []
+      | S k' => (tProj ((ind, npars), k') (tRel 0)) :: projs ind npars k'
+      end.
+
+    Lemma projs_length ind npars k : #|projs ind npars k| = k.
+    Proof. induction k; simpl; auto. Qed.
+
+    Definition on_projection mdecl mind i cshape (k : nat) (p : ident * term) :=
+      let Γ := smash_context [] (cshape.(cshape_args) ++ mdecl.(ind_params)) in
+      match nth_error Γ (context_assumptions cshape.(cshape_args) - S k) with
+      | None => False
+      | Some decl => 
+        let u := abstract_instance mdecl.(ind_universes) in
+        let ind := {| inductive_mind := mind; inductive_ind := i |} in
+        (** The stored projection type already has the references to the inductive
+          type substituted along with the previous arguments replaced by projections.
+          All projections must also be named.
+          *)
+        (decl_name decl = nNamed (fst p)) /\
+        (snd p = subst (inds mind u mdecl.(ind_bodies)) (S (ind_npars mdecl))
+              (subst (projs ind mdecl.(ind_npars) k) 0 
+                (lift 1 k (decl_type decl))))
+      end.
+
+    Record on_projections mdecl mind i idecl (ind_indices : context) cshape :=
+      { on_projs_record : #|idecl.(ind_ctors)| = 1;
+        (** The inductive must be a record *)
+
+        on_projs_noidx : #|ind_indices| = 0;
+        (** The inductive cannot have indices *)
+
+        on_projs_elim : idecl.(ind_kelim) = InType;
+        (** This ensures that all projections are definable *)
+
+        on_projs_all : #|idecl.(ind_projs)| = context_assumptions (cshape_args cshape);
+        (** There are as many projections as (non-let) constructor arguments *)
+
+        on_projs : Alli (on_projection mdecl mind i cshape) 0 idecl.(ind_projs) }.
+
+    Definition check_constructors_smaller φ cshapes ind_sort :=
+      Forall (fun s => leq_universe φ (cshape_sort s) ind_sort) cshapes.
+
+    (** This ensures that all sorts in kelim are lower
+        or equal to the top elimination sort, if set.
+        For inductives in Type we do not check [kelim] currently. *)
+
+    Fixpoint elim_sort_prop_ind ind_ctors_sort :=
+      match ind_ctors_sort with
+      | [] => (* Empty inductive proposition: *) InType
+      | [ s ] => match universe_family (cshape_sort s) with
+                | InProp => (* Not squashed: all arguments are in Prop  *)
+                  (* This is singleton elimination *) InType
+                | _ => (* Squashed: some arguments are higher than Prop,
+                        restrict to Prop *) InProp
+                end
+      | _ => (* Squashed: at least 2 constructors *) InProp
+      end.
+
+    Definition check_ind_sorts (Σ : global_env_ext)
+              params kelim ind_indices cshapes ind_sort : Type :=
+      match universe_family ind_sort with
+      | InProp =>
+        (** The inductive is declared in the impredicative sort Prop *)
+        (** No universe-checking to do: any size of constructor argument is allowed,
+            however elimination restrictions apply. *)
+        leb_sort_family kelim (elim_sort_prop_ind cshapes)
+      | _ =>
+        (** The inductive is predicative: check that all constructors arguments are
+            smaller than the declared universe. *)
+        check_constructors_smaller Σ cshapes ind_sort
+        × if indices_matter then
+            type_local_ctx Σ params ind_indices ind_sort
+          else True
+      end.
+
+    Record on_ind_body Σ mind mdecl i idecl :=
+      { (** The type of the inductive must be an arity, sharing the same params
+            as the rest of the block, and maybe having a context of indices. *)
+        ind_indices : context;
+        ind_sort : Universe.t;
+        ind_arity_eq : idecl.(ind_type)
+                      = it_mkProd_or_LetIn mdecl.(ind_params)
+                                (it_mkProd_or_LetIn ind_indices (tSort ind_sort));
+
+        (** It must be well-typed in the empty context. *)
+        onArity : on_type Σ [] idecl.(ind_type);
+
+        (** The decompose shapes of each constructor *)
+        ind_cshapes : list constructor_shape;
+
+        (** Constructors are well-typed *)
+        onConstructors :
+          on_constructors Σ mdecl i idecl ind_indices idecl.(ind_ctors) ind_cshapes;
+
+        (** Projections, if any, are well-typed *)
+        onProjections :
+          idecl.(ind_projs) <> [] ->
+          match ind_cshapes return Type with
+          | [ o ] =>
+            on_projections mdecl mind i idecl ind_indices o
+          | _ => False
+          end;
+
+        (** The universes and elimination sorts must be correct w.r.t.
+            the universe of the inductive and the universes in its constructors, which
+            are declared in [on_constructors]. *)
+        ind_sorts :
+          check_ind_sorts Σ mdecl.(ind_params) idecl.(ind_kelim)
+                          ind_indices ind_cshapes ind_sort;
+      }.
+
+    Definition on_variance univs (variances : option (list Variance.t)) :=
+      match univs with
+      | Monomorphic_ctx _ => variances = None
+      | Polymorphic_ctx auctx => 
+        match variances with
+        | None => True
+        | Some v => List.length v = #|UContext.instance (AUContext.repr auctx)|
+        end
+      end.
+    
+    (** We allow empty blocks for simplicity
+        (no well-typed reference to them can be made). *)
+
+    Record on_inductive Σ mind mdecl :=
+      { onInductives : Alli (on_ind_body Σ mind mdecl) 0 mdecl.(ind_bodies);
+        (** We check that the context of parameters is well-formed and that
+            the size annotation counts assumptions only (no let-ins). *)
+        onParams : on_context Σ mdecl.(ind_params);
+        onNpars : context_assumptions mdecl.(ind_params) = mdecl.(ind_npars);
+        onVariance : on_variance mdecl.(ind_universes) mdecl.(ind_variance);
+        onGuard : ind_guard mdecl
+      }.
+
+    (** *** Typing of constant declarations *)
+
+    Definition on_constant_decl Σ d :=
+      match d.(cst_body) with
+      | Some trm => lift_sorting checking sorting Σ [] trm (Some d.(cst_type))
+      | None => on_type Σ [] d.(cst_type)
+      end.
+
+    Definition on_global_decl Σ kn decl :=
+      match decl with
+      | ConstantDecl d => on_constant_decl Σ d
+      | InductiveDecl inds => on_inductive Σ kn inds
+      end.
+
+    (** *** Typing of global environment
+
+        All declarations should be typeable and the global
+        set of universe constraints should be consistent. *)
+
+    (** Well-formed global environments have no name clash. *)
+
+    Definition fresh_global (s : kername) : global_env -> Prop :=
+      Forall (fun g => g.1 <> s).
+
+    Definition satisfiable_udecl `{checker_flags} Σ φ
+      := consistent (global_ext_constraints (Σ, φ)).
+
+    (* Check that: *)
+    (*   - declared levels are fresh *)
+    (*   - all levels used in constraints are declared *)
+    (*   - level used in monomorphic contexts are only monomorphic *)
+    Definition on_udecl `{checker_flags} Σ (udecl : universes_decl)
+      := let levels := levels_of_udecl udecl in
+        let global_levels := global_levels Σ in
+        let all_levels := LevelSet.union levels global_levels in
+        LevelSet.For_all (fun l => ~ LevelSet.In l global_levels) levels
+        /\ ConstraintSet.For_all (fun '(l1,_,l2) => LevelSet.In l1 all_levels
+                                                /\ LevelSet.In l2 all_levels)
+                                (constraints_of_udecl udecl)
+        /\ match udecl with
+          | Monomorphic_ctx ctx =>  LevelSet.for_all (negb ∘ Level.is_var) ctx.1
+          | _ => True
+          end
+        /\ satisfiable_udecl Σ udecl.
+
+
+    Inductive on_global_env `{checker_flags} : global_env -> Type :=
+    | globenv_nil : on_global_env []
+    | globenv_decl Σ kn d :
+        on_global_env Σ ->
+        fresh_global kn Σ ->
+        let udecl := universes_decl_of_decl d in
+        on_udecl Σ udecl ->
+        on_global_decl (Σ, udecl) kn d ->
+        on_global_env (Σ ,, (kn, d)).
+
+    Definition on_global_env_ext `{checker_flags} (Σ : global_env_ext) :=
+      on_global_env Σ.1 × on_udecl Σ.1 Σ.2.
+
+  End GlobalMaps.
+
+  Arguments cstr_args_length {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+  Arguments cstr_eq {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+  Arguments on_ctype {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+  Arguments on_cargs {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+  Arguments on_cindices {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+  Arguments on_ctype_positive {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+  Arguments on_ctype_variance {_ checking sorting Σ mdecl i idecl ind_indices cdecl cshape}.
+
+  Arguments ind_indices {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments ind_sort {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments ind_arity_eq {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments ind_cshapes {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments onArity {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments onConstructors {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments onProjections {_ checking sorting Σ mind mdecl i idecl}.
+  Arguments ind_sorts {_ checking sorting Σ mind mdecl i idecl}.
+
+  Lemma Alli_impl_trans : forall (A : Type) (P Q : nat -> A -> Type) (l : list A) (n : nat),
+  Alli P n l -> (forall (n0 : nat) (x : A), P n0 x -> Q n0 x) -> Alli Q n l.
+  Proof.
+    intros. induction X; simpl; constructor; auto.
+  Defined.
+
+  Lemma type_local_ctx_impl (P P' : global_env_ext -> context -> term -> term -> Type) Q Q' Σ Γ Δ u :
+    type_local_ctx P Q Σ Γ Δ u ->
+    (forall Γ t T, P Σ Γ t T -> P' Σ Γ t T) ->
+    (forall Γ t u, Q Σ Γ t u -> Q' Σ Γ t u) ->
+    type_local_ctx P' Q' Σ Γ Δ u.
+  Proof.
+    intros HPQ HP HQ. revert HPQ; induction Δ in Γ, HP, HQ |- *; simpl; auto.
+    destruct a as [na [b|] ty]; simpl; auto.
+    intros. intuition auto. intuition auto.
+  Qed.
+
+  (** This predicate enforces that there exists typing derivations for every typable term in env. *)
+
+  Definition Forall_decls_typing `{checker_flags}
+            (checking : global_env_ext -> context -> term -> term -> Type)
+            (sorting : global_env_ext -> context -> term -> Universe.t -> Type)
+    := on_global_env checking sorting.
+
+  (** ** Induction principle for typing up-to a global environment *)
+
+  (* Lemma refine_type `{checker_flags} Σ Γ t T U : Σ ;;; Γ |- t : T -> T = U -> Σ ;;; Γ |- t : U.
+  Proof. now intros Ht ->. Qed. *)
+
+  Section wf_local.
+    Context `{checker_flags}.
+
+    Definition wf_local_rel Σ Γ Γ'
+      := (All_local_env (lift_sorting
+        (fun Σ0 Γ0 t T => Σ0 ;;; Γ ,,, Γ0 |- t ◃ T) 
+        (fun Σ0 Γ0 t u => Σ0 ;;; Γ ,,, Γ0 |- t ▸□ u)
+        Σ) Γ').
+
+    Definition wf_local_rel_nil {Σ Γ} : wf_local_rel Σ Γ []
+      := localenv_nil.
+
+    Definition wf_local_rel_abs {Σ Γ Γ' A na} :
+      wf_local_rel Σ Γ Γ' -> {u & Σ ;;; Γ ,,, Γ' |- A ▸□ u }
+      -> wf_local_rel Σ Γ (Γ',, vass na A)
+      := localenv_cons_abs.
+
+    Definition wf_local_rel_def {Σ Γ Γ' t A na} :
+      wf_local_rel Σ Γ Γ' ->
+      isType Σ (Γ ,,, Γ') A ->
+      Σ ;;; Γ ,,, Γ' |- t ◃ A ->
+      wf_local_rel Σ Γ (Γ',, vdef na t A)
+      := fun wfΓ' HA Ht => localenv_cons_def wfΓ' (HA,Ht).
+
+    Lemma wf_local_rel_local :
+      forall Σ Γ,
+        wf_local Σ Γ ->
+        wf_local_rel Σ [] Γ.
+    Proof.
+      intros Σ Γ h. eapply All_local_env_impl.
+      - exact h.
+      - intros Δ t [] h'.
+        all: cbn.
+        + rewrite app_context_nil_l. assumption.
+        + rewrite app_context_nil_l. assumption.
+    Defined.
+
+    Lemma wf_local_local_rel Σ Γ :
+      wf_local_rel Σ [] Γ -> wf_local Σ Γ.
+    Proof.
+      intro X. eapply All_local_env_impl. exact X.
+      intros Γ0 t [] XX; cbn in XX; rewrite app_context_nil_l in XX; assumption.
+    Defined.
+
+  End wf_local.
+
+  Section wf_local_size.
+    Context `{checker_flags} (Σ : global_env_ext).
+    Context (csize : forall (Σ : global_env_ext) (Γ : context) (t T : term), checking Σ Γ t T -> size).
+    Context (ssize : forall (Σ : global_env_ext) (Γ : context) (t : term) (u : Universe.t), sorting Σ Γ t u -> size).
+
+    Fixpoint wf_local_size Γ (w : wf_local Σ Γ) : size :=
+      match w with
+      | localenv_nil => 0
+
+      | localenv_cons_abs Γ na t wfΓ tty =>
+        (ssize _ _ t _ (projT2 tty) + wf_local_size _ wfΓ)%nat
+
+      | localenv_cons_def Γ na b t wfΓ tty =>
+        (ssize _ _ t _ tty.1.π2 + csize _ _ b t tty.2 + wf_local_size _ wfΓ)%nat
+      end.
+  End wf_local_size.
+
+End DeclarationTyping.

--- a/bidirectional/theories/BDEnvironmentTyping.v
+++ b/bidirectional/theories/BDEnvironmentTyping.v
@@ -1,4 +1,4 @@
-From Coq Require Import Ascii String OrderedType.
+From Coq Require Import Ascii String OrderedType Lia.
 From MetaCoq.Template Require Import config utils BasicAst AstUtils.
 From MetaCoq.Template Require Import Universes Environment.
 Import List.ListNotations.
@@ -396,13 +396,13 @@ Module Type Typing (T : Term) (E : EnvironmentSig T) (ET : EnvTypingSig T E).
 
   Import T E ET.
 
-  Parameter (ind_guard : mutual_inductive_body -> bool).
+  Parameter Inline ind_guard : mutual_inductive_body -> bool.
 
-  Parameter (conv : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type).
-  Parameter (cumul : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type).
+  Parameter Inline conv : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type.
+  Parameter Inline cumul : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type.
 
-  Parameter (checking : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type).
-  Parameter (sorting : forall `{checker_flags}, global_env_ext -> context -> term -> Universe.t -> Type).
+  Parameter Inline checking : forall `{checker_flags}, global_env_ext -> context -> term -> term -> Type.
+  Parameter Inline sorting : forall `{checker_flags}, global_env_ext -> context -> term -> Universe.t -> Type.
 
   Notation " Σ ;;; Γ |- t ◃ T " :=
     (checking Σ Γ t T) (at level 50, Γ, t, T at next level) : type_scope.
@@ -982,10 +982,16 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Fixpoint All_local_env_size Γ (w : All_local_env (lift_sorting checking sorting Σ) Γ) : size :=
       match w with
-      | localenv_nil => 0
+      | localenv_nil => 1
       | localenv_cons_abs Γ na t wfΓ h => ssize _ _ _ _ h.π2 + All_local_env_size _ wfΓ
       | localenv_cons_def Γ na b t wfΓ h => ssize _ _ _ _ h.1.π2 + csize _ _ _ _ h.2 + All_local_env_size _ wfΓ
       end.
+
+    Lemma All_local_env_size_pos Γ w : 0 < All_local_env_size Γ w.
+    Proof.
+      induction w.
+      all: simpl ; lia.
+    Qed.
 
   End All_local_env_size.
 
@@ -1014,6 +1020,11 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Definition wf_local_size Γ (w : wf_local Σ Γ) : size :=
       All_local_env_size checking sorting csize ssize Σ Γ w.
+
+    Lemma wf_local_size_pos Γ w : 0 < wf_local_size Γ w.
+    Proof.
+      apply All_local_env_size_pos.
+    Qed.
 
     Definition wf_local_rel_size Γ Γ' (w : wf_local_rel Σ Γ Γ') : size :=
       All_local_env_rel_size checking sorting csize ssize Σ Γ Γ' w. 

--- a/bidirectional/theories/BDEnvironmentTyping.v
+++ b/bidirectional/theories/BDEnvironmentTyping.v
@@ -455,6 +455,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
     Inductive ctx_inst Σ (Γ : context) : list term -> context -> Type :=
     | ctx_inst_nil : ctx_inst Σ Γ [] []
     | ctx_inst_ass na t i inst Δ : 
+      lift_sorting checking sorting Σ Γ t None ->
       lift_sorting checking sorting Σ Γ i (Some t) ->
       ctx_inst Σ Γ inst (subst_telescope [i] 0 Δ) ->
       ctx_inst Σ Γ (i :: inst) (vass na t :: Δ)
@@ -888,8 +889,9 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Definition on_constant_decl Σ d :=
       match d.(cst_body) with
-      | Some trm => lift_sorting checking sorting Σ [] trm (Some d.(cst_type))
-      | None => on_type Σ [] d.(cst_type)
+      | Some b => (lift_sorting checking sorting Σ [] d.(cst_type) None) ×
+                  (lift_sorting checking sorting Σ [] b (Some d.(cst_type)))
+      | None => (lift_sorting checking sorting Σ [] d.(cst_type) None)
       end.
 
     Definition on_global_decl Σ kn decl :=

--- a/bidirectional/theories/BDMinimalToPCUIC.v
+++ b/bidirectional/theories/BDMinimalToPCUIC.v
@@ -307,7 +307,7 @@ Proof.
   - clear H4.
     induction X4.
     all: constructor ; auto.
-    destruct r as (? & ? & ? & ? & ?).
+    destruct r as (? & (? & ? & ?) & ? & ?).
     repeat split ; auto.
     apply p1 ; auto.
     all: eexists.

--- a/bidirectional/theories/BDMinimalToPCUIC.v
+++ b/bidirectional/theories/BDMinimalToPCUIC.v
@@ -1,0 +1,491 @@
+From Coq Require Import Bool List Arith Lia.
+From MetaCoq.Template Require Import config utils monad_utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping PCUICInversion PCUICInductiveInversion.
+From MetaCoq.PCUIC Require Import PCUICWeakening PCUICClosed PCUICSubstitution PCUICPrincipality PCUICValidity PCUICCumulativity.
+From MetaCoq.PCUIC Require Import PCUICWfUniverses PCUICSR.
+From MetaCoq.Bidirectional Require Import BDEnvironmentTyping BDMinimalTyping.
+
+Require Import ssreflect.
+From Equations Require Import Equations.
+Require Import Equations.Prop.DepElim.
+
+Module PT := PCUIC.PCUICTyping.
+Module MT := Bidirectional.BDMinimalTyping.
+
+Section BDMinimalToPCUICTyping.
+
+  Let Pcheck `{checker_flags} Σ Γ t T :=
+    PT.wf_local Σ Γ -> PT.isType Σ Γ T -> Σ ;;; Γ |- t : T.
+
+  Let Pinfer `{checker_flags} Σ Γ t T :=
+    PT.wf_local Σ Γ -> Σ ;;; Γ |- t : T.
+
+  Let Psort `{checker_flags} Σ Γ t u :=
+    PT.wf_local Σ Γ -> Σ ;;; Γ |- t : (tSort u).
+
+  Let Pprod `{checker_flags} Σ Γ t na A B :=
+    PT.wf_local Σ Γ -> Σ ;;; Γ |- t : tProd na A B.
+
+  Let Pind `{checker_flags} Σ Γ ind t u args :=
+    PT.wf_local Σ Γ -> Σ ;;; Γ |- t : mkApps (tInd ind u) args.
+
+  Let PΓ `{checker_flags} Σ Γ (wfΓ : wf_local Σ Γ) :=
+    PT.wf_local Σ Γ.
+
+  Lemma wf_arities_context' {cf:checker_flags}:
+    forall (Σ : global_env_ext) (mdecl : mutual_inductive_body),
+      PT.wf Σ ->
+      All (fun idecl => PT.on_type (PT.lift_typing typing) Σ [] (ind_type idecl)) (ind_bodies mdecl) ->
+      PT.wf_local Σ (arities_context (ind_bodies mdecl)).
+  Proof.
+    intros Σ mdecl wfΣ Hdecl.
+    unfold arities_context.
+    revert Hdecl.
+    induction (ind_bodies mdecl) using rev_ind. 1: constructor.
+    intros Ha.
+    rewrite rev_map_app.
+    simpl.    
+    apply All_app in Ha as [Hl Hx].
+    inv Hx. clear X0.
+    destruct X as [s Hs].
+    specialize (IHl Hl).
+    econstructor; eauto.
+    fold (arities_context l) in *.
+    unshelve epose proof (weakening Σ [] (arities_context l) _ _ wfΣ _ Hs).
+    1: now rewrite app_context_nil_l.
+    simpl in X.
+    simpl.
+    eapply (env_prop_typing _ _ typecheck_closed) in Hs; eauto.
+    rewrite -> andb_and in Hs. destruct Hs as [Hs Ht].
+    simpl in Hs. apply (lift_closed #|arities_context l|) in Hs.
+    rewrite -> Hs, app_context_nil_l in X. simpl. exists s.
+    apply X.
+  Qed.
+
+Lemma bd_wf_local `{checker_flags} Σ Γ (all: wf_local Σ Γ) :
+  MT.All_local_env_over_sorting checking infering_sort 
+    (fun Σ Γ _ t T _ => Pcheck Σ Γ t T)
+    (fun Σ Γ _ t u _ => Psort Σ Γ t u) 
+    Σ Γ all ->
+  PT.wf_local Σ Γ.
+Proof.
+  intros allo ; induction allo.
+  all: constructor.
+  1,3: assumption.
+  all: red.
+  - simpl in t0. eexists.
+    auto.
+  - destruct t0. eexists.
+    auto.
+  - destruct t0.
+    apply p0 ; auto.
+    eexists. red. auto.
+Qed.
+
+Lemma type_local_ctx_impl `{checker_flags} Σ Γ Δ u (wfΓ : PT.wf_local Σ Γ):
+  type_local_ctx Pcheck Psort Σ Γ Δ u -> PT.type_local_ctx (lift_typing typing) Σ Γ Δ u.
+Proof.
+  intros HΔ.
+  induction Δ as [|[? []]].
+  1: auto.
+  all: simpl.
+  1: destruct HΔ as ((?&[])&?).
+  2: destruct HΔ.
+  all: have wfΓΔ : PT.wf_local Σ (Γ ,,, Δ) by eapply PCUICContexts.type_local_ctx_wf_local ; eauto.
+  all: repeat split ; auto.
+  ++ eexists. eauto.
+  ++ apply l.
+     2: eexists ; eapply p.
+     all: eauto.
+Qed.
+
+Lemma bd_wf `{checker_flags} Σ : Forall_decls_sorting Pcheck Psort Σ -> PT.wf Σ.
+Proof.
+  intros wfΣ. induction wfΣ.
+  all: constructor.
+  - assumption.
+  - assumption.
+  - constructor ; intuition.
+  - destruct d as [[? [] ?]|].
+    + inversion o0 as [[u Hty] Hb].
+      apply Hb.
+      1: constructor.
+      exists u.
+      simpl.
+      eapply Hty.
+      constructor.
+    + inversion o0. eexists.
+      eauto.
+    + destruct o0.
+      have wf_arities : PT.wf_local (Σ,udecl) (arities_context (ind_bodies m)).
+      { apply wf_arities_context'.
+        1: assumption.
+        induction onInductives.
+        all: constructor ; auto.
+        destruct p.
+        destruct onArity as [? onArity].
+        eexists.
+        eapply onArity.
+        constructor. }
+      have wf_params : PT.wf_local (Σ,udecl) (ind_params m).
+      { clear - onParams.
+        induction onParams.
+        all: constructor.
+        all: auto.
+        1: by destruct t0 ; eexists ; eauto.
+        1: by destruct t0 as ((? & ?) & ?) ; eexists ; eauto.
+        destruct t0 as ((? & ?)&c).
+        apply c.
+        1: auto.
+        eexists. red. eauto. }
+
+      constructor ; auto.
+      
+      remember (ind_bodies m) as l in onInductives |- *.
+      clear - IHwfΣ onInductives wf_arities wf_params.
+      induction onInductives.
+      all: constructor ; auto.
+      destruct p.
+      unshelve econstructor.
+      * exact ind_indices.
+      * exact ind_sort.
+      * eapply map.
+        2: exact ind_cshapes.
+        intros [].
+        constructor ; auto.
+      * assumption.
+      * destruct onArity as [? onArity].
+        eexists.
+        eapply onArity.
+        constructor.
+      * apply All2_map_right.
+        eapply All2_impl.
+        1: exact onConstructors.
+        intros [[] ?] [] [] ; simpl in *.
+
+        have wf_args : PT.wf_local (Σ,udecl) (arities_context (ind_bodies m),,,(ind_params m),,, cshape_args).
+        { eapply PCUICContexts.type_local_ctx_wf_local.
+          1: by apply weaken_wf_local.
+          eapply type_local_ctx_impl ; eauto.
+          by apply weaken_wf_local. }
+
+        constructor ; auto ; simpl in *.
+
+        --destruct on_ctype as [? on_ctype].
+          eexists.
+          apply on_ctype.
+          1: eassumption.
+        --apply type_local_ctx_impl ; eauto.
+          apply weaken_wf_local.
+          all: auto.
+
+        --match goal with |- PT.ctx_inst _ _ ?ctx _ _ => remember ctx as Γ' end.
+          clear -on_cindices wf_args.
+          induction on_cindices.
+          all: constructor.
+          2-3: assumption.
+          apply l0 ; auto.
+          destruct l.
+          eexists. red. eauto.
+
+        --clear - on_ctype_positive.
+          cbn in on_ctype_positive |- *.
+          induction on_ctype_positive.
+          all: constructor ; auto.
+          clear - p. induction p.
+          ++constructor ; assumption.
+          ++econstructor 2 ; eauto.
+          ++constructor 3 ; auto.
+          ++constructor 4 ; auto.
+        --clear - on_ctype_variance.
+          intros v e.
+          specialize (on_ctype_variance v e).
+          unfold cstr_respects_variance in on_ctype_variance.
+          unfold PT.cstr_respects_variance.
+          destruct (variance_universes (PCUICEnvironment.ind_universes m)) ; simpl in * ; auto.
+          destruct p as [[]]. intuition.
+          induction a.
+          all: constructor ; auto.
+
+        
+      * intros projs ; specialize (onProjections projs).
+        clear - onProjections.
+        induction ind_cshapes.
+        1: auto.
+        simpl in *.
+        destruct ind_cshapes.
+        { destruct a. simpl in *.
+          destruct onProjections. constructor ; intuition. }
+        assumption.
+
+      * clear -ind_sorts wf_params.
+        cbn in *.
+        red in ind_sorts |- *.
+        destruct (universe_family ind_sort).
+        --induction ind_cshapes ; auto.
+        --induction ind_cshapes ; auto.
+          simpl in *.
+          destruct ind_cshapes ; auto.
+          simpl in *.
+          destruct a ; auto.
+        --destruct ind_sorts. split.
+          { apply Forall_map.
+            eapply Forall_impl. 1: eassumption.
+            intros [] ? ; assumption. }
+          destruct indices_matter ; auto.
+          apply type_local_ctx_impl.
+          all: auto.
+        --destruct ind_sorts. split.
+          { apply Forall_map.
+            eapply Forall_impl. 1: eassumption.
+            intros [] ? ; assumption. }
+          destruct indices_matter ; auto.
+          apply type_local_ctx_impl.
+          all: auto.
+
+      *  clear -onIndices.
+        intros v e. specialize (onIndices v e).
+        unfold ind_respects_variance in onIndices.
+        unfold PT.ind_respects_variance.
+        destruct (PCUICEnvironment.ind_universes m) ; simpl in * ; auto.
+        destruct cst.
+        replace (PT.level_var_instance 0 l) with (level_var_instance 0 l).
+        2:{ by induction l ; auto. }
+        match goal with |- context [PT.lift_instance ?len ?list] =>
+        replace (PT.lift_instance len list) with (lift_instance len list) end.
+        2:{ apply map_ext. intros []. all: reflexivity. }
+        induction onIndices.
+        all: constructor ; auto.
+Qed.
+  
+Theorem bidirectional_to_PCUIC `{cf : checker_flags} : env_prop Pcheck Pinfer Psort Pprod Pind (@PΓ).
+Proof.
+  apply MT.typing_ind_env.
+
+  { intros. eapply bd_wf_local. eassumption. }
+
+  1-14: intros ; red ; econstructor ; eauto.
+
+  - apply X2.
+    constructor. 1: by auto.
+    eexists. eauto.
+
+  - apply X2.
+    constructor. 1: by auto.
+    eexists. eauto.
+  
+  - apply X2 ; auto.
+    eexists.
+    red. eauto.
+  
+  - apply X4.
+    constructor ; auto.
+    + eexists. eauto.
+    + apply X2 ; auto. eexists. red. eauto.
+  
+  - apply X2 ; auto.
+    specialize (X0 X3).
+    apply validity in X0.
+    2: by apply bd_wf.
+    destruct X0 as [? X0].
+    apply inversion_Prod in X0.
+    2: by apply bd_wf.
+    destruct X0 as (? & ? & ? & _).
+    eexists. eassumption.
+
+  - apply X3 ; auto.
+    suff [] : @isWfArity cf Σ Γ pty by done.
+    eapply WfArity_build_case_predicate_type.
+    + by apply bd_wf.
+    + case isdecl ; split ; eauto.
+    + eapply validity.
+      1: by apply bd_wf.
+      by auto.
+    + eassumption.
+    + unfold params in * ; rewrite <- H0 in * ; eassumption.
+
+  - clear H4.
+    induction X4.
+    all: constructor ; auto.
+    destruct r as (? & ? & ? & ? & ?).
+    repeat split ; auto.
+    apply p1 ; auto.
+    all: eexists.
+    all: apply p0.
+    all: by auto.
+
+  - clear H H0 H1 X0.
+    induction X.
+    all: constructor ; auto.
+    destruct p as (? & ? & ?).
+    eexists.
+    apply p.
+    auto.
+
+  - have Htypes : All (fun d => PT.isType Σ Γ (dtype d)) mfix.
+    { clear H H0 H1 X0.
+      induction X.
+      all: constructor ; auto.
+      destruct p as (? & ? & ?).
+      eexists.
+      apply p.
+      auto.
+    }
+    have wfΓ' : PT.wf_local Σ (Γ,,,fix_context mfix).
+    { apply All_mfix_wf ; auto.
+      by apply bd_wf.
+    }
+    remember (fix_context mfix) as Γ'.
+    clear H H0 H1 HeqΓ'.
+    induction X0.
+    all: constructor ; auto.
+    2:{ inversion_clear X. apply IHX0 ; auto. inversion_clear Htypes. auto. }
+    destruct p as (? & ? & ?).
+    split ; auto.
+    apply p ; auto.
+    inversion_clear Htypes as [| ? ? [u]].
+    exists u.
+    change (tSort u) with (lift0 #|Γ'| (tSort u)).
+    apply weakening.
+    all: auto.
+    by apply bd_wf.
+
+    - clear H H0 H1 X0.
+    induction X.
+    all: constructor ; auto.
+    destruct p as (? & ? & ?).
+    eexists.
+    apply p.
+    auto.
+
+  - have Htypes : All (fun d => PT.isType Σ Γ (dtype d)) mfix.
+    { clear H H0 H1 X0.
+      induction X.
+      all: constructor ; auto.
+      destruct p as (? & ? & ?).
+      eexists.
+      apply p.
+      auto.
+    }
+    have wfΓ' : PT.wf_local Σ (Γ,,,fix_context mfix).
+    { apply All_mfix_wf ; auto.
+      by apply bd_wf.
+    }
+    remember (fix_context mfix) as Γ'.
+    clear H H0 H1 HeqΓ'.
+    induction X0.
+    all: constructor ; auto.
+    2:{ inversion_clear X. apply IHX0 ; auto. inversion_clear Htypes. auto. }
+    destruct p.
+    apply p ; auto.
+    inversion_clear Htypes as [| ? ? [u]].
+    exists u.
+    change (tSort u) with (lift0 #|Γ'| (tSort u)).
+    apply weakening.
+    all: auto.
+    by apply bd_wf.
+
+  - constructor ; auto.
+    suff wfu : (wf_universes Σ (tSort u)) by apply (reflect_bP (wf_universe_reflect _ u)).
+    eapply isType_wf_universes.
+    1: by apply bd_wf.
+    eapply isType_red.
+    1: by apply bd_wf.
+    1: eauto.
+    eapply validity_term.
+    1: by apply bd_wf.
+    auto.
+
+  - apply red_cumul.
+    assumption.
+  
+  - intros. red. intro.
+    have [] : (PT.isType Σ Γ (tProd na A B)).
+    { eapply isType_red.
+      1: by apply bd_wf.
+      1: eauto.
+      eapply validity_term.
+      1: by apply bd_wf.
+      auto.
+    }
+    econstructor.
+    + by auto.
+    + by eassumption.
+    + by apply red_cumul. 
+  
+  - intros. red. intro.
+    have [] : (PT.isType Σ Γ (mkApps (tInd ind ui) args)).
+    { eapply isType_red.
+      1: by apply bd_wf.
+      1: eauto.
+      eapply validity_term.
+      1: by apply bd_wf.
+      auto.
+    }
+    econstructor.
+    + by auto.
+    + by eassumption.
+    + by apply red_cumul. 
+
+  - intros. red. intros ? [].
+    econstructor.
+    all:by eauto.
+
+Qed.
+
+End BDMinimalToPCUICTyping.
+
+Theorem infering_typing `{checker_flags} (Σ : global_env_ext) Γ t T (wfΣ : wf Σ) :
+  PT.wf_local Σ Γ -> Σ ;;; Γ |- t ▹ T -> Σ ;;; Γ |- t : T.
+Proof.
+  intros.
+  apply bidirectional_to_PCUIC.
+  all: assumption.
+Qed.
+
+Theorem checking_typing `{checker_flags} (Σ : global_env_ext) Γ t T (wfΣ : wf Σ) :
+  PT.wf_local Σ Γ -> PT.isType Σ Γ T -> Σ ;;; Γ |- t ◃ T -> Σ ;;; Γ |- t : T.
+Proof.
+  intros wfΓ HT Ht. revert wfΓ HT.
+  apply bidirectional_to_PCUIC.
+  all: assumption.
+Qed.
+
+Theorem infering_sort_typing `{checker_flags} (Σ : global_env_ext) Γ t u (wfΣ : wf Σ) :
+  PT.wf_local Σ Γ -> Σ ;;; Γ |- t ▸□ u -> Σ ;;; Γ |- t : tSort u.
+Proof.
+  intros wfΓ Ht. revert Ht wfΓ.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.
+
+Theorem infering_prod_typing `{checker_flags} (Σ : global_env_ext) Γ t na A B (wfΣ : wf Σ) :
+  PT.wf_local Σ Γ -> Σ ;;; Γ |- t ▸Π (na,A,B) -> Σ ;;; Γ |- t : tProd na A B.
+Proof.
+  intros wfΓ Ht. revert Ht wfΓ.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.
+
+Theorem infering_ind_typing `{checker_flags} (Σ : global_env_ext) Γ t ind u args (wfΣ : wf Σ) :
+PT.wf_local Σ Γ -> Σ ;;; Γ |- t ▸{ind} (u,args) -> Σ ;;; Γ |- t : mkApps (tInd ind u) args.
+Proof.
+  intros wfΓ Ht. revert Ht wfΓ.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.
+
+Theorem wf_local_bd_typing `{checker_flags} (Σ : global_env_ext) Γ (wfΣ : wf Σ) :
+  MT.wf_local Σ Γ -> PT.wf_local Σ Γ.
+Proof.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.
+
+Theorem wf_bd_typing `{checker_flags} (Σ : global_env_ext) (wfΣ : MT.wf Σ) :
+  PT.wf Σ.
+Proof.
+  apply bd_wf.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.

--- a/bidirectional/theories/BDMinimalTyping.v
+++ b/bidirectional/theories/BDMinimalTyping.v
@@ -1,0 +1,838 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import Bool List Arith Lia.
+From Coq Require String.
+From MetaCoq.Template Require Import config utils monad_utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+  PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils
+  PCUICPosition PCUICTyping.
+From MetaCoq.Bidirectional Require Import BDEnvironmentTyping.
+
+From MetaCoq Require Export LibHypsNaming.
+Require Import ssreflect.
+Set Asymmetric Patterns.
+Require Import Equations.Type.Relation.
+Require Import Equations.Prop.DepElim.
+From Equations Require Import Equations.
+Import MonadNotation.
+
+Module BDLookup := Lookup PCUICTerm PCUICEnvironment.
+Include BDLookup.
+
+Module BDEnvTyping := EnvTyping PCUICTerm PCUICEnvironment.
+Include BDEnvTyping.
+
+Notation "Σ ;;; Γ |- t --> t'" := (red Σ Γ t t') (at level 50, Γ, t, t' at next level) : type_scope.
+Reserved Notation " Σ ;;; Γ |- t ▹ T " (at level 50, Γ, t, T at next level).
+Reserved Notation " Σ ;;; Γ |- t ▸□ u " (at level 50, Γ, t, u at next level).
+Reserved Notation " Σ ;;; Γ |- t ▸Π ( na , A , B ) " (at level 50, Γ, t, na, A, B at next level).
+Reserved Notation " Σ ;;; Γ |- t ▸{ ind } ( u , args )" (at level 50, Γ, t, ind, u, args at next level).
+Reserved Notation " Σ ;;; Γ |- t ◃ T " (at level 50, Γ, t, T at next level).
+
+
+Inductive infering `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| infer_Rel n decl :
+    nth_error Γ n = Some decl ->
+    Σ ;;; Γ |- tRel n ▹ lift0 (S n) decl.(decl_type)
+
+| infer_Sort s :
+    wf_universe Σ s->
+    Σ ;;; Γ |- tSort s ▹ tSort (Universe.super s)
+
+| infer_Prod na A B s1 s2 :
+    Σ ;;; Γ |- A ▸□ s1 ->
+    Σ ;;; Γ ,, vass na A |- B ▸□ s2 ->
+    Σ ;;; Γ |- tProd na A B ▹ tSort (Universe.sort_of_product s1 s2)
+
+| infer_Lambda na A t s B :
+    Σ ;;; Γ |- A ▸□ s ->
+    Σ ;;; Γ ,, vass na A |- t ▹ B ->
+    Σ ;;; Γ |- tLambda na A t ▹ tProd na A B
+
+| infer_LetIn na b B t s A :
+    Σ ;;; Γ |- B ▸□ s ->
+    Σ ;;; Γ |- b ◃ B ->
+    Σ ;;; Γ ,, vdef na b B |- t ▹ A ->
+    Σ ;;; Γ |- tLetIn na b B t ▹ tLetIn na b B A
+
+| infer_App t na A B u :
+    Σ ;;; Γ |- t ▸Π (na,A,B) ->
+    Σ ;;; Γ |- u ◃ A ->
+    Σ ;;; Γ |- tApp t u ▹ B{0 := u}
+
+| infer_Const cst u :
+    forall decl (isdecl : declared_constant Σ.1 cst decl),
+    consistent_instance_ext Σ decl.(cst_universes) u ->
+    Σ ;;; Γ |- tConst cst u ▹ subst_instance_constr u decl.(cst_type)
+
+| infer_Ind ind u :
+    forall mdecl idecl (isdecl : declared_inductive Σ.1 mdecl ind idecl),
+    consistent_instance_ext Σ mdecl.(ind_universes) u ->
+    Σ ;;; Γ |- tInd ind u ▹ subst_instance_constr u idecl.(ind_type)
+
+| infer_Construct ind i u :
+    forall mdecl idecl cdecl (isdecl : declared_constructor Σ.1 mdecl idecl (ind, i) cdecl),
+    consistent_instance_ext Σ mdecl.(ind_universes) u ->
+    Σ ;;; Γ |- tConstruct ind i u ▹ type_of_constructor mdecl cdecl (ind, i) u
+
+| infer_Case (indnpar : inductive × nat) (u : Instance.t) (p c : term) (brs : list (nat × term)) (args : list term) :
+  let ind := indnpar.1 in
+  let npar := indnpar.2 in
+   Σ ;;; Γ |- c ▸{ind} (u,args) ->
+  forall mdecl idecl (isdecl : declared_inductive Σ.1 mdecl ind idecl),
+  mdecl.(ind_npars) = npar ->
+  isCoFinite mdecl.(ind_finite) = false ->
+  let params := List.firstn npar args in
+  forall ps pty, build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+  Σ ;;; Γ |- p ◃ pty ->
+  leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
+  forall (btys : list (nat × term)),
+  map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+  All2 (fun br bty =>
+    (br.1 = bty.1) ×
+    (Σ ;;; Γ |- bty.2 ▸□ ps) ×
+    (Σ ;;; Γ |- br.2 ◃ bty.2))
+    brs btys ->
+  Σ ;;; Γ |- tCase indnpar p c brs ▹ mkApps p (skipn npar args ++ [c])
+
+| infer_Proj p c u :
+    forall mdecl idecl pdecl (isdecl : declared_projection Σ.1 mdecl idecl p pdecl) (args : list term),
+    Σ ;;; Γ |- c ▸{fst (fst p)} (u,args) ->
+    #|args| = ind_npars mdecl ->
+    let ty := snd pdecl in
+    Σ ;;; Γ |- tProj p c ▹ subst0 (c :: List.rev args) (subst_instance_constr u ty)
+
+| infer_Fix (mfix : mfixpoint term) n decl :
+    fix_guard mfix ->
+    nth_error mfix n = Some decl ->
+    All (fun d => {s & Σ ;;; Γ |- d.(dtype) ▸□ s}) mfix ->
+    All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype))
+      × (isLambda d.(dbody) = true)) mfix ->
+    wf_fixpoint Σ.1 mfix -> 
+    Σ ;;; Γ |- tFix mfix n ▹ decl.(dtype)
+
+| infer_CoFix mfix n decl :
+    cofix_guard mfix ->
+    nth_error mfix n = Some decl ->
+    All (fun d => {s & Σ ;;; Γ |- d.(dtype) ▸□ s}) mfix ->
+    All (fun d => Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) mfix ->
+    wf_cofixpoint Σ.1 mfix ->
+    Σ ;;; Γ |- tCoFix mfix n ▹ decl.(dtype)
+
+with infering_sort `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> Universe.t -> Type :=
+| infer_sort_Sort t T u:
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T --> tSort u ->
+  Σ ;;; Γ |- t ▸□ u
+
+with infering_prod `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> aname -> term -> term -> Type :=
+| infer_prod_Prod t T na A B:
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T --> tProd na A B ->
+  Σ ;;; Γ |- t ▸Π (na,A,B)
+
+with infering_indu `{checker_flags} (Σ : global_env_ext) (Γ : context) : inductive -> term -> Instance.t -> list term -> Type :=
+| infer_ind_Ind ind t T u args:
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T --> mkApps (tInd ind u) args ->
+  Σ ;;; Γ |- t ▸{ind} (u,args)
+
+with checking `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| check_Cons t T T':
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T <= T' ->
+  Σ ;;; Γ |- t ◃ T'
+
+where " Σ ;;; Γ |- t ▹ T " := (@infering _ Σ Γ t T) : type_scope
+and " Σ ;;; Γ |- t ▸□ u " := (@infering_sort _ Σ Γ t u) : type_scope
+and " Σ ;;; Γ |- t ▸Π ( na , A , B ) " := (@infering_prod _ Σ Γ t na A B) : type_scope
+and " Σ ;;; Γ |- t ▸{ ind } ( u , args ) " := (@infering_indu _ Σ Γ ind t u args) : type_scope
+and " Σ ;;; Γ |- t ◃ T " := (@checking _ Σ Γ t T) : type_scope.
+
+Notation wf_local Σ Γ := (All_local_env (lift_sorting checking infering_sort Σ) Γ).
+
+(** ** Typechecking of global environments, using BDEnvironment to separte typing into checking and sorting *)
+
+Module BDTypingDef <: Typing PCUICTerm PCUICEnvironment BDEnvTyping.
+
+  Definition ind_guard := ind_guard.
+  Definition checking `{checker_flags} := checking.
+  Definition sorting `{checker_flags} := infering_sort.
+  Definition wf_universe := @wf_universe.
+  Definition conv := @conv.
+  Definition cumul := @cumul.
+  Definition smash_context := smash_context.
+  Definition expand_lets := expand_lets.
+  Definition extended_subst := extended_subst.
+  Definition expand_lets_ctx := expand_lets_ctx.
+  Definition lift_context := lift_context.
+  Definition subst_context := subst_context.
+  Definition subst_telescope := subst_telescope.
+  Definition subst_instance_context := subst_instance_context.
+  Definition subst_instance_constr := subst_instance_constr.
+  Definition subst := subst.
+  Definition lift := lift.
+  Definition inds := inds. 
+  Definition noccur_between := noccur_between. 
+  Definition closedn := closedn.
+  Definition destArity := destArity [].
+
+End BDTypingDef.
+
+Module BDDeclarationTyping :=
+  DeclarationTyping
+    PCUICTerm
+    PCUICEnvironment
+    BDEnvTyping
+    BDTypingDef
+    BDLookup.
+Include BDDeclarationTyping.
+
+Fixpoint infering_size `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ▹ T) {struct d} : size
+with infering_sort_size `{checker_flags} {Σ Γ t u} (d : Σ ;;; Γ |- t ▸□ u) {struct d} : size
+with infering_prod_size `{checker_flags} {Σ Γ t na A B} (d : Σ ;;; Γ |- t ▸Π (na, A,B)) {struct d} : size
+with infering_indu_size `{checker_flags} {Σ Γ ind t ui args} (d : Σ ;;; Γ |- t ▸{ind} (ui,args)) {struct d} : size
+with checking_size `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ◃ T) {struct d} : size.
+Proof.
+  all: destruct d ;
+    repeat match goal with
+          | H : infering _ _ _ _ |- _ => apply infering_size in H
+          | H : infering_sort _ _ _ _ |- _ => apply infering_sort_size in H
+          | H : infering_prod _ _ _ _ _ _ |- _ => apply infering_prod_size in H
+          | H : infering_indu _ _ _ _ _ _ |- _ => apply infering_indu_size in H 
+          | H : checking _ _ _ _ |- _ => apply checking_size in H
+          | H : wf_local _ _ |- _ => apply (wf_local_size _ (checking_size _) (infering_sort_size _)) in H
+          end ;
+    match goal with
+    | H : All2 _ _ _ |- _ => idtac
+    | H : All _ _ |- _ => idtac
+    | H1 : size, H2 : size, H3 : size |- _ => exact (S (H1 + H2 + H3))
+    | H1 : size, H2 : size |- _ => exact (S (H1 + H2))
+    | H1 : size |- _  => exact (S H1)
+    | |- _ => exact 1
+    end.
+    - exact (S (i + c0 + (all2_size _ 
+                                        (fun x y p => (infering_sort_size _ _ _ _ _ (fst (snd p)))
+                                                      + (checking_size _ _ _ _ _ (snd (snd p)))) a))).
+    - exact (S (all_size _ (fun d p => infering_sort_size _ _ _ _ _ p.π2) a) +
+               (all_size _ (fun x p => checking_size _ _ _ _ _ p.1) a0)).
+    - exact (S (all_size _ (fun d p => infering_sort_size _ _ _ _ _ p.π2) a) +
+               (all_size _ (fun x => checking_size _ _ _ _ _) a0)).
+  Defined.
+
+Fixpoint infering_size_pos `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ▹ T)
+  : infering_size d > 0
+with infering_sort_size_pos `{checker_flags} {Σ Γ t u} (d : Σ ;;; Γ |- t ▸□ u) {struct d}
+  : infering_sort_size d > 0
+with infering_prod_size_pos `{checker_flags} {Σ Γ t na A B} (d : Σ ;;; Γ |- t ▸Π (na,A,B)) {struct d}
+  : infering_prod_size d > 0
+with infering_indu_size_pos `{checker_flags} {Σ Γ t ind ui args} (d : Σ ;;; Γ |- t ▸{ind} (ui,args)) {struct d}
+  : infering_indu_size d > 0
+with checking_size_pos `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ◃ T) {struct d}
+  : checking_size d > 0.
+Proof.
+  all: destruct d ; cbn.
+  all: lia.
+Qed.
+
+Fixpoint globenv_size (Σ : global_env) : size :=
+  match Σ with
+  | [] => 1
+  | d :: Σ => S (globenv_size Σ)
+  end.
+
+
+Arguments lexprod [A B].
+
+Definition wf `{checker_flags} := Forall_decls_sorting checking infering_sort.
+Definition wf_ext `{checker_flags} := on_global_env_ext checking infering_sort.
+
+Lemma wf_ext_wf {cf:checker_flags} Σ : wf_ext Σ -> wf Σ.
+Proof. intro H; apply H. Qed.
+
+Hint Resolve wf_ext_wf : core.
+
+Lemma wf_ext_consistent {cf:checker_flags} Σ :
+  wf_ext Σ -> consistent Σ.
+Proof.
+  intros [? [? [? [? ?]]]]; assumption.
+Qed.
+
+Hint Resolve wf_ext_consistent : core.
+
+Lemma wf_local_app `{checker_flags} Σ (Γ Γ' : context) : wf_local Σ (Γ ,,, Γ') -> wf_local Σ Γ.
+Proof.
+  induction Γ'. auto.
+  simpl. intros H'; inv H'; eauto.
+Defined.
+Hint Resolve wf_local_app : wf.
+
+Section TypingInduction.
+
+#[local] Notation wfl_size := (wf_local_size _ (@checking_size _) (@infering_sort_size _) _).
+
+  Context (Pcheck : global_env_ext -> context -> term -> term -> Type).
+  Context (Pinfer : global_env_ext -> context -> term -> term -> Type).
+  Context (Psort : global_env_ext -> context -> term -> Universe.t -> Type).
+  Context (Pprod : global_env_ext -> context -> term -> aname -> term -> term -> Type).
+  Context (Pind : global_env_ext -> context -> inductive -> term -> Instance.t -> list term -> Type).
+  Context (PΓ : forall `{checker_flags} Σ Γ, wf_local Σ Γ -> Type).
+  Arguments PΓ {_}.
+
+(* This is what we wish to prove with our mutual induction principle, note how also global environment and local context are built-in *)
+  Definition env_prop `{checker_flags} :=
+    forall Σ (wfΣ : wf Σ.1),
+    (Forall_decls_sorting Pcheck Psort Σ.1) ×
+    (forall Γ wfΓ, PΓ Σ Γ wfΓ) ×
+    (forall Γ t T, Σ ;;; Γ |- t ◃ T -> Pcheck Σ Γ t T) ×
+    (forall Γ t T, Σ ;;; Γ |- t ▹ T -> Pinfer Σ Γ t T) ×
+    (forall Γ t u, Σ ;;; Γ |- t ▸□ u -> Psort Σ Γ t u) ×
+    (forall Γ t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> Pprod Σ Γ t na A B) ×
+    (forall Γ ind t u args, Σ ;;; Γ |- t ▸{ind} (u,args) -> Pind Σ Γ ind t u args).
+
+  Derive Signature for All_local_env.
+
+  Set Equations With UIP.
+  Derive NoConfusion for context_decl.
+  Derive NoConfusion for list.
+  Derive NoConfusion for All_local_env.
+
+  Derive Signature for Alli.
+
+  (** *** To prove the needed induction principle, we unite all possible typing judgments in a big sum type,
+          on which we define a suitable notion of size, wrt. which we perform well-founded induction
+  *)
+
+  Inductive typing_sum `{checker_flags} Σ (wfΣ : wf Σ.1) : Type :=
+    | env_cons : typing_sum Σ wfΣ
+    | context_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ), typing_sum Σ wfΣ
+    | check_cons : forall (Γ : context) T t, Σ ;;; Γ |- t ◃ T -> typing_sum Σ wfΣ
+    | inf_cons : forall (Γ : context) T t, Σ ;;; Γ |- t ▹ T -> typing_sum Σ wfΣ
+    | sort_cons : forall (Γ : context) t u, Σ ;;; Γ |- t ▸□ u -> typing_sum Σ wfΣ
+    | prod_cons : forall (Γ : context) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> typing_sum Σ wfΣ
+    | ind_cons : forall (Γ : context) ind t u args,
+        Σ ;;; Γ |- t ▸{ind} (u,args) -> typing_sum Σ wfΣ.
+
+  Definition typing_sum_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum Σ wfΣ) :=
+  match d with
+    | env_cons => 0
+    | context_cons Γ wfΓ => wfl_size wfΓ
+    | check_cons _ _ _ d => (checking_size d)
+    | inf_cons _ _ _ d => (infering_size d)
+    | sort_cons _ _ _ d => (infering_sort_size d)
+    | prod_cons _ _ _ _ _ d => (infering_prod_size d)
+    | ind_cons _ _ _ _ _ d => (infering_indu_size d)
+  end.
+  
+(*   Definition context_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum Σ wfΣ) := 
+    match d with
+      | env_cons => 0
+      | context_cons Γ wfΓ => wfl_size wfΓ
+      | check_cons Γ wfΓ _ _ d => wfl_size wfΓ
+      | inf_cons Γ wfΓ _ _ d => wfl_size wfΓ
+      | sort_cons Γ wfΓ _ _ d => wfl_size wfΓ
+      | prod_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
+      | ind_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
+    end. *)
+
+  Definition Ptyping_sum `{checker_flags} {Σ wfΣ} (d : typing_sum Σ wfΣ) :=
+  match d with
+    | env_cons => Forall_decls_sorting Pcheck Psort Σ.1
+    | context_cons Γ wfΓ => PΓ Σ Γ wfΓ
+    | check_cons Γ T t _ => Pcheck Σ Γ t T
+    | inf_cons Γ T t _ => Pinfer Σ Γ t T
+    | sort_cons Γ T u _ => Psort Σ Γ T u
+    | prod_cons Γ T na A B _ => Pprod Σ Γ T na A B
+    | ind_cons Γ ind T u args _ => Pind Σ Γ ind T u args
+  end.
+
+  Ltac applyIH := match goal with
+    | IH : forall _ _ d', _ -> Ptyping_sum d' |- Forall_decls_sorting Pcheck Psort _ =>
+      unshelve eapply (IH _ _ (env_cons _ _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- PΓ _ ?Γ ?wfΓ =>
+      unshelve eapply (IH _ _ (context_cons _ _ Γ wfΓ))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pcheck _ ?Γ ?t ?T =>
+      unshelve eapply (IH _ _ (check_cons _ _ Γ T t _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pinfer _ ?Γ ?t ?T =>
+      unshelve eapply (IH _ _ (inf_cons _ _ Γ T t _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d'|- Psort _ ?Γ ?t ?u =>
+      unshelve eapply (IH _ _ (sort_cons _ _ Γ t u _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pprod _ ?Γ ?t ?na ?A ?B =>
+      unshelve eapply (IH _ _ (prod_cons _ _ Γ t na A B _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pind _ ?Γ ?ind ?t ?u ?args =>
+      unshelve eapply (IH _ _ (ind_cons _ _ Γ ind t u args _))
+    end ;
+    match goal with
+    | |- dlexprod _ _ _ _ => constructor ; simpl ; lia
+    | |- dlexprod _ _ _ _ =>
+            constructor 2 ; simpl ; try lia
+    | _ => assumption
+    | _ => simpl ; lia
+    | _ => idtac
+    end.
+
+  Lemma typing_ind_env `{cf : checker_flags} :
+    let Pdecl_check := fun Σ Γ wfΓ t T tyT => Pcheck Σ Γ t T in
+    let Pdecl_sort := fun Σ Γ wfΓ t u tyT => Psort Σ Γ t u in
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (wfΓ : wf_local Σ Γ), 
+      All_local_env_over_sorting checking infering_sort Pdecl_check Pdecl_sort Σ Γ wfΓ -> PΓ Σ Γ wfΓ) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (n : nat) decl,
+      nth_error Γ n = Some decl ->
+      Pinfer Σ Γ (tRel n) (lift0 (S n) decl.(decl_type))) ->
+
+    (forall Σ (wfΣ : wf Σ.1)(PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (s : Universe.t),
+      wf_universe Σ s->
+      Pinfer Σ Γ (tSort s) (tSort (Universe.super s))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (n : aname) (t b : term) (s1 s2 : Universe.t),
+      Σ ;;; Γ |- t ▸□ s1 ->
+      Psort Σ Γ t s1 ->
+      Σ ;;; Γ,, vass n t |- b ▸□ s2 ->
+      Psort Σ (Γ,, vass n t) b s2 -> Pinfer Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (n : aname) (t b : term) (s : Universe.t) (bty : term),
+      Σ ;;; Γ |- t ▸□ s ->
+      Psort Σ Γ t s ->
+      Σ ;;; Γ,, vass n t |- b ▹ bty -> Pinfer Σ (Γ,, vass n t) b bty ->
+      Pinfer Σ Γ (tLambda n t b) (tProd n t bty)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (n : aname) (b B t : term) (s : Universe.t) (A : term),
+      Σ ;;; Γ |- B ▸□ s ->
+      Psort Σ Γ B s ->
+      Σ ;;; Γ |- b ◃ B ->
+      Pcheck Σ Γ b B ->
+      Σ ;;; Γ,, vdef n b B |- t ▹ A ->
+      Pinfer Σ (Γ,, vdef n b B) t A -> Pinfer Σ Γ (tLetIn n b B t) (tLetIn n b B A)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (t : term) na A B u,
+      Σ ;;; Γ |- t ▸Π (na, A, B) -> Pprod Σ Γ t na A B ->
+      Σ ;;; Γ |- u ◃ A -> Pcheck Σ Γ u A ->
+      Pinfer Σ Γ (tApp t u) (subst10 u B)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (cst : kername) u (decl : constant_body),
+      Forall_decls_sorting Pcheck Psort Σ.1 ->
+      declared_constant Σ.1 cst decl ->
+      consistent_instance_ext Σ decl.(cst_universes) u ->
+      Pinfer Σ Γ (tConst cst u) (subst_instance_constr u (cst_type decl))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (ind : inductive) u mdecl idecl,
+      Forall_decls_sorting Pcheck Psort Σ.1 ->
+      declared_inductive Σ.1 mdecl ind idecl ->
+      consistent_instance_ext Σ mdecl.(ind_universes) u ->
+      Pinfer Σ Γ (tInd ind u) (subst_instance_constr u (ind_type idecl))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (ind : inductive) (i : nat) u
+      mdecl idecl cdecl,
+      Forall_decls_sorting Pcheck Psort Σ.1 ->
+      declared_constructor Σ.1 mdecl idecl (ind, i) cdecl ->
+      consistent_instance_ext Σ mdecl.(ind_universes) u ->
+      Pinfer Σ Γ (tConstruct ind i u)
+        (type_of_constructor mdecl cdecl (ind, i) u)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (ind : inductive) u (npar : nat)
+      (p c : term) (brs : list (nat * term)) (args : list term)
+      (mdecl : mutual_inductive_body) (idecl : one_inductive_body)
+      (isdecl : declared_inductive (fst Σ) mdecl ind idecl),
+      Forall_decls_sorting Pcheck Psort Σ.1 ->
+      isCoFinite mdecl.(ind_finite) = false ->
+      Σ ;;; Γ |- c ▸{ind} (u,args) ->
+      Pind Σ Γ ind c u args ->
+      ind_npars mdecl = npar ->
+      let params := firstn npar args in
+      forall ps pty,
+      build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+      Σ ;;; Γ |- p ◃ pty ->
+      Pcheck Σ Γ p pty ->
+      leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
+      forall btys,
+      map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+      All2 (fun br bty => (br.1 = bty.1) ×
+                        (Σ ;;; Γ |- bty.2 ▸□ ps) × Psort Σ Γ bty.2 ps ×
+                        (Σ ;;; Γ |- br.2 ◃ bty.2) × Pcheck Σ Γ br.2 bty.2)
+            brs btys ->
+      Pinfer Σ Γ (tCase (ind,npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (p : projection) (c : term) u
+      mdecl idecl pdecl args,
+      Forall_decls_sorting Pcheck Psort Σ.1 ->
+      declared_projection Σ.1 mdecl idecl p pdecl ->
+      Σ ;;; Γ |- c ▸{fst (fst p)} (u,args) ->
+      Pind Σ Γ (fst (fst p)) c u args ->
+      #|args| = ind_npars mdecl ->
+      let ty := snd pdecl in
+      Pinfer Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance_constr u ty))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
+      fix_guard mfix ->
+      nth_error mfix n = Some decl ->
+      All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+      All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
+                (isLambda d.(dbody) = true) ×
+                Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+      wf_fixpoint Σ.1 mfix ->
+      Pinfer Σ Γ (tFix mfix n) decl.(dtype)) ->
+    
+    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
+      cofix_guard mfix ->
+      nth_error mfix n = Some decl ->
+      All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+      All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
+                Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+      wf_cofixpoint Σ.1 mfix ->
+      Pinfer Σ Γ (tCoFix mfix n) decl.(dtype)) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (t T : term) (u : Universe.t),
+      Σ ;;; Γ |- t ▹ T ->
+      Pinfer Σ Γ t T ->
+      Σ ;;; Γ |- T --> tSort u ->
+      Psort Σ Γ t u) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (t T : term) (na : aname) (A B : term),
+      Σ ;;; Γ |- t ▹ T ->
+      Pinfer Σ Γ t T ->
+      Σ ;;; Γ |- T --> tProd na A B ->
+      Pprod Σ Γ t na A B) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (ind : inductive) (t T : term) (ui : Instance.t)
+      (args : list term),
+      Σ ;;; Γ |- t ▹ T ->
+      Pinfer Σ Γ t T ->
+      Σ ;;; Γ |- T --> mkApps (tInd ind ui) args ->
+      Pind Σ Γ ind t ui args) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
+      (Γ : context) (t T T' : term),
+      Σ ;;; Γ |- t ▹ T ->
+      Pinfer Σ Γ t T ->
+      Σ ;;; Γ |- T <= T' ->
+      Pcheck Σ Γ t T') ->
+      
+    env_prop.
+  Proof.
+    intros Pdecl_check Pdecl_sort HΓ HRel HSort HProd HLambda HLetIn HApp HConst HInd HConstruct HCase
+      HProj HFix HCoFix HiSort HiProd HiInd HCheck ; unfold env_prop.
+      pose (@Fix_F (∑ (Σ : _) (wfΣ : _), typing_sum Σ wfΣ)
+      (dlexprod (precompose lt (fun Σ => globenv_size (fst Σ)))
+        (fun Σ => precompose lt (fun d => typing_sum_size d.π2)))
+      (fun d => Ptyping_sum d.π2.π2)).
+    forward p.
+    2:{ intros Σ wfΣ.
+    enough (HP : forall x : typing_sum Σ wfΣ, Ptyping_sum x).
+    - repeat split ; intros.
+      + exact (HP (env_cons Σ wfΣ)).
+      + exact (HP (context_cons Σ wfΣ Γ wfΓ)).
+      + exact (HP (check_cons Σ wfΣ Γ T t X)).
+      + exact (HP (inf_cons Σ wfΣ Γ T t X)).
+      + exact (HP (sort_cons Σ wfΣ Γ t u X)).
+      + exact (HP (prod_cons Σ wfΣ Γ t na A B X)).
+      + exact (HP (ind_cons Σ wfΣ Γ ind t u args X)).
+    - intros x ; apply (p (Σ ; (wfΣ ; x))).
+      apply wf_dlexprod ; intros ; apply wf_precompose ; apply lt_wf.
+    }
+    clear p.     
+    intros (Σ & wfΣ & d) IH'. simpl.
+    match goal with | IH' : forall y : _ , ?P _ _ -> _ |- _ =>
+      have IH : forall (Σ' : global_env_ext) (wfΣ' : wf Σ'.1) (d' :typing_sum Σ' wfΣ'),
+        P (Σ'; wfΣ'; d') (Σ; wfΣ; d) -> Ptyping_sum d' end.
+    1: intros Σ' wfΣ' d' H; exact (IH' (Σ' ; wfΣ' ; d') H).
+    clear IH'.
+    destruct d ; simpl.
+    4: destruct i.
+    - destruct Σ as [Σ φ]. destruct Σ.
+      1: constructor.
+      destruct p.
+      cbn in  *.
+      have IH' : forall Σ' wfΣ' (d' : typing_sum Σ' wfΣ'), globenv_size (Σ'.1) < S (globenv_size Σ) ->
+                    Ptyping_sum d'
+        by intros ; apply IH ; constructor ; simpl ; assumption.
+      clear IH.
+      inversion_clear wfΣ as [|? ? ? wfΣ' ? ? ? wfg].
+      constructor.
+      + change (Forall_decls_sorting Pcheck Psort (Σ,φ).1).
+        applyIH.
+      + assumption.
+      + assumption.
+      + destruct g as [[? [] ?]| ]; cbn.
+        * applyIH.
+        * inversion wfg.
+          eexists. applyIH.
+          eassumption.
+        * inversion wfg.
+          constructor.
+          3-5: assumption.
+          2:{
+            clear - wfΣ' IH' onParams0.
+            induction onParams0.
+            1: by constructor.
+            -- constructor.
+               1: by assumption.
+               destruct t0.
+               eexists.
+               applyIH.
+               by eassumption. 
+            -- constructor.
+               1: by assumption.
+               destruct t0.
+               constructor.
+               2: by cbn ; applyIH.
+               destruct l.
+               eexists.
+               applyIH.
+               by eassumption. 
+          }
+
+          remember (ind_bodies m) as Γ in onInductives0 |- *.
+          clear - wfΣ' IH' onParams0 onInductives0.
+          induction onInductives0 as [| ? ? ? [] ?].
+          1: by constructor.
+          constructor.
+          2: eassumption.
+          econstructor ; try eassumption.
+          ++ destruct onArity0.
+            eexists. applyIH.
+            eassumption.
+          ++ clear - wfΣ' IH' onConstructors0 onParams0.
+            induction onConstructors0.
+            1: by constructor.
+            constructor.
+            2: assumption.
+            destruct r.
+            constructor.
+            all: try assumption.
+            ** cbn.
+                destruct on_ctype0.
+                eexists.
+                applyIH.
+                eassumption.
+            ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; try eassumption.
+
+            ** clear - wfΣ' IH' onParams0 on_cargs0 on_cindices0.
+               induction on_cindices0.
+               all: constructor ; auto.
+               cbn. applyIH.
+
+          ++ clear - wfΣ' IH' ind_sorts0 onParams0.
+              red in ind_sorts0 |- *.
+              destruct (universe_family ind_sort0).
+              all: intuition.
+              all: destruct indices_matter ; auto.
+              ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
+              ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
+
+
+    - apply HΓ.
+      1: assumption.
+      1:{ applyIH. apply wf_local_size_pos. }
+      dependent induction wfΓ.
+      + constructor.
+      + destruct t0 as (u & d).
+        constructor.
+        * apply IHwfΓ.
+        intros ; apply IH.
+        dependent destruction H ; [constructor | constructor 2] ; auto.
+        simpl in *. lia.
+        
+        * simpl ; red ; applyIH.
+          have ? : 0 < wfl_size wfΓ by apply wf_local_size_pos.
+          lia.
+      + destruct t0 as [[u h] h'].
+        constructor.
+        2: constructor.
+        * apply IHwfΓ.
+          intros ; apply IH.
+          dependent destruction H ; [constructor | constructor 2] ; auto.
+          etransitivity ; eauto.
+          simpl.
+          cbn in h. pose proof (infering_sort_size_pos h). lia.
+        * red. applyIH. pose proof (checking_size_pos h'). simpl in *. lia.
+        * red. applyIH. pose proof (infering_sort_size_pos h). simpl in *. lia.
+
+    - destruct c.
+      unshelve (eapply HCheck ; eauto) ; auto.
+      all: applyIH.
+
+    - unshelve eapply HRel ; auto.
+      all: applyIH.
+
+    - unshelve eapply HSort ; auto.
+      all: applyIH.
+
+    - unshelve eapply HProd ; auto.
+      all: applyIH.
+    
+    - unshelve eapply HLambda ; auto.
+      all: applyIH.
+
+    - unshelve eapply HLetIn ; auto.
+      all: applyIH.
+
+    - unshelve eapply (HApp _ _ _ _ _ _ A) ; auto.
+      all: applyIH.
+
+    - unshelve eapply HConst ; auto.
+      all: applyIH.
+
+    - unshelve eapply HInd ; auto.
+      all: applyIH.
+
+    - unshelve eapply HConstruct ; auto.
+      all: applyIH.
+
+    - destruct indnpar as [ind' npar'] ; cbn in ind ; cbn in npar ; subst ind ; subst npar.
+      unshelve eapply HCase ; auto.
+      1-4: applyIH.
+      match goal with | IH : forall Σ' wfΣ' d', _ _ (_ ; _ ; ?d) -> _ |- _ =>
+        have IH' : forall d' : typing_sum Σ wfΣ, (typing_sum_size d') < (typing_sum_size d) -> Ptyping_sum d' end.
+      1:{ intros. apply IH. constructor 2. assumption. }
+      remember btys as b in e2.
+      clear - IH'. cbn in IH' |- *.
+      induction a.
+      1: by constructor.
+      destruct r as [? [? ?]].
+      constructor.
+      + intuition eauto.
+        1: unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _)) ; try eassumption.
+        2: unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try eassumption.
+        all: simpl ; lia.
+      + apply IHa.
+        intros. apply IH'. simpl in *. lia.
+    
+    - unshelve eapply HProj ; auto.
+      all: applyIH.
+
+    - unshelve eapply HFix ; eauto.
+      1: applyIH.
+
+      all: have IH' : (forall d' : typing_sum Σ wfΣ,
+      (typing_sum_size d') <
+        (typing_sum_size (inf_cons _ wfΣ _ _ (tFix mfix n)
+        (infer_Fix Σ Γ mfix n decl i e a a0 i0)))
+      -> Ptyping_sum d') by intros ; apply IH ; constructor 2 ; assumption.
+      all: simpl in IH'.
+      all: remember (fix_context mfix) as mfixcontext.
+
+      1:{
+        remember (all_size _ _ a0) as s.
+        clear -IH'.
+        dependent induction a.
+        1: by constructor.
+        constructor ; cbn.
+        + destruct p ; eexists ; split.
+          1: eassumption.
+          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _)).
+          all: try assumption.
+          simpl. lia.
+        + apply (IHa s).
+          intros.
+          apply IH'.
+          cbn. lia.
+      }
+
+      remember (all_size _ _ a) as s.
+      clear -IH'.
+      induction a0 as [| ? ? [? ?]].
+      1: by constructor.
+      constructor.
+      + intuition.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try assumption.
+        simpl. lia.
+      + apply IHa0.
+        intros ; apply IH'.
+        cbn. lia.
+
+    - unshelve eapply HCoFix ; eauto.
+      1: applyIH.
+
+      all: have IH' : (forall d' : typing_sum Σ wfΣ,
+      (typing_sum_size d') <
+        (typing_sum_size (inf_cons _ wfΣ _ _ (tCoFix mfix n)
+        (infer_CoFix Σ Γ mfix n decl i e a a0 i0)))
+      -> Ptyping_sum d')
+      by intros ; apply IH ; constructor 2 ; assumption.
+      all: simpl in IH'.
+      all: remember (fix_context mfix) as mfixcontext.
+
+      {
+        remember (all_size _ _ a0) as s.
+        clear -IH'.
+        dependent induction a.
+        1: by constructor.
+        constructor ; cbn.
+        + destruct p ; eexists ; split.
+          1: eassumption.
+          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _)).
+          all: try assumption.
+          simpl. lia.
+        + apply (IHa s).
+          intros.
+          apply IH'.
+          cbn. lia.
+      }
+
+      remember (all_size _ _ a) as s.
+      clear -IH'.
+      induction a0.
+      1: by constructor.
+      constructor.
+      + intuition.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try assumption.
+        simpl. lia.
+      + apply IHa0.
+        intros ; apply IH'.
+        cbn. lia.
+
+    - destruct i.
+      unshelve (eapply HiSort ; try eassumption) ; try eassumption.
+      all:applyIH.
+
+    - destruct i.
+      unshelve (eapply HiProd ; try eassumption) ; try eassumption.
+      all: applyIH.
+
+    - destruct i.
+      unshelve (eapply HiInd ; try eassumption) ; try eassumption.
+      all: applyIH.
+Qed.
+
+End TypingInduction.
+
+
+Ltac my_rename_hyp h th :=
+  match th with
+  | (wf ?E) => fresh "wf" E
+  | (wf (fst_ctx ?E)) => fresh "wf" E
+  | (wf _) => fresh "wf"
+  | (checking _ _ ?t _) => fresh "check" t
+  | (conv _ _ ?t _) => fresh "conv" t
+  | (All_local_env (lift_typing (@checking _) _) ?G) => fresh "wf" G
+  | (All_local_env (lift_typing (@checking _) _) _) => fresh "wf"
+  | (All_local_env _ _ ?G) => fresh "H" G
+  | context [checking _ _ (_ ?t) _] => fresh "IH" t
+  end.
+
+Ltac rename_hyp h ht ::= my_rename_hyp h ht.

--- a/bidirectional/theories/BDMinimalTyping.v
+++ b/bidirectional/theories/BDMinimalTyping.v
@@ -243,22 +243,6 @@ Fixpoint globenv_size (Σ : global_env) : size :=
 
 Arguments lexprod [A B].
 
-Definition wf `{checker_flags} := Forall_decls_sorting checking infering_sort.
-Definition wf_ext `{checker_flags} := on_global_env_ext checking infering_sort.
-
-Lemma wf_ext_wf {cf:checker_flags} Σ : wf_ext Σ -> wf Σ.
-Proof. intro H; apply H. Qed.
-
-Hint Resolve wf_ext_wf : core.
-
-Lemma wf_ext_consistent {cf:checker_flags} Σ :
-  wf_ext Σ -> consistent Σ.
-Proof.
-  intros [? [? [? [? ?]]]]; assumption.
-Qed.
-
-Hint Resolve wf_ext_consistent : core.
-
 Lemma wf_local_app `{checker_flags} Σ (Γ Γ' : context) : wf_local Σ (Γ ,,, Γ') -> wf_local Σ Γ.
 Proof.
   induction Γ'. auto.
@@ -270,24 +254,24 @@ Section TypingInduction.
 
 #[local] Notation wfl_size := (wf_local_size _ (@checking_size _) (@infering_sort_size _) _).
 
-  Context (Pcheck : global_env_ext -> context -> term -> term -> Type).
-  Context (Pinfer : global_env_ext -> context -> term -> term -> Type).
-  Context (Psort : global_env_ext -> context -> term -> Universe.t -> Type).
-  Context (Pprod : global_env_ext -> context -> term -> aname -> term -> term -> Type).
-  Context (Pind : global_env_ext -> context -> inductive -> term -> Instance.t -> list term -> Type).
-  Context (PΓ : forall `{checker_flags} Σ Γ, wf_local Σ Γ -> Type).
-  Arguments PΓ {_}.
+  Context `{cf : checker_flags}.
+  Context (Σ : global_env_ext).
+  Context (wfΣ : wf Σ).
+  Context (Pcheck : context -> term -> term -> Type).
+  Context (Pinfer : context -> term -> term -> Type).
+  Context (Psort : context -> term -> Universe.t -> Type).
+  Context (Pprod : context -> term -> aname -> term -> term -> Type).
+  Context (Pind : context -> inductive -> term -> Instance.t -> list term -> Type).
+  Context (PΓ : forall Γ, wf_local Σ Γ -> Type).
 
 (* This is what we wish to prove with our mutual induction principle, note how also global environment and local context are built-in *)
-  Definition env_prop `{checker_flags} :=
-    forall Σ (wfΣ : wf Σ.1),
-    (Forall_decls_sorting Pcheck Psort Σ.1) ×
-    (forall Γ wfΓ, PΓ Σ Γ wfΓ) ×
-    (forall Γ t T, Σ ;;; Γ |- t ◃ T -> Pcheck Σ Γ t T) ×
-    (forall Γ t T, Σ ;;; Γ |- t ▹ T -> Pinfer Σ Γ t T) ×
-    (forall Γ t u, Σ ;;; Γ |- t ▸□ u -> Psort Σ Γ t u) ×
-    (forall Γ t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> Pprod Σ Γ t na A B) ×
-    (forall Γ ind t u args, Σ ;;; Γ |- t ▸{ind} (u,args) -> Pind Σ Γ ind t u args).
+  Definition env_prop :=
+    (forall Γ wfΓ, PΓ Γ wfΓ) ×
+    (forall Γ t T, Σ ;;; Γ |- t ◃ T -> Pcheck Γ t T) ×
+    (forall Γ t T, Σ ;;; Γ |- t ▹ T -> Pinfer Γ t T) ×
+    (forall Γ t u, Σ ;;; Γ |- t ▸□ u -> Psort Γ t u) ×
+    (forall Γ t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> Pprod Γ t na A B) ×
+    (forall Γ ind t u args, Σ ;;; Γ |- t ▸{ind} (u,args) -> Pind Γ ind t u args).
 
   Derive Signature for All_local_env.
 
@@ -302,19 +286,16 @@ Section TypingInduction.
           on which we define a suitable notion of size, wrt. which we perform well-founded induction
   *)
 
-  Inductive typing_sum `{checker_flags} Σ (wfΣ : wf Σ.1) : Type :=
-    | env_cons : typing_sum Σ wfΣ
-    | context_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ), typing_sum Σ wfΣ
-    | check_cons : forall (Γ : context) T t, Σ ;;; Γ |- t ◃ T -> typing_sum Σ wfΣ
-    | inf_cons : forall (Γ : context) T t, Σ ;;; Γ |- t ▹ T -> typing_sum Σ wfΣ
-    | sort_cons : forall (Γ : context) t u, Σ ;;; Γ |- t ▸□ u -> typing_sum Σ wfΣ
-    | prod_cons : forall (Γ : context) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> typing_sum Σ wfΣ
-    | ind_cons : forall (Γ : context) ind t u args,
-        Σ ;;; Γ |- t ▸{ind} (u,args) -> typing_sum Σ wfΣ.
+  Inductive typing_sum : Type :=
+    | context_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ), typing_sum
+    | check_cons : forall (Γ : context) T t, Σ ;;; Γ |- t ◃ T -> typing_sum
+    | inf_cons : forall (Γ : context) T t, Σ ;;; Γ |- t ▹ T -> typing_sum
+    | sort_cons : forall (Γ : context) t u, Σ ;;; Γ |- t ▸□ u -> typing_sum
+    | prod_cons : forall (Γ : context) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> typing_sum
+    | ind_cons : forall (Γ : context) ind t u args, Σ ;;; Γ |- t ▸{ind} (u,args) -> typing_sum.
 
-  Definition typing_sum_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum Σ wfΣ) :=
+  Definition typing_sum_size (d : typing_sum) :=
   match d with
-    | env_cons => 0
     | context_cons Γ wfΓ => wfl_size wfΓ
     | check_cons _ _ _ d => (checking_size d)
     | inf_cons _ _ _ d => (infering_size d)
@@ -322,44 +303,30 @@ Section TypingInduction.
     | prod_cons _ _ _ _ _ d => (infering_prod_size d)
     | ind_cons _ _ _ _ _ d => (infering_indu_size d)
   end.
-  
-(*   Definition context_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum Σ wfΣ) := 
-    match d with
-      | env_cons => 0
-      | context_cons Γ wfΓ => wfl_size wfΓ
-      | check_cons Γ wfΓ _ _ d => wfl_size wfΓ
-      | inf_cons Γ wfΓ _ _ d => wfl_size wfΓ
-      | sort_cons Γ wfΓ _ _ d => wfl_size wfΓ
-      | prod_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
-      | ind_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
-    end. *)
 
-  Definition Ptyping_sum `{checker_flags} {Σ wfΣ} (d : typing_sum Σ wfΣ) :=
+  Definition Ptyping_sum (d : typing_sum) :=
   match d with
-    | env_cons => Forall_decls_sorting Pcheck Psort Σ.1
-    | context_cons Γ wfΓ => PΓ Σ Γ wfΓ
-    | check_cons Γ T t _ => Pcheck Σ Γ t T
-    | inf_cons Γ T t _ => Pinfer Σ Γ t T
-    | sort_cons Γ T u _ => Psort Σ Γ T u
-    | prod_cons Γ T na A B _ => Pprod Σ Γ T na A B
-    | ind_cons Γ ind T u args _ => Pind Σ Γ ind T u args
+    | context_cons Γ wfΓ => PΓ Γ wfΓ
+    | check_cons Γ T t _ => Pcheck Γ t T
+    | inf_cons Γ T t _ => Pinfer Γ t T
+    | sort_cons Γ T u _ => Psort Γ T u
+    | prod_cons Γ T na A B _ => Pprod Γ T na A B
+    | ind_cons Γ ind T u args _ => Pind Γ ind T u args
   end.
 
   Ltac applyIH := match goal with
-    | IH : forall _ _ d', _ -> Ptyping_sum d' |- Forall_decls_sorting Pcheck Psort _ =>
-      unshelve eapply (IH _ _ (env_cons _ _))
-    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- PΓ _ ?Γ ?wfΓ =>
-      unshelve eapply (IH _ _ (context_cons _ _ Γ wfΓ))
-    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pcheck _ ?Γ ?t ?T =>
-      unshelve eapply (IH _ _ (check_cons _ _ Γ T t _))
-    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pinfer _ ?Γ ?t ?T =>
-      unshelve eapply (IH _ _ (inf_cons _ _ Γ T t _))
-    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d'|- Psort _ ?Γ ?t ?u =>
-      unshelve eapply (IH _ _ (sort_cons _ _ Γ t u _))
-    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pprod _ ?Γ ?t ?na ?A ?B =>
-      unshelve eapply (IH _ _ (prod_cons _ _ Γ t na A B _))
-    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pind _ ?Γ ?ind ?t ?u ?args =>
-      unshelve eapply (IH _ _ (ind_cons _ _ Γ ind t u args _))
+    | IH : forall d', _ -> Ptyping_sum d' |- PΓ ?Γ ?wfΓ =>
+      unshelve eapply (IH (context_cons Γ wfΓ))
+    | IH : forall d', _ -> Ptyping_sum d' |- Pcheck ?Γ ?t ?T =>
+      unshelve eapply (IH (check_cons Γ T t _))
+    | IH : forall d', _ -> Ptyping_sum d' |- Pinfer ?Γ ?t ?T =>
+      unshelve eapply (IH (inf_cons Γ T t _))
+    | IH : forall d', _ -> Ptyping_sum d'|- Psort ?Γ ?t ?u =>
+      unshelve eapply (IH (sort_cons Γ t u _))
+    | IH : forall d', _ -> Ptyping_sum d' |- Pprod ?Γ ?t ?na ?A ?B =>
+      unshelve eapply (IH (prod_cons Γ t na A B _))
+    | IH : forall d', _ -> Ptyping_sum d' |- Pind ?Γ ?ind ?t ?u ?args =>
+      unshelve eapply (IH (ind_cons Γ ind t u args _))
     end ;
     match goal with
     | |- dlexprod _ _ _ _ => constructor ; simpl ; lia
@@ -370,312 +337,186 @@ Section TypingInduction.
     | _ => idtac
     end.
 
-  Lemma typing_ind_env `{cf : checker_flags} :
-    let Pdecl_check := fun Σ Γ wfΓ t T tyT => Pcheck Σ Γ t T in
-    let Pdecl_sort := fun Σ Γ wfΓ t u tyT => Psort Σ Γ t u in
+  Lemma typing_ind_env :
+    let Pdecl_check := fun Σ Γ wfΓ t T tyT => Pcheck Γ t T in
+    let Pdecl_sort := fun Σ Γ wfΓ t u tyT => Psort Γ t u in
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (wfΓ : wf_local Σ Γ), 
-      All_local_env_over_sorting checking infering_sort Pdecl_check Pdecl_sort Σ Γ wfΓ -> PΓ Σ Γ wfΓ) ->
+    (forall (Γ : context) (wfΓ : wf_local Σ Γ), 
+      All_local_env_over_sorting checking infering_sort Pdecl_check Pdecl_sort Σ Γ wfΓ -> PΓ Γ wfΓ) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (n : nat) decl,
+    (forall (Γ : context) (n : nat) decl,
       nth_error Γ n = Some decl ->
-      Pinfer Σ Γ (tRel n) (lift0 (S n) decl.(decl_type))) ->
+      Pinfer Γ (tRel n) (lift0 (S n) decl.(decl_type))) ->
 
-    (forall Σ (wfΣ : wf Σ.1)(PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (s : Universe.t),
+    (forall (Γ : context) (s : Universe.t),
       wf_universe Σ s->
-      Pinfer Σ Γ (tSort s) (tSort (Universe.super s))) ->
+      Pinfer Γ (tSort s) (tSort (Universe.super s))) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (n : aname) (t b : term) (s1 s2 : Universe.t),
+    (forall (Γ : context) (n : aname) (t b : term) (s1 s2 : Universe.t),
       Σ ;;; Γ |- t ▸□ s1 ->
-      Psort Σ Γ t s1 ->
+      Psort Γ t s1 ->
       Σ ;;; Γ,, vass n t |- b ▸□ s2 ->
-      Psort Σ (Γ,, vass n t) b s2 ->
-      Pinfer Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
+      Psort (Γ,, vass n t) b s2 ->
+      Pinfer Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (n : aname) (t b : term) (s : Universe.t) (bty : term),
+    (forall (Γ : context) (n : aname) (t b : term) (s : Universe.t) (bty : term),
       Σ ;;; Γ |- t ▸□ s ->
-      Psort Σ Γ t s ->
-      Σ ;;; Γ,, vass n t |- b ▹ bty -> Pinfer Σ (Γ,, vass n t) b bty ->
-      Pinfer Σ Γ (tLambda n t b) (tProd n t bty)) ->
+      Psort Γ t s ->
+      Σ ;;; Γ,, vass n t |- b ▹ bty ->
+      Pinfer (Γ,, vass n t) b bty ->
+      Pinfer Γ (tLambda n t b) (tProd n t bty)) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (n : aname) (b B t : term) (s : Universe.t) (A : term),
+    (forall (Γ : context) (n : aname) (b B t : term) (s : Universe.t) (A : term),
       Σ ;;; Γ |- B ▸□ s ->
-      Psort Σ Γ B s ->
+      Psort Γ B s ->
       Σ ;;; Γ |- b ◃ B ->
-      Pcheck Σ Γ b B ->
+      Pcheck Γ b B ->
       Σ ;;; Γ,, vdef n b B |- t ▹ A ->
-      Pinfer Σ (Γ,, vdef n b B) t A -> Pinfer Σ Γ (tLetIn n b B t) (tLetIn n b B A)) ->
+      Pinfer (Γ,, vdef n b B) t A ->
+      Pinfer Γ (tLetIn n b B t) (tLetIn n b B A)) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (t : term) na A B u,
-      Σ ;;; Γ |- t ▸Π (na, A, B) -> Pprod Σ Γ t na A B ->
-      Σ ;;; Γ |- u ◃ A -> Pcheck Σ Γ u A ->
-      Pinfer Σ Γ (tApp t u) (subst10 u B)) ->
+    (forall (Γ : context) (t : term) na A B u,
+      Σ ;;; Γ |- t ▸Π (na, A, B) ->
+      Pprod Γ t na A B ->
+      Σ ;;; Γ |- u ◃ A ->
+      Pcheck Γ u A ->
+      Pinfer Γ (tApp t u) (subst10 u B)) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (cst : kername) u (decl : constant_body),
-      Forall_decls_sorting Pcheck Psort Σ.1 ->
+    (forall (Γ : context) (cst : kername) u (decl : constant_body),
       declared_constant Σ.1 cst decl ->
       consistent_instance_ext Σ decl.(cst_universes) u ->
-      Pinfer Σ Γ (tConst cst u) (subst_instance_constr u (cst_type decl))) ->
+      Pinfer Γ (tConst cst u) (subst_instance_constr u (cst_type decl))) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (ind : inductive) u mdecl idecl,
-      Forall_decls_sorting Pcheck Psort Σ.1 ->
+    (forall (Γ : context) (ind : inductive) u mdecl idecl,
       declared_inductive Σ.1 mdecl ind idecl ->
       consistent_instance_ext Σ mdecl.(ind_universes) u ->
-      Pinfer Σ Γ (tInd ind u) (subst_instance_constr u (ind_type idecl))) ->
+      Pinfer Γ (tInd ind u) (subst_instance_constr u (ind_type idecl))) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (ind : inductive) (i : nat) u
+    (forall (Γ : context) (ind : inductive) (i : nat) u
       mdecl idecl cdecl,
-      Forall_decls_sorting Pcheck Psort Σ.1 ->
       declared_constructor Σ.1 mdecl idecl (ind, i) cdecl ->
       consistent_instance_ext Σ mdecl.(ind_universes) u ->
-      Pinfer Σ Γ (tConstruct ind i u)
+      Pinfer Γ (tConstruct ind i u)
         (type_of_constructor mdecl cdecl (ind, i) u)) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (ind : inductive) u (npar : nat)
+    (forall (Γ : context) (ind : inductive) u (npar : nat)
       (p c : term) (brs : list (nat * term)) (args : list term)
       (mdecl : mutual_inductive_body) (idecl : one_inductive_body)
       (isdecl : declared_inductive (fst Σ) mdecl ind idecl),
-      Forall_decls_sorting Pcheck Psort Σ.1 ->
       isCoFinite mdecl.(ind_finite) = false ->
       Σ ;;; Γ |- c ▸{ind} (u,args) ->
-      Pind Σ Γ ind c u args ->
+      Pind Γ ind c u args ->
       ind_npars mdecl = npar ->
       let params := firstn npar args in
       forall ps pty,
       wf_universe Σ ps ->
       build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
       Σ ;;; Γ |- p ◃ pty ->
-      Pcheck Σ Γ p pty ->
+      Pcheck Γ p pty ->
       leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
       forall btys,
       map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
       All2 (fun br bty => (br.1 = bty.1) ×
-                        (Σ ;;; Γ |- br.2 ◃ bty.2) × Pcheck Σ Γ br.2 bty.2)
+                        (Σ ;;; Γ |- br.2 ◃ bty.2) × Pcheck Γ br.2 bty.2)
             brs btys ->
-      Pinfer Σ Γ (tCase (ind,npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
+      Pinfer Γ (tCase (ind,npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (p : projection) (c : term) u
+    (forall (Γ : context) (p : projection) (c : term) u
       mdecl idecl pdecl args,
-      Forall_decls_sorting Pcheck Psort Σ.1 ->
       declared_projection Σ.1 mdecl idecl p pdecl ->
       Σ ;;; Γ |- c ▸{fst (fst p)} (u,args) ->
-      Pind Σ Γ (fst (fst p)) c u args ->
+      Pind Γ (fst (fst p)) c u args ->
       #|args| = ind_npars mdecl ->
       let ty := snd pdecl in
-      Pinfer Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance_constr u ty))) ->
+      Pinfer Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance_constr u ty))) ->
 
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
+    (forall (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
       fix_guard mfix ->
       nth_error mfix n = Some decl ->
-      All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+      All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Γ d.(dtype) s}) mfix ->
       All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
                 (isLambda d.(dbody) = true) ×
-                Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+                Pcheck (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
       wf_fixpoint Σ.1 mfix ->
-      Pinfer Σ Γ (tFix mfix n) decl.(dtype)) ->
+      Pinfer Γ (tFix mfix n) decl.(dtype)) ->
     
-    (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
+    (forall (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
       cofix_guard mfix ->
       nth_error mfix n = Some decl ->
-      All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+      All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Γ d.(dtype) s}) mfix ->
       All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
-                Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+                Pcheck (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
       wf_cofixpoint Σ.1 mfix ->
-      Pinfer Σ Γ (tCoFix mfix n) decl.(dtype)) ->
+      Pinfer Γ (tCoFix mfix n) decl.(dtype)) ->
 
-    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (t T : term) (u : Universe.t),
+    (forall (Γ : context) (t T : term) (u : Universe.t),
       Σ ;;; Γ |- t ▹ T ->
-      Pinfer Σ Γ t T ->
+      Pinfer Γ t T ->
       Σ ;;; Γ |- T --> tSort u ->
-      Psort Σ Γ t u) ->
+      Psort Γ t u) ->
 
-    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (t T : term) (na : aname) (A B : term),
+    (forall (Γ : context) (t T : term) (na : aname) (A B : term),
       Σ ;;; Γ |- t ▹ T ->
-      Pinfer Σ Γ t T ->
+      Pinfer Γ t T ->
       Σ ;;; Γ |- T --> tProd na A B ->
-      Pprod Σ Γ t na A B) ->
+      Pprod Γ t na A B) ->
 
-    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (ind : inductive) (t T : term) (ui : Instance.t)
+    (forall (Γ : context) (ind : inductive) (t T : term) (ui : Instance.t)
       (args : list term),
       Σ ;;; Γ |- t ▹ T ->
-      Pinfer Σ Γ t T ->
+      Pinfer Γ t T ->
       Σ ;;; Γ |- T --> mkApps (tInd ind ui) args ->
-      Pind Σ Γ ind t ui args) ->
+      Pind Γ ind t ui args) ->
 
-    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (t T T' : term),
+    (forall (Γ : context) (t T T' : term),
       Σ ;;; Γ |- t ▹ T ->
-      Pinfer Σ Γ t T ->
+      Pinfer Γ t T ->
       Σ ;;; Γ |- T <= T' ->
-      Pcheck Σ Γ t T') ->
+      Pcheck Γ t T') ->
       
     env_prop.
   Proof.
     intros Pdecl_check Pdecl_sort HΓ HRel HSort HProd HLambda HLetIn HApp HConst HInd HConstruct HCase
       HProj HFix HCoFix HiSort HiProd HiInd HCheck ; unfold env_prop.
-      pose (@Fix_F (∑ (Σ : _) (wfΣ : _), typing_sum Σ wfΣ)
-      (dlexprod (precompose lt (fun Σ => globenv_size (fst Σ)))
-        (fun Σ => precompose lt (fun d => typing_sum_size d.π2)))
-      (fun d => Ptyping_sum d.π2.π2)).
+      pose (@Fix_F typing_sum (precompose lt typing_sum_size) Ptyping_sum) as p.
     forward p.
-    2:{ intros Σ wfΣ.
-    enough (HP : forall x : typing_sum Σ wfΣ, Ptyping_sum x).
+    2:{
+    enough (HP : forall x : typing_sum, Ptyping_sum x).
     - repeat split ; intros.
-      + exact (HP (env_cons Σ wfΣ)).
-      + exact (HP (context_cons Σ wfΣ Γ wfΓ)).
-      + exact (HP (check_cons Σ wfΣ Γ T t X)).
-      + exact (HP (inf_cons Σ wfΣ Γ T t X)).
-      + exact (HP (sort_cons Σ wfΣ Γ t u X)).
-      + exact (HP (prod_cons Σ wfΣ Γ t na A B X)).
-      + exact (HP (ind_cons Σ wfΣ Γ ind t u args X)).
-    - intros x ; apply (p (Σ ; (wfΣ ; x))).
-      apply wf_dlexprod ; intros ; apply wf_precompose ; apply lt_wf.
+      + exact (HP (context_cons Γ wfΓ)).
+      + exact (HP (check_cons Γ T t X)).
+      + exact (HP (inf_cons Γ T t X)).
+      + exact (HP (sort_cons Γ t u X)).
+      + exact (HP (prod_cons Γ t na A B X)).
+      + exact (HP (ind_cons Γ ind t u args X)).
+    - intros x ; apply p.
+      apply wf_precompose ; apply lt_wf.
     }
     clear p.     
-    intros (Σ & wfΣ & d) IH'. simpl.
-    match goal with | IH' : forall y : _ , ?P _ _ -> _ |- _ =>
-      have IH : forall (Σ' : global_env_ext) (wfΣ' : wf Σ'.1) (d' :typing_sum Σ' wfΣ'),
-        P (Σ'; wfΣ'; d') (Σ; wfΣ; d) -> Ptyping_sum d' end.
-    1: intros Σ' wfΣ' d' H; exact (IH' (Σ' ; wfΣ' ; d') H).
-    clear IH'.
+    intros d IH.
     destruct d ; simpl.
-    4: destruct i.
-    - destruct Σ as [Σ φ]. destruct Σ.
-      1: constructor.
-      destruct p.
-      cbn in  *.
-      have IH' : forall Σ' wfΣ' (d' : typing_sum Σ' wfΣ'), globenv_size (Σ'.1) < S (globenv_size Σ) ->
-                    Ptyping_sum d'
-        by intros ; apply IH ; constructor ; simpl ; assumption.
-      clear IH.
-      inversion_clear wfΣ as [|? ? ? wfΣ' ? ? ? wfg].
-      constructor.
-      + change (Forall_decls_sorting Pcheck Psort (Σ,φ).1).
-        applyIH.
-      + assumption.
-      + assumption.
-      + destruct g as [[? [] ?]| ]; cbn.
-        * inversion wfg as [[] ?].
-        split.
-        1: eexists.
-        all: applyIH.
-        eassumption.
-        * inversion wfg.
-          eexists. applyIH.
-          eassumption.
-        * inversion wfg.
-          constructor.
-          3-5: assumption.
-          2:{
-            clear - wfΣ' IH' onParams0.
-            induction onParams0.
-            1: by constructor.
-            -- constructor.
-               1: by assumption.
-               destruct t0.
-               eexists.
-               applyIH.
-               by eassumption. 
-            -- constructor.
-               1: by assumption.
-               destruct t0.
-               constructor.
-               2: by cbn ; applyIH.
-               destruct l.
-               eexists.
-               applyIH.
-               by eassumption. 
-          }
-
-          remember (ind_bodies m) as Γ in onInductives0 |- *.
-          clear - wfΣ' IH' onParams0 onInductives0.
-          induction onInductives0 as [| ? ? ? [] ?].
-          1: by constructor.
-          constructor.
-          2: eassumption.
-          econstructor ; try eassumption.
-          ++ destruct onArity0.
-            eexists. applyIH.
-            eassumption.
-          ++ clear - wfΣ' IH' onConstructors0 onParams0.
-            induction onConstructors0.
-            1: by constructor.
-            constructor.
-            2: assumption.
-            destruct r.
-            constructor.
-            all: try assumption.
-            ** cbn.
-                destruct on_ctype0.
-                eexists.
-                applyIH.
-                eassumption.
-            ** eapply type_local_ctx_impl.
-                1: eassumption.
-                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; try eassumption.
-
-            ** clear - wfΣ' IH' onParams0 on_cargs0 on_cindices0.
-                induction on_cindices0.
-                all: constructor ; auto.
-                1: destruct l ; eexists.
-                2: cbn.
-                all: applyIH.
-                eassumption.
-
-          ++ clear - wfΣ' IH' ind_sorts0 onParams0.
-              red in ind_sorts0 |- *.
-              destruct (universe_family ind_sort0).
-              all: intuition.
-              all: destruct indices_matter ; auto.
-              ** eapply type_local_ctx_impl.
-                1: eassumption.
-                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
-              ** eapply type_local_ctx_impl.
-                1: eassumption.
-                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
-
-
+    3: destruct i.
+    
     - apply HΓ.
-      1: assumption.
-      1:{ applyIH. apply wf_local_size_pos. }
       dependent induction wfΓ.
       + constructor.
       + destruct t0 as (u & d).
         constructor.
         * apply IHwfΓ.
         intros ; apply IH.
-        dependent destruction H ; [constructor | constructor 2] ; auto.
         simpl in *. lia.
         
-        * simpl ; red ; applyIH.
-          have ? : 0 < wfl_size wfΓ by apply wf_local_size_pos.
+        * simpl. red.
+          applyIH.
+          assert (0 < wfl_size wfΓ) by apply wf_local_size_pos.
+          simpl.
           lia.
       + destruct t0 as [[u h] h'].
         constructor.
         2: constructor.
         * apply IHwfΓ.
           intros ; apply IH.
-          dependent destruction H ; [constructor | constructor 2] ; auto.
-          etransitivity ; eauto.
-          simpl.
-          cbn in h. pose proof (infering_sort_size_pos h). lia.
+          simpl in *. pose proof (infering_sort_size_pos h). lia.
         * red. applyIH. pose proof (checking_size_pos h'). simpl in *. lia.
         * red. applyIH. pose proof (infering_sort_size_pos h). simpl in *. lia.
 
@@ -698,7 +539,7 @@ Section TypingInduction.
     - unshelve eapply HLetIn ; auto.
       all: applyIH.
 
-    - unshelve eapply (HApp _ _ _ _ _ _ A) ; auto.
+    - eapply HApp ; eauto.
       all: applyIH.
 
     - unshelve eapply HConst ; auto.
@@ -712,104 +553,81 @@ Section TypingInduction.
 
     - destruct indnpar as [ind' npar'] ; cbn in ind ; cbn in npar ; subst ind ; subst npar.
       unshelve eapply HCase ; auto.
-      1-4: applyIH.
-      match goal with | IH : forall Σ' wfΣ' d', _ _ (_ ; _ ; ?d) -> _ |- _ =>
-        have IH' : forall d' : typing_sum Σ wfΣ, (typing_sum_size d') < (typing_sum_size d) -> Ptyping_sum d' end.
-      1:{ intros. apply IH. constructor 2. assumption. }
+      1-2: applyIH.
       remember btys as b in e2.
-      clear - IH'. cbn in IH' |- *.
+      clear Heqb.
+      cbn in IH.
       induction a.
       1: by constructor.
       destruct r.
       constructor.
       + intuition eauto.
-        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try eassumption. simpl. lia.
+        applyIH.
       + apply IHa.
-        intros. apply IH'. simpl in *. lia.
+        intros. apply IH. simpl in *. lia.
     
     - unshelve eapply HProj ; auto.
       all: applyIH.
 
     - unshelve eapply HFix ; eauto.
-      1: applyIH.
 
-      all: have IH' : (forall d' : typing_sum Σ wfΣ,
-      (typing_sum_size d') <
-        (typing_sum_size (inf_cons _ wfΣ _ _ (tFix mfix n)
-        (infer_Fix Σ Γ mfix n decl i e a a0 i0)))
-      -> Ptyping_sum d') by intros ; apply IH ; constructor 2 ; assumption.
-      all: simpl in IH'.
+      all: simpl in IH.
       all: remember (fix_context mfix) as mfixcontext.
 
-      1:{
-        remember (all_size _ _ a0) as s.
-        clear -IH'.
+      + remember (all_size _ _ a0) as s.
+        clear -IH.
         dependent induction a.
         1: by constructor.
         constructor ; cbn.
-        + destruct p ; eexists ; split.
+        * destruct p ; eexists ; split.
           1: eassumption.
-          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _)).
-          all: try assumption.
-          simpl. lia.
-        + apply (IHa s).
+          applyIH.
+        * apply (IHa s).
           intros.
-          apply IH'.
+          apply IH.
           cbn. lia.
-      }
 
-      remember (all_size _ _ a) as s.
-      clear -IH'.
-      induction a0 as [| ? ? [? ?]].
-      1: by constructor.
-      constructor.
-      + intuition.
-        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try assumption.
-        simpl. lia.
-      + apply IHa0.
-        intros ; apply IH'.
-        cbn. lia.
+      + remember (all_size _ _ a) as s.
+        clear -IH.
+        induction a0 as [| ? ? [? ?]].
+        1: by constructor.
+        constructor.
+        * intuition.
+          applyIH.
+        * apply IHa0.
+          intros.
+          apply IH.
+          cbn. lia.
 
     - unshelve eapply HCoFix ; eauto.
-      1: applyIH.
 
-      all: have IH' : (forall d' : typing_sum Σ wfΣ,
-      (typing_sum_size d') <
-        (typing_sum_size (inf_cons _ wfΣ _ _ (tCoFix mfix n)
-        (infer_CoFix Σ Γ mfix n decl i e a a0 i0)))
-      -> Ptyping_sum d')
-      by intros ; apply IH ; constructor 2 ; assumption.
-      all: simpl in IH'.
+      all: simpl in IH.
       all: remember (fix_context mfix) as mfixcontext.
 
-      {
-        remember (all_size _ _ a0) as s.
-        clear -IH'.
+      + remember (all_size _ _ a0) as s.
+        clear -IH.
         dependent induction a.
         1: by constructor.
         constructor ; cbn.
-        + destruct p ; eexists ; split.
+        * destruct p ; eexists ; split.
           1: eassumption.
-          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _)).
-          all: try assumption.
-          simpl. lia.
-        + apply (IHa s).
+          applyIH.
+        * apply (IHa s).
           intros.
-          apply IH'.
+          apply IH.
           cbn. lia.
-      }
 
-      remember (all_size _ _ a) as s.
-      clear -IH'.
-      induction a0.
-      1: by constructor.
-      constructor.
-      + intuition.
-        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try assumption.
-        simpl. lia.
-      + apply IHa0.
-        intros ; apply IH'.
-        cbn. lia.
+      + remember (all_size _ _ a) as s.
+        clear -IH.
+        induction a0 as [| ? ? ?].
+        1: by constructor.
+        constructor.
+        * intuition.
+          applyIH.
+        * apply IHa0.
+          intros.
+          apply IH.
+          cbn. lia.
 
     - destruct i.
       unshelve (eapply HiSort ; try eassumption) ; try eassumption.

--- a/bidirectional/theories/BDMinimalTyping.v
+++ b/bidirectional/theories/BDMinimalTyping.v
@@ -91,7 +91,6 @@ Inductive infering `{checker_flags} (Σ : global_env_ext) (Γ : context) : term 
   map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
   All2 (fun br bty =>
     (br.1 = bty.1) ×
-    (∑ u , (Σ ;;; Γ |- bty.2 ▸□ u)) ×
     (Σ ;;; Γ |- br.2 ◃ bty.2))
     brs btys ->
   Σ ;;; Γ |- tCase indnpar p c brs ▹ mkApps p (skipn npar args ++ [c])
@@ -213,8 +212,7 @@ Proof.
     | |- _ => exact 1
     end.
     - exact (S (i + c0 + (all2_size _ 
-                                      (fun x y p => (infering_sort_size _ _ _ _ _ (fst (snd p)).π2)
-                                                    + (checking_size _ _ _ _ _ (snd (snd p)))) a))).
+                                      (fun x y p => checking_size _ _ _ _ _ (snd p))) a)).
     - exact (S (all_size _ (fun d p => infering_sort_size _ _ _ _ _ p.π2) a) +
                (all_size _ (fun x p => checking_size _ _ _ _ _ p.1) a0)).
     - exact (S (all_size _ (fun d p => infering_sort_size _ _ _ _ _ p.π2) a) +
@@ -463,7 +461,6 @@ Section TypingInduction.
       forall btys,
       map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
       All2 (fun br bty => (br.1 = bty.1) ×
-                        (∑ u, (Σ ;;; Γ |- bty.2 ▸□ u) × Psort Σ Γ bty.2 u) ×
                         (Σ ;;; Γ |- br.2 ◃ bty.2) × Pcheck Σ Γ br.2 bty.2)
             brs btys ->
       Pinfer Σ Γ (tCase (ind,npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
@@ -723,11 +720,10 @@ Section TypingInduction.
       clear - IH'. cbn in IH' |- *.
       induction a.
       1: by constructor.
-      destruct r as [? [[? ?] ?]].
+      destruct r.
       constructor.
       + intuition eauto.
-        * eexists. split ; eauto. unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _)) ; try eassumption. simpl. lia.
-        * unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try eassumption. simpl. lia.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _)) ; try eassumption. simpl. lia.
       + apply IHa.
         intros. apply IH'. simpl in *. lia.
     

--- a/bidirectional/theories/BDMinimalTyping.v
+++ b/bidirectional/theories/BDMinimalTyping.v
@@ -395,7 +395,8 @@ Section TypingInduction.
       Σ ;;; Γ |- t ▸□ s1 ->
       Psort Σ Γ t s1 ->
       Σ ;;; Γ,, vass n t |- b ▸□ s2 ->
-      Psort Σ (Γ,, vass n t) b s2 -> Pinfer Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
+      Psort Σ (Γ,, vass n t) b s2 ->
+      Pinfer Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
 
     (forall Σ (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
       (Γ : context) (n : aname) (t b : term) (s : Universe.t) (bty : term),

--- a/bidirectional/theories/BDMinimalTyping.v
+++ b/bidirectional/theories/BDMinimalTyping.v
@@ -84,6 +84,7 @@ Inductive infering `{checker_flags} (Σ : global_env_ext) (Γ : context) : term 
   isCoFinite mdecl.(ind_finite) = false ->
   let params := List.firstn npar args in
   forall ps pty, build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+  wf_universe Σ ps ->
   Σ ;;; Γ |- p ◃ pty ->
   leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
   forall (btys : list (nat × term)),
@@ -453,6 +454,7 @@ Section TypingInduction.
       ind_npars mdecl = npar ->
       let params := firstn npar args in
       forall ps pty,
+      wf_universe Σ ps ->
       build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
       Σ ;;; Γ |- p ◃ pty ->
       Pcheck Σ Γ p pty ->
@@ -572,7 +574,11 @@ Section TypingInduction.
       + assumption.
       + assumption.
       + destruct g as [[? [] ?]| ]; cbn.
-        * applyIH.
+        * inversion wfg as [[] ?].
+        split.
+        1: eexists.
+        all: applyIH.
+        eassumption.
         * inversion wfg.
           eexists. applyIH.
           eassumption.
@@ -628,9 +634,12 @@ Section TypingInduction.
                 all: intros ; applyIH ; eapply type_local_ctx_wf_local ; try eassumption.
 
             ** clear - wfΣ' IH' onParams0 on_cargs0 on_cindices0.
-               induction on_cindices0.
-               all: constructor ; auto.
-               cbn. applyIH.
+                induction on_cindices0.
+                all: constructor ; auto.
+                1: destruct l ; eexists.
+                2: cbn.
+                all: applyIH.
+                eassumption.
 
           ++ clear - wfΣ' IH' ind_sorts0 onParams0.
               red in ind_sorts0 |- *.

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -89,8 +89,9 @@ Proof.
               unfold PT.cstr_respects_variance.
               destruct (variance_universes (PCUICEnvironment.ind_universes m)) ; simpl in * ; auto.
               destruct p as [[]]. intuition.
-              induction a ; intuition.
-              all: admit.
+              induction a.
+              all: constructor ; auto.
+
             
         -- intros projs ; specialize (onProjections projs).
            clear - onProjections.
@@ -106,10 +107,11 @@ Proof.
            cbn in *.
            red in ind_sorts |- *.
            destruct (universe_family ind_sort).
-           all: admit.
-(*            ++ induction ind_cshapes ; auto.
+           ++ induction ind_cshapes ; auto.
+           ++ induction ind_cshapes ; auto.
               simpl in *.
               destruct ind_cshapes ; auto.
+              simpl in *.
               destruct a ; auto.
            ++ destruct ind_sorts. split.
               { apply Forall_map.
@@ -130,7 +132,7 @@ Proof.
               1: auto.
               ** destruct y as [[] ].
                  repeat split ; auto.
-              ** destruct y. repeat split ; auto. *)
+              ** destruct y. repeat split ; auto.
 
         -- clear -onIndices.
            intros v e. specialize (onIndices v e).
@@ -138,13 +140,18 @@ Proof.
            unfold PT.ind_respects_variance.
            destruct (PCUICEnvironment.ind_universes m) ; simpl in * ; auto.
            destruct cst.
-           admit.
+           replace (PT.level_var_instance 0 l) with (level_var_instance 0 l).
+           2:{ by induction l ; auto. }
+           match goal with |- context [PT.lift_instance ?len ?list] =>
+            replace (PT.lift_instance len list) with (lift_instance len list) end.
+           2:{ apply map_ext. intros []. all: reflexivity. }
+           induction onIndices.
+           all: constructor ; auto.
 
       * clear - onParams.
         induction onParams.
         all: constructor ; intuition.
-Admitted.
-      
+Qed.      
 
 Lemma bd_wf_local `{checker_flags} Σ Γ (all: wf_local Σ Γ) :
   BD.All_local_env_over_sorting checking infering_sort 
@@ -208,4 +215,4 @@ Proof.
 
 Qed.
 
-End BDToPCUICTyping.      
+End BDToPCUICTyping.

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -139,7 +139,7 @@ Proof.
       * clear - onParams.
         induction onParams.
         all: constructor ; intuition.
-Admitted.
+Qed.
       
 
 Lemma bd_wf_local `{checker_flags} Σ Γ (all: wf_local Σ Γ) :

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -90,6 +90,7 @@ Proof.
               destruct (variance_universes (PCUICEnvironment.ind_universes m)) ; simpl in * ; auto.
               destruct p as [[]]. intuition.
               induction a ; intuition.
+              all: admit.
             
         -- intros projs ; specialize (onProjections projs).
            clear - onProjections.
@@ -105,7 +106,8 @@ Proof.
            cbn in *.
            red in ind_sorts |- *.
            destruct (universe_family ind_sort).
-           ++ induction ind_cshapes ; auto.
+           all: admit.
+(*            ++ induction ind_cshapes ; auto.
               simpl in *.
               destruct ind_cshapes ; auto.
               destruct a ; auto.
@@ -128,7 +130,7 @@ Proof.
               1: auto.
               ** destruct y as [[] ].
                  repeat split ; auto.
-              ** destruct y. repeat split ; auto.
+              ** destruct y. repeat split ; auto. *)
 
         -- clear -onIndices.
            intros v e. specialize (onIndices v e).
@@ -195,49 +197,15 @@ Proof.
     all: constructor.
     all: intuition.
     
-  - left.
-    apply PCUICPrincipality.isWfArity_sort.
+  - apply red_cumul.
     assumption.
 
   - apply red_cumul.
     assumption.
   
-  - destruct X3 as [ [[? [? []]] ] | [? []]].
-    + left.
-      eexists ; eexists ; split ; eauto.
-      eapply bd_wf_local ; eassumption.
-    + right.
-      eexists.
-      eassumption.
-
   - apply red_cumul.
     assumption.
-    
-  - destruct X3 as [ [[? [? []]] ] | [? []]].
-    + left.
-      eexists ; eexists ; split ; eauto.
-      eapply bd_wf_local ; eassumption.
-    + right.
-      eexists.
-      eassumption.
 
-  - apply red_cumul.
-    assumption.
-    
-  - destruct X2 as [ [[? [? []]] ] | [? []]].
-    + left.
-      eexists ; eexists ; split ; eauto.
-      eapply bd_wf_local ; eassumption.
-    + right.
-      eexists.
-      eassumption.
 Qed.
 
-End BDToPCUICTyping.
-
-  
-
-
-  
-
-      
+End BDToPCUICTyping.      

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -261,3 +261,11 @@ Proof.
   apply bidirectional_to_PCUIC.
   assumption.
 Qed.
+
+Theorem wf_bd_typing `{checker_flags} (Σ : global_env_ext) (wfΣ : BD.wf Σ) :
+  PT.wf Σ.
+Proof.
+  apply bd_wf.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -204,14 +204,17 @@ Proof.
     all: constructor.
     all: intuition.
     
-  - apply red_cumul.
-    assumption.
+  - constructor.
+    all: assumption.
 
   - apply red_cumul.
     assumption.
   
   - apply red_cumul.
     assumption.
+
+  - apply red_cumul.
+    assumption. 
 
 Qed.
 

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -1,0 +1,232 @@
+From Coq Require Import Bool List Arith Lia.
+From MetaCoq.Template Require Import config utils monad_utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping.
+From MetaCoq.PCUIC Require Import PCUICPrincipality PCUICClosed PCUICValidity PCUICCumulativity PCUICSR.
+From MetaCoq.Bidirectional Require Import BDEnvironmentTyping BDTyping.
+
+Require Import ssreflect.
+From Equations Require Import Equations.
+Require Import Equations.Prop.DepElim.
+
+
+Module PT := PCUIC.PCUICTyping.
+Module BD := Bidirectional.BDTyping.
+
+Section BDToPCUICTyping.
+
+  Definition Pcheck `{checker_flags} Σ Γ t T :=
+    Σ ;;; Γ |- t : T.
+
+  Definition Pinfer `{checker_flags} Σ Γ t T :=
+    Σ ;;; Γ |- t : T.
+
+  Definition Psort `{checker_flags} Σ Γ t u :=
+    Σ ;;; Γ |- t : (tSort u).
+
+  Definition Pprod `{checker_flags} Σ Γ t na A B :=
+    Σ ;;; Γ |- t : tProd na A B.
+
+  Definition Pind `{checker_flags} Σ Γ ind t u args :=
+    Σ ;;; Γ |- t : mkApps (tInd ind u) args.
+
+  Definition PΓ `{checker_flags} Σ Γ (wfΓ : wf_local Σ Γ) :=
+    PT.wf_local Σ Γ.
+
+Lemma bd_wf `{checker_flags} Σ : Forall_decls_sorting Pcheck Psort Σ -> PT.wf Σ.
+Proof.
+   intros wfΣ. induction wfΣ.
+  all: constructor.
+  - assumption.
+  - assumption.
+  - constructor ; intuition.
+  - destruct d as [[? [] ?]|].
+    + assumption.
+    + destruct o0. eexists.
+      eauto.
+    + destruct o0.
+      constructor ; intuition.
+      * induction onInductives.
+        all: constructor ; auto.
+        destruct p.
+        unshelve econstructor.
+        -- exact ind_indices.
+        -- exact ind_sort.
+        -- eapply map.
+           2: exact ind_cshapes.
+           intros [].
+           constructor ; auto.
+        -- assumption.
+        -- assumption.
+        -- apply All2_map_right.
+           eapply All2_impl.
+           1: exact onConstructors.
+           intros [[] ?] [] [] ; simpl in *. constructor ; auto ; simpl in *.
+           ++ match goal with |- PT.type_local_ctx _ _ ?ctx _ _ => remember ctx as Γ' end.
+              clear -on_cargs.
+              induction cshape_args as [|[? []]].
+              1: auto.
+              ** destruct on_cargs as [[] ].
+                 repeat split ; auto.
+              ** destruct on_cargs. repeat split ; auto.
+           ++  match goal with |- PT.ctx_inst _ _ ?ctx _ _ => remember ctx as Γ' end.
+               clear -on_cindices.
+               induction on_cindices.
+               all: constructor.
+               all: assumption.
+           ++ clear - on_ctype_positive.
+              cbn in on_ctype_positive |- *.
+              induction on_ctype_positive.
+              all: constructor ; auto.
+              clear - p. induction p.
+              ** constructor ; assumption.
+              ** constructor 2 ; auto.
+              ** constructor 3 ; auto.
+              ** constructor 4 ; auto.
+           ++ clear - on_ctype_variance.
+              intros v e.
+              specialize (on_ctype_variance v e).
+              unfold respects_variance in on_ctype_variance.
+              unfold PT.respects_variance.
+              destruct (PCUICEnvironment.ind_universes m) ; simpl in *.
+              ** destruct on_ctype_variance as [a ?] ; split ; auto.
+                 induction a ; intuition.
+              ** destruct cst ; intuition.
+                 unfold level_var_instance in a ; unfold PT.level_var_instance.
+                 match goal with |- PT.All2_local_env (PT.on_decl ?Q) ?ctx ?ctx' =>
+                  remember ctx as Γ ; remember ctx' as Γ' end.
+                  clear - a.
+                  induction a.
+                  all: constructor ; auto.
+            
+        -- intros projs ; specialize (onProjections projs).
+           clear - onProjections.
+           induction ind_cshapes.
+           1: auto.
+           simpl in *.
+           destruct ind_cshapes.
+           { destruct a. simpl in *.
+             destruct onProjections. constructor ; intuition. }
+           assumption.
+
+        -- clear -ind_sorts.
+           cbn in *.
+           red in ind_sorts |- *.
+           destruct (universe_family ind_sort).
+           ++ induction ind_cshapes ; auto.
+              simpl in *.
+              destruct ind_cshapes ; auto.
+              destruct a ; auto.
+           ++ destruct ind_sorts. split.
+              { apply Forall_map.
+                eapply Forall_impl. 1: eassumption.
+                intros [] ? ; assumption. }
+              destruct indices_matter ; auto.
+              induction ind_indices as [|[? []]].
+              1: auto.
+              ** destruct y as [[] ].
+                 repeat split ; auto.
+              ** destruct y. repeat split ; auto.
+           ++ destruct ind_sorts. split.
+              { apply Forall_map.
+                eapply Forall_impl. 1: eassumption.
+                intros [] ? ; assumption. }
+              destruct indices_matter ; auto.
+              induction ind_indices as [|[? []]].
+              1: auto.
+              ** destruct y as [[] ].
+                 repeat split ; auto.
+              ** destruct y. repeat split ; auto.
+      * clear - onParams.
+        induction onParams.
+        all: constructor ; intuition.
+Admitted.
+      
+
+Lemma bd_wf_local `{checker_flags} Σ Γ (all: wf_local Σ Γ) :
+  BD.All_local_env_over_sorting checking infering_sort 
+    (fun Σ Γ _ t T _ => Pcheck Σ Γ t T)
+    (fun Σ Γ _ t u _ => Psort Σ Γ t u) 
+    Σ Γ all ->
+  PT.wf_local Σ Γ.
+Proof.
+  intros allo ; induction allo.
+  all: constructor.
+  1,3: assumption.
+  all: red.
+  - simpl in t0. eexists.
+     eassumption.
+  - destruct t0. eexists.
+    eassumption.
+  - destruct t0.
+    assumption.
+Qed.   
+  
+Theorem Bidirectional_to_PCUIC `{cf : checker_flags} : env_prop Pcheck Pinfer Psort Pprod Pind (@PΓ).
+Proof.
+  apply BD.typing_ind_env.
+
+  1:{ intros. eapply bd_wf_local. eassumption. }
+
+  all: intros ; red ; econstructor ; eauto.
+
+  - clear - X5. induction X5.
+    all: constructor.
+    all: intuition.
+
+  - clear - X0. induction X0.
+    all: constructor.
+    2: auto.
+    destruct p as [? []].
+    eexists. eauto.
+    
+  - remember (fix_context mfix) as Γ'. clear - X1. induction X1.
+    all: constructor.
+    all: intuition.
+  
+  - clear - X0. induction X0.
+    all: constructor.
+    2: auto.
+    destruct p as [? []].
+    eexists. eauto.
+  
+  - remember (fix_context mfix) as Γ'. clear - X1. induction X1.
+    all: constructor.
+    all: intuition.
+    
+  - left.
+    apply PCUICPrincipality.isWfArity_sort.
+    assumption.
+
+  - apply red_cumul.
+    assumption.
+  
+  - have ? : PT.wf Σ.1 by apply bd_wf.
+    eapply isWfArity_or_Type_red ; eauto.
+    eapply validity_term ; eauto.
+
+  - apply red_cumul.
+    assumption.
+    
+  - have ? : PT.wf Σ.1 by apply bd_wf.
+    eapply isWfArity_or_Type_red ; eauto.
+    eapply validity_term ; eauto.
+
+  - apply red_cumul.
+    assumption.
+    
+  - destruct X2 as [ [[? [? []]] ] | [? []]].
+    + left.
+      eexists ; eexists ; split ; eauto.
+      eapply bd_wf_local ; eassumption.
+    + right.
+      eexists.
+      eassumption.
+  
+Qed.
+
+  
+
+
+  
+
+      

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -34,7 +34,7 @@ Section BDToPCUICTyping.
 
 Lemma bd_wf `{checker_flags} Σ : Forall_decls_sorting Pcheck Psort Σ -> PT.wf Σ.
 Proof.
-   intros wfΣ. induction wfΣ.
+  intros wfΣ. induction wfΣ.
   all: constructor.
   - assumption.
   - assumption.
@@ -196,7 +196,7 @@ Proof.
     all: intuition.
     
   - left.
-    apply isWfArity_sort.
+    apply PCUICPrincipality.isWfArity_sort.
     assumption.
 
   - apply red_cumul.
@@ -232,6 +232,8 @@ Proof.
       eexists.
       eassumption.
 Qed.
+
+End BDToPCUICTyping.
 
   
 

--- a/bidirectional/theories/BDToPCUIC.v
+++ b/bidirectional/theories/BDToPCUIC.v
@@ -14,22 +14,22 @@ Module BD := Bidirectional.BDTyping.
 
 Section BDToPCUICTyping.
 
-  Definition Pcheck `{checker_flags} Σ Γ t T :=
+  Let Pcheck `{checker_flags} Σ Γ t T :=
     Σ ;;; Γ |- t : T.
 
-  Definition Pinfer `{checker_flags} Σ Γ t T :=
+  Let Pinfer `{checker_flags} Σ Γ t T :=
     Σ ;;; Γ |- t : T.
 
-  Definition Psort `{checker_flags} Σ Γ t u :=
+  Let Psort `{checker_flags} Σ Γ t u :=
     Σ ;;; Γ |- t : (tSort u).
 
-  Definition Pprod `{checker_flags} Σ Γ t na A B :=
+  Let Pprod `{checker_flags} Σ Γ t na A B :=
     Σ ;;; Γ |- t : tProd na A B.
 
-  Definition Pind `{checker_flags} Σ Γ ind t u args :=
+  Let Pind `{checker_flags} Σ Γ ind t u args :=
     Σ ;;; Γ |- t : mkApps (tInd ind u) args.
 
-  Definition PΓ `{checker_flags} Σ Γ (wfΓ : wf_local Σ Γ) :=
+  Let PΓ `{checker_flags} Σ Γ (wfΓ : wf_local Σ Γ) :=
     PT.wf_local Σ Γ.
 
 Lemma bd_wf `{checker_flags} Σ : Forall_decls_sorting Pcheck Psort Σ -> PT.wf Σ.
@@ -172,7 +172,7 @@ Proof.
     assumption.
 Qed.
   
-Theorem Bidirectional_to_PCUIC `{cf : checker_flags} : env_prop Pcheck Pinfer Psort Pprod Pind (@PΓ).
+Theorem bidirectional_to_PCUIC `{cf : checker_flags} : env_prop Pcheck Pinfer Psort Pprod Pind (@PΓ).
 Proof.
   apply BD.typing_ind_env.
 
@@ -219,3 +219,45 @@ Proof.
 Qed.
 
 End BDToPCUICTyping.
+
+Theorem infering_typing `{checker_flags} (Σ : global_env_ext) Γ t T (wfΣ : wf Σ) :
+  Σ ;;; Γ |- t ▹ T -> Σ ;;; Γ |- t : T.
+Proof.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.
+
+Theorem checking_typing `{checker_flags} (Σ : global_env_ext) Γ t T (wfΣ : wf Σ) :
+  Σ ;;; Γ |- t ◃ T -> Σ ;;; Γ |- t : T.
+Proof.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.
+
+Theorem infering_sort_typing `{checker_flags} (Σ : global_env_ext) Γ t u (wfΣ : wf Σ) :
+Σ ;;; Γ |- t ▸□ u -> Σ ;;; Γ |- t : tSort u.
+Proof.
+apply bidirectional_to_PCUIC.
+assumption.
+Qed.
+
+Theorem infering_prod_typing `{checker_flags} (Σ : global_env_ext) Γ t na A B (wfΣ : wf Σ) :
+Σ ;;; Γ |- t ▸Π (na,A,B) -> Σ ;;; Γ |- t : tProd na A B.
+Proof.
+apply bidirectional_to_PCUIC.
+assumption.
+Qed.
+
+Theorem infering_ind_typing `{checker_flags} (Σ : global_env_ext) Γ t ind u args (wfΣ : wf Σ) :
+Σ ;;; Γ |- t ▸{ind} (u,args) -> Σ ;;; Γ |- t : mkApps (tInd ind u) args.
+Proof.
+apply bidirectional_to_PCUIC.
+assumption.
+Qed.
+
+Theorem wf_local_bd_typing `{checker_flags} (Σ : global_env_ext) Γ (wfΣ : wf Σ) :
+BD.wf_local Σ Γ -> PT.wf_local Σ Γ.
+Proof.
+  apply bidirectional_to_PCUIC.
+  assumption.
+Qed.

--- a/bidirectional/theories/BDTyping.v
+++ b/bidirectional/theories/BDTyping.v
@@ -149,10 +149,10 @@ Inductive infering `{checker_flags} (Σ : global_env_ext) (Γ : context) : term 
     Σ ;;; Γ |- tCoFix mfix n ▹ decl.(dtype)
 
 with infering_sort `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> Universe.t -> Type :=
-| infer_sort_Sort t T u s :
+| infer_sort_Sort t T u:
   Σ ;;; Γ |- t ▹ T ->
   Σ ;;; Γ |- T --> tSort u ->
-  Σ ;;; Γ |- tSort u ▸□ s ->
+  wf_universe Σ u ->
   Σ ;;; Γ |- t ▸□ u
 
 with infering_prod `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> aname -> term -> term -> Type :=
@@ -605,13 +605,12 @@ Section TypingInduction.
       Pinfer Σ Γ (tCoFix mfix n) decl.(dtype)) ->
 
     (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)
-      (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term) (u s : Universe.t),
+      (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term) (u : Universe.t),
       PΓ Σ Γ wfΓ ->
       Σ ;;; Γ |- t ▹ T ->
       Pinfer Σ Γ t T ->
       Σ ;;; Γ |- T --> tSort u ->
-      Σ ;;; Γ |- tSort u ▸□ s ->
-      Psort Σ Γ (tSort u) s ->
+      wf_universe Σ u ->
       Psort Σ Γ t u) ->
 
     (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (PΣ : Forall_decls_sorting Pcheck Psort Σ.1)

--- a/bidirectional/theories/BDTyping.v
+++ b/bidirectional/theories/BDTyping.v
@@ -1,0 +1,958 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import Bool List Arith Lia.
+From Coq Require String.
+From MetaCoq.Template Require Import config utils monad_utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+  PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils
+  PCUICPosition PCUICTyping.
+From MetaCoq.Bidirectional Require Import BDEnvironmentTyping.
+
+From MetaCoq Require Export LibHypsNaming.
+Require Import ssreflect.
+Set Asymmetric Patterns.
+Require Import Equations.Type.Relation.
+Require Import Equations.Prop.DepElim.
+From Equations Require Import Equations.
+Import MonadNotation.
+
+Module BDLookup := Lookup PCUICTerm PCUICEnvironment.
+Include BDLookup.
+
+Module BDEnvTyping := EnvTyping PCUICTerm PCUICEnvironment.
+Include BDEnvTyping.
+
+Section WfArity.
+  Context (checking : forall (Σ : global_env_ext) (Γ : context), term -> term -> Type).
+  Context (sorting : forall (Σ : global_env_ext) (Γ : context), term -> Universe.t -> Type).
+
+  Definition isWfArity_rel Σ (Γ : context) T :=
+    { ctx & { s & (destArity [] T = Some (ctx, s)) ×
+      All_local_env_rel (lift_sorting checking sorting Σ) Γ ctx } }.
+
+  Context (cproperty : forall (Σ : global_env_ext) (Γ Γ' : context),
+              All_local_env_rel (lift_sorting checking sorting Σ) Γ Γ' ->
+              forall (t T : term), checking Σ (Γ,,,Γ') t T -> Type).
+  Context (sproperty : forall (Σ : global_env_ext) (Γ Γ' : context),
+              All_local_env_rel (lift_sorting checking sorting Σ) Γ Γ' ->
+              forall (t : term) (u : Universe.t), sorting Σ (Γ,,,Γ') t u -> Type).
+
+  Definition isWfArity_prop_rel Σ (Γ : context) T :=
+    { wfa : isWfArity_rel Σ Γ T &
+      All_local_env_over_rel checking sorting cproperty sproperty Σ Γ wfa.π1 wfa.π2.π2.2 }.
+End WfArity.
+
+Notation "Σ ;;; Γ |- t --> t'" := (red Σ Γ t t') (at level 50, Γ, t, t' at next level) : type_scope.
+Reserved Notation " Σ ;;; Γ |- t ▹ T " (at level 50, Γ, t, T at next level).
+Reserved Notation " Σ ;;; Γ |- t ▸□ u " (at level 50, Γ, t, u at next level).
+Reserved Notation " Σ ;;; Γ |- t ▸Π ( na , A , B ) " (at level 50, Γ, t, na, A, B at next level).
+Reserved Notation " Σ ;;; Γ |- t ▸{ ind } ( u , args )" (at level 50, Γ, t, ind, u, args at next level).
+Reserved Notation " Σ ;;; Γ |- t ◃ T " (at level 50, Γ, t, T at next level).
+
+
+Inductive infering `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| infer_Rel n decl :
+    nth_error Γ n = Some decl ->
+    Σ ;;; Γ |- tRel n ▹ lift0 (S n) decl.(decl_type)
+
+| infer_Sort l :
+    LevelSet.In l (global_ext_levels Σ) ->
+    Σ ;;; Γ |- tSort (Universe.make l) ▹ tSort (Universe.super l)
+
+| infer_Prod na A B s1 s2 :
+    Σ ;;; Γ |- A ▸□ s1 ->
+    Σ ;;; Γ ,, vass na A |- B ▸□ s2 ->
+    Σ ;;; Γ |- tProd na A B ▹ tSort (Universe.sort_of_product s1 s2)
+
+| infer_Lambda na A t s B :
+    Σ ;;; Γ |- A ▸□ s ->
+    Σ ;;; Γ ,, vass na A |- t ▹ B ->
+    Σ ;;; Γ |- tLambda na A t ▹ tProd na A B
+
+| infer_LetIn na b B t s A :
+    Σ ;;; Γ |- B ▸□ s ->
+    Σ ;;; Γ |- b ◃ B ->
+    Σ ;;; Γ ,, vdef na b B |- t ▹ A ->
+    Σ ;;; Γ |- tLetIn na b B t ▹ tLetIn na b B A
+
+| infer_App t na A B u :
+    Σ ;;; Γ |- t ▸Π (na,A,B) ->
+    Σ ;;; Γ |- u ◃ A ->
+    Σ ;;; Γ |- tApp t u ▹ B{0 := u}
+
+| infer_Const cst u :
+    forall decl (isdecl : declared_constant Σ.1 cst decl),
+    consistent_instance_ext Σ decl.(cst_universes) u ->
+    Σ ;;; Γ |- tConst cst u ▹ subst_instance_constr u decl.(cst_type)
+
+| infer_Ind ind u :
+    forall mdecl idecl (isdecl : declared_inductive Σ.1 mdecl ind idecl),
+    consistent_instance_ext Σ mdecl.(ind_universes) u ->
+    Σ ;;; Γ |- tInd ind u ▹ subst_instance_constr u idecl.(ind_type)
+
+| infer_Construct ind i u :
+    forall mdecl idecl cdecl (isdecl : declared_constructor Σ.1 mdecl idecl (ind, i) cdecl),
+    consistent_instance_ext Σ mdecl.(ind_universes) u ->
+    Σ ;;; Γ |- tConstruct ind i u ▹ type_of_constructor mdecl cdecl (ind, i) u
+
+| infer_Case (indnpar : inductive × nat) (u : Instance.t) (p c : term) (brs : list (nat × term)) (args : list term) :
+  let ind := indnpar.1 in
+  let npar := indnpar.2 in
+   Σ ;;; Γ |- c ▸{ind} (u,args) ->
+  forall mdecl idecl (isdecl : declared_inductive Σ.1 mdecl ind idecl),
+  mdecl.(ind_npars) = npar ->
+  isCoFinite mdecl.(ind_finite) = false ->
+  let params := List.firstn npar args in
+  forall ps pty, build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+  Σ ;;; Γ |- p ◃ pty ->
+  leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
+  forall (btys : list (nat × term)),
+  map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+  All2 (fun br bty =>
+    (br.1 = bty.1) ×
+    (Σ ;;; Γ |- bty.2 ▸□ ps) ×
+    (Σ ;;; Γ |- br.2 ◃ bty.2))
+    brs btys ->
+  Σ ;;; Γ |- tCase indnpar p c brs ▹ mkApps p (skipn npar args ++ [c])
+
+| infer_Proj p c u :
+    forall mdecl idecl pdecl (isdecl : declared_projection Σ.1 mdecl idecl p pdecl) (args : list term),
+    Σ ;;; Γ |- c ▸{fst (fst p)} (u,args) ->
+    #|args| = ind_npars mdecl ->
+    let ty := snd pdecl in
+    Σ ;;; Γ |- tProj p c ▹ subst0 (c :: List.rev args) (subst_instance_constr u ty)
+
+| infer_Fix (mfix : mfixpoint term) n decl :
+    fix_guard mfix ->
+    nth_error mfix n = Some decl ->
+    All (fun d => {s & Σ ;;; Γ |- d.(dtype) ▸□ s}) mfix ->
+    All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype))
+      × (isLambda d.(dbody) = true)) mfix ->
+    wf_fixpoint Σ.1 mfix -> 
+    Σ ;;; Γ |- tFix mfix n ▹ decl.(dtype)
+
+| infer_CoFix mfix n decl :
+    cofix_guard mfix ->
+    nth_error mfix n = Some decl ->
+    All (fun d => {s & Σ ;;; Γ |- d.(dtype) ▸□ s}) mfix ->
+    All (fun d => Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) mfix ->
+    wf_cofixpoint Σ.1 mfix ->
+    Σ ;;; Γ |- tCoFix mfix n ▹ decl.(dtype)
+
+with infering_sort `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> Universe.t -> Type :=
+| infer_sort_Sort t T u :
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T --> tSort u ->
+  Σ ;;; Γ |- t ▸□ u
+
+with infering_prod `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> name -> term -> term -> Type :=
+| infer_prod_Prod t T na A B:
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T --> tProd na A B ->
+  Σ ;;; Γ |- t ▸Π (na,A,B)
+
+with infering_indu `{checker_flags} (Σ : global_env_ext) (Γ : context) : inductive -> term -> Instance.t -> list term -> Type :=
+| infer_ind_Red ind t T u args:
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T --> mkApps (tInd ind u) args ->
+  Σ ;;; Γ |- t ▸{ind} (u,args)
+
+with checking `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
+| check_Cons t T T' :
+  Σ ;;; Γ |- t ▹ T ->
+  Σ ;;; Γ |- T <= T' ->
+  Σ ;;; Γ |- t ◃ T'
+
+where " Σ ;;; Γ |- t ▹ T " := (@infering _ Σ Γ t T) : type_scope
+and " Σ ;;; Γ |- t ▸□ u " := (@infering_sort _ Σ Γ t u) : type_scope
+and " Σ ;;; Γ |- t ▸Π ( na , A , B ) " := (@infering_prod _ Σ Γ t na A B) : type_scope
+and " Σ ;;; Γ |- t ▸{ ind } ( u , args ) " := (@infering_indu _ Σ Γ ind t u args) : type_scope
+and " Σ ;;; Γ |- t ◃ T " := (@checking _ Σ Γ t T) : type_scope.
+
+Notation wf_local Σ Γ := (All_local_env (lift_sorting checking infering_sort Σ) Γ).
+Notation wf_local_rel Σ Γ Γ' := (All_local_env_rel (lift_sorting checking infering_sort Σ) Γ Γ').
+
+
+(* Lemma meta_conv {cf : checker_flags} Σ Γ t A B :
+    Σ ;;; Γ |- t : A ->
+    A = B ->
+    Σ ;;; Γ |- t : B.
+Proof.
+  intros h []; assumption.
+Qed. *)
+
+
+(** ** Typechecking of global environments *)
+
+Module BDTypingDef <: Typing PCUICTerm PCUICEnvironment BDEnvTyping.
+
+  Definition ind_guard := ind_guard.
+  Definition checking `{checker_flags} := checking.
+  Definition sorting `{checker_flags} := infering_sort.
+  Definition conv := @conv.
+  Definition cumul := @cumul.
+  Definition smash_context := smash_context.
+  Definition lift_context := lift_context.
+  Definition subst_telescope := subst_telescope.
+  Definition subst_instance_context := subst_instance_context.
+  Definition subst_instance_constr := subst_instance_constr.
+  Definition subst := subst.
+  Definition lift := lift.
+  Definition inds := inds. 
+  Definition noccur_between := noccur_between. 
+  Definition closedn := closedn.
+
+End BDTypingDef.
+
+Module BDDeclarationTyping :=
+  DeclarationTyping
+    PCUICTerm
+    PCUICEnvironment
+    BDEnvTyping
+    BDTypingDef
+    BDLookup.
+Include BDDeclarationTyping.
+
+Fixpoint infering_size `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ▹ T) {struct d} : size
+with infering_sort_size `{checker_flags} {Σ Γ t u} (d : Σ ;;; Γ |- t ▸□ u) {struct d} : size
+with infering_prod_size `{checker_flags} {Σ Γ t na A B} (d : Σ ;;; Γ |- t ▸Π (na, A,B)) {struct d} : size
+with infering_indu_size `{checker_flags} {Σ Γ ind t ui args} (d : Σ ;;; Γ |- t ▸{ind} (ui,args)) {struct d} : size
+with checking_size `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ◃ T) {struct d} : size.
+Proof.
+  all: destruct d ;
+    repeat match goal with
+           | H : infering _ _ _ _ |- _ => apply infering_size in H
+           | H : infering_sort _ _ _ _ |- _ => apply infering_sort_size in H
+           | H : infering_prod _ _ _ _ _ _ |- _ => apply infering_prod_size in H
+           | H : infering_indu _ _ _ _ _ _ |- _ => apply infering_indu_size in H 
+           | H : checking _ _ _ _ |- _ => apply checking_size in H
+           end ;
+    match goal with
+    | H : All2 _ _ _ |- _ => idtac
+    | H : All _ _ |- _ => idtac
+    | H1 : size, H2 : size, H3 : size |- _ => exact (S (H1 + H2 + H3))
+    | H1 : size, H2 : size |- _ => exact (S (H1 + H2))
+    | H1 : size |- _  => exact (S H1)
+    | _ => exact 1
+    end. 
+    - exact (S (i + c0 + (all2_size _ 
+                                        (fun x y p => (infering_sort_size _ _ _ _ _ (fst (snd p)))
+                                                      + (checking_size _ _ _ _ _ (snd (snd p)))) a))).
+    - exact (S (all_size _ (fun d p => infering_sort_size _ _ _ _ _ p.π2) a) +
+               (all_size _ (fun x p => checking_size _ _ _ _ _ p.1) a0)).
+    - exact (S (all_size _ (fun d p => infering_sort_size _ _ _ _ _ p.π2) a) +
+               (all_size _ (fun x => checking_size _ _ _ _ _) a0)).
+  Defined.
+
+Definition wfarity_size `{checker_flags} {Σ Γ T} (d : isWfArity_rel checking infering_sort Σ Γ T) : size.
+Proof.
+  destruct d as (ctx & u & e & wf).
+  exact (wf_local_rel_size Σ (@checking_size _) (@infering_sort_size _) _ _ wf).
+Defined.
+
+Fixpoint infering_size_pos `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ▹ T)
+  : infering_size d > 0
+with infering_sort_size_pos `{checker_flags} {Σ Γ t u} (d : Σ ;;; Γ |- t ▸□ u) {struct d}
+  : infering_sort_size d > 0
+with infering_prod_size_pos `{checker_flags} {Σ Γ t na A B} (d : Σ ;;; Γ |- t ▸Π (na,A,B)) {struct d}
+  : infering_prod_size d > 0
+with infering_indu_size_pos `{checker_flags} {Σ Γ t ind ui args} (d : Σ ;;; Γ |- t ▸{ind} (ui,args)) {struct d}
+  : infering_indu_size d > 0
+with checking_size_pos `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t ◃ T) {struct d}
+  : checking_size d > 0.
+Proof.
+  all: destruct d ; simpl ; lia.
+Qed.
+
+Fixpoint globenv_size (Σ : global_env) : size :=
+  match Σ with
+  | [] => 1
+  | d :: Σ => S (globenv_size Σ)
+  end.
+
+(** To get a good induction principle for typing derivations,
+     we need:
+    - size of the global_env_ext, including size of the global declarations in it
+    - size of the derivation. *)
+
+Arguments lexprod [A B].
+
+Definition wf `{checker_flags} := Forall_decls_typing checking infering_sort.
+Definition wf_ext `{checker_flags} := on_global_env_ext checking infering_sort.
+
+Lemma wf_ext_wf {cf:checker_flags} Σ : wf_ext Σ -> wf Σ.
+Proof. intro H; apply H. Qed.
+
+Hint Resolve wf_ext_wf : core.
+
+Lemma wf_ext_consistent {cf:checker_flags} Σ :
+  wf_ext Σ -> consistent Σ.
+Proof.
+  intros [? [? [? [? ?]]]]; assumption.
+Qed.
+
+Hint Resolve wf_ext_consistent : core.
+
+
+Section TypingInduction.
+
+#[local] Notation wfl_size := (wf_local_size _ (@checking_size _) (@infering_sort_size _) _).
+
+  Context (Pcheck : global_env_ext -> context -> term -> term -> Type).
+  Context (Pinfer : global_env_ext -> context -> term -> term -> Type).
+  Context (Psort : global_env_ext -> context -> term -> Universe.t -> Type).
+  Context (Pprod : global_env_ext -> context -> term -> name -> term -> term -> Type).
+  Context (Pind : global_env_ext -> context -> inductive -> term -> Instance.t -> list term -> Type).
+  Context (PΓ : forall `{checker_flags} Σ Γ, wf_local Σ Γ -> Type).
+  Arguments PΓ {_}.
+
+  Definition env_prop `{checker_flags} :=
+    forall Σ (wfΣ : wf Σ.1),
+    (Forall_decls_typing Pcheck Psort Σ.1) ×
+    (forall Γ (wfΓ : wf_local Σ Γ), PΓ Σ Γ wfΓ) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t T, Σ ;;; Γ |- t ◃ T -> Pcheck Σ Γ t T) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t T, Σ ;;; Γ |- t ▹ T -> Pinfer Σ Γ t T) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t u, Σ ;;; Γ |- t ▸□ u -> Psort Σ Γ t u) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> Pprod Σ Γ t na A B) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) ind t u args, Σ ;;; Γ |- t ▸{ind} (u,args) -> Pind Σ Γ ind t u args).
+
+  Lemma wf_local_app `{checker_flags} Σ (Γ Γ' : context) : wf_local Σ (Γ,,,Γ') -> wf_local Σ Γ.
+  Proof.
+    induction Γ'. auto.
+    simpl. intros H'; inv H'; eauto.
+  Defined.
+  Hint Resolve wf_local_app : wf.
+
+  Derive Signature for All_local_env.
+
+  Set Equations With UIP.
+  Derive NoConfusion for context_decl.
+  Derive NoConfusion for list.
+  Derive NoConfusion for All_local_env.
+
+  Lemma size_wf_local_app `{checker_flags} {Σ} (Γ Γ' : context) (Hwf : wf_local Σ (Γ ,,, Γ')) :
+    wfl_size (wf_local_app _ _ _ Hwf) <=
+    wfl_size Hwf.
+  Proof.
+    induction Γ' in Γ, Hwf |- *; try lia. simpl. lia.
+    depelim Hwf.
+    - inversion H0. subst. noconf H4. simpl. unfold eq_rect_r. simpl. specialize (IHΓ' _ Hwf). lia.
+    - inversion H0. subst. noconf H4. specialize (IHΓ' _ Hwf). simpl. unfold eq_rect_r. simpl. lia.
+  Qed.
+
+  Lemma wf_local_inv `{checker_flags} {Σ Γ'} (w : wf_local Σ Γ') :
+    forall d Γ,
+      Γ' = d :: Γ ->
+      ∑ w' : wf_local Σ Γ,
+        match d.(decl_body) with
+        | Some b =>
+          ∑ u (ty : Σ ;;; Γ |- b ◃ d.(decl_type)),
+            { ty' : Σ ;;; Γ |- d.(decl_type) ▸□ u |
+              wfl_size w' <
+              wfl_size w /\
+              checking_size ty <= wfl_size w /\
+              infering_sort_size ty' <= wfl_size w }
+
+        | None =>
+          ∑ u,
+            { ty : Σ ;;; Γ |- d.(decl_type) ▸□ u |
+              wfl_size w' < wfl_size w /\
+              infering_sort_size ty <= wfl_size w }
+        end.
+  Proof.
+    intros d Γ.
+    destruct w.
+    - simpl. congruence.
+    - intros [=]. subst d Γ0.
+      exists w. simpl. destruct t0 ; simpl in *. exists x.
+      exists i.
+      pose (infering_sort_size_pos i).
+      simpl. split.
+      + lia.
+      + auto with arith.
+    - intros [=]. subst d Γ0.
+      exists w. simpl in *.
+      dependent inversion t0 as [[u h] h'].
+      exists u, h', h. simpl in *.
+      pose (infering_sort_size_pos h).
+      pose (checking_size_pos h').
+      intuition lia.
+  Qed.
+
+  Lemma isWfArity_sort `{checker_flags} {Σ Γ} u : isWfArity_rel checking infering_sort Σ Γ (tSort u).
+  Proof.
+    red. exists []. exists u.
+    split.
+    1: by rewrite /destArity /=.
+    by constructor.
+  Defined.
+
+  Derive Signature for Alli.
+
+  (** *** Inductive principle, giving extra-strong premisses,
+          including environment and context well-formedness
+  *)
+
+  Inductive typing_sum `{checker_flags} Σ (wfΣ : wf Σ.1) : Type :=
+    | env_cons : typing_sum Σ wfΣ
+    | context_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ), typing_sum Σ wfΣ
+    | check_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) T t, Σ ;;; Γ |- t ◃ T -> typing_sum Σ wfΣ
+    | inf_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) T t, Σ ;;; Γ |- t ▹ T -> typing_sum Σ wfΣ
+    | sort_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) t u, Σ ;;; Γ |- t ▸□ u -> typing_sum Σ wfΣ
+    | prod_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> typing_sum Σ wfΣ
+    | ind_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) ind t u args,
+        Σ ;;; Γ |- t ▸{ind} (u,args) -> typing_sum Σ wfΣ.
+
+  Definition typing_sum_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum Σ wfΣ) :=
+  match d with
+    | env_cons => 0
+    | context_cons Γ wfΓ => wfl_size wfΓ
+    | check_cons Γ wfΓ _ _ d => (wfl_size wfΓ) + (checking_size d)
+    | inf_cons Γ wfΓ _ _ d => (wfl_size wfΓ) + (infering_size d)
+    | sort_cons Γ wfΓ _ _ d => (wfl_size wfΓ) + (infering_sort_size d)
+    | prod_cons Γ wfΓ _ _ _ _ d => (wfl_size wfΓ) + (infering_prod_size d)
+    | ind_cons Γ wfΓ _ _ _ _ d => (wfl_size wfΓ) + (infering_indu_size d)
+  end.
+
+  Definition context_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum Σ wfΣ) := 
+  match d with
+    | env_cons => 0
+    | context_cons Γ wfΓ => wfl_size wfΓ
+    | check_cons Γ wfΓ _ _ d => wfl_size wfΓ
+    | inf_cons Γ wfΓ _ _ d => wfl_size wfΓ
+    | sort_cons Γ wfΓ _ _ d => wfl_size wfΓ
+    | prod_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
+    | ind_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
+  end.
+
+  Definition Ptyping_sum `{checker_flags} {Σ wfΣ} (d : typing_sum Σ wfΣ) :=
+  match d with
+    | env_cons => Forall_decls_typing Pcheck Psort Σ.1
+    | context_cons Γ wfΓ => PΓ Σ Γ wfΓ
+    | check_cons Γ _ T t _ => Pcheck Σ Γ t T
+    | inf_cons Γ _ T t _ => Pinfer Σ Γ t T
+    | sort_cons Γ _ T u _ => Psort Σ Γ T u
+    | prod_cons Γ _ T na A B _ => Pprod Σ Γ T na A B
+    | ind_cons Γ _ ind T u args _ => Pind Σ Γ ind T u args
+  end.
+
+  Ltac applyIH := match goal with
+    | IH : forall _ _ d', _ -> Ptyping_sum d' |- Forall_decls_typing Pcheck Psort _ =>
+          unshelve eapply (IH _ _ (env_cons _ _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- PΓ _ ?Γ ?wfΓ =>
+          unshelve eapply (IH _ _ (context_cons _ _ Γ wfΓ))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pcheck _ ?Γ ?t ?T =>
+          unshelve eapply (IH _ _ (check_cons _ _ Γ _ T t _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pinfer _ ?Γ ?t ?T =>
+          unshelve eapply (IH _ _ (inf_cons _ _ Γ _ T t _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d'|- Psort _ ?Γ ?t ?u =>
+          unshelve eapply (IH _ _ (sort_cons _ _ Γ _ t u _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pprod _ ?Γ ?t ?na ?A ?B =>
+          unshelve eapply (IH _ _ (prod_cons _ _ Γ _ t na A B _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pind _ ?Γ ?ind ?t ?u ?args =>
+          unshelve eapply (IH _ _ (ind_cons _ _ Γ _ ind t u args _))
+    end ;
+    match goal with
+    | |- isWfArity _ _ _ (tSort _) => apply isWfArity_sort ; try assumption ; try (by constructor)
+    | |- dlexprod _ _ _ _ => constructor ; simpl ; lia
+    | |- dlexprod _ _ _ _ =>
+            constructor 2 ; simpl ;
+            (match goal with | |- dlexprod _ _ (?x1;_) (?y1;_) => replace x1 with y1 by lia end ; constructor 2) ||
+            constructor ; try lia
+    | _ => assumption
+    | _ => simpl ; lia
+    | _ => idtac
+    end.
+
+  Lemma typing_ind_env `{cf : checker_flags} :
+    let Pdecl_check := fun Σ Γ wfΓ t T tyT => Pcheck Σ Γ t T in
+    let Pdecl_sort := fun Σ Γ wfΓ t u tyT => Psort Σ Γ t u in
+
+    (forall Σ (wfΣ : wf Σ.1)  (Γ : context) (wfΓ : wf_local Σ Γ), 
+          All_local_env_over checking infering_sort Pdecl_check Pdecl_sort Σ Γ wfΓ -> PΓ Σ Γ wfΓ) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : nat) decl,
+        nth_error Γ n = Some decl ->
+        PΓ Σ Γ wfΓ ->
+        Pinfer Σ Γ (tRel n) (lift0 (S n) decl.(decl_type))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (l : Level.t),
+        PΓ Σ Γ wfΓ ->
+        LevelSet.In l (global_ext_levels Σ) ->
+        Pinfer Σ Γ (tSort (Universe.make l)) (tSort (Universe.super l))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (t b : term) (s1 s2 : Universe.t),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▸□ s1 ->
+        Psort Σ Γ t s1 ->
+        Σ ;;; Γ,, vass n t |- b ▸□ s2 ->
+        Psort Σ (Γ,, vass n t) b s2 -> Pinfer Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (t b : term)
+            (s : Universe.t) (bty : term),
+            PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▸□ s ->
+        Psort Σ Γ t s ->
+        Σ ;;; Γ,, vass n t |- b ▹ bty -> Pinfer Σ (Γ,, vass n t) b bty ->
+        Pinfer Σ Γ (tLambda n t b) (tProd n t bty)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (b B t : term)
+            (s : Universe.t) (A : term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- B ▸□ s ->
+        Psort Σ Γ B s ->
+        Σ ;;; Γ |- b ◃ B ->
+        Pcheck Σ Γ b B ->
+        Σ ;;; Γ,, vdef n b B |- t ▹ A ->
+        Pinfer Σ (Γ,, vdef n b B) t A -> Pinfer Σ Γ (tLetIn n b B t) (tLetIn n b B A)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t : term) na A B u,
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▸Π (na, A, B) -> Pprod Σ Γ t na A B ->
+        Σ ;;; Γ |- u ◃ A -> Pcheck Σ Γ u A ->
+        Pinfer Σ Γ (tApp t u) (subst10 u B)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (cst : kername) u (decl : constant_body),
+        Forall_decls_typing Pcheck Psort Σ.1 ->
+        PΓ Σ Γ wfΓ ->
+        declared_constant Σ.1 cst decl ->
+        consistent_instance_ext Σ decl.(cst_universes) u ->
+        Pinfer Σ Γ (tConst cst u) (subst_instance_constr u (cst_type decl))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) u
+          mdecl idecl,
+        Forall_decls_typing Pcheck Psort Σ.1 ->
+        PΓ Σ Γ wfΓ ->
+        declared_inductive Σ.1 mdecl ind idecl ->
+        consistent_instance_ext Σ mdecl.(ind_universes) u ->
+        Pinfer Σ Γ (tInd ind u) (subst_instance_constr u (ind_type idecl))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) (i : nat) u
+            mdecl idecl cdecl,
+        Forall_decls_typing Pcheck Psort Σ.1 ->
+        PΓ Σ Γ wfΓ ->
+        declared_constructor Σ.1 mdecl idecl (ind, i) cdecl ->
+        consistent_instance_ext Σ mdecl.(ind_universes) u ->
+        Pinfer Σ Γ (tConstruct ind i u)
+          (type_of_constructor mdecl cdecl (ind, i) u)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) u (npar : nat)
+            (p c : term) (brs : list (nat * term))
+            (args : list term) (mdecl : mutual_inductive_body) (idecl : one_inductive_body)
+            (isdecl : declared_inductive (fst Σ) mdecl ind idecl),
+        Forall_decls_typing Pcheck Psort Σ.1 -> PΓ Σ Γ wfΓ ->
+        isCoFinite mdecl.(ind_finite) = false ->
+        Σ ;;; Γ |- c ▸{ind} (u,args) ->
+        Pind Σ Γ ind c u args ->
+        ind_npars mdecl = npar ->
+        let params := firstn npar args in
+        forall ps pty,
+        build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+        Σ ;;; Γ |- p ◃ pty ->
+        Pcheck Σ Γ p pty ->
+        leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
+        forall btys,
+        map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+        All2 (fun br bty => (br.1 = bty.1) ×
+                          (Σ ;;; Γ |- bty.2 ▸□ ps) × Psort Σ Γ bty.2 ps ×
+                          (Σ ;;; Γ |- br.2 ◃ bty.2) × Pcheck Σ Γ br.2 bty.2)
+              brs btys ->
+        Pinfer Σ Γ (tCase (ind,npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : projection) (c : term) u
+          mdecl idecl pdecl args,
+        Forall_decls_typing Pcheck Psort Σ.1 -> PΓ Σ Γ wfΓ ->
+        declared_projection Σ.1 mdecl idecl p pdecl ->
+        Σ ;;; Γ |- c ▸{fst (fst p)} (u,args) ->
+        Pind Σ Γ (fst (fst p)) c u args ->
+        #|args| = ind_npars mdecl ->
+        let ty := snd pdecl in
+        Pinfer Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance_constr u ty))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : mfixpoint term) (n : nat) decl,
+        fix_guard mfix ->
+        nth_error mfix n = Some decl ->
+        All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+        All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
+                  (isLambda d.(dbody) = true) ×
+                  Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+        wf_fixpoint Σ.1 mfix ->
+        Pinfer Σ Γ (tFix mfix n) decl.(dtype)) ->
+    
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : mfixpoint term) (n : nat) decl,
+        cofix_guard mfix ->
+        nth_error mfix n = Some decl ->
+        All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+        All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
+                  Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+        wf_cofixpoint Σ.1 mfix ->
+        Pinfer Σ Γ (tCoFix mfix n) decl.(dtype)) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term) (u : Universe.t),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T --> tSort u ->
+        Psort Σ Γ t u) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term) (na : name) (A B : term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T --> tProd na A B ->
+        Pprod Σ Γ t na A B) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) (t T : term) (ui : Instance.t)
+          (args : list term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T --> mkApps (tInd ind ui) args ->
+        Pind Σ Γ ind t ui args) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T T' : term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T <= T' ->
+        Pcheck Σ Γ t T') ->
+      
+    env_prop.
+  Proof.
+    intros Pdecl_check Pdecl_sort HΓ HRel HSort HProd HLambda HLetIn HApp HConst HInd HConstruct HCase
+      HProj HFix HCoFix HiSort HiProd HiInd HCheck ; unfold env_prop.
+    pose (@Fix_F (∑ (Σ : _) (wfΣ : _), typing_sum Σ wfΣ)
+            (dlexprod (precompose lt (fun Σ => globenv_size (fst Σ)))
+              (fun Σ => precompose (dlexprod lt (fun _ => lt)) (fun d => (typing_sum_size d.π2 ; context_size d.π2))))
+            (fun d => Ptyping_sum d.π2.π2)).
+    forward p.
+    2:{ intros Σ wfΣ.
+        enough (HP : forall x : typing_sum Σ wfΣ, Ptyping_sum x).
+        - repeat split ; intros.
+          + exact (HP (env_cons Σ wfΣ)).
+          + exact (HP (context_cons Σ wfΣ Γ wfΓ)).
+          + exact (HP (check_cons Σ wfΣ Γ wfΓ T t X)).
+          + exact (HP (inf_cons Σ wfΣ Γ wfΓ T t X)).
+          + exact (HP (sort_cons Σ wfΣ Γ wfΓ t u X)).
+          + exact (HP (prod_cons Σ wfΣ Γ wfΓ t na A B X)).
+          + exact (HP (ind_cons Σ wfΣ Γ wfΓ ind t u args X)).
+        - intros x ; apply (p (Σ ; (wfΣ ; x))).
+          apply wf_dlexprod ; intros ; apply wf_precompose ; [ | apply wf_dlexprod ; intros] ; apply lt_wf.
+    }
+    clear p.     
+    intros (Σ & wfΣ & d) IH'. simpl.
+    match goal with | IH' : forall y : _ , ?P _ _ -> _ |- _ =>
+      have IH : forall (Σ' : global_env_ext) (wfΣ' : wf Σ'.1) (d' :typing_sum Σ' wfΣ'),
+        P (Σ'; wfΣ'; d') (Σ; wfΣ; d) -> Ptyping_sum d' end.
+    1: intros Σ' wfΣ' d' H; exact (IH' (Σ' ; wfΣ' ; d') H).
+    clear IH'.
+    destruct d ; simpl.
+    4: destruct i.
+    - destruct Σ as [Σ φ]. destruct Σ.
+      1: constructor.
+      destruct p.
+      cbn in  *.
+      have IH' : forall Σ' wfΣ' (d' : typing_sum Σ' wfΣ'), globenv_size (Σ'.1) < S (globenv_size Σ) ->
+                    Ptyping_sum d'
+        by intros ; apply IH ; constructor ; simpl ; assumption.
+      clear IH.
+      dependent destruction wfΣ.
+      constructor.
+      + change (Forall_decls_typing Pcheck Psort (Σ,φ).1).
+        applyIH.
+      + assumption.
+      + assumption.
+      + destruct g as [[? [] ?]| ]; cbn.
+        * applyIH.
+          constructor.
+        * dependent elimination o0.
+          eexists. applyIH.
+          1: by constructor.
+          eassumption.
+        * dependent elimination o0.
+          constructor.
+          3-5: assumption.
+          2:{
+            clear - wfΣ IH' onParams0.
+            induction onParams0.
+            1: by constructor.
+            -- constructor.
+               1: by assumption.
+               destruct t0.
+               eexists.
+               applyIH.
+               by eassumption. 
+            -- constructor.
+               1: by assumption.
+               destruct t0.
+               constructor.
+               2: by cbn ; applyIH.
+               destruct l.
+               eexists.
+               applyIH.
+               by eassumption. 
+          }
+           have wftypes : wf_local (Σ, udecl) (arities_context (ind_bodies m)).
+          { admit. }
+          remember (ind_bodies m) as Γ in onInductives0 |- *.
+          clear - wfΣ IH' onParams0 wftypes onInductives0.
+          induction onInductives0 as [| ? ? ? [] ?].
+          1: by constructor.
+          constructor.
+          2: eassumption.
+          econstructor ; try eassumption.
+          ++ destruct onArity0.
+            eexists. applyIH.
+            1: by constructor.
+            eassumption.
+          ++ clear - wfΣ IH' onConstructors0 onParams0 wftypes.
+            induction onConstructors0.
+            1: by constructor.
+            constructor.
+            2: assumption.
+            destruct r.
+            constructor.
+            all: try assumption.
+            ** cbn.
+                destruct on_ctype0.
+                eexists.
+                applyIH.
+                eassumption.
+            ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; try eassumption.
+                admit. (*well-formedness of context concatenation, when both contexts are well-formed *)
+                  
+
+
+            ** admit.
+          ++ clear - wfΣ IH' ind_sorts0.
+              red in ind_sorts0 |- *.
+              destruct (universe_family ind_sort0).
+              all: intuition.
+              all: destruct indices_matter ; auto.
+              ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
+              ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
+
+
+    - apply HΓ.
+      1: assumption.
+      dependent induction wfΓ.
+      + constructor.
+      + destruct t0 as (u & d).
+        constructor.
+        * apply IHwfΓ.
+          intros ; apply IH.
+          dependent destruction H ; [constructor | constructor 2] ; auto.
+          etransitivity ; eauto.
+          constructor.
+          simpl ; cbn in d ; pose proof (infering_sort_size_pos d) ; lia.
+        * constructor.
+          red ; applyIH.
+          cbn in d ; pose proof (infering_sort_size_pos d) ; lia.
+      + destruct t0 as [[u h] h'].
+        constructor.
+        2: constructor.
+        * apply IHwfΓ.
+          intros ; apply IH.
+          dependent destruction H ; [constructor | constructor 2] ; auto.
+          etransitivity ; eauto.
+          constructor.
+          simpl. cbn in h ; pose proof (infering_sort_size_pos h) ; lia.
+        * red ; applyIH.
+          cbn in h' ; pose proof (checking_size_pos h') ; lia.
+        * red ; applyIH.
+          cbn in h ; pose proof (infering_sort_size_pos h) ; lia.
+
+    - destruct c.
+      unshelve (eapply HCheck ; eauto) ; auto.
+      all: applyIH.
+
+    - unshelve eapply HRel ; auto.
+      applyIH.
+
+    - unshelve eapply HSort ; auto.
+      applyIH.
+
+    - unshelve eapply HProd ; auto.
+      all: applyIH.
+        * constructor ; auto.
+          econstructor.
+          eassumption.
+        * simpl ; lia.
+    
+    - unshelve eapply HLambda ; auto.
+      all: applyIH.
+      * constructor ; auto.
+        econstructor.
+        eassumption.
+      * simpl ; lia.
+
+    - unshelve eapply HLetIn ; auto.
+      all: applyIH.
+      * constructor ; auto.
+        econstructor.
+        2: by eauto.
+        econstructor.
+        eauto.
+      * simpl ; lia.
+
+    - unshelve eapply (HApp _ _ _ _ _ _ A) ; auto.
+      all: applyIH.
+        
+    - unshelve eapply HConst ; auto.
+      all: applyIH.
+
+    - unshelve eapply HInd ; auto.
+      all: applyIH.
+
+    - unshelve eapply HConstruct ; auto.
+      all: applyIH.
+
+    - destruct indnpar as [ind' npar'] ; cbn in ind ; cbn in npar ; subst ind ; subst npar.
+      unshelve eapply HCase ; auto.
+      1-4: applyIH.
+      match goal with | IH : forall Σ' wfΣ' d', _ _ (_ ; _ ; ?d) -> _ |- _ =>
+        have IH' : forall d' : typing_sum Σ wfΣ, (typing_sum_size d') < (typing_sum_size d) -> Ptyping_sum d' end.
+      1: by intros ; apply IH ; constructor 2 ; constructor 1 ; assumption.
+      clear IH.
+      revert a wfΓ IH'. simpl. clear. intros.
+      induction a ; simpl in *.
+      1: by constructor.
+      destruct r as [? [? ?]].
+      constructor.
+      + intuition eauto.
+        1: unshelve eapply (IH' (sort_cons _ wfΣ _ wfΓ _ _ _)) ; try eassumption.
+        2: unshelve eapply (IH' (check_cons _ wfΣ _ wfΓ _ _ _)) ; try eassumption.
+        all: simpl ; lia.
+      + apply IHa.
+        intros. apply IH'. simpl in *. lia.
+    
+    - unshelve eapply HProj ; auto.
+      all: applyIH.
+
+    - unshelve eapply HFix ; eauto.
+
+      all: have IH' : (forall d' : typing_sum Σ wfΣ,
+      (typing_sum_size d') <
+        (typing_sum_size (inf_cons _ wfΣ _ wfΓ _ (tFix mfix n)
+        (infer_Fix Σ Γ mfix n decl i e a a0 i0)))
+      -> Ptyping_sum d')
+       by intros ; apply IH ; constructor 2 ; constructor 1 ; assumption.
+      all: simpl in IH'.
+      all: remember (fix_context mfix) as mfixcontext.
+
+      {
+        remember (all_size _ _ a0) as s.
+        clear -IH'.
+        dependent induction a.
+        1: by constructor.
+        constructor ; cbn.
+        + destruct p ; eexists ; split.
+          1: eassumption.
+          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _ _)).
+          all: try assumption.
+          simpl. lia.
+        + apply (IHa s).
+          intros.
+          apply IH'.
+          cbn. lia.
+      }
+
+      have wfΓmfix : wf_local Σ (Γ ,,, mfixcontext).
+      { admit. }
+      remember (all_size _ (fun d p => infering_sort_size p.π2) a) as s.
+      have wf_size : wfl_size wfΓmfix <= wfl_size wfΓ + s.
+      { admit. }
+
+      clear -IH' wf_size.
+      induction a0 as [| ? ? [? ?]].
+      1: by constructor.
+      constructor.
+      + intuition.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _ _)) ; try assumption.
+        simpl. lia.
+      + apply IHa0.
+        intros ; apply IH'.
+        cbn. lia.
+
+    - unshelve eapply HCoFix ; eauto.
+
+      all: have IH' : (forall d' : typing_sum Σ wfΣ,
+      (typing_sum_size d') <
+        (typing_sum_size (inf_cons _ wfΣ _ wfΓ _ (tCoFix mfix n)
+        (infer_CoFix Σ Γ mfix n decl i e a a0 i0)))
+      -> Ptyping_sum d')
+      by intros ; apply IH ; constructor 2 ; constructor 1 ; assumption.
+      all: simpl in IH'.
+      all: remember (fix_context mfix) as mfixcontext.
+
+      {
+        remember (all_size _ _ a0) as s.
+        clear -IH'.
+        dependent induction a.
+        1: by constructor.
+        constructor ; cbn.
+        + destruct p ; eexists ; split.
+          1: eassumption.
+          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _ _)).
+          all: try assumption.
+          simpl. lia.
+        + apply (IHa s).
+          intros.
+          apply IH'.
+          cbn. lia.
+      }
+
+      have wfΓmfix : wf_local Σ (Γ,,,mfixcontext).
+      { admit. }
+      remember (all_size _ (fun d p => infering_sort_size p.π2) a) as s.
+      have wf_size : wfl_size wfΓmfix <= wfl_size wfΓ + s.
+      { admit. }
+
+      clear -IH' wf_size.
+      induction a0.
+      1: by constructor.
+      constructor.
+      + intuition.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _ _)) ; try assumption.
+        simpl. lia.
+      + apply IHa0.
+        intros ; apply IH'.
+        cbn. lia.
+
+    - destruct i.
+      unshelve (eapply HiSort ; try eassumption) ; try eassumption.
+      all: applyIH.
+
+    - destruct i.
+      unshelve (eapply HiProd ; try eassumption) ; try eassumption.
+      all: applyIH.
+
+    - destruct i.
+      unshelve (eapply HiInd ; try eassumption) ; try eassumption.
+      all: applyIH.
+      
+  Admitted.
+
+End TypingInduction.
+
+
+Ltac my_rename_hyp h th :=
+  match th with
+  | (wf ?E) => fresh "wf" E
+  | (wf (fst_ctx ?E)) => fresh "wf" E
+  | (wf _) => fresh "wf"
+  | (checking _ _ ?t _) => fresh "check" t
+  | (conv _ _ ?t _) => fresh "conv" t
+  | (All_local_env (lift_typing (@checking _) _) ?G) => fresh "wf" G
+  | (All_local_env (lift_typing (@checking _) _) _) => fresh "wf"
+  | (All_local_env _ _ ?G) => fresh "H" G
+  | context [checking _ _ (_ ?t) _] => fresh "IH" t
+  end.
+
+Ltac rename_hyp h ht ::= my_rename_hyp h ht.

--- a/bidirectional/theories/BDTyping.v
+++ b/bidirectional/theories/BDTyping.v
@@ -693,7 +693,19 @@ Section TypingInduction.
                by eassumption. 
           }
            have wftypes : wf_local (Σ, udecl) (arities_context (ind_bodies m)).
-          { admit. }
+          { 
+            unfold arities_context.
+            clear - wfΣ IH' onInductives0.
+            rewrite rev_map_spec -map_rev.
+            apply Alli_rev in onInductives0.
+            induction onInductives0 as [| ? ? ? [? ? ? []] ?].
+            1: by constructor.
+            cbn. constructor.
+            1: assumption.
+            eexists.
+            cbn.
+            admit. (* weakening *)
+            }
           remember (ind_bodies m) as Γ in onInductives0 |- *.
           clear - wfΣ IH' onParams0 wftypes onInductives0.
           induction onInductives0 as [| ? ? ? [] ?].
@@ -721,12 +733,19 @@ Section TypingInduction.
             ** eapply type_local_ctx_impl.
                 1: eassumption.
                 all: intros ; applyIH ; eapply type_local_ctx_wf_local ; try eassumption.
-                admit. (*well-formedness of context concatenation, when both contexts are well-formed *)
+                all: admit. (*well-formedness of context concatenation, when both contexts are well-formed *)
                   
 
 
-            ** admit.
-          ++ clear - wfΣ IH' ind_sorts0.
+            ** clear - wfΣ IH' wftypes onParams0 on_cargs0 on_cindices0.
+               induction on_cindices0.
+               all: constructor ; auto.
+               cbn. applyIH.
+               eapply type_local_ctx_wf_local.
+               1: admit. (*well-formedness of context concatenation*)
+               eassumption.
+
+          ++ clear - wfΣ IH' ind_sorts0 onParams0.
               red in ind_sorts0 |- *.
               destruct (universe_family ind_sort0).
               all: intuition.
@@ -867,7 +886,7 @@ Section TypingInduction.
       { admit. }
       remember (all_size _ (fun d p => infering_sort_size p.π2) a) as s.
       have wf_size : wfl_size wfΓmfix <= wfl_size wfΓ + s.
-      { admit. }
+      { admit. } 
 
       clear -IH' wf_size.
       induction a0 as [| ? ? [? ?]].

--- a/bidirectional/theories/BDTyping.v
+++ b/bidirectional/theories/BDTyping.v
@@ -762,10 +762,6 @@ Section TypingInduction.
               ** eapply type_local_ctx_impl.
                 1: eassumption.
                 all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
-              ** eapply type_local_ctx_impl.
-                 1: eassumption.
-                 all: intros.
-                 all: applyIH.
 
 
     - apply HΓ.

--- a/bidirectional/theories/BDTypingInduction.v
+++ b/bidirectional/theories/BDTypingInduction.v
@@ -1,0 +1,610 @@
+(* Distributed under the terms of the MIT license.   *)
+
+From Coq Require Import Bool List Arith Lia.
+From Coq Require String.
+From MetaCoq.Template Require Import config utils monad_utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils PCUICTyping.
+From MetaCoq.Bidirectional Require Import BDEnvironmentTyping BDTyping.
+
+From MetaCoq Require Export LibHypsNaming.
+Require Import ssreflect.
+Set Asymmetric Patterns.
+Require Import Equations.Type.Relation.
+Require Import Equations.Prop.DepElim.
+From Equations Require Import Equations.
+
+Section TypingInduction.
+
+#[local] Notation wfl_size := (wf_local_size _ (@checking_size _) (@infering_sort_size _) _).
+
+  Context (Pcheck : global_env_ext -> context -> term -> term -> Type).
+  Context (Pinfer : global_env_ext -> context -> term -> term -> Type).
+  Context (Psort : global_env_ext -> context -> term -> Universe.t -> Type).
+  Context (Pprod : global_env_ext -> context -> term -> name -> term -> term -> Type).
+  Context (Pind : global_env_ext -> context -> inductive -> term -> Instance.t -> list term -> Type).
+  Context (PΓ : forall `{checker_flags} Σ Γ, wf_local Σ Γ -> Type).
+  Arguments PΓ {_}.
+
+  Definition env_prop_ctx `{checker_flags} :=
+    forall Σ (wfΣ : wf Σ.1),
+    (Forall_decls_typing Pcheck Psort Σ.1) ×
+    (forall Γ (wfΓ : wf_local Σ Γ), PΓ Σ Γ wfΓ) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t T, Σ ;;; Γ |- t ◃ T -> Pcheck Σ Γ t T) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t T, Σ ;;; Γ |- t ▹ T -> Pinfer Σ Γ t T) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t u, Σ ;;; Γ |- t ▸□ u -> Psort Σ Γ t u) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> Pprod Σ Γ t na A B) ×
+    (forall Γ (wfΓ : wf_local Σ Γ) ind t u args, Σ ;;; Γ |- t ▸{ind} (u,args) -> Pind Σ Γ ind t u args).
+
+  (** *** Inductive principle including context well-formedness missing in BDTyping, that needs weakening
+  *)
+
+  Inductive typing_sum_ctx `{checker_flags} Σ (wfΣ : wf Σ.1) : Type :=
+    | env_cons : typing_sum_ctx Σ wfΣ
+    | context_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ), typing_sum_ctx Σ wfΣ
+    | check_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) T t, Σ ;;; Γ |- t ◃ T -> typing_sum_ctx Σ wfΣ
+    | inf_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) T t, Σ ;;; Γ |- t ▹ T -> typing_sum_ctx Σ wfΣ
+    | sort_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) t u, Σ ;;; Γ |- t ▸□ u -> typing_sum_ctx Σ wfΣ
+    | prod_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) t na A B, Σ ;;; Γ |- t ▸Π (na,A,B) -> typing_sum_ctx Σ wfΣ
+    | ind_cons : forall (Γ : context) (wfΓ : wf_local Σ Γ) ind t u args,
+        Σ ;;; Γ |- t ▸{ind} (u,args) -> typing_sum_ctx Σ wfΣ.
+
+  Definition typing_sum_ctx_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum_ctx Σ wfΣ) :=
+  match d with
+    | env_cons => 0
+    | context_cons Γ wfΓ => wfl_size wfΓ
+    | check_cons Γ wfΓ _ _ d => (wfl_size wfΓ) + (checking_size d)
+    | inf_cons Γ wfΓ _ _ d => (wfl_size wfΓ) + (infering_size d)
+    | sort_cons Γ wfΓ _ _ d => (wfl_size wfΓ) + (infering_sort_size d)
+    | prod_cons Γ wfΓ _ _ _ _ d => (wfl_size wfΓ) + (infering_prod_size d)
+    | ind_cons Γ wfΓ _ _ _ _ d => (wfl_size wfΓ) + (infering_indu_size d)
+  end.
+
+  Definition context_size `{checker_flags} {Σ} {wfΣ : wf Σ.1} (d : typing_sum_ctx Σ wfΣ) := 
+  match d with
+    | env_cons => 0
+    | context_cons Γ wfΓ => wfl_size wfΓ
+    | check_cons Γ wfΓ _ _ d => wfl_size wfΓ
+    | inf_cons Γ wfΓ _ _ d => wfl_size wfΓ
+    | sort_cons Γ wfΓ _ _ d => wfl_size wfΓ
+    | prod_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
+    | ind_cons Γ wfΓ _ _ _ _ d => wfl_size wfΓ
+  end.
+
+  Definition Ptyping_sum `{checker_flags} {Σ wfΣ} (d : typing_sum_ctx Σ wfΣ) :=
+  match d with
+    | env_cons => Forall_decls_typing Pcheck Psort Σ.1
+    | context_cons Γ wfΓ => PΓ Σ Γ wfΓ
+    | check_cons Γ _ T t _ => Pcheck Σ Γ t T
+    | inf_cons Γ _ T t _ => Pinfer Σ Γ t T
+    | sort_cons Γ _ T u _ => Psort Σ Γ T u
+    | prod_cons Γ _ T na A B _ => Pprod Σ Γ T na A B
+    | ind_cons Γ _ ind T u args _ => Pind Σ Γ ind T u args
+  end.
+
+  Ltac applyIH := match goal with
+    | IH : forall _ _ d', _ -> Ptyping_sum d' |- Forall_decls_typing Pcheck Psort _ =>
+          unshelve eapply (IH _ _ (env_cons _ _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- PΓ _ ?Γ ?wfΓ =>
+          unshelve eapply (IH _ _ (context_cons _ _ Γ wfΓ))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pcheck _ ?Γ ?t ?T =>
+          unshelve eapply (IH _ _ (check_cons _ _ Γ _ T t _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pinfer _ ?Γ ?t ?T =>
+          unshelve eapply (IH _ _ (inf_cons _ _ Γ _ T t _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d'|- Psort _ ?Γ ?t ?u =>
+          unshelve eapply (IH _ _ (sort_cons _ _ Γ _ t u _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pprod _ ?Γ ?t ?na ?A ?B =>
+          unshelve eapply (IH _ _ (prod_cons _ _ Γ _ t na A B _))
+    | IH : forall Σ' wfΣ' d', _ -> Ptyping_sum d' |- Pind _ ?Γ ?ind ?t ?u ?args =>
+          unshelve eapply (IH _ _ (ind_cons _ _ Γ _ ind t u args _))
+    end ;
+    match goal with
+    | |- isWfArity _ _ _ (tSort _) => apply isWfArity_sort ; try assumption ; try (by constructor)
+    | |- dlexprod _ _ _ _ => constructor ; simpl ; lia
+    | |- dlexprod _ _ _ _ =>
+            constructor 2 ; simpl ;
+            (match goal with | |- dlexprod _ _ (?x1;_) (?y1;_) => replace x1 with y1 by lia end ; constructor 2) ||
+            constructor ; try lia
+    | _ => assumption
+    | _ => simpl ; lia
+    | _ => idtac
+    end.
+
+  Lemma typing_ind_env `{cf : checker_flags} :
+    let Pdecl_check := fun Σ Γ wfΓ t T tyT => Pcheck Σ Γ t T in
+    let Pdecl_sort := fun Σ Γ wfΓ t u tyT => Psort Σ Γ t u in
+
+    (forall Σ (wfΣ : wf Σ.1)  (Γ : context) (wfΓ : wf_local Σ Γ), 
+          All_local_env_over checking infering_sort Pdecl_check Pdecl_sort Σ Γ wfΓ -> PΓ Σ Γ wfΓ) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : nat) decl,
+        nth_error Γ n = Some decl ->
+        PΓ Σ Γ wfΓ ->
+        Pinfer Σ Γ (tRel n) (lift0 (S n) decl.(decl_type))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (l : Level.t),
+        PΓ Σ Γ wfΓ ->
+        LevelSet.In l (global_ext_levels Σ) ->
+        Pinfer Σ Γ (tSort (Universe.make l)) (tSort (Universe.super l))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (t b : term) (s1 s2 : Universe.t),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▸□ s1 ->
+        Psort Σ Γ t s1 ->
+        Σ ;;; Γ,, vass n t |- b ▸□ s2 ->
+        Psort Σ (Γ,, vass n t) b s2 -> Pinfer Σ Γ (tProd n t b) (tSort (Universe.sort_of_product s1 s2))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (t b : term)
+            (s : Universe.t) (bty : term),
+            PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▸□ s ->
+        Psort Σ Γ t s ->
+        Σ ;;; Γ,, vass n t |- b ▹ bty -> Pinfer Σ (Γ,, vass n t) b bty ->
+        Pinfer Σ Γ (tLambda n t b) (tProd n t bty)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (n : name) (b B t : term)
+            (s : Universe.t) (A : term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- B ▸□ s ->
+        Psort Σ Γ B s ->
+        Σ ;;; Γ |- b ◃ B ->
+        Pcheck Σ Γ b B ->
+        Σ ;;; Γ,, vdef n b B |- t ▹ A ->
+        Pinfer Σ (Γ,, vdef n b B) t A -> Pinfer Σ Γ (tLetIn n b B t) (tLetIn n b B A)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t : term) na A B u,
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▸Π (na, A, B) -> Pprod Σ Γ t na A B ->
+        Σ ;;; Γ |- u ◃ A -> Pcheck Σ Γ u A ->
+        Pinfer Σ Γ (tApp t u) (subst10 u B)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (cst : kername) u (decl : constant_body),
+        Forall_decls_typing Pcheck Psort Σ.1 ->
+        PΓ Σ Γ wfΓ ->
+        declared_constant Σ.1 cst decl ->
+        consistent_instance_ext Σ decl.(cst_universes) u ->
+        Pinfer Σ Γ (tConst cst u) (subst_instance_constr u (cst_type decl))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) u
+          mdecl idecl,
+        Forall_decls_typing Pcheck Psort Σ.1 ->
+        PΓ Σ Γ wfΓ ->
+        declared_inductive Σ.1 mdecl ind idecl ->
+        consistent_instance_ext Σ mdecl.(ind_universes) u ->
+        Pinfer Σ Γ (tInd ind u) (subst_instance_constr u (ind_type idecl))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) (i : nat) u
+            mdecl idecl cdecl,
+        Forall_decls_typing Pcheck Psort Σ.1 ->
+        PΓ Σ Γ wfΓ ->
+        declared_constructor Σ.1 mdecl idecl (ind, i) cdecl ->
+        consistent_instance_ext Σ mdecl.(ind_universes) u ->
+        Pinfer Σ Γ (tConstruct ind i u)
+          (type_of_constructor mdecl cdecl (ind, i) u)) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) u (npar : nat)
+            (p c : term) (brs : list (nat * term))
+            (args : list term) (mdecl : mutual_inductive_body) (idecl : one_inductive_body)
+            (isdecl : declared_inductive (fst Σ) mdecl ind idecl),
+        Forall_decls_typing Pcheck Psort Σ.1 -> PΓ Σ Γ wfΓ ->
+        isCoFinite mdecl.(ind_finite) = false ->
+        Σ ;;; Γ |- c ▸{ind} (u,args) ->
+        Pind Σ Γ ind c u args ->
+        ind_npars mdecl = npar ->
+        let params := firstn npar args in
+        forall ps pty,
+        build_case_predicate_type ind mdecl idecl params u ps = Some pty ->
+        Σ ;;; Γ |- p ◃ pty ->
+        Pcheck Σ Γ p pty ->
+        leb_sort_family (universe_family ps) idecl.(ind_kelim) ->
+        forall btys,
+        map_option_out (build_branches_type ind mdecl idecl params u p) = Some btys ->
+        All2 (fun br bty => (br.1 = bty.1) ×
+                          (Σ ;;; Γ |- bty.2 ▸□ ps) × Psort Σ Γ bty.2 ps ×
+                          (Σ ;;; Γ |- br.2 ◃ bty.2) × Pcheck Σ Γ br.2 bty.2)
+              brs btys ->
+        Pinfer Σ Γ (tCase (ind,npar) p c brs) (mkApps p (skipn npar args ++ [c]))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : projection) (c : term) u
+          mdecl idecl pdecl args,
+        Forall_decls_typing Pcheck Psort Σ.1 -> PΓ Σ Γ wfΓ ->
+        declared_projection Σ.1 mdecl idecl p pdecl ->
+        Σ ;;; Γ |- c ▸{fst (fst p)} (u,args) ->
+        Pind Σ Γ (fst (fst p)) c u args ->
+        #|args| = ind_npars mdecl ->
+        let ty := snd pdecl in
+        Pinfer Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance_constr u ty))) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : mfixpoint term) (n : nat) decl,
+        PΓ Σ Γ wfΓ ->
+        fix_guard mfix ->
+        nth_error mfix n = Some decl ->
+        All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+        All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
+                  (isLambda d.(dbody) = true) ×
+                  Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+        wf_fixpoint Σ.1 mfix ->
+        Pinfer Σ Γ (tFix mfix n) decl.(dtype)) ->
+    
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : mfixpoint term) (n : nat) decl,
+        PΓ Σ Γ wfΓ ->
+        cofix_guard mfix ->
+        nth_error mfix n = Some decl ->
+        All (fun d => {s & (Σ ;;; Γ |- d.(dtype) ▸□ s) × Psort Σ Γ d.(dtype) s}) mfix ->
+        All (fun d => (Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) ◃ lift0 #|fix_context mfix| d.(dtype)) ×
+                  Pcheck Σ (Γ ,,, fix_context mfix) d.(dbody) (lift0 #|fix_context mfix| d.(dtype))) mfix ->
+        wf_cofixpoint Σ.1 mfix ->
+        Pinfer Σ Γ (tCoFix mfix n) decl.(dtype)) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term) (u : Universe.t),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T --> tSort u ->
+        Psort Σ Γ t u) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term) (na : name) (A B : term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T --> tProd na A B ->
+        Pprod Σ Γ t na A B) ->
+
+    (forall (Σ : global_env_ext) (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) (t T : term) (ui : Instance.t)
+          (args : list term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T --> mkApps (tInd ind ui) args ->
+        Pind Σ Γ ind t ui args) ->
+
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T T' : term),
+        PΓ Σ Γ wfΓ ->
+        Σ ;;; Γ |- t ▹ T ->
+        Pinfer Σ Γ t T ->
+        Σ ;;; Γ |- T <= T' ->
+        Pcheck Σ Γ t T') ->
+      
+    env_prop_ctx.
+  Proof.
+    intros Pdecl_check Pdecl_sort HΓ HRel HSort HProd HLambda HLetIn HApp HConst HInd HConstruct HCase
+      HProj HFix HCoFix HiSort HiProd HiInd HCheck ; unfold env_prop_ctx.
+    pose (@Fix_F (∑ (Σ : _) (wfΣ : _), typing_sum_ctx Σ wfΣ)
+            (dlexprod (precompose lt (fun Σ => globenv_size (fst Σ)))
+              (fun Σ => precompose (dlexprod lt (fun _ => lt)) (fun d => (typing_sum_ctx_size d.π2 ; context_size d.π2))))
+            (fun d => Ptyping_sum d.π2.π2)).
+    forward p.
+    2:{ intros Σ wfΣ.
+        enough (HP : forall x : typing_sum_ctx Σ wfΣ, Ptyping_sum x).
+        - repeat split ; intros.
+          + exact (HP (env_cons Σ wfΣ)).
+          + exact (HP (context_cons Σ wfΣ Γ wfΓ)).
+          + exact (HP (check_cons Σ wfΣ Γ wfΓ T t X)).
+          + exact (HP (inf_cons Σ wfΣ Γ wfΓ T t X)).
+          + exact (HP (sort_cons Σ wfΣ Γ wfΓ t u X)).
+          + exact (HP (prod_cons Σ wfΣ Γ wfΓ t na A B X)).
+          + exact (HP (ind_cons Σ wfΣ Γ wfΓ ind t u args X)).
+        - intros x ; apply (p (Σ ; (wfΣ ; x))).
+          apply wf_dlexprod ; intros ; apply wf_precompose ; [ | apply wf_dlexprod ; intros] ; apply lt_wf.
+    }
+    clear p.     
+    intros (Σ & wfΣ & d) IH'. simpl.
+    match goal with | IH' : forall y : _ , ?P _ _ -> _ |- _ =>
+      have IH : forall (Σ' : global_env_ext) (wfΣ' : wf Σ'.1) (d' :typing_sum_ctx Σ' wfΣ'),
+        P (Σ'; wfΣ'; d') (Σ; wfΣ; d) -> Ptyping_sum d' end.
+    1: intros Σ' wfΣ' d' H; exact (IH' (Σ' ; wfΣ' ; d') H).
+    clear IH'.
+    destruct d ; simpl.
+    4: destruct i.
+    - destruct Σ as [Σ φ]. destruct Σ.
+      1: constructor.
+      destruct p.
+      cbn in  *.
+      have IH' : forall Σ' wfΣ' (d' : typing_sum_ctx Σ' wfΣ'), globenv_size (Σ'.1) < S (globenv_size Σ) ->
+                    Ptyping_sum d'
+        by intros ; apply IH ; constructor ; simpl ; assumption.
+      clear IH.
+      dependent destruction wfΣ.
+      constructor.
+      + change (Forall_decls_typing Pcheck Psort (Σ,φ).1).
+        applyIH.
+      + assumption.
+      + assumption.
+      + destruct g as [[? [] ?]| ]; cbn.
+        * applyIH.
+          constructor.
+        * dependent elimination o0.
+          eexists. applyIH.
+          1: by constructor.
+          eassumption.
+        * dependent elimination o0.
+          constructor.
+          3-5: assumption.
+          2:{
+            clear - wfΣ IH' onParams0.
+            induction onParams0.
+            1: by constructor.
+            -- constructor.
+               1: by assumption.
+               destruct t0.
+               eexists.
+               applyIH.
+               by eassumption. 
+            -- constructor.
+               1: by assumption.
+               destruct t0.
+               constructor.
+               2: by cbn ; applyIH.
+               destruct l.
+               eexists.
+               applyIH.
+               by eassumption. 
+          }
+           have wftypes : wf_local (Σ, udecl) (arities_context (ind_bodies m)).
+          { 
+            unfold arities_context.
+            clear - wfΣ IH' onInductives0.
+            rewrite rev_map_spec -map_rev.
+            apply Alli_rev in onInductives0.
+            induction onInductives0 as [| ? ? ? [? ? ? []] ?].
+            1: by constructor.
+            cbn. constructor.
+            1: assumption.
+            eexists.
+            cbn.
+            admit. (* weakening *)
+            }
+          remember (ind_bodies m) as Γ in onInductives0 |- *.
+          clear - wfΣ IH' onParams0 wftypes onInductives0.
+          induction onInductives0 as [| ? ? ? [] ?].
+          1: by constructor.
+          constructor.
+          2: eassumption.
+          econstructor ; try eassumption.
+          ++ destruct onArity.
+            eexists. applyIH.
+            1: by constructor.
+            eassumption.
+          ++ clear - wfΣ IH' onConstructors onParams0 wftypes.
+            induction onConstructors.
+            1: by constructor.
+            constructor.
+            2: assumption.
+            destruct r.
+            constructor.
+            all: try assumption.
+            ** cbn.
+                destruct on_ctype.
+                eexists.
+                applyIH.
+                eassumption.
+            ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; try eassumption.
+                all: admit. (*well-formedness of context concatenation, when both contexts are well-formed *)
+                  
+
+
+            ** clear - wfΣ IH' wftypes onParams0 on_cargs on_cindices.
+               induction on_cindices.
+               all: constructor ; auto.
+               cbn. applyIH.
+               eapply type_local_ctx_wf_local.
+               1: admit. (*well-formedness of context concatenation*)
+               eassumption.
+
+          ++ clear - wfΣ IH' ind_sorts onParams0.
+              red in ind_sorts |- *.
+              destruct (universe_family ind_sort).
+              all: intuition.
+              all: destruct indices_matter ; auto.
+              ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
+              ** eapply type_local_ctx_impl.
+                1: eassumption.
+                all: intros ; applyIH ; eapply type_local_ctx_wf_local ; eassumption.
+
+
+    - apply HΓ.
+      1: assumption.
+      dependent induction wfΓ.
+      + constructor.
+      + destruct t0 as (u & d).
+        constructor.
+        * apply IHwfΓ.
+          intros ; apply IH.
+          dependent destruction H ; [constructor | constructor 2] ; auto.
+          etransitivity ; eauto.
+          constructor.
+          simpl ; cbn in d ; pose proof (infering_sort_size_pos d) ; lia.
+        * constructor.
+          red ; applyIH.
+          cbn in d ; pose proof (infering_sort_size_pos d) ; lia.
+      + destruct t0 as [[u h] h'].
+        constructor.
+        2: constructor.
+        * apply IHwfΓ.
+          intros ; apply IH.
+          dependent destruction H ; [constructor | constructor 2] ; auto.
+          etransitivity ; eauto.
+          constructor.
+          simpl. cbn in h ; pose proof (infering_sort_size_pos h) ; lia.
+        * red ; applyIH.
+          cbn in h' ; pose proof (checking_size_pos h') ; lia.
+        * red ; applyIH.
+          cbn in h ; pose proof (infering_sort_size_pos h) ; lia.
+
+    - destruct c.
+      unshelve (eapply HCheck ; eauto) ; auto.
+      all: applyIH.
+
+    - unshelve eapply HRel ; auto.
+      applyIH.
+
+    - unshelve eapply HSort ; auto.
+      applyIH.
+
+    - unshelve eapply HProd ; auto.
+      all: applyIH.
+        * constructor ; auto.
+          econstructor.
+          eassumption.
+        * simpl ; lia.
+    
+    - unshelve eapply HLambda ; auto.
+      all: applyIH.
+      * constructor ; auto.
+        econstructor.
+        eassumption.
+      * simpl ; lia.
+
+    - unshelve eapply HLetIn ; auto.
+      all: applyIH.
+      * constructor ; auto.
+        econstructor.
+        2: by eauto.
+        econstructor.
+        eauto.
+      * simpl ; lia.
+
+    - unshelve eapply (HApp _ _ _ _ _ _ A) ; auto.
+      all: applyIH.
+        
+    - unshelve eapply HConst ; auto.
+      all: applyIH.
+
+    - unshelve eapply HInd ; auto.
+      all: applyIH.
+
+    - unshelve eapply HConstruct ; auto.
+      all: applyIH.
+
+    - destruct indnpar as [ind' npar'] ; cbn in ind ; cbn in npar ; subst ind ; subst npar.
+      unshelve eapply HCase ; auto.
+      1-4: applyIH.
+      match goal with | IH : forall Σ' wfΣ' d', _ _ (_ ; _ ; ?d) -> _ |- _ =>
+        have IH' : forall d' : typing_sum_ctx Σ wfΣ, (typing_sum_ctx_size d') < (typing_sum_ctx_size d) -> Ptyping_sum d' end.
+      1: by intros ; apply IH ; constructor 2 ; constructor 1 ; assumption.
+      clear IH.
+      revert a wfΓ IH'. simpl. clear. intros.
+      induction a ; simpl in *.
+      1: by constructor.
+      destruct r as [? [? ?]].
+      constructor.
+      + intuition eauto.
+        1: unshelve eapply (IH' (sort_cons _ wfΣ _ wfΓ _ _ _)) ; try eassumption.
+        2: unshelve eapply (IH' (check_cons _ wfΣ _ wfΓ _ _ _)) ; try eassumption.
+        all: simpl ; lia.
+      + apply IHa.
+        intros. apply IH'. simpl in *. lia.
+    
+    - unshelve eapply HProj ; auto.
+      all: applyIH.
+
+    - unshelve eapply HFix ; eauto.
+      1: applyIH.
+
+      all: have IH' : (forall d' : typing_sum_ctx Σ wfΣ,
+      (typing_sum_ctx_size d') <
+        (typing_sum_ctx_size (inf_cons _ wfΣ _ wfΓ _ (tFix mfix n)
+        (infer_Fix Σ Γ mfix n decl i e a a0 i0)))
+      -> Ptyping_sum d')
+       by intros ; apply IH ; constructor 2 ; constructor 1 ; assumption.
+      all: simpl in IH'.
+      all: remember (fix_context mfix) as mfixcontext.
+
+      {
+        remember (all_size _ _ a0) as s.
+        clear -IH'.
+        dependent induction a.
+        1: by constructor.
+        constructor ; cbn.
+        + destruct p ; eexists ; split.
+          1: eassumption.
+          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _ _)).
+          all: try assumption.
+          simpl. lia.
+        + apply (IHa s).
+          intros.
+          apply IH'.
+          cbn. lia.
+      }
+
+      have wfΓmfix : wf_local Σ (Γ ,,, mfixcontext).
+      { admit. }
+      remember (all_size _ (fun d p => infering_sort_size p.π2) a) as s.
+      have wf_size : wfl_size wfΓmfix <= wfl_size wfΓ + s.
+      { admit. } 
+
+      clear -IH' wf_size.
+      induction a0 as [| ? ? [? ?]].
+      1: by constructor.
+      constructor.
+      + intuition.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _ _)) ; try assumption.
+        simpl. lia.
+      + apply IHa0.
+        intros ; apply IH'.
+        cbn. lia.
+
+    - unshelve eapply HCoFix ; eauto.
+      1: applyIH.
+
+      all: have IH' : (forall d' : typing_sum_ctx Σ wfΣ,
+      (typing_sum_ctx_size d') <
+        (typing_sum_ctx_size (inf_cons _ wfΣ _ wfΓ _ (tCoFix mfix n)
+        (infer_CoFix Σ Γ mfix n decl i e a a0 i0)))
+      -> Ptyping_sum d')
+      by intros ; apply IH ; constructor 2 ; constructor 1 ; assumption.
+      all: simpl in IH'.
+      all: remember (fix_context mfix) as mfixcontext.
+
+      {
+        remember (all_size _ _ a0) as s.
+        clear -IH'.
+        dependent induction a.
+        1: by constructor.
+        constructor ; cbn.
+        + destruct p ; eexists ; split.
+          1: eassumption.
+          unshelve eapply (IH' (sort_cons _ wfΣ _ _ _ _ _)).
+          all: try assumption.
+          simpl. lia.
+        + apply (IHa s).
+          intros.
+          apply IH'.
+          cbn. lia.
+      }
+
+      have wfΓmfix : wf_local Σ (Γ,,,mfixcontext).
+      { admit. }
+      remember (all_size _ (fun d p => infering_sort_size p.π2) a) as s.
+      have wf_size : wfl_size wfΓmfix <= wfl_size wfΓ + s.
+      { admit. }
+
+      clear -IH' wf_size.
+      induction a0.
+      1: by constructor.
+      constructor.
+      + intuition.
+        unshelve eapply (IH' (check_cons _ wfΣ _ _ _ _ _)) ; try assumption.
+        simpl. lia.
+      + apply IHa0.
+        intros ; apply IH'.
+        cbn. lia.
+
+    - destruct i.
+      unshelve (eapply HiSort ; try eassumption) ; try eassumption.
+      all: applyIH.
+
+    - destruct i.
+      unshelve (eapply HiProd ; try eassumption) ; try eassumption.
+      all: applyIH.
+
+    - destruct i.
+      unshelve (eapply HiInd ; try eassumption) ; try eassumption.
+      all: applyIH.
+      
+  Admitted.
+
+End TypingInduction.

--- a/bidirectional/theories/PCUICToBD.v
+++ b/bidirectional/theories/PCUICToBD.v
@@ -1,0 +1,205 @@
+From Coq Require Import Bool List Arith Lia.
+From MetaCoq.Template Require Import config utils monad_utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping.
+From MetaCoq.PCUIC Require Import PCUICArities PCUICInversion PCUICInductiveInversion PCUICReduction PCUICSubstitution PCUICConversion PCUICCumulativity PCUICWfUniverses PCUICValidity PCUICSR.
+From MetaCoq.Bidirectional Require Import BDEnvironmentTyping BDMinimalTyping BDMinimalToPCUIC.
+
+Require Import ssreflect.
+From Equations Require Import Equations.
+Require Import Equations.Prop.DepElim.
+
+Lemma conv_infer_sort `{checker_flags} (Σ : global_env_ext) Γ t s :
+  (∑ T' : term, Σ ;;; Γ |- t ▹ T' × Σ ;;; Γ |- T' <= tSort s) ->
+  {s' & Σ ;;; Γ |- t ▸□ s' × leq_universe Σ s' s}.
+Proof.
+  intros (?&?&Cumt).
+  apply cumul_Sort_r_inv in Cumt ; auto.
+  destruct Cumt as (?&?&?).
+  eexists. split.
+  1: econstructor.
+  all: eassumption.
+Qed.
+
+Lemma conv_check `{checker_flags} (Σ : global_env_ext) Γ t T :
+  (∑ T' : term, Σ ;;; Γ |- t ▹ T' × Σ ;;; Γ |- T' <= T) ->
+  Σ ;;; Γ |- t ◃ T.
+Proof.
+  intros (?&?&Cumt).
+  econstructor.
+  all: eassumption.
+Qed.
+
+Lemma conv_infer_prod `{checker_flags} (Σ : global_env_ext) (wfΣ : PT.wf Σ) Γ t n A B:
+  (∑ T', (Σ ;;; Γ |- t ▹ T') × (Σ ;;; Γ |- T' <= tProd n A B)) ->
+  ∑ n' A' B', Σ ;;; Γ |- t ▸Π (n',A',B')
+      × (Σ ;;; Γ |- A' = A) × (Σ ;;; Γ ,, vass n A |- B' <= B).
+Proof.
+  intros (?&?&Cumt).
+  apply cumul_Prod_r_inv in Cumt ; auto.
+  destruct Cumt as (?&?&?&((?&?)&?)&?).
+  eexists. eexists. eexists. repeat split.
+  1: econstructor.
+  all: eassumption.
+Qed.
+
+Lemma conv_infer_ind `{checker_flags} (Σ : global_env_ext) (wfΣ : PT.wf Σ) Γ t ind ui args :
+  (∑ T', (Σ ;;; Γ |- t ▹ T') × (Σ ;;; Γ |- T' <= mkApps (tInd ind ui) args)) ->
+  ∑ ui' args', Σ ;;; Γ |- t ▸{ind} (ui',args')
+      × (PCUICEquality.R_global_instance Σ (eq_universe Σ) (leq_universe Σ) (IndRef ind) #|args| ui' ui)
+      × (All2 (fun a a' => Σ ;;; Γ |- a = a') args args').
+Proof.
+  intros (?&?&Cumt).
+  apply invert_cumul_ind_r in Cumt ; auto.
+  destruct Cumt as (?&?&?&?&?).
+  eexists. eexists. repeat split.
+  1: econstructor.
+  all:eassumption.
+Qed.
+
+Section PCUICToBD.
+
+Lemma typing_infering `{checker_flags} :
+        PT.env_prop (fun Σ Γ t T => {T' & Σ ;;; Γ |- t ▹ T' × Σ ;;; Γ |- T' <= T})
+         (fun Σ Γ _ => MT.wf_local Σ Γ).
+Proof.
+  apply PT.typing_ind_env.
+
+  all: intros Σ wfΣ Γ wfΓ.
+
+  - intros MTwfΓ.
+    induction MTwfΓ.
+    all: constructor ; auto.
+    + apply conv_infer_sort in p ; auto.
+      destruct p as (?&?&?).
+      eexists.
+      eassumption.
+    + apply conv_check in p ; auto.
+      apply conv_infer_sort in p0 ; auto.
+      destruct p0 as (?&?&?).
+      split.
+      1: eexists.
+      all: eassumption.
+  
+  - intros.
+    eexists.
+    split.
+    + constructor.
+      eassumption.
+    + apply cumul_refl.
+      apply PCUICEquality.leq_term_refl.
+    
+  - intros.
+    eexists.
+    split.
+    + constructor. assumption.
+    + apply cumul_refl.
+      apply PCUICEquality.leq_term_refl.
+
+  - intros n A B ? ? ? ? CumA ? CumB.
+    apply conv_infer_sort in CumA ; auto.
+    destruct CumA as (?&?&?).
+    apply conv_infer_sort in CumB ; auto.
+    destruct CumB as (?&?&?).
+    eexists.
+    split.
+    + constructor ; eassumption.
+    + constructor.
+      constructor.
+      apply leq_universe_product_mon.
+      all: assumption.
+
+  - intros n A t ? ? ? ? CumA ? (?&?&?).
+    apply conv_infer_sort in CumA ; auto.
+    destruct CumA as (?&?&?).
+    eexists.
+    split.
+    + econstructor. all: eassumption.
+    + apply congr_cumul_prod.
+      all: by auto.
+
+  - intros n t A u ? ? ? ? CumA ? Cumt ? (?&?&?).
+    apply conv_infer_sort in CumA ; auto.
+    destruct CumA as (?&?&?).
+    apply conv_check in Cumt ; auto.
+    eexists.
+    split.
+    + econstructor.
+      all: eassumption.
+    + apply cumul_LetIn_bo.
+      eassumption.
+
+  - intros t na A B u ? ? Cumt ? (?&?&?).
+    apply conv_infer_prod in Cumt ; auto.
+    destruct Cumt as (?&?&?&?&?&?).
+    eexists.
+    split.
+    + econstructor ; eauto.
+      econstructor ; eauto.
+      eapply cumul_trans ; eauto.
+      apply conv_cumul.
+      by apply conv_sym.
+    + eapply substitution_cumul0.
+      all: eassumption.
+  
+  - intros.
+    eexists.
+    split.
+    + econstructor.
+      all: eassumption.
+    + apply cumul_refl.
+      apply PCUICEquality.leq_term_refl.
+  
+  - intros.
+    eexists.
+    split.
+    + econstructor.
+      all: eassumption.
+    + apply cumul_refl.
+      apply PCUICEquality.leq_term_refl.
+
+  - intros.
+    eexists.
+    split.
+    + econstructor.
+      all: eassumption.
+    + apply cumul_refl.
+      apply PCUICEquality.leq_term_refl.
+  
+  - intros ind u npar p c brs args mdecl idecl ? ? ? ? params ps pty ? ? Cump ? ? ? Cumc btys ? Cumbrs.
+    apply conv_check in Cump.
+    apply conv_infer_ind in Cumc ; auto.
+    destruct Cumc as (ui'&args'&?&?&?).
+    eexists.
+    split.
+    2:{
+      apply cumul_mkApps ; auto.
+      1: apply cumul_refl ; apply PCUICEquality.leq_term_refl.
+      eapply All2_app.
+      2:constructor ; auto.
+      eapply All2_skipn.
+      apply conv_terms_sym.
+      eapply All2_impl.
+      1: eassumption.
+      eauto. }
+    econstructor.
+    all:admit.
+
+  - admit.
+  
+  - admit.
+  
+  - admit.
+  
+  - intros ? ? ? ? ? ? (?&?&?) ? (?&?&?) ?.
+    eexists.
+    split.
+    1: eassumption.
+    eapply cumul_trans ; eauto.
+
+Admitted.
+
+
+
+
+
+

--- a/bidirectional/theories/PCUICToBD.v
+++ b/bidirectional/theories/PCUICToBD.v
@@ -1,17 +1,13 @@
 From Coq Require Import Bool List Arith Lia.
 From MetaCoq.Template Require Import config utils monad_utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst PCUICTyping.
-From MetaCoq.PCUIC Require Import PCUICArities PCUICInversion PCUICInductiveInversion PCUICReduction PCUICSubstitution PCUICConversion PCUICCumulativity PCUICWfUniverses PCUICValidity PCUICSR.
+From MetaCoq.PCUIC Require Import PCUICEquality PCUICArities PCUICInversion PCUICInductives PCUICInductiveInversion PCUICReduction PCUICSubstitution PCUICConversion PCUICCumulativity PCUICWfUniverses PCUICValidity PCUICSR PCUICContextConversion.
 From MetaCoq.Bidirectional Require Import BDEnvironmentTyping BDMinimalTyping BDMinimalToPCUIC.
 
 Require Import ssreflect.
 From Equations Require Import Equations.
 Require Import Equations.Prop.DepElim.
-
-Lemma wf_pt `{checker_flags} Σ : PT.wf Σ -> MT.wf Σ.
-Proof.
-Admitted.
-
+     
 
 Lemma conv_infer_sort `{checker_flags} (Σ : global_env_ext) Γ t s :
   (∑ T' : term, Σ ;;; Γ |- t ▹ T' × Σ ;;; Γ |- T' <= tSort s) ->
@@ -165,24 +161,8 @@ Proof.
     econstructor.
     all: eassumption.
     
-  - intros ind u npar p c brs args mdecl idecl ? ? ? ? params ps pty ? ? Cump ? ? ? Cumc btys ? Cumbrs.
-    apply conv_check in Cump.
-    apply conv_infer_ind in Cumc ; auto.
-    destruct Cumc as (ui'&args'&?&?&?).
-    eexists.
-    split.
-    2:{
-      apply cumul_mkApps ; auto.
-      1: reflexivity.
-      eapply All2_app.
-      2:constructor ; auto.
-      eapply All2_skipn.
-      apply conv_terms_sym.
-      eapply All2_impl.
-      1: eassumption.
-      eauto. }
-    econstructor.
-    all:admit.
+  - admit.
+
 
   - intros ? c u mdecl idecl [] isdecl args ? ? ? Cumc ? ty.
     apply conv_infer_ind in Cumc as (ui'&args'&?&?&?) ; auto.
@@ -197,7 +177,7 @@ Proof.
       eassumption.
 
     + assert (Σ ;;; Γ |- c : mkApps (tInd p.1.1 ui') args').
-      { apply infering_ind_typing in i0 ; auto. by apply wf_pt. }
+      { apply infering_ind_typing in i0 ; auto. admit. }
       assert (PT.consistent_instance_ext Σ (ind_universes mdecl) u).
         { destruct isdecl.
           apply validity_term in X1 as [] ; auto.

--- a/bidirectional/theories/PCUICToBD.v
+++ b/bidirectional/theories/PCUICToBD.v
@@ -176,8 +176,7 @@ Proof.
       eapply All2_length.
       eassumption.
 
-    + assert (Σ ;;; Γ |- c : mkApps (tInd p.1.1 ui') args').
-      { apply infering_ind_typing in i0 ; auto. admit. }
+    + assert (Σ ;;; Γ |- c : mkApps (tInd p.1.1 ui') args') by (apply infering_ind_typing in i0 ; auto).
       assert (PT.consistent_instance_ext Σ (ind_universes mdecl) u).
         { destruct isdecl.
           apply validity_term in X1 as [] ; auto.

--- a/bidirectional/theories/README.md
+++ b/bidirectional/theories/README.md
@@ -1,0 +1,15 @@
+# Bidirectional Typing
+
+## General
+
+| File                  | Description                                  |
+|-----------------------|----------------------------------------------|
+| [BDEnvironmentTyping] | Variant of EnvironmentTyping to accomodate for the distinction between checking and sorting |
+| [BDTyping]            | Main description of bidirectional typing, in a "paranoid" way, *ie.* one that does not rely on strong metatheoretic properties to imply undirected typing |
+| [BDToPCUIC]           | Proof that bidirectional typing implies undirected typing |
+| [BDTypingInduction]   | Traces of older work, not worth looking at (the complete proof of the right induction principle is in [BDTyping]) |
+
+[BDEnvironmentTyping]: BDEnvironmentTyping.v
+[BDTyping]: BDTyping.v
+[BDToPCUIC]: BDToPCUIC.v
+[BDTypingInduction]: BDTypingInduction.v


### PR DESCRIPTION
Definition of an inductive to represent bidirectional typing derivations – intended in particular to serve as a middle point between the type-checker and the undirected PCUIC typing.