### PR TITLE
Implement denotation of evars, with special case for "fresh_evar_id"

### DIFF
--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -119,6 +119,10 @@ struct
     match q with
     | Datatypes.O -> 0
     | Datatypes.S x -> succ (unquote_int x)
+  
+  let unquote_evar env evm n l = 
+    let id = Evar.unsafe_of_int (unquote_int n) in
+    evm, mkEvar (id, Array.of_list l)
 
   let unquote_bool (q : quoted_bool) : bool = q
 

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -148,7 +148,8 @@ struct
   let tMPfile = ast "MPfile"
   let tMPbound = ast "MPbound"
   let tMPdot = ast "MPdot"
-
+  let tfresh_evar_id = ast "fresh_evar_id"
+  
   let tproplevel = ast "level.prop_level_type"
   let tlevelSProp = ast "level.lsprop"
   let tlevelProp = ast "level.lprop"

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -10,7 +10,8 @@ sig
   val unquote_name : quoted_name -> Name.t
   val unquote_aname : quoted_aname -> Name.t Context.binder_annot
   val unquote_relevance : quoted_relevance -> Sorts.relevance
-  val unquote_int :  quoted_int -> int
+  val unquote_evar : Environ.env -> Evd.evar_map -> quoted_int -> Constr.t list -> Evd.evar_map * Constr.t
+  val unquote_int : quoted_int -> int
   val unquote_bool : quoted_bool -> bool
   (* val unquote_sort : quoted_sort -> Sorts.t *)
   (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)
@@ -36,6 +37,9 @@ let map_evm (f : 'a -> 'b -> 'a * 'c) (evm : 'a) (l : 'b list) : 'a * ('c list) 
   let evm, res = List.fold_left (fun (evm, l) b -> let evm, c = f evm b in evm, c :: l) (evm, []) l in
   evm, List.rev res
 
+let fold_env_evm_right (f : 'a -> 'b -> 'c -> 'a * 'b * 'd) (env : 'a) (evm : 'b) (l : 'c list) : 'a * 'b * ('d list) =
+  List.fold_right (fun b (env, evm, l) -> let env, evm, c = f env evm b in env, evm, c :: l) l (env, evm, [])
+
 module Denoter (D : BaseDenoter) =
 struct
 
@@ -45,28 +49,42 @@ struct
       ACoq_tApp (f, xs) -> app_full_abs f (xs @ acc)
     | _ -> (trm, acc)
 
-  let denote_term (evm : Evd.evar_map) (trm: D.t) : Evd.evar_map * Constr.t =
-    let rec aux evm (trm: D.t) : _ * Constr.t =
+  let push_rec_types (lna,typarray) env =
+    let open Context.Rel.Declaration in
+    let ctxt = CArray.map2_i (fun i na t -> LocalAssum (na, Vars.lift i t)) lna typarray in
+    Array.fold_left (fun e assum -> Environ.push_rel assum e) env ctxt
+
+  let denote_term (env : Environ.env) (evm : Evd.evar_map) (trm: D.t) : Evd.evar_map * Constr.t =
+    let open Context.Rel.Declaration in
+    let rec aux env evm (trm: D.t) : _ * Constr.t =
       (*    debug (fun () -> Pp.(str "denote_term" ++ spc () ++ pr_constr trm)) ; *)
       match D.inspect_term trm with
       | ACoq_tRel x -> evm, Constr.mkRel (D.unquote_int x + 1)
       | ACoq_tVar x -> evm, Constr.mkVar (D.unquote_ident x)
+      | ACoq_tEvar (n, l) -> 
+        let evm, l' = map_evm (aux env) evm l in
+        D.unquote_evar env evm n l'
       | ACoq_tSort x -> let evm, u = D.unquote_universe evm x in evm, Constr.mkType u
