### PR TITLE
Add missing reduction for predicate types

### DIFF
--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -886,3 +886,17 @@ Inductive view_ind : term -> Type :=
 Equations view_indc (t : term) : view_ind t :=
   view_indc (tInd ind u) => view_ind_tInd ind u;
   view_indc t => view_ind_other t _.
+
+Inductive view_prod_sort : term -> Type :=
+| view_prod_sort_prod na A B : view_prod_sort (tProd na A B)
+| view_prod_sort_sort u : view_prod_sort (tSort u)
+| view_prod_sort_other t :
+    ~isProd t ->
+    ~isSort t ->
+    view_prod_sort t.
+
+Equations view_prod_sortc (t : term) : view_prod_sort t := { 
+  | tProd na A B => view_prod_sort_prod na A B;
+  | tSort u => view_prod_sort_sort u;
+  | t => view_prod_sort_other t _ _
+  }.

--- a/safechecker/theories/PCUICWfReduction.v
+++ b/safechecker/theories/PCUICWfReduction.v
@@ -6,7 +6,6 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICWeakening PCUICPosition PCUICCumulativity PCUICSafeLemmata PCUICSN
      PCUICPretty PCUICArities PCUICConfluence PCUICSize
      PCUICContextConversion PCUICConversion PCUICWfUniverses.
-From MetaCoq.SafeChecker Require Import PCUICSafeReduce PCUICSafeConversion.
 
 From Equations Require Import Equations.
 Require Import ssreflect ssrbool.


### PR DESCRIPTION
The safe checker was destructing the inferred type of predicates
directly as an arity, which was not complete. It meant that the
following example was not accepted by the safe checker:

```coq
Definition WrappedType := Type.
Definition WrappedNat : WrappedType := nat.
Definition foo : nat :=
  match 0 return WrappedNat with
  | 0 => 0
  | S n => 0
  end.
```

To fix we now use reduction for the predicate type.

Note that I defined an `mkAssumArity` that makes an arity from assumptions only and where the context is also in reverse order of normal contexts; otherwise, even with an accumulator, it requires passing some implications through when recursing which seemed more complicated than necessary (or maybe I am missing something :)).