-      | ACoq_tCast (t,c,ty) -> let evm, t = aux evm t in
-        let evm, ty = aux evm ty in
+      | ACoq_tCast (t,c,ty) -> let evm, t = aux env evm t in
+        let evm, ty = aux env evm ty in
         evm, Constr.mkCast (t, D.unquote_cast_kind c, ty)
-      | ACoq_tProd (n,t,b) -> let evm, t = aux evm t in
-        let evm, b = aux evm b in
-        evm, Constr.mkProd (D.unquote_aname n, t, b)
-      | ACoq_tLambda (n,t,b) -> let evm, t = aux evm t in
-        let evm, b = aux evm b in
-        evm, Constr.mkLambda (D.unquote_aname n, t, b)
-      | ACoq_tLetIn (n,e,t,b) -> let evm, e = aux evm e in
-        let evm, t = aux evm t in
-        let evm, b = aux evm b in
-        evm, Constr.mkLetIn (D.unquote_aname n, e, t, b)
-      | ACoq_tApp (f,xs) -> let evm, f = aux evm f in
-        let evm, xs = map_evm aux evm xs in
+      | ACoq_tProd (n,t,b) -> let evm, t = aux env evm t in
+        let n = D.unquote_aname n in
+        let evm, b = aux (Environ.push_rel (LocalAssum (n, t)) env) evm b in
+        evm, Constr.mkProd (n, t, b)
+      | ACoq_tLambda (n,t,b) ->
+        let n = D.unquote_aname n in
+        let evm, t = aux env evm t in
+        let evm, b = aux (Environ.push_rel (LocalAssum (n, t)) env) evm b in
+        evm, Constr.mkLambda (n, t, b)
+      | ACoq_tLetIn (n,e,t,b) -> 
+        let n = D.unquote_aname n in
+        let evm, e = aux env evm e in
+        let evm, t = aux env evm t in
+        let evm, b = aux (Environ.push_rel (LocalDef (n, e, t)) env) evm b in
+        evm, Constr.mkLetIn (n, e, t, b)
+      | ACoq_tApp (f,xs) -> let evm, f = aux env evm f in
+        let evm, xs = map_evm (aux env) evm xs in
         evm, Constr.mkApp (f, Array.of_list xs)
       | ACoq_tConst (s,u) ->
         let s = D.unquote_kn s in
@@ -83,28 +101,32 @@ struct
       | ACoq_tCase (((i, _), r), ty, d, brs) ->
         let ind = D.unquote_inductive i in
         let relevance = D.unquote_relevance r in 
-        let evm, ty = aux evm ty in
-        let evm, d = aux evm d in
-        let evm, brs = map_evm aux evm (List.map snd brs) in
+        let evm, ty = aux env evm ty in
+        let evm, d = aux env evm d in
+        let evm, brs = map_evm (aux env) evm (List.map snd brs) in
         (* todo: reify better case_info *)
         let ci = Inductiveops.make_case_info (Global.env ()) ind relevance Constr.RegularStyle in
         evm, Constr.mkCase (ci, ty, d, Array.of_list brs)
       | ACoq_tFix (lbd, i) ->
         let (names,types,bodies,rargs) = (List.map (fun p->p.adname) lbd,  List.map (fun p->p.adtype) lbd, List.map (fun p->p.adbody) lbd,
                                           List.map (fun p->p.rarg) lbd) in
-        let evm, types = map_evm aux evm types in
-        let evm, bodies = map_evm aux evm bodies in
+        let evm, types = map_evm (aux env) evm types in
         let (names,rargs) = (List.map D.unquote_aname names, List.map D.unquote_int rargs) in
         let la = Array.of_list in
-        evm, Constr.mkFix ((la rargs, D.unquote_int i), (la names, la types, la bodies))
+        let lnames = la names and ltypes = la types in
+        let env = push_rec_types (lnames, ltypes) env in
+        let evm, bodies = map_evm (aux env) evm bodies in
+        evm, Constr.mkFix ((la rargs, D.unquote_int i), (lnames, ltypes, la bodies))
       | ACoq_tCoFix (lbd, i) ->
         let (names,types,bodies,rargs) = (List.map (fun p->p.adname) lbd,  List.map (fun p->p.adtype) lbd, List.map (fun p->p.adbody) lbd,
                                           List.map (fun p->p.rarg) lbd) in
-        let evm, types = map_evm aux evm types in
-        let evm, bodies = map_evm aux evm bodies in
+        let evm, types = map_evm (aux env) evm types in
         let (names,rargs) = (List.map D.unquote_aname names, List.map D.unquote_int rargs) in
         let la = Array.of_list in
-        evm, Constr.mkCoFix (D.unquote_int i, (la names, la types, la bodies))
+        let lnames = la names and ltypes = la types in
+        let env = push_rec_types (lnames, ltypes) env in
+        let evm, bodies = map_evm (aux env) evm bodies in
+        evm, Constr.mkCoFix (D.unquote_int i, (lnames, ltypes, la bodies))
 
       | ACoq_tProj (proj,t) ->
          let (ind, npars, arg) = D.unquote_proj proj in
@@ -115,19 +137,9 @@ struct
                   | Some p -> Names.Constant.label p
                   | None -> failwith "tproj case of denote_term") in
          let p' = Names.Projection.make (Projection.Repr.make ind' ~proj_npars ~proj_arg l) false in
-         let evm, t' = aux evm t in
+         let evm, t' = aux env evm t in
          evm, Constr.mkProj (p', t')
-      (* | _ ->  not_supported_verb trm "big_case"
-       * 
-       * | ACoq_tProj (proj,t) ->
-       *   let (ind, _, narg) = D.unquote_proj proj in (\* todo: is narg the correct projection? *\)
-       *   let ind' = D.unquote_inductive ind in
-       *   let projs = Recordops.lookup_projections ind' in
-       *   let evm, t = aux evm t in
-       *   (match List.nth projs (D.unquote_int narg) with
-       *    | Some p -> evm, Constr.mkProj (Names.Projection.make p false, t)
-       *    | None -> (\*bad_term trm *\) ) *)
-      | _ -> failwith "big case of denote_term"
-    in aux evm trm
+      
+    in aux env evm trm
 
 end

--- a/template-coq/src/g_template_coq.mlg
+++ b/template-coq/src/g_template_coq.mlg
@@ -180,8 +180,9 @@ END
 TACTIC EXTEND TemplateCoq_denote_term
     | [ "denote_term" constr(c) tactic(tac) ] ->
       { Proofview.Goal.enter (begin fun gl ->
+         let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
-         let evm, c = Constr_denoter.denote_term evm (to_constr_evars evm c) in
+         let evm, c = Constr_denoter.denote_term env evm (to_constr_evars evm c) in
          Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm)
 	   (ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c]))
       end) }

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -137,11 +137,13 @@ let of_cast_kind (ck: BasicAst.cast_kind) : Constr.cast_kind =
   | RevertCast -> Constr.REVERTcast
 
   (* todo(gmm): determine what of these already exist. *)
-let rec to_constr_ev (evm : Evd.evar_map) (t : Ast0.term) : Evd.evar_map * Constr.t =
-  denote_term evm t
+let rec to_constr_ev env (evm : Evd.evar_map) (t : Ast0.term) : Evd.evar_map * Constr.t =
+  denote_term env evm t
 
 let to_constr (t : Ast0.term) : Constr.t =
-  snd (to_constr_ev Evd.empty t)
+  let env = Global.env () in
+  let evm = Evd.from_env env in
+  snd (to_constr_ev env evm t)
 
 let tmOfConstr (t : Constr.t) : Ast0.term tm =
   Plugin_core.with_env_evm (fun env _ -> tmReturn (quote_term env t))

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -220,16 +220,16 @@ let denote_universes_entry evm trm (* of type universes_entry *) : _ * Entries.u
   | _ -> bad_term_verb trm "denote_universes_entry"
 
 
-let unquote_one_inductive_entry evm trm (* of type one_inductive_entry *) : _ * Entries.one_inductive_entry =
+let unquote_one_inductive_entry env evm trm (* of type one_inductive_entry *) : _ * Entries.one_inductive_entry =
   let (h,args) = app_full trm [] in
   if constr_equall h tBuild_one_inductive_entry then
     match args with
     | id::ar::template::cnames::ctms::[] ->
        let id = unquote_ident id in
-       let evm, ar = denote_term evm ar in
+       let evm, ar = denote_term env evm ar in
        let template = unquote_bool template in
        let cnames = List.map unquote_ident (unquote_list cnames) in
-       let evm, ctms = map_evm denote_term evm (unquote_list ctms) in
+       let evm, ctms = map_evm (denote_term env) evm (unquote_list ctms) in
        evm, { mind_entry_typename = id ;
               mind_entry_arity = ar;
               mind_entry_template = template;
@@ -244,32 +244,33 @@ let map_option f o =
   | Some x -> Some (f x)
   | None -> None          
 
-let denote_decl evm d = 
+let denote_decl env evm d = 
   let (h, args) = app_full d [] in
   if constr_equall h tmkdecl then
     match args with
     | name :: body :: typ :: [] ->
       let name = unquote_aname name in
-      let evm, ty = denote_term evm typ in
-      (match unquote_option body with
+      let evm, ty = denote_term env evm typ in
+      let evm, decl = (match unquote_option body with
       | None -> evm, Context.Rel.Declaration.LocalAssum (name, ty)
-      | Some body -> let evm, body = denote_term evm body in
+      | Some body -> let evm, body = denote_term env evm body in
         evm, Context.Rel.Declaration.LocalDef (name, body, ty))
+      in Environ.push_rel decl env, evm, decl
     | _ -> bad_term_verb d "denote_decl"
   else bad_term_verb d "denote_decl"
 
-let denote_context evm ctx =
-  map_evm denote_decl evm (unquote_list ctx)
+let denote_context env evm ctx =
+  fold_env_evm_right denote_decl env evm (unquote_list ctx)
   
-let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) : _ * Entries.mutual_inductive_entry =
+let unquote_mutual_inductive_entry env evm trm (* of type mutual_inductive_entry *) : _ * Entries.mutual_inductive_entry =
   let (h,args) = app_full trm [] in
   if constr_equall h tBuild_mutual_inductive_entry then
     match args with
     | record::finite::params::inds::univs::variance::priv::[] ->
        let record = map_option (map_option (fun x -> [|x|])) (unquote_map_option (unquote_map_option unquote_ident) record) in
        let finite = denote_mind_entry_finite finite in
-       let evm, params = denote_context evm params in
-       let evm, inds = map_evm unquote_one_inductive_entry evm (unquote_list inds) in
+       let envpars, evm, params = denote_context env evm params in
+       let evm, inds = map_evm (unquote_one_inductive_entry env) evm (unquote_list inds) in
        let evm, univs = denote_universes_entry evm univs in
        let evm, variance = denote_variances evm variance in
        let priv = unquote_map_option unquote_bool priv in
@@ -287,7 +288,7 @@ let unquote_mutual_inductive_entry evm trm (* of type mutual_inductive_entry *) 
 
 let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (mind: Constr.t) : unit =
   let mind = reduce_all env evm mind in
-  let evm, mind = unquote_mutual_inductive_entry evm mind in
+  let evm, mind = unquote_mutual_inductive_entry env evm mind in
   ignore (DeclareInd.declare_mutual_inductive_with_eliminations mind Names.Id.Map.empty [])
 
 let not_in_tactic s =
@@ -332,19 +333,19 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
     else
       let name = unquote_ident (reduce_all env evm name) in
       let opaque = unquote_bool (reduce_all env evm opaque) in
-      let evm,body = denote_term evm (reduce_all env evm body) in
+      let evm,body = denote_term env evm (reduce_all env evm body) in
       let evm,typ =
         match unquote_option typ with
         | None -> (evm, None)
         | Some t ->
-          let (evm, t) = denote_term evm (reduce_all env evm t) in
+          let (evm, t) = denote_term env evm (reduce_all env evm t) in
           (evm, Some t)
       in
       Plugin_core.run (Plugin_core.tmDefinition name ~poly ~opaque typ body) env evm
         (fun env evm res -> k (env, evm, quote_kn res))
   | TmLemmaTerm (name, typ) ->
     let ident = unquote_ident (reduce_all env evm name) in
-    let evm,typ = denote_term evm (reduce_all env evm typ) in
+    let evm,typ = denote_term env evm (reduce_all env evm typ) in
     Plugin_core.run (Plugin_core.tmLemma ident ~poly typ) env evm
       (fun env evm kn -> k (env, evm, quote_kn kn))
 
@@ -364,7 +365,7 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
     then not_in_tactic "tmAxiom"
     else
       let name = unquote_ident (reduce_all env evm name) in
-      let evm,typ = denote_term evm (reduce_all env evm typ) in
+      let evm,typ = denote_term env evm (reduce_all env evm typ) in
       Plugin_core.run (Plugin_core.tmAxiom name ~poly typ) env evm
         (fun a b c -> k (a,b,quote_kn c))
 
@@ -437,7 +438,7 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
     in k (env, evm, trm)
   | TmEvalTerm (s,trm) ->
     let red = unquote_reduction_strategy env evm (reduce_all env evm s) in
-    let evm,trm = denote_term evm (reduce_all env evm trm) in
+    let evm,trm = denote_term env evm (reduce_all env evm trm) in
     Plugin_core.run (Plugin_core.tmEval red trm) env evm
       (fun env evm trm -> k (env, evm, quote_term env trm))
   | TmMkInductive mind ->
@@ -448,7 +449,7 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
     begin
        try
          let t = reduce_all env evm t in
-         let evm, t' = denote_term evm t in
+         let evm, t' = denote_term env evm t in
          let typ = Retyping.get_type_of env evm (EConstr.of_constr t') in
          let evm, typ = Evarsolve.refresh_universes (Some false) env evm typ in
          let make_typed_term typ term evm =
@@ -465,7 +466,7 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
         with Reduction.NotArity -> CErrors.user_err (str "unquoting ill-typed term")
       end
   | TmUnquoteTyped (typ, t) ->
-       let evm, t' = denote_term evm (reduce_all env evm t) in
+       let evm, t' = denote_term env evm (reduce_all env evm t) in
        (* let t' = Typing.e_solve_evars env evdref (EConstr.of_constr t') in *)
        let evm = Typing.check env evm (EConstr.of_constr t') (EConstr.of_constr typ) in
        k (env, evm, t')
@@ -494,7 +495,7 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
         Not_found -> k (env, evm, constr_mkApp (cNone_instance, [|typ|]))
     end
   | TmInferInstanceTerm typ ->
-    let evm,typ = denote_term evm (reduce_all env evm typ) in
+    let evm,typ = denote_term env evm (reduce_all env evm typ) in
     Plugin_core.run (Plugin_core.tmInferInstance typ) env evm
       (fun env evm -> function
            None -> k (env, evm, constr_mkAppl (cNone, [| tTerm|]))
@@ -502,6 +503,6 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Environ.env * Evd.
            let qtrm = quote_term env trm in
            k (env, evm, constr_mkApp (cSome, [| Lazy.force tTerm; qtrm |])))
   | TmPrintTerm trm ->
-    let evm,trm = denote_term evm (reduce_all env evm trm) in
+    let evm,trm = denote_term env evm (reduce_all env evm trm) in
     Plugin_core.run (Plugin_core.tmPrint trm) env evm
       (fun env evm _ -> k (env, evm, Lazy.force unit_tt))

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -52,6 +52,12 @@ Inductive term : Type :=
 | tFix (mfix : mfixpoint term) (idx : nat)
 | tCoFix (mfix : mfixpoint term) (idx : nat).
 
+(** This can be used to represent holes, that, when unquoted, turn into fresh existential variables. 
+    The fresh evar will depend on the whole context at this point in the term, despite the empty instance.
+    Denotation will call Coq's Typing.solve_evars to try and fill these holes using typing information.
+*)
+Definition hole := tEvar fresh_evar_id [].
+
 Definition mkApps t us :=
   match us with
   | nil => t

--- a/template-coq/theories/BasicAst.v
+++ b/template-coq/theories/BasicAst.v
@@ -218,6 +218,10 @@ Inductive conv_pb :=
   | Cumul.
 Derive NoConfusion EqDec for conv_pb.
 
+(* This opaque natural number is a hack to inform unquoting to generate
+  a fresh evar when encountering it. *)
+Definition fresh_evar_id : nat. exact 0. Qed.
+
 (* Parametrized by term because term is not yet defined *)
 Record def term := mkdef {
   dname : aname; (* the name, annotated with relevance **)

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -87,6 +87,7 @@ Register MetaCoq.Template.BasicAst.VarRef as metacoq.ast.VarRef.
 Register MetaCoq.Template.BasicAst.ConstRef as metacoq.ast.ConstRef.
 Register MetaCoq.Template.BasicAst.IndRef as metacoq.ast.IndRef.
 Register MetaCoq.Template.BasicAst.ConstructRef as metacoq.ast.ConstructRef.
+Register MetaCoq.Template.BasicAst.fresh_evar_id as metacoq.ast.fresh_evar_id.
 
 (* Universes *)
 

--- a/test-suite/evars.v
+++ b/test-suite/evars.v
@@ -1,4 +1,8 @@
-Require Import MetaCoq.Template.Loader.
+From Coq Require Import String List.
+From MetaCoq.Template Require Import Ast Loader.
+Import ListNotations.
+Definition bAnon := {| binder_name := nAnon; binder_relevance := Relevant |}.
+Definition bNamed s := {| binder_name := nNamed s; binder_relevance := Relevant |}.
 
 Goal True.
   evar (n : nat).
@@ -11,3 +15,30 @@ Goal True.
   exact I.
   Unshelve. exact 0.
 Qed.
+
+(** Evars *)
+MetaCoq Quote Definition lnil := @nil.
+MetaCoq Quote Definition listnat := (list nat).
+MetaCoq Unquote Definition foo := (tCast (tApp lnil [hole]) Cast listnat).
+
+Local Open Scope string_scope.
+
+Goal list nat.
+  (* Back and forth *)
+  let x := open_constr:(nil) in quote_term x (fun qt => 
+    ltac:(denote_term qt (fun unqt => set (e := eq_refl : unqt = x :> list bool)))).
+    (* Creation of evars by denotation of 'hole' *)
+  let x := eval cbv in (tApp lnil [hole]) in
+  denote_term x (fun k => exact k).
+Defined.
+
+Goal True.
+  let x := eval cbv in (tLambda bAnon listnat hole) in
+  (* We check that created evars are in the right context *)
+  denote_term x (fun k => set (ev := k); revert ev).
+  instantiate (1 := list nat).
+  instantiate (1 := l).
+  exact I.
+Qed.
+
+


### PR DESCRIPTION
This implements denotation of evars, along with their instance, and we check that `unquote ∘ quote` is the identity for them (existing evars are preserved). We special-case on an opaque nat `BasicAst.fresh_evar_id` during denotation and corresponding term `hole := tEvar (fresh_evar_id, [])` to rather produce a fresh evar (in the current environment of the denotation) with a fresh evar as type. This allows to denote partial terms. Note that we don't call typechecking to fill the holes explicitely in `denote_term` but the tactic engine itself will call it. In the monad, tmMkDefinition does call a typechecking phase to fill the holes before trying to give the definition to the kernel. 