### PR TITLE
Primitive integers and floats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,5 @@ erasure/src/pCUICErrors.ml
 erasure/src/pCUICErrors.mli
 erasure/src/pCUICTypeChecker.ml
 erasure/src/pCUICTypeChecker.mli
+erasure/src/pCUICPrimitive.ml
+erasure/src/pCUICPrimitive.mli

--- a/checker/theories/Checker.v
+++ b/checker/theories/Checker.v
@@ -447,7 +447,8 @@ Inductive type_error :=
 | IllFormedFix (m : mfixpoint term) (i : nat)
 | UnsatisfiedConstraints (c : ConstraintSet.t)
 | UnsatisfiableConstraints (c : ConstraintSet.t)
-| NotEnoughFuel (n : nat).
+| NotEnoughFuel (n : nat)
+| NotSupported (s : string).
 
 Definition string_of_type_error (e : type_error) : string :=
   match e with
@@ -468,6 +469,7 @@ Definition string_of_type_error (e : type_error) : string :=
   | UnsatisfiedConstraints c => "Unsatisfied constraints"
   | UnsatisfiableConstraints c => "Unsatisfiable constraints"
   | NotEnoughFuel n => "Not enough fuel"
+  | NotSupported s => s ^ " are not supported"
   end.
 
 Inductive typing_result (A : Type) :=
@@ -769,6 +771,8 @@ Section Typecheck2.
       | Some f => ret f.(dtype)
       | None => raise (IllFormedFix mfix n)
       end
+
+    | tInt _ | tFloat _ => raise (NotSupported "primitive types")
     end.
 
   Definition check (Γ : context) (t : term) (ty : term) : typing_result unit :=

--- a/checker/theories/Retyping.v
+++ b/checker/theories/Retyping.v
@@ -99,6 +99,8 @@ Section TypeOf.
       | Some f => ret f.(dtype)
       | None => raise (IllFormedFix mfix n)
       end
+
+    | tInt _ | tFloat _ => raise (NotSupported "primitive types")
     end.
 
   Definition sort_of (Γ : context) (t : term) : typing_result Universe.t :=

--- a/configure.sh
+++ b/configure.sh
@@ -16,8 +16,7 @@ if command -v coqc >/dev/null 2>&1
 then
     COQLIB=`coqc -where`
 
-    if [ "$1" == "local" ]
-    then
+    if [ "$1" = "local" ]; then
         echo "Building MetaCoq locally"
         CHECKER_DEPS="-R ../template-coq/theories MetaCoq.Template -I ../template-coq/build"
         PCUIC_MLDEPS="-I ../checker/src"

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -31,6 +31,8 @@ src/kernames.ml
 # src/typing0.ml
 
 # From PCUIC
+src/pCUICPrimitive.mli
+src/pCUICPrimitive.ml
 src/pCUICAst.ml
 src/pCUICAst.mli
 src/pCUICAstUtils.ml

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -14,6 +14,7 @@ Classes0
 Logic1
 Relation
 Relation_Properties
+PCUICPrimitive
 PCUICAst
 PCUICAstUtils
 PCUICUnivSubst

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Export utils BasicAst Universes.
+From MetaCoq.PCUIC Require Import PCUICPrimitive.
 (** * Extracted terms
 
   These are the terms produced by extraction: compared to kernel terms,
@@ -37,8 +38,7 @@ Inductive term : Set :=
 | tProj      : projection -> term -> term
 | tFix       : mfixpoint term -> nat -> term
 | tCoFix     : mfixpoint term -> nat -> term
-| tInt       : uint63_model -> term
-| tFloat     : float64_model -> term.
+| tPrim      : prim_val term -> term.
 
 Fixpoint mkApps t us :=
   match us with

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -1,6 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Export utils BasicAst Universes.
-
 (** * Extracted terms
 
   These are the terms produced by extraction: compared to kernel terms,
@@ -37,7 +36,9 @@ Inductive term : Set :=
                term (* discriminee *) -> list (nat * term) (* branches *) -> term
 | tProj      : projection -> term -> term
 | tFix       : mfixpoint term -> nat -> term
-| tCoFix     : mfixpoint term -> nat -> term.
+| tCoFix     : mfixpoint term -> nat -> term
+| tInt       : uint63_model -> term
+| tFloat     : float64_model -> term.
 
 Fixpoint mkApps t us :=
   match us with

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils Kernames.
 From MetaCoq.Erasure Require Import EAst.
+From MetaCoq.PCUIC Require PCUICPrimitive.
 Require Import ssreflect ssrbool.
 
 
@@ -267,8 +268,7 @@ Fixpoint string_of_term (t : term) : string :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  | tInt i => "Int(" ^ string_of_Z (proj1_sig i) ^ ")"
-  | tFloat f => "Float(" ^ "<float>" ^ ")"
+  | tPrim p => "Prim(" ^ PCUICPrimitive.string_of_prim string_of_term p ^ ")"
   end.
 
 (** Compute all the global environment dependencies of the term *)

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -267,6 +267,8 @@ Fixpoint string_of_term (t : term) : string :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
+  | tInt i => "Int(" ^ string_of_Z (proj1_sig i) ^ ")"
+  | tFloat f => "Float(" ^ "<float>" ^ ")"
   end.
 
 (** Compute all the global environment dependencies of the term *)

--- a/erasure/theories/EInduction.v
+++ b/erasure/theories/EInduction.v
@@ -28,8 +28,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->
+    (forall p, P (tPrim p)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/erasure/theories/EInduction.v
+++ b/erasure/theories/EInduction.v
@@ -28,6 +28,8 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -32,8 +32,7 @@ Fixpoint lift n k t : term :=
   | tVar _ => t
   | tConst _ => t
   | tConstruct _ _ => t
-  | tInt _ => t
-  | tFloat _ => t
+  | tPrim _ => t
   end.
 
 Notation lift0 n := (lift n 0).

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -32,8 +32,9 @@ Fixpoint lift n k t : term :=
   | tVar _ => t
   | tConst _ => t
   | tConstruct _ _ => t
+  | tInt _ => t
+  | tFloat _ => t
   end.
-
 
 Notation lift0 n := (lift n 0).
 Definition up := lift 1 0.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -66,8 +66,7 @@ Section optimize.
     | tVar _ => t
     | tConst _ => t
     | tConstruct _ _ => t
-    | tInt _ => t
-    | tFloat _ => t
+    | tPrim _ => t
     end.
 
   Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -66,6 +66,8 @@ Section optimize.
     | tVar _ => t
     | tConst _ => t
     | tConstruct _ _ => t
+    | tInt _ => t
+    | tFloat _ => t
     end.
 
   Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -2,6 +2,7 @@
 From Coq Require Import Program.
 From MetaCoq.Template Require Import utils.
 From MetaCoq.Erasure Require Import EAst EAstUtils ETyping.
+From MetaCoq.PCUIC Require Import PCUICPrimitive.
 
 (** * Pretty printing *)
 
@@ -159,10 +160,8 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ dname) l) n)
-  | tInt i => 
-    parens top (string_of_uint63_model i)
-  | tFloat f => 
-    parens top (string_of_float64_model f)
+  | tPrim p => 
+    parens top (string_of_prim (print_term Γ false false) p)
   end.
 
 End print_term.

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -5,7 +5,6 @@ From MetaCoq.Erasure Require Import EAst EAstUtils ETyping.
 
 (** * Pretty printing *)
 
-
 Section print_term.
   Context (Σ : global_context).
 
@@ -160,6 +159,10 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ dname) l) n)
+  | tInt i => 
+    parens top (string_of_uint63_model i)
+  | tFloat f => 
+    parens top (string_of_float64_model f)
   end.
 
 End print_term.

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -1,6 +1,6 @@
 From MetaCoq.Template Require Import Reflect.
 From MetaCoq.Erasure Require Import EAst EInduction.
-From MetaCoq.PCUIC Require Import PCUICReflect.
+From MetaCoq.PCUIC Require Import PCUICReflect PCUICPrimitive.
 From Equations Require Import Equations.
 
 Local Ltac finish :=
@@ -23,8 +23,7 @@ Local Ltac term_dec_tac term_dec :=
          | i : kername, i' : kername |- _ => fcase (kername_eq_dec i i')
          | i : string, i' : kername |- _ => fcase (string_dec i i')
          | n : name, n' : name |- _ => fcase (eq_dec n n')
-         | i : uint63_model, i' : uint63_model |- _ => fcase (eq_dec i i')
-         | i : float64_model, i' : float64_model |- _ => fcase (eq_dec i i')         
+         | i : prim_val _, i' : prim_val _ |- _ => fcase (eq_dec i i')
          | i : inductive, i' : inductive |- _ => fcase (eq_dec i i')
          | x : inductive * nat, y : inductive * nat |- _ =>
            fcase (eq_dec x y)

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -23,6 +23,8 @@ Local Ltac term_dec_tac term_dec :=
          | i : kername, i' : kername |- _ => fcase (kername_eq_dec i i')
          | i : string, i' : kername |- _ => fcase (string_dec i i')
          | n : name, n' : name |- _ => fcase (eq_dec n n')
+         | i : uint63_model, i' : uint63_model |- _ => fcase (eq_dec i i')
+         | i : float64_model, i' : float64_model |- _ => fcase (eq_dec i i')         
          | i : inductive, i' : inductive |- _ => fcase (eq_dec i i')
          | x : inductive * nat, y : inductive * nat |- _ =>
            fcase (eq_dec x y)

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -206,8 +206,9 @@ Proof.
       split; eauto.
   - assert (HT : Σ;;; Γ ,,, Γ' |- PCUICAst.tFix mfix n : (decl.(dtype))).
     econstructor; eauto. eapply All_impl. eassumption. intros.
-    destruct X4; cbn in *; firstorder.
-    eapply (All_impl X1). firstorder.
+    destruct X4; cbn in *; pcuicfo.
+    exists x0; auto.
+    eapply (All_impl X1). pcuicfo.
     
     eapply weakening_typing in HT; auto.
     2:{ apply All_local_env_app_inv in X2 as [X2 _]. eapply X2. }
@@ -238,8 +239,9 @@ Proof.
 
   - assert (HT : Σ;;; Γ ,,, Γ' |- PCUICAst.tCoFix mfix n : (decl.(dtype))).
     econstructor; eauto. eapply All_impl. eassumption. intros.
-    destruct X4; cbn in *; firstorder.
-    eapply (All_impl X1). firstorder.
+    destruct X4; cbn in *; pcuicfo.
+    now exists x0.
+    eapply (All_impl X1). pcuicfo.
     
     eapply weakening_typing in HT; auto.
     2:{ apply All_local_env_app_inv in X2 as [X2 _]. eapply X2. }

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -131,7 +131,8 @@ Proof.
     eapply All2_All_left in X3. 2:{ idtac. intros ? ? [[? e] ?]. exact e. }
 
     eapply All2_impl. eapply All2_All_mix_left.
-    all: firstorder.
+    eauto. eauto.
+    all: pcuicfo.
   - econstructor.
 
     eapply All2_impl. eapply All2_All_mix_left. eassumption. eassumption.
@@ -258,7 +259,8 @@ Proof.
   - assert (Hw :  wf_local (Σ.1, univs) (subst_instance_context u (Γ ,,, types))).
     { (* rewrite subst_instance_context_app. *)
       assert(All (fun d => isType Σ Γ (dtype d)) mfix).
-      eapply (All_impl X0); firstorder. 
+      eapply (All_impl X0); pcuicfo.
+      now destruct X5 as [s [Hs ?]]; exists s.
       eapply All_mfix_wf in X5; auto. subst types.
       
       revert X5. clear - wfΣ wfΓ H2 H3 X2 X3.
@@ -292,7 +294,8 @@ Proof.
   - assert (Hw :  wf_local (Σ.1, univs) (subst_instance_context u (Γ ,,, types))).
   { (* rewrite subst_instance_context_app. *)
     assert(All (fun d => isType Σ Γ (dtype d)) mfix).
-    eapply (All_impl X0); firstorder. 
+    eapply (All_impl X0); pcuicfo.
+    destruct X5 as [s [Hs ?]]; now exists s.
     eapply All_mfix_wf in X5; auto. subst types.
     
     revert X5. clear - wfΣ wfΓ H2 H3 X2 X3.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Program.
 From MetaCoq.Template Require Import config utils Kernames.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICPrimitive
      PCUICReflect PCUICWeakeningEnv
      PCUICTyping PCUICInversion PCUICGeneration
      PCUICConfluence PCUICConversion 
@@ -366,6 +366,11 @@ Section Erase.
   
   End EraseMfix.
 
+  Equations erase_prim (ep : prim_val term) : PCUICPrimitive.prim_val E.term :=
+  erase_prim (_; primIntModel i) := (_; primIntModel i);
+  erase_prim (_; primFloatModel f) := (_; primFloatModel f).
+  
+
   Equations? (noeqns noind) erase (Γ : context) (t : term) (Ht : welltyped Σ Γ t) : E.term
       by struct t :=
     erase Γ t Ht with (is_erasable Σ HΣ Γ t Ht) :=
@@ -404,8 +409,7 @@ Section Erase.
       erase Γ (tCoFix mfix n) Ht _ :=
         let mfix' := erase_mfix (erase) Γ mfix _ in
         E.tCoFix mfix' n;
-      erase Γ (tInt i) Ht _ := E.tInt i;
-      erase Γ (tFloat f) Ht _ := E.tFloat f
+      erase Γ (tPrim p) Ht _ := E.tPrim (erase_prim p)
     }.
   Proof.
     all:try clear b'; try clear f'; try clear brs'; try clear erase.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -403,7 +403,9 @@ Section Erase.
         E.tFix mfix' n;
       erase Γ (tCoFix mfix n) Ht _ :=
         let mfix' := erase_mfix (erase) Γ mfix _ in
-        E.tCoFix mfix' n
+        E.tCoFix mfix' n;
+      erase Γ (tInt i) Ht _ := E.tInt i;
+      erase Γ (tFloat f) Ht _ := E.tFloat f
     }.
   Proof.
     all:try clear b'; try clear f'; try clear brs'; try clear erase.

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
+Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt
+    MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *) ExtrOCamlFloats.
 
 (** * Extraction setup for the erasure phase of template-coq.
 

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt
-    MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *) ExtrOCamlFloats.
+From Coq Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlFloats.
+From MetaCoq.Template Require Import MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *).
 
 (** * Extraction setup for the erasure phase of template-coq.
 

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -2,6 +2,7 @@
 
 theories/PCUICUtils.v
 theories/PCUICRelations.v
+theories/PCUICPrimitive.v
 theories/PCUICAst.v
 theories/PCUICSize.v
 theories/PCUICAstUtils.v

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -87,7 +87,7 @@ Proof.
           constructor; pcuic.
           eapply context_relation_app in convctx as [_ convctx].
           unshelve eapply (context_relation_impl convctx).
-          simpl; firstorder. destruct X. constructor; auto.
+          simpl; pcuicfo. destruct X. constructor; auto.
           eapply conv_conv_ctx; eauto.
           eapply context_relation_app_inv. constructor; pcuic.
           constructor; pcuic. constructor; pcuic. now symmetry.

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Export utils Universes BasicAst
      Environment EnvironmentTyping.
+From MetaCoq.PCUIC Require Export PCUICPrimitive.
 From Equations Require Import Equations.
 (** * AST of the Polymorphic Cumulative Calculus of Inductive Constructions
 
@@ -36,9 +37,8 @@ Inductive term :=
 | tProj (p : projection) (c : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
 | tCoFix (mfix : mfixpoint term) (idx : nat)
-(** We use faithful models of primitive types in PCUIC *)
-| tInt (z : uint63_model)
-| tFloat (f : float64_model).
+(** We use faithful models of primitive type values in PCUIC *)
+| tPrim (prim : prim_val term).
 
 Derive NoConfusion for term.
 

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -42,6 +42,8 @@ Inductive term :=
 
 Derive NoConfusion for term.
 
+Notation prim_val := (prim_val term).
+
 Fixpoint mkApps t us :=
   match us with
   | nil => t

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -1,5 +1,4 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import Floats.SpecFloat.
 From MetaCoq.Template Require Export utils Universes BasicAst
      Environment EnvironmentTyping.
 From Equations Require Import Equations.
@@ -20,17 +19,6 @@ Ltac pcuicfo_gen tac :=
 
 Tactic Notation "pcuicfo" := pcuicfo_gen auto.
 Tactic Notation "pcuicfo" tactic(tac) := pcuicfo_gen tac.
-
-(** Model of unsigned integers *)   
-Definition uint_size := 63.
-Definition uint_wB := (2 ^ (Z.of_nat uint_size))%Z.
-Definition uint63_model := { z : Z | ((0 <=? z) && (z <? uint_wB))%Z }.
-
-(** Model of floats *)
-Definition prec := 53%Z.
-Definition emax := 1024%Z.
-(** We consider valid binary encordings of floats as our model *)
-Definition float64_model := sig (valid_binary prec emax).
 
 Inductive term :=
 | tRel (n : nat)

--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -11,9 +11,6 @@ Derive Signature for All All2.
 Definition string_of_aname (b : binder_annot name) :=
   string_of_name b.(binder_name).
 
-Definition string_of_float64_model (f : float64_model) := 
-  "<float>".
-
 Fixpoint string_of_term (t : term) :=
   match t with
   | tRel n => "Rel(" ^ string_of_nat n ^ ")"
@@ -39,8 +36,7 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  | tInt n => "Int(" ^ string_of_Z (proj1_sig n) ^ ")"
-  | tFloat f => "Float(" ^ string_of_float64_model f ^ ")"
+  | tPrim i => "Int(" ^ string_of_prim string_of_term i ^ ")"
   end.
 
 Lemma lookup_env_nil c s : lookup_env [] c = Some s -> False.

--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -11,6 +11,9 @@ Derive Signature for All All2.
 Definition string_of_aname (b : binder_annot name) :=
   string_of_name b.(binder_name).
 
+Definition string_of_float64_model (f : float64_model) := 
+  "<float>".
+
 Fixpoint string_of_term (t : term) :=
   match t with
   | tRel n => "Rel(" ^ string_of_nat n ^ ")"
@@ -36,6 +39,8 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
+  | tInt n => "Int(" ^ string_of_Z (proj1_sig n) ^ ")"
+  | tFloat f => "Float(" ^ string_of_float64_model f ^ ")"
   end.
 
 Lemma lookup_env_nil c s : lookup_env [] c = Some s -> False.

--- a/pcuic/theories/PCUICCSubst.v
+++ b/pcuic/theories/PCUICCSubst.v
@@ -11,7 +11,6 @@ From Equations Require Import Equations.
 
     no lifting involved and one term at a time. *)
 
-
 Local Ltac inv H := inversion H; subst.
 
 Fixpoint csubst t k u :=

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -1065,6 +1065,8 @@ Section WeakNormalization.
     - exfalso; eapply invert_ind_ind; eauto.
     - exfalso; eapply invert_fix_ind; eauto.
     - now rewrite head_mkApps /head /=.
+    - now eapply inversion_Int in typed.
+    - now eapply inversion_Float in typed. 
   Qed.
 
   Lemma wh_neutral_empty t ty : axiom_free Σ ->

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -738,8 +738,8 @@ Section Normalization.
     - simpl in cl; move/andP: cl => [clf cla].
       eapply inversion_App in typed as [na [A [B [Hf _]]]]; eauto.
     - simpl in cl; move/andP: cl => [/andP[_ clc] _].
-      eapply inversion_Case in typed; firstorder eauto.
-    - eapply inversion_Proj in typed; firstorder auto.
+      eapply inversion_Case in typed; pcuicfo eauto.
+    - eapply inversion_Proj in typed; pcuicfo auto.
   Qed.
 
   Lemma ind_normal_constructor t i u args : 

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -1065,8 +1065,7 @@ Section WeakNormalization.
     - exfalso; eapply invert_ind_ind; eauto.
     - exfalso; eapply invert_fix_ind; eauto.
     - now rewrite head_mkApps /head /=.
-    - now eapply inversion_Int in typed.
-    - now eapply inversion_Float in typed. 
+    - now eapply inversion_Prim in typed.
   Qed.
 
   Lemma wh_neutral_empty t ty : axiom_free Σ ->

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -1212,8 +1212,7 @@ Lemma term_closedn_list_ind :
     (forall k (s : projection) (t : term), P k t -> P k (tProj s t)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tFix m n)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tCoFix m n)) ->
-    (forall k i, P k (tInt i)) ->
-    (forall k f, P k (tFloat f)) ->
+    (forall k p, P k (tPrim p)) ->
     forall k (t : term), closedn k t -> P k t.
 Proof.
   intros until t. revert k t.

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -331,8 +331,6 @@ Proof.
   now rewrite closedn_subst_instance_constr IHl.
 Qed.
 
-Arguments skipn : simpl never.
-
 Lemma destArity_spec ctx T :
   match destArity ctx T with
   | Some (ctx', s) => it_mkProd_or_LetIn ctx T = it_mkProd_or_LetIn ctx' (tSort s)
@@ -940,8 +938,7 @@ Proof.
     now move/andP: oib => [].
   - pose proof (onConstructors oib).
     red in X. eapply All_forallb. eapply All2_All_left; eauto.
-    firstorder auto.
-    eapply on_ctype in X0.
+    intros cdecl cs X0; eapply on_ctype in X0.
     now move/andP: X0 => [].
   - eapply All_forallb.
     pose proof (onProjections oib).
@@ -1130,8 +1127,8 @@ Proof.
   erewrite hidecl in clbodies. simpl in clbodies.
   unfold closed_inductive_body in clbodies.
   move/andP: clbodies => [/andP [_ cl] _].
-  eapply forallb_All in cl. apply (All_impl cl). 
-  intros [[? ?] ?]; simpl; firstorder.
+  eapply forallb_All in cl. apply (All_impl cl).
+  now intros [[? ?] ?]; simpl.
 Qed.
 
 Lemma declared_minductive_closed_inds {cf:checker_flags} :
@@ -1215,6 +1212,8 @@ Lemma term_closedn_list_ind :
     (forall k (s : projection) (t : term), P k t -> P k (tProj s t)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tFix m n)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tCoFix m n)) ->
+    (forall k i, P k (tInt i)) ->
+    (forall k f, P k (tFloat f)) ->
     forall k (t : term), closedn k t -> P k t.
 Proof.
   intros until t. revert k t.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -2047,15 +2047,15 @@ Section RedConfluence.
     intros x y H.
     induction H; firstorder.
     - red in p.
-      induction p. repeat constructor. firstorder.
+      induction p. repeat constructor. pcuicfo.
       constructor 2.
       econstructor 3 with (Γ ,, vass na y); auto.
     - subst.
-      induction a. repeat constructor. firstorder.
+      induction a. repeat constructor. pcuicfo.
       constructor 2.
       econstructor 3 with (Γ ,, vdef na y t'); auto.
     - subst.
-      induction a. constructor. constructor. red. right. firstorder.
+      induction a. constructor. constructor. red. right. pcuicfo.
       constructor 2.
       econstructor 3 with (Γ ,, vdef na b' y); auto.
     - clear H. induction IHOnOne2_local_env. constructor. now constructor 3.
@@ -2257,7 +2257,7 @@ Section RedConfluence.
   Lemma clos_refl_trans_out Γ x y :
     clos_refl_trans (red1 Σ Γ) x y -> clos_refl_trans red1_rel (Γ, x) (Γ, y).
   Proof.
-    induction 1. constructor. red. left. firstorder.
+    induction 1. constructor. red. left. pcuicfo.
     constructor 2.
     econstructor 3; eauto.
   Qed.
@@ -2317,8 +2317,8 @@ Section RedConfluence.
       clear - Hctx. induction (fix_context mfix0).
       + assumption.
       + simpl. destruct a as [na [b|] ty].
-        * constructor ; firstorder (hnf ; auto).
-        * constructor ; firstorder (hnf ; auto).
+        * constructor ; pcuicfo (hnf ; auto).
+        * constructor ; pcuicfo (hnf ; auto).
     - eapply red_cofix_one_ty.
       eapply OnOne2_impl ; eauto.
       intros [? ? ? ?] [? ? ? ?] [[r ih] e]. simpl in *.
@@ -2333,8 +2333,8 @@ Section RedConfluence.
       clear - Hctx. induction (fix_context mfix0).
       + assumption.
       + simpl. destruct a as [na [b|] ty].
-        * constructor ; firstorder (hnf ; auto).
-        * constructor ; firstorder (hnf ; auto).
+        * constructor ; pcuicfo (hnf ; auto).
+        * constructor ; pcuicfo (hnf ; auto).
     - auto.
     - eapply red_trans; eauto.
   Qed.
@@ -2632,7 +2632,7 @@ Section RedConfluence.
   Lemma clos_rt_red1_red1_rel_alpha Γ x y :
     clos_refl_trans (red1 Σ Γ) x y -> clos_refl_trans red1_rel_alpha (Γ, x) (Γ, y).
   Proof.
-    induction 1. constructor. red. left. firstorder.
+    induction 1. constructor. red. left. pcuicfo.
     constructor 2.
     econstructor 3; eauto.
   Qed.

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -520,13 +520,13 @@ Proof.
     unfold lift_typing in X |- *.
     now rewrite app_context_assoc.
   - apply IHΓ. auto. eapply All_local_env_subst; eauto. simpl; intros.
-    destruct T; unfold lift_typing in X |- *; simpl in *; firstorder auto.
+    destruct T; unfold lift_typing in X |- *; simpl in *; pcuicfo auto.
     rewrite Nat.add_0_r.
     eapply (substitution _ (Δ' ,,, Γ) [vdef na b t] [b] Γ0) in X; eauto.
     rewrite -{1}(subst_empty 0 b). repeat constructor. now rewrite !subst_empty.
-    exists x.
+    destruct X as [s Hs]; exists s.
     rewrite Nat.add_0_r.
-    eapply (substitution _ _ [vdef na b t] [b] Γ0) in p; eauto.
+    eapply (substitution _ _ [vdef na b t] [b] Γ0) in Hs; eauto.
     rewrite -{1}(subst_empty 0 b). repeat constructor. now rewrite !subst_empty.
 Qed.
 
@@ -551,9 +551,9 @@ Qed.
 Lemma wf_local_rel_empty {cf:checker_flags} Σ Γ : wf_local_rel Σ [] Γ <~> wf_local Σ Γ.
 Proof.
   split.
-  - intros h. eapply (All_local_env_impl _ _ _ h). firstorder.
+  - intros h. eapply (All_local_env_impl _ _ _ h). pcuicfo.
     red in X |- *. now rewrite app_context_nil_l in X.
-  - intros h. eapply (All_local_env_impl _ _ _ h). firstorder.
+  - intros h. eapply (All_local_env_impl _ _ _ h). pcuicfo.
     red in X |- *. now rewrite app_context_nil_l.
 Qed.
 

--- a/pcuic/theories/PCUICConvCumInversion.v
+++ b/pcuic/theories/PCUICConvCumInversion.v
@@ -108,7 +108,8 @@ Section fixed.
       all: depelim e.
       all: depelim w0.
       all: apply All2_length in a.
-      all: constructor; constructor; rewrite a; auto.
+      all: try (constructor; constructor; rewrite a; auto).
+      all: destruct leq; cbn; repeat constructor.
     - clear -a1 a a0.
       induction a1 in args, args', x2, a, x3, a0, a1 |- *; depelim a; depelim a0; [now constructor|].
       constructor.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -292,7 +292,7 @@ Proof.
         eapply All_local_assum_subst; eauto.
         simpl. intros.
         destruct X as [s [Ht2 isp]].
-        exists s; firstorder.
+        exists s; pcuicfo.
         rewrite Nat.add_0_r. eapply (substitution _ Γ [vdef na b ty] [b] Γ1 _ (tSort s)); auto.
         rewrite -{1}(subst_empty 0 b).
         repeat (constructor; auto). rewrite !subst_empty.
@@ -342,7 +342,7 @@ Proof.
           eapply All_local_assum_subst; eauto.
           simpl. intros.
           destruct X as [s [Ht2 isp]].
-          exists s; firstorder auto.
+          exists s; pcuicfo auto.
           rewrite Nat.add_0_r. eapply (substitution _ Γ [vass na ty] [t] Γ1 _ (tSort s)); auto.
           repeat (constructor; auto). now rewrite subst_empty.
           now rewrite app_context_assoc in Ht2. }
@@ -619,7 +619,7 @@ Proof.
   eapply build_branches_type_lookup in e2. eauto.
   2:eauto.
   3:destruct declc; eauto.
-  2:{ eapply (All2_impl a); firstorder. }
+  2:{ eapply (All2_impl a); pcuicfo eauto. }
   destruct e2 as [nargs [br [brty [[[Hnth Hnth'] brtyped]]]]].
   epose proof (All2_nth_error _ _ _ a H).
   specialize (X0 Hnth').
@@ -885,7 +885,7 @@ Lemma cumul_prop1 (Σ : global_env_ext) Γ A B u :
 Proof.
   intros.
   destruct X0 as [s Hs].
-  eapply cumul_prop_inv in H. 4:eauto. firstorder. auto.
+  eapply cumul_prop_inv in H. 4:eauto. pcuicfo. auto.
   right; eauto.
 Qed.
 
@@ -899,7 +899,7 @@ Lemma cumul_prop2 (Σ : global_env_ext) Γ A B u :
 Proof.
   intros.
   destruct X0 as [s Hs].
-  eapply cumul_prop_inv in H. 4:eauto. firstorder. auto.
+  eapply cumul_prop_inv in H. 4:eauto. pcuicfo. auto.
   left; eauto.
 Qed.
 
@@ -913,7 +913,7 @@ Lemma cumul_sprop1 (Σ : global_env_ext) Γ A B u :
 Proof.
   intros.
   destruct X0 as [s Hs].
-  eapply cumul_sprop_inv in H. 4:eauto. firstorder. auto.
+  eapply cumul_sprop_inv in H. 4:eauto. pcuicfo. auto.
   right; eauto.
 Qed.
 
@@ -927,7 +927,7 @@ Lemma cumul_sprop2 (Σ : global_env_ext) Γ A B u :
 Proof.
   intros.
   destruct X0 as [s Hs].
-  eapply cumul_sprop_inv in H. 4:eauto. firstorder. auto.
+  eapply cumul_sprop_inv in H. 4:eauto. pcuicfo. auto.
   left; eauto.
 Qed.
 

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -203,8 +203,7 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
     ) mfix mfix' ->
     eq_term_upto_univ_napp Σ Re Rle napp (tCoFix mfix idx) (tCoFix mfix' idx)
     
-| eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
-| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f).
+| eq_Prim i : eq_term_upto_univ_napp Σ Re Rle napp (tPrim i) (tPrim i).
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 
@@ -893,8 +892,7 @@ Fixpoint eqb_term_upto_univ_napp Σ (equ lequ : Universe.t -> Universe.t -> bool
       eqb_annot x.(dname) y.(dname)
     ) mfix mfix'
 
-  | tInt i, tInt i' => eqb i i'
-  | tFloat f, tFloat f' => eqb f f'
+  | tPrim p, tPrim p' => eqb p p'
 
   | _, _ => false
   end.
@@ -1036,7 +1034,6 @@ Proof.
     cbn -[eqb]. intros x X0 y. eqspec; [|rewrite andb_false_r; discriminate].
     intro. rtoProp. split; tas. split;tas. split; eapply X0; tea.
     now apply eqb_annot_spec.
-  - eqspec; [|discriminate]. constructor.
   - eqspec; [|discriminate]. constructor.
 Qed.
 
@@ -1231,7 +1228,6 @@ Proof.
         -- constructor. intro bot. apply f.
            inversion bot. subst. inversion X0. subst. apply X2.
   - cbn - [eqb]. eqspecs. do 2 constructor.
-  - cbn - [eqb]. eqspecs. do 2 constructor.
 Qed.
 
 Lemma compare_global_instance_refl :
@@ -1300,7 +1296,6 @@ Proof.
       destruct p as [e1 e2].
       rewrite -> e1 by assumption. rewrite -> e2 by assumption.
       rewrite eqb_annot_refl; assumption.
-  - apply eq_dec_to_bool_refl.
   - apply eq_dec_to_bool_refl.
 Qed.
 

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -201,7 +201,10 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
       (x.(rarg) = y.(rarg)) *
       eq_binder_annot x.(dname) y.(dname)
     ) mfix mfix' ->
-    eq_term_upto_univ_napp Σ Re Rle napp (tCoFix mfix idx) (tCoFix mfix' idx).
+    eq_term_upto_univ_napp Σ Re Rle napp (tCoFix mfix idx) (tCoFix mfix' idx)
+    
+| eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
+| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f).
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 
@@ -890,6 +893,9 @@ Fixpoint eqb_term_upto_univ_napp Σ (equ lequ : Universe.t -> Universe.t -> bool
       eqb_annot x.(dname) y.(dname)
     ) mfix mfix'
 
+  | tInt i, tInt i' => eqb i i'
+  | tFloat f, tFloat f' => eqb f f'
+
   | _, _ => false
   end.
 
@@ -1030,6 +1036,8 @@ Proof.
     cbn -[eqb]. intros x X0 y. eqspec; [|rewrite andb_false_r; discriminate].
     intro. rtoProp. split; tas. split;tas. split; eapply X0; tea.
     now apply eqb_annot_spec.
+  - eqspec; [|discriminate]. constructor.
+  - eqspec; [|discriminate]. constructor.
 Qed.
 
 Lemma reflect_eq_term_upto_univ Σ equ lequ (Re Rle : Universe.t -> Universe.t -> Prop) napp :
@@ -1222,6 +1230,8 @@ Proof.
               apply X2.
         -- constructor. intro bot. apply f.
            inversion bot. subst. inversion X0. subst. apply X2.
+  - cbn - [eqb]. eqspecs. do 2 constructor.
+  - cbn - [eqb]. eqspecs. do 2 constructor.
 Qed.
 
 Lemma compare_global_instance_refl :
@@ -1237,6 +1247,15 @@ Proof.
   rtoProp. split; auto.
   destruct t; simpl; auto.
   eapply forallb2_map, forallb2_refl; intro; apply eqb_refl.
+Qed.
+
+Lemma eq_dec_to_bool_refl {A} {ea : Classes.EqDec A} (x : A) : 
+  eq_dec_to_bool x x.
+Proof.
+  unfold eq_dec_to_bool.
+  destruct (Classes.eq_dec x x).
+  constructor.
+  congruence.
 Qed.
 
 Lemma eqb_term_upto_univ_refl :
@@ -1281,6 +1300,8 @@ Proof.
       destruct p as [e1 e2].
       rewrite -> e1 by assumption. rewrite -> e2 by assumption.
       rewrite eqb_annot_refl; assumption.
+  - apply eq_dec_to_bool_refl.
+  - apply eq_dec_to_bool_refl.
 Qed.
 
 (** ** Behavior on mkApps and it_mkLambda_or_LetIn **  *)

--- a/pcuic/theories/PCUICInduction.v
+++ b/pcuic/theories/PCUICInduction.v
@@ -35,6 +35,8 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -231,9 +233,12 @@ Lemma term_forall_mkApps_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, P t.
 Proof.
   intros until t.
+  rename X14 into Pint. rename X15 into Pfloat.
   assert (Acc (MR lt size) t) by eapply measure_wf, Wf_nat.lt_wf.
   induction H. rename X14 into auxt. clear H. rename x into t.
   move auxt at top.

--- a/pcuic/theories/PCUICInduction.v
+++ b/pcuic/theories/PCUICInduction.v
@@ -35,8 +35,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->
+    (forall p, P (tPrim p)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/pcuic/theories/PCUICInduction.v
+++ b/pcuic/theories/PCUICInduction.v
@@ -12,6 +12,7 @@ Set Asymmetric Patterns.
   Allows to get the right induction principle on lists of terms appearing
   in the term syntax (in evar, applications, branches of cases and (co-)fixpoints. *)
 
+Notation prim_ind P p := (P (tPrim p)).
 
 (** Custom induction principle on syntax, dealing with the various lists appearing in terms. *)
 
@@ -35,7 +36,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall p, P (tPrim p)) ->
+    (forall p, prim_ind P p) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -232,12 +233,11 @@ Lemma term_forall_mkApps_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->
+    (forall i, prim_ind P i) ->
     forall t : term, P t.
 Proof.
   intros until t.
-  rename X14 into Pint. rename X15 into Pfloat.
+  rename X14 into Pprim.
   assert (Acc (MR lt size) t) by eapply measure_wf, Wf_nat.lt_wf.
   induction H. rename X14 into auxt. clear H. rename x into t.
   move auxt at top.

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -2592,7 +2592,7 @@ Proof.
   - subst c.
     exists (lift_constraint #|u| x).
     rewrite -> In_lift_constraints.
-    firstorder eauto.
+    pcuicfo eauto.
     specialize (clcstra _ H0).
     simpl in *.
     destruct x as [[l c] r]; rewrite /subst_instance_cstr; simpl.
@@ -2615,8 +2615,9 @@ Proof.
   subst.
   exists x; intuition eauto.
   now rewrite ConstraintSetFact.add_iff.
-  firstorder eauto.
-  subst. exists x0; firstorder.
+  destruct H0 as [c' [-> ?]].
+  eexists c'; split; firstorder eauto.
+  now rewrite ConstraintSetFact.add_iff.
 Qed.
 
 Lemma subst_instance_variance_cstrs l u i i' :

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -1300,7 +1300,10 @@ Lemma invert_red1_letin {cf:checker_flags} (Σ : global_env_ext) Γ C na d ty b 
     red1 Σ.1 (Γ ,, vdef na d ty) b b') +
   (C = subst10 d b)%type.
 Proof.
-  intros H; depelim H; try solve_discr; firstorder auto.
+  intros H; depelim H; try solve_discr; pcuicfo auto.
+  - left. left. left. eexists; eauto.
+  - left. left. right. eexists; eauto.
+  - left. right. eexists; eauto.
 Qed.
 
 Lemma decompose_prod_assum_it_mkProd_or_LetIn' ctx Γ t :
@@ -1360,7 +1363,7 @@ Lemma destInd_head_subst s k t f : destInd (head (subst s k t)) = Some f ->
   (destInd (head t) = Some f) +  
   (∑ n u, (head t = tRel n) /\ k <= n /\ (nth_error s (n - k) = Some u /\ destInd (head  (lift0 k u)) = Some f)).
 Proof.
-  induction t in s, k, f |- *; simpl; try solve [firstorder auto].
+  induction t in s, k, f |- *; simpl; try solve [pcuicfo auto].
   elim: leb_spec_Set => le; intros destI.
    right.
   destruct nth_error eqn:Heq.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -239,6 +239,21 @@ Section Inversion.
     intros Γ mfix idx T h. invtac h.
   Qed.
 
+  (** At this stage we don't typecheck primitive types *)
+  Lemma inversion_Int :
+    forall {Γ i T},
+      Σ ;;; Γ |- tInt i : T -> False.
+  Proof.
+    intros Γ i T h. now depind h.
+  Qed.
+
+  Lemma inversion_Float :
+    forall {Γ f T},
+      Σ ;;; Γ |- tFloat f : T -> False.
+  Proof.
+    intros Γ i T h. now depind h.
+  Qed.
+
   Lemma inversion_it_mkLambda_or_LetIn :
     forall {Γ Δ t T},
       Σ ;;; Γ |- it_mkLambda_or_LetIn Δ t : T ->

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -239,17 +239,10 @@ Section Inversion.
     intros Γ mfix idx T h. invtac h.
   Qed.
 
-  (** At this stage we don't typecheck primitive types *)
-  Lemma inversion_Int :
+  (** At this stage we don't typecheck primitive values *)
+  Lemma inversion_Prim :
     forall {Γ i T},
-      Σ ;;; Γ |- tInt i : T -> False.
-  Proof.
-    intros Γ i T h. now depind h.
-  Qed.
-
-  Lemma inversion_Float :
-    forall {Γ f T},
-      Σ ;;; Γ |- tFloat f : T -> False.
+      Σ ;;; Γ |- tPrim i : T -> False.
   Proof.
     intros Γ i T h. now depind h.
   Qed.

--- a/pcuic/theories/PCUICLiftSubst.v
+++ b/pcuic/theories/PCUICLiftSubst.v
@@ -1813,6 +1813,8 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (s : projection) (t : term), P Γ t -> P Γ (tProj s t)) ->
     (forall Γ (m : mfixpoint term) (n : nat), tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tFix m n)) ->
     (forall Γ (m : mfixpoint term) (n : nat), tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
+    (forall Γ i, P Γ (tInt i)) ->
+    (forall Γ f, P Γ (tFloat f)) ->
     forall Γ (t : term), P Γ t.
 Proof.
   intros. revert Γ t0.

--- a/pcuic/theories/PCUICLiftSubst.v
+++ b/pcuic/theories/PCUICLiftSubst.v
@@ -1793,6 +1793,7 @@ Hint Rewrite @subst_inst : sigma.
 Hint Rewrite shiftk_shift_l shiftk_shift : sigma.
 (* Hint Rewrite Upn_eq : sigma. *)
 
+(** Can't move to PCUICInduction because of fix_context definition *)
 Lemma term_forall_ctx_list_ind :
   forall P : context -> term -> Type,
     (forall Γ (n : nat), P Γ (tRel n)) ->
@@ -1813,8 +1814,7 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (s : projection) (t : term), P Γ t -> P Γ (tProj s t)) ->
     (forall Γ (m : mfixpoint term) (n : nat), tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tFix m n)) ->
     (forall Γ (m : mfixpoint term) (n : nat), tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
-    (forall Γ i, P Γ (tInt i)) ->
-    (forall Γ f, P Γ (tFloat f)) ->
+    (forall Γ p, P Γ (tPrim p)) ->
     forall Γ (t : term), P Γ t.
 Proof.
   intros. revert Γ t0.
@@ -1842,6 +1842,7 @@ Proof.
   destruct mfix; constructor.
   split. apply auxt. apply auxt. apply auxm.
 Defined.
+
 
 Fixpoint subst_app (t : term) (us : list term) : term :=
   match t, us with

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -47,6 +47,7 @@ Fixpoint nameless (t : term) : bool :=
   | tCoFix mfix idx =>
     forallb (fun d => banon d.(dname)) mfix &&
     forallb (test_def nameless nameless) mfix
+  | tInt _ | tFloat _ => true
   end.
 
 Definition anonymize (b : binder_annot name) : binder_annot name :=  
@@ -76,6 +77,8 @@ Fixpoint nl (t : term) : term :=
   | tProj p c => tProj p (nl c)
   | tFix mfix idx => tFix (map (map_def_anon nl nl) mfix) idx
   | tCoFix mfix idx => tCoFix (map (map_def_anon nl nl) mfix) idx
+  | tInt n => tInt n
+  | tFloat f => tFloat f
   end.
 
 Definition map_decl_anon f (d : context_decl) := {|

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -47,7 +47,7 @@ Fixpoint nameless (t : term) : bool :=
   | tCoFix mfix idx =>
     forallb (fun d => banon d.(dname)) mfix &&
     forallb (test_def nameless nameless) mfix
-  | tInt _ | tFloat _ => true
+  | tPrim _ => true
   end.
 
 Definition anonymize (b : binder_annot name) : binder_annot name :=  
@@ -77,8 +77,7 @@ Fixpoint nl (t : term) : term :=
   | tProj p c => tProj p (nl c)
   | tFix mfix idx => tFix (map (map_def_anon nl nl) mfix) idx
   | tCoFix mfix idx => tCoFix (map (map_def_anon nl nl) mfix) idx
-  | tInt n => tInt n
-  | tFloat f => tFloat f
+  | tPrim p => tPrim p
   end.
 
 Definition map_decl_anon f (d : context_decl) := {|

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -52,8 +52,7 @@ Section Normal.
     end ->
     whnf Γ (mkApps (tFix mfix idx) v)
   | whnf_cofixapp mfix idx v : whnf Γ (mkApps (tCoFix mfix idx) v)
-  | whnf_int i : whnf Γ (tInt i)
-  | whnf_float f : whnf Γ (tFloat f)
+  | whnf_prim p : whnf Γ (tPrim p)
 
   with whne (Γ : context) : term -> Type :=
   | whne_rel i :
@@ -253,8 +252,6 @@ Proof.
     apply mkApps_eq_inj in eq as (<-&<-); auto.
   - destruct l using MCList.rev_ind; [|now rewrite <- mkApps_nested in eq].
     cbn in *; subst; auto.
-  - destruct l using MCList.rev_ind; [|now rewrite <- mkApps_nested in eq].
-    cbn in *; subst; auto.
 Qed.
 
 Lemma whnf_fixapp' {flags} Σ Γ mfix idx narg body v :
@@ -386,11 +383,6 @@ Proof with eauto using sq with pcuic.
                  constructor.
                  assumption.
         -- left. constructor. eapply whnf_fixapp. rewrite E1. eauto.
-      * destruct v as [ | ? v]...
-        right. intros [w]. depelim w. depelim w. all:help. clear IHt.
-        eapply whne_mkApps_inv in w as []...
-        -- depelim w. help.
-        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence.
       * destruct v as [ | ? v]...
         right. intros [w]. depelim w. depelim w. all:help. clear IHt.
         eapply whne_mkApps_inv in w as []...
@@ -937,7 +929,6 @@ Proof.
       now inv e.
   - eapply red1_mkApps_tCoFix_inv in r as [[(?&->&?)|(?&->&?)]|(?&->&?)]; eauto.
   - depelim r. solve_discr.
-  - depelim r; solve_discr. 
 Qed.
 
 Lemma whnf_pres Σ Γ t t' :
@@ -1002,8 +993,7 @@ Inductive whnf_red Σ Γ : term -> term -> Type :=
                       red Σ (Γ,,, fix_context mfix) (dbody d) (dbody d'))
          mfix mfix' ->
     whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx)
-| whnf_red_tInt i : whnf_red Σ Γ (tInt i) (tInt i)
-| whnf_red_tFloat f : whnf_red Σ Γ (tFloat f) (tFloat f).
+| whnf_red_tPrim i : whnf_red Σ Γ (tPrim i) (tPrim i).
 
 Derive Signature for whnf_red.
 
@@ -1290,7 +1280,6 @@ Proof.
       intros ? ? (?&[= -> -> ->]).
       auto.
   - depelim r; solve_discr.
-  - depelim r; solve_discr. 
 Qed.
 
 Lemma whnf_red_inv Σ Γ t t' :
@@ -1380,7 +1369,6 @@ Proof.
   - apply eq_term_upto_univ_napp_mkApps_l_inv in eq as (?&?&(?&?)&->).
     depelim e.
     apply whnf_cofixapp.
-  - depelim eq; auto.
   - depelim eq; auto.
 Qed.
 

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -52,6 +52,8 @@ Section Normal.
     end ->
     whnf Γ (mkApps (tFix mfix idx) v)
   | whnf_cofixapp mfix idx v : whnf Γ (mkApps (tCoFix mfix idx) v)
+  | whnf_int i : whnf Γ (tInt i)
+  | whnf_float f : whnf Γ (tFloat f)
 
   with whne (Γ : context) : term -> Type :=
   | whne_rel i :
@@ -155,7 +157,7 @@ Section Normal.
         right. exists x0, x1, x2, x3, x4. repeat split; eauto. now eapply nth_error_app_left.
       + rewrite <- mkApps_snoc in x.
         eapply (f_equal decompose_app) in x;
-          rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence.
+          rewrite !decompose_app_mkApps in x; cbn in *; try intuition congruence.
         inversion x. subst. 
         right. exists mfix, idx, rarg, body, arg. repeat split; eauto.
   Qed.
@@ -173,7 +175,7 @@ Local Ltac inv H := inversion H; subst; clear H.
 Ltac help' := try repeat match goal with
 | [ H0 : _ = mkApps _ _ |- _ ] => 
   eapply (f_equal decompose_app) in H0;
-    rewrite !decompose_app_mkApps in H0; cbn in *; firstorder congruence
+    rewrite !decompose_app_mkApps in H0; cbn in *; intuition congruence
 | [ H1 : tApp _ _ = mkApps _ ?args |- _ ] =>
   destruct args using rev_ind; cbn in *; [ inv H1 |
                                            rewrite <- mkApps_nested in H1; cbn in *; inv H1
@@ -198,7 +200,7 @@ Defined.
 Lemma negb_is_true b :
  ~ is_true b -> is_true (negb b).
 Proof.
-  destruct b; firstorder.
+  destruct b; pcuicfo.
 Qed.
 Hint Resolve negb_is_true : core.
 
@@ -249,6 +251,10 @@ Proof.
     lia.
   - destruct (mkApps_elim t l).
     apply mkApps_eq_inj in eq as (<-&<-); auto.
+  - destruct l using MCList.rev_ind; [|now rewrite <- mkApps_nested in eq].
+    cbn in *; subst; auto.
+  - destruct l using MCList.rev_ind; [|now rewrite <- mkApps_nested in eq].
+    cbn in *; subst; auto.
 Qed.
 
 Lemma whnf_fixapp' {flags} Σ Γ mfix idx narg body v :
@@ -307,6 +313,8 @@ Proof.
   - inv whn; solve_discr; easy.
 Qed.
 
+Set Firstorder Solver auto with core.
+
 Definition whnf_whne_dec flags Σ Γ t :
   ({∥whnf flags Σ Γ t∥} + {~∥whnf flags Σ  Γ t∥}) *
   ({∥whne flags Σ Γ t∥} + {~∥whne flags Σ Γ t∥}).
@@ -335,18 +343,18 @@ Proof with eauto using sq with pcuic.
         right. intros [w]. depelim w. depelim w. all:help. clear IHt.
         eapply whne_mkApps_inv in w as []...
         -- depelim w. help.
-        -- firstorder congruence.
+        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence.
       * destruct v as [ | ? v]...
         right. intros [w]. depelim w. depelim w. all:help. clear IHt.
         eapply whne_mkApps_inv in w as []...
         -- depelim w. help.
-        -- firstorder congruence.
+        -- destruct s0 as (?&?&?&?&?&?&?); congruence.
       * destruct v as [ | ? v]...
         destruct (RedFlags.beta flags) eqn:?.
         -- right. intros [w]. depelim w. depelim w. all:help. clear IHl.
            eapply whne_mkApps_inv in w as []...
            ++ depelim w. congruence. help.
-           ++ firstorder congruence.
+           ++ destruct s0 as (?&?&?&?&?&?&?); congruence.
         -- left; constructor.
            apply whnf_mkApps.
            constructor.
@@ -360,23 +368,34 @@ Proof with eauto using sq with pcuic.
                  eapply whne_mkApps_inv in w as []; eauto.
                  --- depelim w; [|congruence]. help. 
                      eapply (f_equal decompose_app) in x; 
-                       rewrite !decompose_app_mkApps in x; cbn in *; try firstorder congruence. 
+                       rewrite !decompose_app_mkApps in x; cbn in *; try intuition congruence. 
                      inv x. destruct rarg; inv e0.
                  --- destruct s0 as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv e.
                      rewrite E1 in e0. inv e0.
                      eapply (nth_error_app_left v [x0]) in e1.
                      rewrite E2 in e1. inv e1...
-                 --- help.
-                     eapply (f_equal decompose_app) in x; 
-                       rewrite !decompose_app_mkApps in x;
-                       cbn in *; try firstorder congruence.
-                     inv x. rewrite E1 in y. congruence. 
+                 --- solve_discr.
+                     rewrite E1 in e. injection e as -> ->.
+                     rewrite E2 in e0. injection e0 as ->.
+                     apply n; sq; auto.
+                 --- solve_discr.
+                     rewrite E1 in y. congruence.
               ** left.
                  constructor.
                  apply whnf_mkApps.
                  constructor.
                  assumption.
         -- left. constructor. eapply whnf_fixapp. rewrite E1. eauto.
+      * destruct v as [ | ? v]...
+        right. intros [w]. depelim w. depelim w. all:help. clear IHt.
+        eapply whne_mkApps_inv in w as []...
+        -- depelim w. help.
+        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence.
+      * destruct v as [ | ? v]...
+        right. intros [w]. depelim w. depelim w. all:help. clear IHt.
+        eapply whne_mkApps_inv in w as []...
+        -- depelim w. help.
+        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence.
     + right. intros [w]. eapply n. constructor. now eapply whnf_mkApps_inv. 
   - destruct (IHt Γ) as [_ []].
     + left. destruct s as [w]. constructor. now eapply whne_mkApps.
@@ -392,7 +411,10 @@ Proof with eauto using sq with pcuic.
                    destruct s as (? & ? & ? & ? & ? & ? & ? & ? & ?). inv e.
                    rewrite E1 in e0. inv e0.
                    eapply (nth_error_app_left v [x0]) in e1.
-                   rewrite E2 in e1. inv e1...
+                   rewrite E2 in e1. inv e1... solve_discr.
+                   rewrite E1 in e. injection e as -> ->.
+                   rewrite E2 in e0. injection e0 as ->.
+                   apply n0; sq; auto.
                --- left. constructor. apply whne_mkApps. constructor. assumption.
          ++ right. intros [[ | (mfix' & idx' & narg' & body' & a' & [=] & ? & ? & ?) ] % whne_mkApps_inv]; subst; cbn...
             congruence.
@@ -914,6 +936,8 @@ Proof.
       destruct s as [->|(?&?)]; [easy|].
       now inv e.
   - eapply red1_mkApps_tCoFix_inv in r as [[(?&->&?)|(?&->&?)]|(?&->&?)]; eauto.
+  - depelim r. solve_discr.
+  - depelim r; solve_discr. 
 Qed.
 
 Lemma whnf_pres Σ Γ t t' :
@@ -977,7 +1001,9 @@ Inductive whnf_red Σ Γ : term -> term -> Type :=
                       red Σ Γ (dtype d) (dtype d') ×
                       red Σ (Γ,,, fix_context mfix) (dbody d) (dbody d'))
          mfix mfix' ->
-    whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx).
+    whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx)
+| whnf_red_tInt i : whnf_red Σ Γ (tInt i) (tInt i)
+| whnf_red_tFloat f : whnf_red Σ Γ (tFloat f) (tFloat f).
 
 Derive Signature for whnf_red.
 
@@ -1263,6 +1289,8 @@ Proof.
       cbn.
       intros ? ? (?&[= -> -> ->]).
       auto.
+  - depelim r; solve_discr.
+  - depelim r; solve_discr. 
 Qed.
 
 Lemma whnf_red_inv Σ Γ t t' :
@@ -1352,6 +1380,8 @@ Proof.
   - apply eq_term_upto_univ_napp_mkApps_l_inv in eq as (?&?&(?&?)&->).
     depelim e.
     apply whnf_cofixapp.
+  - depelim eq; auto.
+  - depelim eq; auto.
 Qed.
 
 Lemma whnf_eq_term {cf:checker_flags} f Σ φ Γ t t' :

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -96,8 +96,7 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (m : mfixpoint term) (n : nat),
         All_local_env (on_local_decl (fun Γ' t => P (Γ ,,, Γ') t)) (fix_context m) ->
         tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
-    (forall Γ i, P Γ (tInt i)) ->
-    (forall Γ f, P Γ (tFloat f)) ->    
+    (forall Γ p, P Γ (tPrim p)) ->
     forall Γ (t : term), P Γ t.
 Proof.
   intros.
@@ -389,8 +388,7 @@ Section ParallelReduction.
     | tSort _
     | tInd _ _
     | tConstruct _ _ _ 
-    | tInt _
-    | tFloat _ => true
+    | tPrim _ => true
     | _ => false
     end.
 

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -96,6 +96,8 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (m : mfixpoint term) (n : nat),
         All_local_env (on_local_decl (fun Γ' t => P (Γ ,,, Γ') t)) (fix_context m) ->
         tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
+    (forall Γ i, P Γ (tInt i)) ->
+    (forall Γ f, P Γ (tFloat f)) ->    
     forall Γ (t : term), P Γ t.
 Proof.
   intros.
@@ -148,6 +150,7 @@ Proof.
   eapply X13; try (apply aux; red; simpl; lia).
   apply auxl'. simpl. lia.
   red. apply All_pair. split; apply auxl; simpl; auto.
+
 Defined.
 
 (** All2 lemmas *)
@@ -385,7 +388,9 @@ Section ParallelReduction.
     | tVar _
     | tSort _
     | tInd _ _
-    | tConstruct _ _ _ => true
+    | tConstruct _ _ _ 
+    | tInt _
+    | tFloat _ => true
     | _ => false
     end.
 

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -244,8 +244,7 @@ Lemma term_ind_size_app :
         tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat),
         tFixProp (P) P m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->
+    (forall p, P (tPrim p)) ->
     forall (t : term), P t.
 Proof.
   intros.
@@ -338,32 +337,13 @@ Ltac finish_discr :=
          | [ H : pred_atom (mkApps _ _) |- _ ] => apply pred_atom_mkApps in H; intuition subst
          end.
 
-Definition application_atom t :=
-  match t with
-  | tVar _
-  | tSort _
-  | tInd _ _
-  | tConstruct _ _ _
-  | tLambda _ _ _ => true
-  | _ => false
-  end.
-
-Lemma application_atom_mkApps {t l} : application_atom (mkApps t l) -> application_atom t /\ l = [].
-Proof.
-  induction l in t |- *; simpl; auto.
-  intros. destruct (IHl _ H). discriminate.
-Qed.
-
 Ltac solve_discr ::=
   (try (progress (prepare_discr; finish_discr; cbn [mkApps] in * )));
   (try (match goal with
-        | [ H : is_true (application_atom _) |- _ ] => discriminate
         | [ H : is_true (atom _) |- _ ] => discriminate
         | [ H : is_true (atom (mkApps _ _)) |- _ ] => destruct (atom_mkApps H); subst; try discriminate
         | [ H : is_true (pred_atom _) |- _ ] => discriminate
         | [ H : is_true (pred_atom (mkApps _ _)) |- _ ] => destruct (pred_atom_mkApps H); subst; try discriminate
-        | [ H : is_true (application_atom (mkApps _ _)) |- _ ] =>
-          destruct (application_atom_mkApps H); subst; try discriminate
         end)).
 
 Lemma is_constructor_app_ge n l l' : is_constructor n l -> is_constructor n (l ++ l').
@@ -1522,7 +1502,7 @@ Section Rho.
     rename r (rho Γ t) = rho Δ (rename r t).
   Proof.
     revert t Γ Δ r.
-    refine (term_ind_size_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
+    refine (term_ind_size_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
       intros; try subst Γ; try rename Γ0 into Γ(* ; rename_all_hyps *).
     all:auto 2.
 

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -244,6 +244,8 @@ Lemma term_ind_size_app :
         tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat),
         tFixProp (P) P m -> P (tCoFix m n)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall (t : term), P t.
 Proof.
   intros.
@@ -1520,7 +1522,7 @@ Section Rho.
     rename r (rho Γ t) = rho Δ (rename r t).
   Proof.
     revert t Γ Δ r.
-    refine (term_ind_size_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
+    refine (term_ind_size_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
       intros; try subst Γ; try rename Γ0 into Γ(* ; rename_all_hyps *).
     all:auto 2.
 

--- a/pcuic/theories/PCUICPretty.v
+++ b/pcuic/theories/PCUICPretty.v
@@ -191,7 +191,7 @@ Section print_term.
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_aname ∘ dname) l) n)
   | tInt i => 
-    parens top (string_of_Z (proj1_sig i))
+    parens top (string_of_uint63_model i)
   | tFloat f => 
     parens top (string_of_float64_model f)
   end.

--- a/pcuic/theories/PCUICPretty.v
+++ b/pcuic/theories/PCUICPretty.v
@@ -190,6 +190,10 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_aname ∘ dname) l) n)
+  | tInt i => 
+    parens top (string_of_Z (proj1_sig i))
+  | tFloat f => 
+    parens top (string_of_float64_model f)
   end.
 
 End print_term.

--- a/pcuic/theories/PCUICPretty.v
+++ b/pcuic/theories/PCUICPretty.v
@@ -190,10 +190,7 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_aname ∘ dname) l) n)
-  | tInt i => 
-    parens top (string_of_uint63_model i)
-  | tFloat f => 
-    parens top (string_of_float64_model f)
+  | tPrim i => parens top (string_of_prim (print_term Γ true false) i)
   end.
 
 End print_term.

--- a/pcuic/theories/PCUICPrimitive.v
+++ b/pcuic/theories/PCUICPrimitive.v
@@ -1,13 +1,13 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Export utils Universes BasicAst Reflect
+From MetaCoq.Template Require Import utils Universes BasicAst Reflect
      Environment EnvironmentTyping.
 From Equations Require Import Equations.
 From Coq Require Import ssreflect.
 
 Variant prim_tag := 
   | primInt
-  | primFloat
-  | primArray.
+  | primFloat.
+  (* | primArray. *)
 Derive NoConfusion EqDec for prim_tag.
 
 (** We don't enforce the type of the array here*)
@@ -26,15 +26,15 @@ Inductive prim_model (term : Type) : prim_tag -> Type :=
 (* | primArrayModel (a : array_model term) : prim_model term primArray. *)
 Arguments primIntModel {term}.
 Arguments primFloatModel {term}.
-Arguments primArrayModel {term}.
+(* Arguments primArrayModel {term}. *)
 
 Derive Signature NoConfusion for prim_model.
 
-Definition prim_model_of term (p : prim_tag) : Type := 
+Definition prim_model_of (term : Type) (p : prim_tag) : Type := 
   match p with
   | primInt => uint63_model
   | primFloat => float64_model
-  | primArray => array_model term
+  (* | primArray => array_model term *)
   end.
 
 Definition prim_val term := ∑ t : prim_tag, prim_model term t.
@@ -45,7 +45,7 @@ Definition prim_model_val {term} (p : prim_val term) : prim_model_of term (prim_
   match prim_val_model p in prim_model _ t return prim_model_of term t with
   | primIntModel i => i
   | primFloatModel f => f
-  | primArrayModel a => a
+  (* | primArrayModel a => a *)
   end.
 
 Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) : proj1_sig x = proj1_sig y -> x = y.
@@ -84,11 +84,13 @@ Qed.
 (** Propositional UIP is needed below *)
 Set Equations With UIP.
 
-Instance prim_model_eqdec {term} (e : EqDec term) : forall p : prim_tag, EqDec (prim_model term p).
+Instance prim_model_eqdec {term} (*e : EqDec term*) : forall p : prim_tag, EqDec (prim_model term p).
 Proof. eqdec_proof. Qed.
 
-Instance prim_tag_model_eqdec {term} (e : EqDec term) : EqDec (prim_val term).
+Instance prim_tag_model_eqdec term : EqDec (prim_val term).
 Proof. eqdec_proof. Defined.
+
+Instance prim_val_reflect_eq term : ReflectEq (prim_val term) := EqDec_ReflectEq _.
 
 (** Printing *)
 
@@ -99,5 +101,5 @@ Definition string_of_prim {term} (soft : term -> string) (p : prim_val term) : s
   match p.π2 return string with
   | primIntModel f => "(int: " ^ string_of_Z (proj1_sig f) ^ ")"
   | primFloatModel f => "(float: " ^ string_of_float64_model f ^ ")"
-  | primArrayModel a => "(array:" ^ ")"
+  (* | primArrayModel a => "(array:" ^ ")" *)
   end.

--- a/pcuic/theories/PCUICPrimitive.v
+++ b/pcuic/theories/PCUICPrimitive.v
@@ -1,0 +1,103 @@
+(* Distributed under the terms of the MIT license. *)
+From MetaCoq.Template Require Export utils Universes BasicAst Reflect
+     Environment EnvironmentTyping.
+From Equations Require Import Equations.
+From Coq Require Import ssreflect.
+
+Variant prim_tag := 
+  | primInt
+  | primFloat
+  | primArray.
+Derive NoConfusion EqDec for prim_tag.
+
+(** We don't enforce the type of the array here*)
+Record array_model (term : Type) :=
+  { array_instance : Instance.t;
+    array_type : term;
+    array_default : term;
+    array_value : list term }.
+Derive NoConfusion for array_model.
+Instance array_model_eqdec {term} (e : EqDec term) : EqDec (array_model term).
+Proof. eqdec_proof. Qed.
+
+Inductive prim_model (term : Type) : prim_tag -> Type :=
+| primIntModel (i : uint63_model) : prim_model term primInt
+| primFloatModel (f : float64_model) : prim_model term primFloat.
+(* | primArrayModel (a : array_model term) : prim_model term primArray. *)
+Arguments primIntModel {term}.
+Arguments primFloatModel {term}.
+Arguments primArrayModel {term}.
+
+Derive Signature NoConfusion for prim_model.
+
+Definition prim_model_of term (p : prim_tag) : Type := 
+  match p with
+  | primInt => uint63_model
+  | primFloat => float64_model
+  | primArray => array_model term
+  end.
+
+Definition prim_val term := ∑ t : prim_tag, prim_model term t.
+Definition prim_val_tag {term} (s : prim_val term) := s.π1.
+Definition prim_val_model {term} (s : prim_val term) : prim_model term (prim_val_tag s) := s.π2.
+
+Definition prim_model_val {term} (p : prim_val term) : prim_model_of term (prim_val_tag p) :=
+  match prim_val_model p in prim_model _ t return prim_model_of term t with
+  | primIntModel i => i
+  | primFloatModel f => f
+  | primArrayModel a => a
+  end.
+
+Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) : proj1_sig x = proj1_sig y -> x = y.
+Proof.
+  destruct x as [x p], y as [y q]; simpl; intros ->.
+  now destruct (uip p q).
+Qed.
+
+Instance reflect_eq_Z : ReflectEq Z := EqDec_ReflectEq _.
+
+Local Obligation Tactic := idtac.
+#[program]
+Instance reflect_eq_uint63 : ReflectEq uint63_model := 
+  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
+Next Obligation.
+  cbn -[eqb].
+  intros x y.
+  elim: eqb_spec. constructor.
+  now apply exist_irrel_eq.
+  intros neq; constructor => H'; apply neq; now subst x.
+Qed.
+
+Instance reflect_eq_spec_float : ReflectEq SpecFloat.spec_float := EqDec_ReflectEq _.
+  
+#[program]
+Instance reflect_eq_float64 : ReflectEq float64_model := 
+  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
+Next Obligation.
+  cbn -[eqb].
+  intros x y.
+  elim: eqb_spec. constructor.
+  now apply exist_irrel_eq.
+  intros neq; constructor => H'; apply neq; now subst x.
+Qed.
+
+(** Propositional UIP is needed below *)
+Set Equations With UIP.
+
+Instance prim_model_eqdec {term} (e : EqDec term) : forall p : prim_tag, EqDec (prim_model term p).
+Proof. eqdec_proof. Qed.
+
+Instance prim_tag_model_eqdec {term} (e : EqDec term) : EqDec (prim_val term).
+Proof. eqdec_proof. Defined.
+
+(** Printing *)
+
+Definition string_of_float64_model (f : float64_model) := 
+  "<>".
+
+Definition string_of_prim {term} (soft : term -> string) (p : prim_val term) : string :=
+  match p.π2 return string with
+  | primIntModel f => "(int: " ^ string_of_Z (proj1_sig f) ^ ")"
+  | primFloatModel f => "(float: " ^ string_of_float64_model f ^ ")"
+  | primArrayModel a => "(array:" ^ ")"
+  end.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -343,8 +343,7 @@ Section Principality.
       rewrite nthe' in nthe; noconf nthe.
       repeat split; eauto.
       eapply type_CoFix; eauto.
-    - now apply inversion_Int in hA.
-    - now apply inversion_Float in hA.
+    - now apply inversion_Prim in hA.
   Qed.
 
   (** A weaker version that is often convenient to use. *)

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -343,6 +343,8 @@ Section Principality.
       rewrite nthe' in nthe; noconf nthe.
       repeat split; eauto.
       eapply type_CoFix; eauto.
+    - now apply inversion_Int in hA.
+    - now apply inversion_Float in hA.
   Qed.
 
   (** A weaker version that is often convenient to use. *)
@@ -594,7 +596,8 @@ Proof.
     eapply PCUICValidity.validity; eauto.
     eapply (type_Case _ _ (ind, npar)). eapply isdecl.
     all:eauto.
-    eapply (All2_impl X5); firstorder.
+    eapply (All2_impl X5); pcuicfo.
+    destruct b1 as [s [? ?]]. now exists s.
     eapply conv_cumul.
     eapply mkApps_conv_args; pcuic.
     eapply All2_app. simpl in *.
@@ -637,8 +640,9 @@ Proof.
     econstructor; eauto.
     eapply PCUICValidity.validity; eauto.
     econstructor. 2:eapply H0. all:eauto.
-    eapply (All_impl X0); firstorder.
-    eapply (All_impl X1); firstorder.
+    eapply (All_impl X0); pcuicfo.
+    destruct X2 as [s [Hs ?]]; now exists s.
+    eapply (All_impl X1); pcuicfo.
     eapply All2_nth_error in a; eauto.
     destruct a as [[[eqty _] _] _].
     constructor. eapply eq_term_empty_leq_term in eqty.
@@ -649,12 +653,13 @@ Proof.
     econstructor; eauto.
     eapply PCUICValidity.validity; eauto.
     eapply type_CoFix. 2:eapply H0. all:eauto.
-    eapply (All_impl X0); firstorder.
-    eapply (All_impl X1); firstorder.
+    eapply (All_impl X0); pcuicfo.
+    destruct X2 as [s [? ?]]; now exists s.
+    eapply (All_impl X1); pcuicfo.
     eapply All2_nth_error in a; eauto.
     destruct a as [[[eqty _] _] _].
     constructor. apply eq_term_empty_leq_term in eqty.
-    now eapply leq_term_empty_leq_term. Show Existentials.
+    now eapply leq_term_empty_leq_term.
 Qed.
 
 Lemma typing_eq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' : 

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -20,6 +20,39 @@ Local Ltac fcase c :=
   let e := fresh "e" in
   case c ; intro e ; [ subst ; try (left ; reflexivity) | finish ].
 
+Instance reflect_eq_Z : ReflectEq Z := EqDec_ReflectEq _.
+
+Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) : proj1_sig x = proj1_sig y -> x = y.
+Proof.
+  destruct x as [x p], y as [y q]; simpl; intros ->.
+  now destruct (uip p q).
+Qed.
+
+Local Obligation Tactic := idtac.
+#[program]
+Instance reflect_eq_uint63 : ReflectEq uint63_model := 
+  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
+Next Obligation.
+  cbn -[eqb].
+  intros x y.
+  elim: eqb_spec. constructor.
+  now apply exist_irrel_eq.
+  intros neq; constructor => H'; apply neq; now subst x.
+Qed.
+
+Instance reflect_eq_spec_float : ReflectEq SpecFloat.spec_float := EqDec_ReflectEq _.
+  
+#[program]
+Instance reflect_eq_float64 : ReflectEq float64_model := 
+  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
+Next Obligation.
+  cbn -[eqb].
+  intros x y.
+  elim: eqb_spec. constructor.
+  now apply exist_irrel_eq.
+  intros neq; constructor => H'; apply neq; now subst x.
+Qed.
+
 Local Ltac term_dec_tac term_dec :=
   repeat match goal with
          | t : term, u : term |- _ => fcase (term_dec t u)
@@ -34,6 +67,8 @@ Local Ltac term_dec_tac term_dec :=
          | i : string, i' : kername |- _ => fcase (string_dec i i')
          | n : name, n' : name |- _ => fcase (eq_dec n n')
          | n : aname, n' : aname |- _ => fcase (eq_dec n n')
+         | i : uint63_model, j : uint63_model |- _ => fcase (eq_dec i j)
+         | i : float64_model, j : float64_model |- _ => fcase (eq_dec i j)
          | i : inductive, i' : inductive |- _ => fcase (eq_dec i i')
          | x : inductive * nat, y : inductive * nat |- _ =>
            fcase (eq_dec x y)

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -20,39 +20,6 @@ Local Ltac fcase c :=
   let e := fresh "e" in
   case c ; intro e ; [ subst ; try (left ; reflexivity) | finish ].
 
-Instance reflect_eq_Z : ReflectEq Z := EqDec_ReflectEq _.
-
-Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) : proj1_sig x = proj1_sig y -> x = y.
-Proof.
-  destruct x as [x p], y as [y q]; simpl; intros ->.
-  now destruct (uip p q).
-Qed.
-
-Local Obligation Tactic := idtac.
-#[program]
-Instance reflect_eq_uint63 : ReflectEq uint63_model := 
-  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
-Next Obligation.
-  cbn -[eqb].
-  intros x y.
-  elim: eqb_spec. constructor.
-  now apply exist_irrel_eq.
-  intros neq; constructor => H'; apply neq; now subst x.
-Qed.
-
-Instance reflect_eq_spec_float : ReflectEq SpecFloat.spec_float := EqDec_ReflectEq _.
-  
-#[program]
-Instance reflect_eq_float64 : ReflectEq float64_model := 
-  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
-Next Obligation.
-  cbn -[eqb].
-  intros x y.
-  elim: eqb_spec. constructor.
-  now apply exist_irrel_eq.
-  intros neq; constructor => H'; apply neq; now subst x.
-Qed.
-
 Local Ltac term_dec_tac term_dec :=
   repeat match goal with
          | t : term, u : term |- _ => fcase (term_dec t u)

--- a/pcuic/theories/PCUICReflect.v
+++ b/pcuic/theories/PCUICReflect.v
@@ -34,8 +34,7 @@ Local Ltac term_dec_tac term_dec :=
          | i : string, i' : kername |- _ => fcase (string_dec i i')
          | n : name, n' : name |- _ => fcase (eq_dec n n')
          | n : aname, n' : aname |- _ => fcase (eq_dec n n')
-         | i : uint63_model, j : uint63_model |- _ => fcase (eq_dec i j)
-         | i : float64_model, j : float64_model |- _ => fcase (eq_dec i j)
+         | i : prim_val, j : prim_val |- _ => fcase (eq_dec i j)
          | i : inductive, i' : inductive |- _ => fcase (eq_dec i i')
          | x : inductive * nat, y : inductive * nat |- _ =>
            fcase (eq_dec x y)

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -716,8 +716,7 @@ Proof.
 
   - (* Case congruence on discriminee *) 
     eapply type_Cumul. eapply type_Case; eauto.
-    * solve_all.
-      firstorder auto.
+    * solve_all. destruct b0 as [s Hs]; exists s; pcuic.
     * pose proof typec as typec'.
       eapply (env_prop_typing _ _ validity) in typec' as wat; auto.
       unshelve eapply isType_mkApps_Ind in wat as [parsubst [argsubst wat]]; eauto.

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -366,7 +366,8 @@ Proof.
   - move/andb_and: clt => [] ? ?. f_equal; eauto.
   - move/andb_and: clt => [] /andb_and[] ? ? b1.
     red in X. solve_all. f_equal; eauto.
-    eapply All_map_eq. eapply (All_impl b1). firstorder.
+    eapply All_map_eq. eapply (All_impl b1). pcuicfo.
+    unfold on_snd. f_equal. now eapply a0.
   - f_equal; eauto. red in X. solve_all.
     move/andb_and: b => []. eauto. intros.
     apply map_def_eq_spec; eauto.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -130,8 +130,8 @@ Proof.
       rewrite H [firstn _ [u]]firstn_0 // app_nil_r in Hr |- *.
       specialize (IHctx Hr). rewrite app_assoc.
       now econstructor.
-    * destruct a as [na' [b'|] ty']; simpl in *; noconf H.
-      rewrite skipn_S in Hl, Hr, H. subst b.
+    * rewrite skipn_S in Hl, Hr, H.
+      destruct a as [na' [b'|] ty']; simpl in *; noconf H.
       pose proof (context_subst_length Hl). rewrite subst_context_length in H.
       rewrite {3}H -subst_app_simpl [firstn #|ctx| _ ++ _]firstn_skipn. constructor.
       apply IHctx => //.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -372,7 +372,7 @@ Proof.
         eapply closed_upwards; eauto; lia.
       + simpl in X. rewrite -X in cp.
         eapply forallb_All in cp. eapply All_map_id; eauto.
-        eapply (All_impl cp); firstorder auto.
+        eapply (All_impl cp); pcuicfo.
         destruct x; unfold on_snd; simpl; f_equal.
         apply subst_closedn. rewrite context_assumptions_fold.
         eapply closed_upwards; eauto; lia.
@@ -1004,14 +1004,14 @@ Lemma subst_decompose_prod_assum_rec ctx t s k :
   (decompose_prod_assum (subst_context s k ctx) (subst s (length ctx + k) t) =
   (subst_context s k ctx' ,,, ctx'', t'')).
 Proof.
-  induction t in ctx, k |- *; simpl; try solve [ eexists _, _; firstorder eauto ].
+  induction t in ctx, k |- *; simpl; try solve [ eexists _, _; pcuicfo ].
   - elim: leb_spec_Set => comp.
     + destruct (nth_error s (n - (#|ctx| + k))) eqn:Heq.
       * destruct decompose_prod_assum eqn:Heq'.
         eexists _, _; intuition eauto.
         now rewrite decompose_prod_assum_ctx Heq'.
-      * eexists _,_; firstorder eauto.
-    + eexists _,_; firstorder eauto.
+      * eexists _,_; pcuicfo.
+    + eexists _,_; pcuicfo.
   - destruct decompose_prod_assum eqn:Heq.
     rewrite decompose_prod_assum_ctx in Heq.
     destruct (decompose_prod_assum [] t2) eqn:Heq'.

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -11,6 +11,13 @@ Definition uint63_from_model (i : uint63_model) : Int63.int :=
 Definition float64_from_model (f : float64_model) : PrimFloat.float :=
   FloatOps.SF2Prim (proj1_sig f).
 
+Definition trans_prim {term} (t : prim_val term) : Ast.term :=
+  match t.π2 with
+  | primIntModel i => Ast.tInt (uint63_from_model i)
+  | primFloatModel f => Ast.tFloat (float64_from_model f)
+  | primArrayModel a => Ast.tRel 0 (* todo *)
+  end.
+
 Fixpoint trans (t : PCUICAst.term) : Ast.term :=
   match t with
   | PCUICAst.tRel n => tRel n
@@ -34,8 +41,7 @@ Fixpoint trans (t : PCUICAst.term) : Ast.term :=
   | PCUICAst.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  | PCUICAst.tInt i => tInt (uint63_from_model i)
-  | PCUICAst.tFloat f => tFloat (float64_from_model f)
+  | PCUICAst.tPrim i => trans_prim i
   end.
 
 Definition trans_decl (d : PCUICAst.context_decl) :=

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -11,11 +11,10 @@ Definition uint63_from_model (i : uint63_model) : Int63.int :=
 Definition float64_from_model (f : float64_model) : PrimFloat.float :=
   FloatOps.SF2Prim (proj1_sig f).
 
-Definition trans_prim {term} (t : prim_val term) : Ast.term :=
+Definition trans_prim (t : prim_val) : Ast.term :=
   match t.π2 with
   | primIntModel i => Ast.tInt (uint63_from_model i)
   | primFloatModel f => Ast.tFloat (float64_from_model f)
-  | primArrayModel a => Ast.tRel 0 (* todo *)
   end.
 
 Fixpoint trans (t : PCUICAst.term) : Ast.term :=

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -1,8 +1,15 @@
 (* Distributed under the terms of the MIT license. *)
+From Coq Require Import Int63 FloatOps FloatAxioms.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils.
 Set Warnings "-notation-overridden".
 From MetaCoq.Template Require Import config utils AstUtils BasicAst Ast.
 Set Warnings "+notation-overridden".
+
+Definition uint63_from_model (i : uint63_model) : Int63.int :=
+  Int63.of_Z (proj1_sig i).
+
+Definition float64_from_model (f : float64_model) : PrimFloat.float :=
+  FloatOps.SF2Prim (proj1_sig f).
 
 Fixpoint trans (t : PCUICAst.term) : Ast.term :=
   match t with
@@ -27,6 +34,8 @@ Fixpoint trans (t : PCUICAst.term) : Ast.term :=
   | PCUICAst.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
+  | PCUICAst.tInt i => tInt (uint63_from_model i)
+  | PCUICAst.tFloat f => tFloat (float64_from_model f)
   end.
 
 Definition trans_decl (d : PCUICAst.context_decl) :=

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -966,7 +966,8 @@ in All (for wf_local assumptions)
       unfold map_def.
       reflexivity.
     + eapply All_map, (All_impl X0).
-      firstorder.
+      intuition auto. destruct X2 as [s [? ?]].
+      exists s; intuition auto.
     + fold trans.
       subst types.
       eapply trans_mfix_All2;eassumption.
@@ -978,7 +979,8 @@ in All (for wf_local assumptions)
       unfold map_def.
       reflexivity.
     + fold trans.
-      eapply All_map, (All_impl X0); firstorder.
+      eapply All_map, (All_impl X0).
+      intros x [s ?]; exists s; intuition auto.
     + fold trans;subst types.
       (* like trans_mfix_All2 without isLambda *)
       admit.

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -59,6 +59,7 @@ Proof.
   - f_equal; auto. red in X. solve_list.
   - f_equal; auto; red in X; solve_list.
   - f_equal; auto; red in X; solve_list.
+  - destruct p as [? []]; eauto.
 Qed.
 
 Definition on_fst {A B C} (f:A->C) (p:A×B) := (f p.1, p.2).
@@ -296,6 +297,7 @@ Proof.
       cbn in *.
       now rewrite e, e0.  
     + apply IHX.
+  - destruct p as [? []]; eauto.
 Qed.
 
 
@@ -355,6 +357,7 @@ Proof.
       destruct p.
       now rewrite e, e0.
     + apply IHX.
+  - destruct p as [? []]; eauto.
 Qed.
 
 Lemma trans_cst_type decl:
@@ -475,10 +478,12 @@ Proof.
       2: destruct (trans ty1);cbn;trivial.
       cbn. rewrite IHparams.
       cbn. now rewrite trans_subst.
+      destruct prim as [? []]; eauto.
     + destruct ty;cbn;trivial.
       2: destruct (trans ty1);cbn;trivial.
       cbn. destruct pars;trivial.
       cbn. now rewrite IHparams.
+      destruct prim as [? []]; eauto.
 Qed.
 
 
@@ -538,6 +543,7 @@ Proof.
   - rewrite <- IHx3.
     reflexivity.
   - destruct (trans x1);cbn;trivial.
+  - destruct prim as [? []]; eauto.
 Qed.
 
 Lemma trans_mkProd_or_LetIn a t:

--- a/pcuic/theories/PCUICUnivSubst.v
+++ b/pcuic/theories/PCUICUnivSubst.v
@@ -32,7 +32,7 @@ Instance subst_instance_constr : UnivSubst term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def (subst_instance_constr u) (subst_instance_constr u)) mfix in
     tCoFix mfix' idx
-  | tInt _ | tFloat _ => c
+  | tPrim _ => c
   end.
 
 Instance subst_instance_decl : UnivSubst context_decl

--- a/pcuic/theories/PCUICUnivSubst.v
+++ b/pcuic/theories/PCUICUnivSubst.v
@@ -11,7 +11,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction PCUICLiftSubst.
 Instance subst_instance_constr : UnivSubst term :=
   fix subst_instance_constr u c {struct c} : term :=
   match c with
-  | tRel _ | tVar _  => c
+  | tRel _ | tVar _ => c
   | tEvar ev args => tEvar ev (List.map (subst_instance_constr u) args)
   | tSort s => tSort (subst_instance_univ u s)
   | tConst c u' => tConst c (subst_instance_instance u u')
@@ -32,6 +32,7 @@ Instance subst_instance_constr : UnivSubst term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def (subst_instance_constr u) (subst_instance_constr u)) mfix in
     tCoFix mfix' idx
+  | tInt _ | tFloat _ => c
   end.
 
 Instance subst_instance_decl : UnivSubst context_decl

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -347,7 +347,7 @@ Proof.
                       /\ In c' (CS.elements ctrs)).
   - generalize (CS.elements ctrs), CS.empty.
     induction l; cbn.
-    + firstorder.
+    + pcuicfo. now destruct H0 as [? ?].
     + intros t. etransitivity. 1: eapply IHl.
       split; intros [HH|HH].
       * destruct a as [[l1 a] l2]. apply CS.add_spec in HH.
@@ -1085,9 +1085,11 @@ Proof.
     econstructor. now rewrite nth_error_map, H.
   - cbn. econstructor; eauto.
     eapply OnOne2_map. eapply OnOne2_impl. 1: eassumption.
-    firstorder.
+    (* Used to be pcuicfo *)
+    simpl in *; intuition; simpl in *. unfold on_Trel.
+    simpl. split; auto.
   - cbn; econstructor;
-    eapply OnOne2_map; eapply OnOne2_impl; [ eassumption | firstorder].
+    eapply OnOne2_map; eapply OnOne2_impl; [ eassumption | pcuicfo].
   - cbn; econstructor;
       eapply OnOne2_map; eapply OnOne2_impl; [ eassumption | ].
     intros. destruct X1. destruct p. inversion e. destruct x, y; cbn in *; subst.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -267,12 +267,11 @@ Section Validity.
       assumption.
       
     - (* Fix *)
-      eapply nth_error_all in X0; eauto.
-      firstorder auto.
+      eapply nth_error_all in X0 as [s Hs]; eauto.
+      pcuic.
     
     - (* CoFix *)
-      eapply nth_error_all in X0; eauto.
-      firstorder auto.
+      eapply nth_error_all in X0 as [s Hs]; pcuic.
 
     - (* Conv *)
       now exists s.

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -644,7 +644,7 @@ Section Wcbv.
   (*   intros H; depind H; try solve_discr. *)
   (*   - depelim H. *)
   (*   - depelim H. *)
-  (*   - eexists _, _; firstorder eauto. *)
+  (*   - eexists _, _; pcuicfo eauto. *)
   (*   - now depelim H. *)
   (*   - discriminate. *)
   (* Qed. *)

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -293,7 +293,7 @@ Proof.
         eapply closed_upwards; eauto; lia.
       + simpl in X. rewrite -X in cp.
         eapply forallb_All in cp. eapply All_map_id; eauto.
-        eapply (All_impl cp); firstorder auto.
+        eapply (All_impl cp); intuition auto.
         destruct x; unfold on_snd; simpl; f_equal.
         apply lift_closed. rewrite context_assumptions_fold.
         eapply closed_upwards; eauto; lia.

--- a/pcuic/theories/TemplateToPCUIC.v
+++ b/pcuic/theories/TemplateToPCUIC.v
@@ -40,8 +40,8 @@ Fixpoint trans (t : Ast.term) : term :=
   | Ast.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  | Ast.tInt n => tInt (uint63_to_model n)
-  | Ast.tFloat n => tFloat (float64_to_model n)
+  | Ast.tInt n => tPrim (primInt; primIntModel (uint63_to_model n))
+  | Ast.tFloat n => tPrim (primFloat; primFloatModel (float64_to_model n))
   end.
 
 Definition trans_decl (d : Ast.context_decl) :=

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -27,6 +27,8 @@ src/typing0.ml
 
 
 # From PCUIC
+src/pCUICPrimitive.mli
+src/pCUICPrimitive.ml
 src/pCUICAst.ml
 src/pCUICAst.mli
 src/pCUICAstUtils.ml

--- a/safechecker/src/metacoq_safechecker_plugin.mlpack
+++ b/safechecker/src/metacoq_safechecker_plugin.mlpack
@@ -14,6 +14,7 @@ Classes0
 Logic1
 Relation
 Relation_Properties
+PCUICPrimitive
 PCUICAst
 PCUICAstUtils
 PCUICInduction

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-Require Import OrdersTac ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
+Require Import OrdersTac ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt
+    MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *) ExtrOCamlFloats.
 Require Import MetaCoq.Template.utils.
 From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion
      SafeTemplateChecker.
@@ -10,6 +11,7 @@ From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion
     should use these same directives for consistency.
 *)
 
+(** Here we could extract uint63_from/to_model to the identity *)
 
 (* Ignore [Decimal.int] before the extraction issue is solved:
    https://github.com/coq/coq/issues/7017. *)

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -31,6 +31,7 @@ Extract Constant Equations.Init.pr1 => "fst".
 Extract Constant Equations.Init.pr2 => "snd".
 Extraction Inline Equations.Init.pr1 Equations.Init.pr2.
 Extraction Inline Equations.Prop.Logic.transport Equations.Prop.Logic.transport_r MCEquality.transport.
+Extraction Inline Equations.Prop.Logic.True_rect_dep Equations.Prop.Logic.False_rect_dep.
 
 Extract Constant PCUICTyping.guard_checking => "{ fix_guard = (fun _ _ _ -> true); cofix_guard = (fun _ _ _ -> true) }".
 

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -33,6 +33,9 @@ Extraction Inline Equations.Init.pr1 Equations.Init.pr2.
 Extraction Inline Equations.Prop.Logic.transport Equations.Prop.Logic.transport_r MCEquality.transport.
 Extraction Inline Equations.Prop.Logic.True_rect_dep Equations.Prop.Logic.False_rect_dep.
 
+(** This Inline is because of a problem of weak type variables (partial application?) *)
+Extraction Inline PCUICPrimitive.prim_val_reflect_eq.
+
 Extract Constant PCUICTyping.guard_checking => "{ fix_guard = (fun _ _ _ -> true); cofix_guard = (fun _ _ _ -> true) }".
 
 Cd "src".

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -1,7 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-Require Import OrdersTac ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt
-    MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *) ExtrOCamlFloats.
-Require Import MetaCoq.Template.utils.
+From Coq Require Import OrdersTac ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlFloats.
+From MetaCoq.Template Require Import utils MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *).
 From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion
      SafeTemplateChecker.
 

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -4058,31 +4058,14 @@ Section Conversion.
   Qed.
 
   (* TODO move to PCUICNormal *)
-  Lemma whnf_mkApps_tInt_inv : 
-    forall (f : RedFlags.t) (Σ : global_env) (Γ : context) i (args : list term),
-      whnf f Σ Γ (mkApps (tInt i) args) -> args = [].
+  Lemma whnf_mkApps_tPrim_inv : 
+    forall (f : RedFlags.t) (Σ : global_env) (Γ : context) p (args : list term),
+      whnf f Σ Γ (mkApps (tPrim p) args) -> args = [].
   Proof.
     intros * wh.
     inversion wh; solve_discr.
     clear -X.
-    remember (mkApps (tInt i) args) eqn:teq.
-    exfalso.
-    revert teq.
-    induction X in args |- *; intros; solve_discr.
-    destruct args as [|? ? _] using MCList.rev_ind; [easy|].
-    rewrite <- mkApps_nested in teq.
-    cbn in teq. noconf teq.
-    eauto.
-  Qed.
-  
-  Lemma whnf_mkApps_tFloat_inv : 
-    forall (rf : RedFlags.t) (Σ : global_env) (Γ : context) f (args : list term),
-      whnf rf Σ Γ (mkApps (tFloat f) args) -> args = [].
-  Proof.
-    intros * wh.
-    inversion wh; solve_discr.
-    clear -X.
-    remember (mkApps (tFloat f) args) eqn:teq.
+    remember (mkApps (tPrim p) args) eqn:teq.
     exfalso.
     revert teq.
     induction X in args |- *; intros; solve_discr.
@@ -4150,10 +4133,7 @@ Section Conversion.
     - constructor; eexists _, (decompose_stack π).1.
       split; [constructor; eauto with pcuic|].
       eauto with pcuic.
-    - apply whnf_mkApps_tInt_inv in wh as ->.
-      constructor; eexists _, [].
-      eauto using whnf_red with pcuic.
-    - apply whnf_mkApps_tFloat_inv in wh as ->.
+    - apply whnf_mkApps_tPrim_inv in wh as ->.
       constructor; eexists _, [].
       eauto using whnf_red with pcuic.
     - constructor; eexists _, (decompose_stack π).1.
@@ -4539,7 +4519,6 @@ Section Conversion.
       apply inversion_Sort in h2 as (_&h2&_); auto.
       apply inversion_Sort in h1 as (_&h1&_); auto.      
       eapply conv_pb_relb_complete in H0; eauto.
-    - now rewrite eq_dec_to_bool_refl in noteq.
     - now rewrite eq_dec_to_bool_refl in noteq.
   Qed.
   

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1256,6 +1256,8 @@ Section Reduce.
       unfold is_true in typ.
       unfold PCUICAst.fst_ctx in *.
       congruence.
+    - now eapply inversion_Int in typ.
+    - now eapply inversion_Float in typ.
   Qed.
   
   Definition isCoFix_app t :=
@@ -1287,6 +1289,8 @@ Section Reduce.
     - exfalso; eapply invert_fix_ind; eauto.
     - unfold isCoFix_app in cof.
       now rewrite decompose_app_mkApps in cof.
+    - now eapply inversion_Int in typ.
+    - now eapply inversion_Float in typ.
   Qed.
   
   Lemma whnf_fix_arg_whne mfix idx body Γ t before args aftr ty :
@@ -1435,6 +1439,11 @@ Section Reduce.
           apply inversion_App in h as (?&?&?&?&?); auto.
           apply inversion_Prod in t0 as (?&?&?&?&?); auto.
           eapply PCUICConversion.cumul_Sort_Prod_inv; eauto.
+      + exfalso.
+        eapply welltyped_context in h as [s Hs]; tas.
+        now eapply inversion_Int in Hs.
+      + exfalso; eapply welltyped_context in h as [s Hs]; tas.
+        now eapply inversion_Float in Hs.
     - unfold zipp. case_eq (decompose_stack π0). intros l ρ e.
       constructor. constructor. eapply whne_mkApps.
       eapply whne_rel_nozeta. assumption.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1256,8 +1256,7 @@ Section Reduce.
       unfold is_true in typ.
       unfold PCUICAst.fst_ctx in *.
       congruence.
-    - now eapply inversion_Int in typ.
-    - now eapply inversion_Float in typ.
+    - now eapply inversion_Prim in typ.
   Qed.
   
   Definition isCoFix_app t :=
@@ -1289,8 +1288,7 @@ Section Reduce.
     - exfalso; eapply invert_fix_ind; eauto.
     - unfold isCoFix_app in cof.
       now rewrite decompose_app_mkApps in cof.
-    - now eapply inversion_Int in typ.
-    - now eapply inversion_Float in typ.
+    - now eapply inversion_Prim in typ.
   Qed.
   
   Lemma whnf_fix_arg_whne mfix idx body Γ t before args aftr ty :
@@ -1441,9 +1439,7 @@ Section Reduce.
           eapply PCUICConversion.cumul_Sort_Prod_inv; eauto.
       + exfalso.
         eapply welltyped_context in h as [s Hs]; tas.
-        now eapply inversion_Int in Hs.
-      + exfalso; eapply welltyped_context in h as [s Hs]; tas.
-        now eapply inversion_Float in Hs.
+        now eapply inversion_Prim in Hs.
     - unfold zipp. case_eq (decompose_stack π0). intros l ρ e.
       constructor. constructor. eapply whne_mkApps.
       eapply whne_rel_nozeta. assumption.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -261,7 +261,10 @@ Section TypeOf.
 
     infer Γ (tCoFix mfix n) wt with inspect (nth_error mfix n) :=
       { | ret (Some f) => ret f.(dtype);
-        | ret None => ! }
+        | ret None => ! };
+
+    infer Γ (tInt i) wt := ! ;
+    infer Γ (tFloat f) wt := !
   }.
   Proof.
     all:try clear infer.
@@ -655,6 +658,9 @@ Section TypeOf.
         congruence.
       
     - now eapply inversion_CoFix in HT as [decl [fg [hnth [htys [hbods [wf cum]]]]]]; auto.
+
+    - now eapply inversion_Int in HT.
+    - now eapply inversion_Float in HT.
   Defined.
 
   Definition type_of Γ t wt : term := (infer Γ t wt).

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -263,8 +263,7 @@ Section TypeOf.
       { | ret (Some f) => ret f.(dtype);
         | ret None => ! };
 
-    infer Γ (tInt i) wt := ! ;
-    infer Γ (tFloat f) wt := !
+    infer Γ (tPrim p) wt := !
   }.
   Proof.
     all:try clear infer.
@@ -659,8 +658,7 @@ Section TypeOf.
       
     - now eapply inversion_CoFix in HT as [decl [fg [hnth [htys [hbods [wf cum]]]]]]; auto.
 
-    - now eapply inversion_Int in HT.
-    - now eapply inversion_Float in HT.
+    - now eapply inversion_Prim in HT.
   Defined.
 
   Definition type_of Γ t wt : term := (infer Γ t wt).

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -456,7 +456,7 @@ Section Typecheck.
         ret (dtype decl; _)
       end
 
-    | tInt _ | tFloat _ => raise (Msg "Primitive types are not supported")
+    | tPrim _ => raise (Msg "Primitive types are not supported")
     end.
 
   (* tRel *)

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -455,6 +455,8 @@ Section Typecheck.
         wfcofix <- check_eq_true (wf_cofixpoint Σ.1 mfix) (Msg "Ill-formed cofixpoint: not producing values in a mutually coinductive family") ;;
         ret (dtype decl; _)
       end
+
+    | tInt _ | tFloat _ => raise (Msg "Primitive types are not supported")
     end.
 
   (* tRel *)

--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -16,6 +16,7 @@ theories/utils/MCSquash.v
 theories/utils/MCString.v
 theories/utils/wGraph.v
 theories/utils/MCUtils.v
+theories/utils/MC_ExtrOCamlInt63.v
 
 # common
 theories/common/uGraph.v

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -59,14 +59,16 @@ gen-src/extractable.mli
 gen-src/int63.ml
 gen-src/int63.mli
 
-# gen-src/sumbool.mli
-# gen-src/sumbool.ml
-# gen-src/zeven.mli
-# gen-src/zeven.ml
-# gen-src/zArith_dec.mli
-# gen-src/zArith_dec.ml
-# gen-src/zbool.mli
-# gen-src/zbool.ml
+gen-src/sumbool.mli
+gen-src/sumbool.ml
+gen-src/zeven.mli
+gen-src/zeven.ml
+gen-src/zArith_dec.mli
+gen-src/zArith_dec.ml
+gen-src/zbool.mli
+gen-src/zbool.ml
+gen-src/zpower.mli
+gen-src/zpower.ml
 gen-src/specFloat.mli
 gen-src/specFloat.ml
 gen-src/floatOps.mli

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -58,6 +58,21 @@ gen-src/extractable.mli
 #gen-src/induction.mli
 gen-src/int63.ml
 gen-src/int63.mli
+
+# gen-src/sumbool.mli
+# gen-src/sumbool.ml
+# gen-src/zeven.mli
+# gen-src/zeven.ml
+# gen-src/zArith_dec.mli
+# gen-src/zArith_dec.ml
+# gen-src/zbool.mli
+# gen-src/zbool.ml
+gen-src/specFloat.mli
+gen-src/specFloat.ml
+gen-src/floatOps.mli
+gen-src/floatOps.ml
+# gen-src/float64.mli
+# gen-src/float64.ml
 gen-src/liftSubst.ml
 gen-src/liftSubst.mli
 gen-src/list0.ml
@@ -76,6 +91,10 @@ gen-src/mCProd.ml
 gen-src/mCProd.mli
 gen-src/mCRelations.ml
 gen-src/mCRelations.mli
+gen-src/primFloat.mli
+gen-src/primFloat.ml
+gen-src/decimalString.mli
+gen-src/decimalString.ml
 gen-src/mCString.ml
 gen-src/mCString.mli
 gen-src/mCUtils.ml

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -56,6 +56,8 @@ gen-src/extractable.ml
 gen-src/extractable.mli
 #gen-src/induction.ml
 #gen-src/induction.mli
+gen-src/int63.ml
+gen-src/int63.mli
 gen-src/liftSubst.ml
 gen-src/liftSubst.mli
 gen-src/list0.ml

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -11,6 +11,7 @@ BinPosDef
 BinPos
 BinNat
 BinInt
+Int63
 Ascii
 String0
 Orders

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -36,6 +36,10 @@ MCRelations
 MCOption
 MCProd
 MCCompare
+SpecFloat
+PrimFloat
+FloatOps
+DecimalString
 MCString
 MCUtils
 Signature

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -36,6 +36,11 @@ MCRelations
 MCOption
 MCProd
 MCCompare
+Sumbool
+Zeven
+ZArith_dec
+Zbool
+Zpower
 SpecFloat
 PrimFloat
 FloatOps

--- a/template-coq/gen-src/specFloat.ml.orig
+++ b/template-coq/gen-src/specFloat.ml.orig
@@ -1,0 +1,553 @@
+open BinInt
+open BinPos
+open Bool
+open Datatypes
+open Zbool
+open Zpower
+
+type spec_float =
+| S754_zero of bool
+| S754_infinity of bool
+| S754_nan
+| S754_finite of bool * int * int
+
+(** val emin : int -> int -> int **)
+
+let emin prec emax =
+  Z.sub (Z.sub ((fun p->1+2*p) 1) emax) prec
+
+(** val fexp : int -> int -> int -> int **)
+
+let fexp prec emax e =
+  Z.max (Z.sub e prec) (emin prec emax)
+
+(** val digits2_pos : int -> int **)
+
+let rec digits2_pos n =
+  (fun f2p1 f2p f1 p ->
+  if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))
+    (fun p -> Pos.succ (digits2_pos p))
+    (fun p -> Pos.succ (digits2_pos p))
+    (fun _ -> 1)
+    n
+
+(** val coq_Zdigits2 : int -> int **)
+
+let coq_Zdigits2 n =
+  (fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+    (fun _ -> n)
+    (fun p -> (digits2_pos p))
+    (fun p -> (digits2_pos p))
+    n
+
+(** val canonical_mantissa : int -> int -> int -> int -> bool **)
+
+let canonical_mantissa prec emax m e =
+  coq_Zeq_bool (fexp prec emax (Z.add (digits2_pos m) e)) e
+
+(** val bounded : int -> int -> int -> int -> bool **)
+
+let bounded prec emax m e =
+  (&&) (canonical_mantissa prec emax m e) (Z.leb e (Z.sub emax prec))
+
+(** val valid_binary : int -> int -> spec_float -> bool **)
+
+let valid_binary prec emax = function
+| S754_finite (_, m, e) -> bounded prec emax m e
+| _ -> true
+
+(** val iter_pos : ('a1 -> 'a1) -> int -> 'a1 -> 'a1 **)
+
+let rec iter_pos f n x =
+  (fun f2p1 f2p f1 p ->
+  if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))
+    (fun n' -> iter_pos f n' (iter_pos f n' (f x)))
+    (fun n' -> iter_pos f n' (iter_pos f n' x))
+    (fun _ -> f x)
+    n
+
+type location =
+| Coq_loc_Exact
+| Coq_loc_Inexact of comparison
+
+(** val location_rect : 'a1 -> (comparison -> 'a1) -> location -> 'a1 **)
+
+let location_rect f f0 = function
+| Coq_loc_Exact -> f
+| Coq_loc_Inexact x -> f0 x
+
+(** val location_rec : 'a1 -> (comparison -> 'a1) -> location -> 'a1 **)
+
+let location_rec f f0 = function
+| Coq_loc_Exact -> f
+| Coq_loc_Inexact x -> f0 x
+
+type shr_record = { shr_m : int; shr_r : bool; shr_s : bool }
+
+(** val shr_m : shr_record -> int **)
+
+let shr_m s =
+  s.shr_m
+
+(** val shr_r : shr_record -> bool **)
+
+let shr_r s =
+  s.shr_r
+
+(** val shr_s : shr_record -> bool **)
+
+let shr_s s =
+  s.shr_s
+
+(** val shr_1 : shr_record -> shr_record **)
+
+let shr_1 mrs =
+  let { shr_m = m; shr_r = r; shr_s = s } = mrs in
+  let s0 = (||) r s in
+  ((fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+     (fun _ -> { shr_m = 0; shr_r = false; shr_s = s0 })
+     (fun p0 ->
+     (fun f2p1 f2p f1 p ->
+  if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))
+       (fun p -> { shr_m = p; shr_r = true; shr_s = s0 })
+       (fun p -> { shr_m = p; shr_r = false; shr_s = s0 })
+       (fun _ -> { shr_m = 0; shr_r = true; shr_s = s0 })
+       p0)
+     (fun p0 ->
+     (fun f2p1 f2p f1 p ->
+  if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))
+       (fun p -> { shr_m = ((~-) p); shr_r = true; shr_s = s0 })
+       (fun p -> { shr_m = ((~-) p); shr_r = false; shr_s = s0 })
+       (fun _ -> { shr_m = 0; shr_r = true; shr_s = s0 })
+       p0)
+     m)
+
+(** val loc_of_shr_record : shr_record -> location **)
+
+let loc_of_shr_record mrs =
+  let { shr_m = _; shr_r = shr_r0; shr_s = shr_s0 } = mrs in
+  if shr_r0
+  then if shr_s0 then Coq_loc_Inexact Gt else Coq_loc_Inexact Eq
+  else if shr_s0 then Coq_loc_Inexact Lt else Coq_loc_Exact
+
+(** val shr_record_of_loc : int -> location -> shr_record **)
+
+let shr_record_of_loc m = function
+| Coq_loc_Exact -> { shr_m = m; shr_r = false; shr_s = false }
+| Coq_loc_Inexact c ->
+  (match c with
+   | Eq -> { shr_m = m; shr_r = true; shr_s = false }
+   | Lt -> { shr_m = m; shr_r = false; shr_s = true }
+   | Gt -> { shr_m = m; shr_r = true; shr_s = true })
+
+(** val shr : shr_record -> int -> int -> shr_record * int **)
+
+let shr mrs e n =
+  (fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+    (fun _ -> (mrs, e))
+    (fun p -> ((iter_pos shr_1 p mrs), (Z.add e n)))
+    (fun _ -> (mrs, e))
+    n
+
+(** val shr_fexp :
+    int -> int -> int -> int -> location -> shr_record * int **)
+
+let shr_fexp prec emax m e l =
+  shr (shr_record_of_loc m l) e
+    (Z.sub (fexp prec emax (Z.add (coq_Zdigits2 m) e)) e)
+
+(** val round_nearest_even : int -> location -> int **)
+
+let round_nearest_even mx = function
+| Coq_loc_Exact -> mx
+| Coq_loc_Inexact c ->
+  (match c with
+   | Eq -> if Z.even mx then mx else Z.add mx 1
+   | Lt -> mx
+   | Gt -> Z.add mx 1)
+
+(** val binary_round_aux :
+    int -> int -> bool -> int -> int -> location -> spec_float **)
+
+let binary_round_aux prec emax sx mx ex lx =
+  let (mrs', e') = shr_fexp prec emax mx ex lx in
+  let (mrs'', e'') =
+    shr_fexp prec emax
+      (round_nearest_even mrs'.shr_m (loc_of_shr_record mrs')) e'
+      Coq_loc_Exact
+  in
+  ((fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+     (fun _ -> S754_zero sx)
+     (fun m ->
+     if Z.leb e'' (Z.sub emax prec)
+     then S754_finite (sx, m, e'')
+     else S754_infinity sx)
+     (fun _ -> S754_nan)
+     mrs''.shr_m)
+
+(** val shl_align : int -> int -> int -> int * int **)
+
+let shl_align mx ex ex' =
+  (fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+    (fun _ -> (mx, ex))
+    (fun _ -> (mx, ex))
+    (fun d -> ((shift_pos d mx), ex'))
+    (Z.sub ex' ex)
+
+(** val binary_round : int -> int -> bool -> int -> int -> spec_float **)
+
+let binary_round prec emax sx mx ex =
+  let (mz, ez) = shl_align mx ex (fexp prec emax (Z.add (digits2_pos mx) ex))
+  in
+  binary_round_aux prec emax sx mz ez Coq_loc_Exact
+
+(** val binary_normalize : int -> int -> int -> int -> bool -> spec_float **)
+
+let binary_normalize prec emax m e szero =
+  (fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+    (fun _ -> S754_zero szero)
+    (fun m0 -> binary_round prec emax false m0 e)
+    (fun m0 -> binary_round prec emax true m0 e)
+    m
+
+(** val coq_SFopp : spec_float -> spec_float **)
+
+let coq_SFopp = function
+| S754_zero sx -> S754_zero (negb sx)
+| S754_infinity sx -> S754_infinity (negb sx)
+| S754_nan -> S754_nan
+| S754_finite (sx, mx, ex) -> S754_finite ((negb sx), mx, ex)
+
+(** val coq_SFabs : spec_float -> spec_float **)
+
+let coq_SFabs = function
+| S754_zero _ -> S754_zero false
+| S754_infinity _ -> S754_infinity false
+| S754_nan -> S754_nan
+| S754_finite (_, mx, ex) -> S754_finite (false, mx, ex)
+
+(** val coq_SFcompare : spec_float -> spec_float -> comparison option **)
+
+let coq_SFcompare f1 f2 =
+  match f1 with
+  | S754_zero _ ->
+    (match f2 with
+     | S754_zero _ -> Some Eq
+     | S754_infinity s -> Some (if s then Gt else Lt)
+     | S754_nan -> None
+     | S754_finite (s, _, _) -> Some (if s then Gt else Lt))
+  | S754_infinity s ->
+    (match f2 with
+     | S754_infinity s0 ->
+       Some (if s then if s0 then Eq else Lt else if s0 then Gt else Eq)
+     | S754_nan -> None
+     | _ -> Some (if s then Lt else Gt))
+  | S754_nan -> None
+  | S754_finite (s1, m1, e1) ->
+    (match f2 with
+     | S754_zero _ -> Some (if s1 then Lt else Gt)
+     | S754_infinity s -> Some (if s then Gt else Lt)
+     | S754_nan -> None
+     | S754_finite (s2, m2, e2) ->
+       Some
+         (if s1
+          then if s2
+               then (match Z.compare e1 e2 with
+                     | Eq -> coq_CompOpp (Pos.compare_cont Eq m1 m2)
+                     | Lt -> Gt
+                     | Gt -> Lt)
+               else Lt
+          else if s2
+               then Gt
+               else (match Z.compare e1 e2 with
+                     | Eq -> Pos.compare_cont Eq m1 m2
+                     | x -> x)))
+
+(** val coq_SFeqb : spec_float -> spec_float -> bool **)
+
+let coq_SFeqb f1 f2 =
+  match coq_SFcompare f1 f2 with
+  | Some c -> (match c with
+               | Eq -> true
+               | _ -> false)
+  | None -> false
+
+(** val coq_SFltb : spec_float -> spec_float -> bool **)
+
+let coq_SFltb f1 f2 =
+  match coq_SFcompare f1 f2 with
+  | Some c -> (match c with
+               | Lt -> true
+               | _ -> false)
+  | None -> false
+
+(** val coq_SFleb : spec_float -> spec_float -> bool **)
+
+let coq_SFleb f1 f2 =
+  match coq_SFcompare f1 f2 with
+  | Some _ -> true
+  | None -> false
+
+(** val coq_SFclassify : int -> spec_float -> Float64.float_class **)
+
+let coq_SFclassify prec = function
+| S754_zero s -> if s then PZero else NZero
+| S754_infinity s -> if s then NInf else PInf
+| S754_nan -> NaN
+| S754_finite (s, m, _) ->
+  if s
+  then if Pos.eqb (digits2_pos m) (Z.to_pos prec) then NNormal else NSubn
+  else if Pos.eqb (digits2_pos m) (Z.to_pos prec) then PNormal else PSubn
+
+(** val coq_SFmul : int -> int -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFmul prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_zero sy -> S754_zero (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_zero (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_infinity sx ->
+    (match y with
+     | S754_infinity sy -> S754_infinity (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_infinity (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero sy -> S754_zero (xorb sx sy)
+     | S754_infinity sy -> S754_infinity (xorb sx sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       binary_round_aux prec emax (xorb sx sy) (Pos.mul mx my) (Z.add ex ey)
+         Coq_loc_Exact)
+
+(** val cond_Zopp : bool -> int -> int **)
+
+let cond_Zopp b m =
+  if b then Z.opp m else m
+
+(** val coq_SFadd : int -> int -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFadd prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_zero sy -> if eqb sx sy then x else S754_zero false
+     | S754_nan -> S754_nan
+     | _ -> y)
+  | S754_infinity sx ->
+    (match y with
+     | S754_infinity sy -> if eqb sx sy then x else S754_nan
+     | S754_nan -> S754_nan
+     | _ -> x)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero _ -> x
+     | S754_infinity _ -> y
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       let ez = Z.min ex ey in
+       binary_normalize prec emax
+         (Z.add (cond_Zopp sx (fst (shl_align mx ex ez)))
+           (cond_Zopp sy (fst (shl_align my ey ez)))) ez false)
+
+(** val coq_SFsub : int -> int -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFsub prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_zero sy -> if eqb sx (negb sy) then x else S754_zero false
+     | S754_infinity sy -> S754_infinity (negb sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) -> S754_finite ((negb sy), my, ey))
+  | S754_infinity sx ->
+    (match y with
+     | S754_infinity sy -> if eqb sx (negb sy) then x else S754_nan
+     | S754_nan -> S754_nan
+     | _ -> x)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero _ -> x
+     | S754_infinity sy -> S754_infinity (negb sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       let ez = Z.min ex ey in
+       binary_normalize prec emax
+         (Z.sub (cond_Zopp sx (fst (shl_align mx ex ez)))
+           (cond_Zopp sy (fst (shl_align my ey ez)))) ez false)
+
+(** val new_location_even : int -> int -> location **)
+
+let new_location_even nb_steps k =
+  if coq_Zeq_bool k 0
+  then Coq_loc_Exact
+  else Coq_loc_Inexact (Z.compare (Z.mul ((fun p->2*p) 1) k) nb_steps)
+
+(** val new_location_odd : int -> int -> location **)
+
+let new_location_odd nb_steps k =
+  if coq_Zeq_bool k 0
+  then Coq_loc_Exact
+  else Coq_loc_Inexact
+         (match Z.compare (Z.add (Z.mul ((fun p->2*p) 1) k) 1) nb_steps with
+          | Eq -> Lt
+          | x -> x)
+
+(** val new_location : int -> int -> location **)
+
+let new_location nb_steps =
+  if Z.even nb_steps
+  then new_location_even nb_steps
+  else new_location_odd nb_steps
+
+(** val coq_SFdiv_core_binary :
+    int -> int -> int -> int -> int -> int -> (int * int) * location **)
+
+let coq_SFdiv_core_binary prec emax m1 e1 m2 e2 =
+  let d1 = coq_Zdigits2 m1 in
+  let d2 = coq_Zdigits2 m2 in
+  let e' =
+    Z.min (fexp prec emax (Z.sub (Z.add d1 e1) (Z.add d2 e2))) (Z.sub e1 e2)
+  in
+  let s = Z.sub (Z.sub e1 e2) e' in
+  let m' =
+    (fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+      (fun _ -> m1)
+      (fun _ -> Z.shiftl m1 s)
+      (fun _ -> 0)
+      s
+  in
+  let (q, r) = Z.div_eucl m' m2 in ((q, e'), (new_location m2 r))
+
+(** val coq_SFdiv : int -> int -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFdiv prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_infinity sy -> S754_zero (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_zero (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_infinity sx ->
+    (match y with
+     | S754_zero sy -> S754_infinity (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_infinity (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero sy -> S754_infinity (xorb sx sy)
+     | S754_infinity sy -> S754_zero (xorb sx sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       let (p, lz) = coq_SFdiv_core_binary prec emax mx ex my ey in
+       let (mz, ez) = p in binary_round_aux prec emax (xorb sx sy) mz ez lz)
+
+(** val coq_SFsqrt_core_binary :
+    int -> int -> int -> int -> (int * int) * location **)
+
+let coq_SFsqrt_core_binary prec emax m e =
+  let d = coq_Zdigits2 m in
+  let e' = Z.min (fexp prec emax (Z.div2 (Z.add (Z.add d e) 1))) (Z.div2 e) in
+  let s = Z.sub e (Z.mul ((fun p->2*p) 1) e') in
+  let m' =
+    (fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))
+      (fun _ -> m)
+      (fun _ -> Z.shiftl m s)
+      (fun _ -> 0)
+      s
+  in
+  let (q, r) = Z.sqrtrem m' in
+  let l =
+    if coq_Zeq_bool r 0
+    then Coq_loc_Exact
+    else Coq_loc_Inexact (if Z.leb r q then Lt else Gt)
+  in
+  ((q, e'), l)
+
+(** val coq_SFsqrt : int -> int -> spec_float -> spec_float **)
+
+let coq_SFsqrt prec emax x = match x with
+| S754_zero _ -> x
+| S754_infinity s -> if s then S754_nan else x
+| S754_nan -> S754_nan
+| S754_finite (sx, mx, ex) ->
+  if sx
+  then S754_nan
+  else let (p, lz) = coq_SFsqrt_core_binary prec emax mx ex in
+       let (mz, ez) = p in binary_round_aux prec emax false mz ez lz
+
+(** val coq_SFnormfr_mantissa : int -> spec_float -> int **)
+
+let coq_SFnormfr_mantissa prec = function
+| S754_finite (_, mx, ex) -> if Z.eqb ex (Z.opp prec) then mx else 0
+| _ -> 0
+
+(** val coq_SFldexp : int -> int -> spec_float -> int -> spec_float **)
+
+let coq_SFldexp prec emax f e =
+  match f with
+  | S754_finite (sx, mx, ex) -> binary_round prec emax sx mx (Z.add ex e)
+  | _ -> f
+
+(** val coq_SFfrexp : int -> int -> spec_float -> spec_float * int **)
+
+let coq_SFfrexp prec emax f = match f with
+| S754_finite (sx, mx, ex) ->
+  if Pos.leb (Z.to_pos prec) (digits2_pos mx)
+  then ((S754_finite (sx, mx, (Z.opp prec))), (Z.add ex prec))
+  else let d = Z.sub prec (digits2_pos mx) in
+       ((S754_finite (sx, (shift_pos (Z.to_pos d) mx), (Z.opp prec))),
+       (Z.sub (Z.add ex prec) d))
+| _ -> (f, (Z.sub (Z.mul ((~-) ((fun p->2*p) 1)) emax) prec))
+
+(** val coq_SFone : int -> int -> spec_float **)
+
+let coq_SFone prec emax =
+  binary_round prec emax false 1 0
+
+(** val coq_SFulp : int -> int -> spec_float -> spec_float **)
+
+let coq_SFulp prec emax x =
+  coq_SFldexp prec emax (coq_SFone prec emax)
+    (fexp prec emax (snd (coq_SFfrexp prec emax x)))
+
+(** val coq_SFpred_pos : int -> int -> spec_float -> spec_float **)
+
+let coq_SFpred_pos prec emax x = match x with
+| S754_finite (_, mx, _) ->
+  let d =
+    if Pos.eqb ((fun p->2*p) mx) (shift_pos (Z.to_pos prec) 1)
+    then coq_SFldexp prec emax (coq_SFone prec emax)
+           (fexp prec emax (Z.sub (snd (coq_SFfrexp prec emax x)) 1))
+    else coq_SFulp prec emax x
+  in
+  coq_SFsub prec emax x d
+| _ -> x
+
+(** val coq_SFmax_float : int -> int -> spec_float **)
+
+let coq_SFmax_float prec emax =
+  S754_finite (false, (Pos.sub (shift_pos (Z.to_pos prec) 1) 1),
+    (Z.sub emax prec))
+
+(** val coq_SFsucc : int -> int -> spec_float -> spec_float **)
+
+let coq_SFsucc prec emax x = match x with
+| S754_zero _ -> coq_SFldexp prec emax (coq_SFone prec emax) (emin prec emax)
+| S754_infinity s -> if s then coq_SFopp (coq_SFmax_float prec emax) else x
+| S754_nan -> x
+| S754_finite (s, _, _) ->
+  if s
+  then coq_SFopp (coq_SFpred_pos prec emax (coq_SFopp x))
+  else coq_SFadd prec emax x (coq_SFulp prec emax x)
+
+(** val coq_SFpred : int -> int -> spec_float -> spec_float **)
+
+let coq_SFpred prec emax f =
+  coq_SFopp (coq_SFsucc prec emax (coq_SFopp f))

--- a/template-coq/gen-src/specFloat.ml.rej
+++ b/template-coq/gen-src/specFloat.ml.rej
@@ -1,0 +1,16 @@
+***************
+*** 4,9 ****
+  open Datatypes
+  open Zbool
+  open Zpower
+  
+  type spec_float =
+  | S754_zero of bool
+--- 4,10 ----
+  open Datatypes
+  open Zbool
+  open Zpower
++ open Float64
+  
+  type spec_float =
+  | S754_zero of bool

--- a/template-coq/specFloat.patch
+++ b/template-coq/specFloat.patch
@@ -1,0 +1,10 @@
+--- gen-src/specFloat.ml.orig	2020-12-04 21:48:20.000000000 +0100
++++ gen-src/specFloat.ml	2020-12-04 21:48:33.000000000 +0100
+@@ -4,6 +4,7 @@
+ open Datatypes
+ open Zbool
+ open Zpower
++open Float64
+ 
+ type spec_float =
+ | S754_zero of bool

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -9,6 +9,7 @@ struct
   type t = Ast0.term
   type quoted_ident = char list
   type quoted_int = Datatypes.nat
+  type quoted_int63 = Uint63.t
   type quoted_bool = bool
   type quoted_name = name
   type quoted_aname = name binder_annot
@@ -77,7 +78,7 @@ struct
       rarg=rarg x
     }
 
-  let inspect_term (tt: t):(t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj) structure_of_term=
+  let inspect_term (tt: t):(t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term=
     match tt with
     | Coq_tRel n -> ACoq_tRel n
     | Coq_tVar v -> ACoq_tVar v
@@ -95,6 +96,7 @@ struct
     | Coq_tProj (a,b) -> ACoq_tProj (a,b)
     | Coq_tFix (a,b) -> ACoq_tFix (List.map unquote_def a,b)
     | Coq_tCoFix (a,b) -> ACoq_tCoFix (List.map unquote_def a,b)
+    | Coq_tInt i -> ACoq_tInt i
 
 
   let unquote_ident (qi: quoted_ident) : Id.t =
@@ -125,6 +127,8 @@ struct
     evm, mkEvar (id, Array.of_list l)
 
   let unquote_bool (q : quoted_bool) : bool = q
+  
+  let unquote_int63 i = i
 
   (* val unquote_sort : quoted_sort -> Sorts.t *)
   (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -10,6 +10,7 @@ struct
   type quoted_ident = char list
   type quoted_int = Datatypes.nat
   type quoted_int63 = Uint63.t
+  type quoted_float64 = Float64.t
   type quoted_bool = bool
   type quoted_name = name
   type quoted_aname = name binder_annot
@@ -69,6 +70,8 @@ struct
   let mkInd = mkInd
   let mkCase = mkCase
   let mkProj = mkProj
+  let mkInt = mkInt
+  let mkFloat = mkFloat
 
   let unquote_def (x: 't BasicAst.def) : ('t, name binder_annot, quoted_int) adef =
     {
@@ -78,7 +81,9 @@ struct
       rarg=rarg x
     }
 
-  let inspect_term (tt: t):(t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term=
+  let inspect_term (tt: t):(t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, 
+    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, 
+    quoted_int63, quoted_float64) structure_of_term=
     match tt with
     | Coq_tRel n -> ACoq_tRel n
     | Coq_tVar v -> ACoq_tVar v
@@ -97,7 +102,7 @@ struct
     | Coq_tFix (a,b) -> ACoq_tFix (List.map unquote_def a,b)
     | Coq_tCoFix (a,b) -> ACoq_tCoFix (List.map unquote_def a,b)
     | Coq_tInt i -> ACoq_tInt i
-
+    | Coq_tFloat f -> ACoq_tFloat f
 
   let unquote_ident (qi: quoted_ident) : Id.t =
     let s = list_to_string qi in
@@ -129,6 +134,8 @@ struct
   let unquote_bool (q : quoted_bool) : bool = q
   
   let unquote_int63 i = i
+
+  let unquote_float64 i = i
 
   (* val unquote_sort : quoted_sort -> Sorts.t *)
   (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -10,6 +10,7 @@ struct
   type quoted_ident = char list
   type quoted_int = Datatypes.nat
   type quoted_int63 = Uint63.t
+  type quoted_float64 = Float64.t
   type quoted_bool = bool
   type quoted_name = BasicAst.name
   type quoted_aname = BasicAst.aname
@@ -74,6 +75,8 @@ struct
   let quote_bool x = x
 
   let quote_int63 x = x
+
+  let quote_float64 x = x
 
   (* NOTE: fails if it hits Prop or SProp *)
   let quote_nonprop_level (l : Univ.Level.t) : Universes0.Level.t =
@@ -236,6 +239,7 @@ struct
   let mkConstruct (ind, i) u = Coq_tConstruct (ind, i, u)
   let mkLetIn na b t t' = Coq_tLetIn (na,b,t,t')
   let mkInt i = Coq_tInt i
+  let mkFloat f = Coq_tFloat f
 
   let rec seq f t =
     if f < t then
@@ -341,9 +345,12 @@ struct
        Some (Right mind_entry)
     | None -> None *)
 
-  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term =
+  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind,
+    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, 
+    quoted_int63, quoted_float64) structure_of_term =
    match t with
   | Coq_tRel n -> ACoq_tRel n
+  (* todo ! *)
     (* so on *)
   | _ ->  failwith "not yet implemented"
 

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -9,6 +9,7 @@ struct
   type t = Ast0.term
   type quoted_ident = char list
   type quoted_int = Datatypes.nat
+  type quoted_int63 = Uint63.t
   type quoted_bool = bool
   type quoted_name = BasicAst.name
   type quoted_aname = BasicAst.aname
@@ -55,7 +56,7 @@ struct
   let quote_relevance = function
     | Sorts.Relevant -> BasicAst.Relevant
     | Sorts.Irrelevant -> BasicAst.Irrelevant
- 
+
   let quote_name = function
     | Anonymous -> Coq_nAnon
     | Name i -> Coq_nNamed (quote_ident i)
@@ -150,7 +151,7 @@ struct
   let is_Eq = function
     | Univ.Eq -> true
     | _ -> false
-               
+
   let quote_univ_constraint ((l, ct, l') : Univ.univ_constraint) : quoted_univ_constraint =
     ((quote_nonprop_level l, quote_constraint_type ct), quote_nonprop_level l')
 
@@ -232,6 +233,7 @@ struct
   let mkInd i u = Coq_tInd (i, u)
   let mkConstruct (ind, i) u = Coq_tConstruct (ind, i, u)
   let mkLetIn na b t t' = Coq_tLetIn (na,b,t,t')
+  let mkInt i = Coq_tInt i
 
   let rec seq f t =
     if f < t then
@@ -278,7 +280,7 @@ struct
 
   let mk_mutual_inductive_body finite npars params inds uctx variance =
     {ind_finite = finite;
-     ind_npars = npars; ind_params = params; ind_bodies = inds; 
+     ind_npars = npars; ind_params = params; ind_bodies = inds;
      ind_universes = uctx; ind_variance = variance}
 
   let mk_constant_body ty tm uctx =
@@ -315,7 +317,7 @@ struct
       mind_entry_variance = variance;
       mind_entry_private = None }
 
-  let quote_definition_entry ty body ctx = 
+  let quote_definition_entry ty body ctx =
     { definition_entry_type = ty;
       definition_entry_body = body;
       definition_entry_universes = ctx;
@@ -324,11 +326,11 @@ struct
   let quote_parameter_entry ty ctx =
     { parameter_entry_type = ty;
       parameter_entry_universes = ctx }
-  
+
   let quote_constant_entry = function
     | Left ce -> DefinitionEntry ce
     | Right pe -> ParameterEntry pe
-(* 
+(*
   let quote_entry e =
     match e with
     | Some (Left (ty, body, ctx)) ->
@@ -337,7 +339,7 @@ struct
        Some (Right mind_entry)
     | None -> None *)
 
-  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj) structure_of_term =
+  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term =
    match t with
   | Coq_tRel n -> ACoq_tRel n
     (* so on *)
@@ -364,7 +366,7 @@ struct
 
   let mkPolymorphic_entry names c = Universes0.Polymorphic_entry (names, c)
   let mkMonomorphic_entry c = Universes0.Monomorphic_entry c
-  
+
 end
 
 module ExtractedASTQuoter = Quoter.Quoter(ExtractedASTBaseQuoter)

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -73,6 +73,8 @@ struct
 
   let quote_bool x = x
 
+  let quote_int63 x = x
+
   (* NOTE: fails if it hits Prop or SProp *)
   let quote_nonprop_level (l : Univ.Level.t) : Universes0.Level.t =
     if Univ.Level.is_prop l || Univ.Level.is_sprop l then

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -78,7 +78,10 @@ struct
     | Constr.Int i -> i
     | _ -> not_supported_verb trm "unquote_int63"
   
-
+  let unquote_float64 trm =
+    match Constr.kind trm with 
+    | Constr.Float f -> f
+    | _ -> not_supported_verb trm "unquote_float64"
 
   let unquote_char trm =
     let (h,args) = app_full trm [] in
@@ -343,7 +346,9 @@ struct
 
 
   let inspect_term (t:Constr.t)
-  : (Constr.t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term =
+  : (Constr.t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, 
+    quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, 
+    quoted_int63, quoted_float64) structure_of_term =
     let (h,args) = app_full t [] in
     if constr_equall h tRel then
       match args with
@@ -435,7 +440,14 @@ struct
       match args with
         proj::t::_ -> ACoq_tProj (proj, t)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-
+    else if constr_equall h tInt then
+      match args with
+        t::_ -> ACoq_tInt t
+      | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
+    else if constr_equall h tFloat then
+      match args with
+        t::_ -> ACoq_tFloat t
+      | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
     else
       CErrors.user_err (str"inspect_term: cannot recognize " ++ print_term t ++ str" (maybe you forgot to reduce it?)")
 

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -73,6 +73,9 @@ struct
       false
     else not_supported_verb trm "from_bool"
 
+  let unquote_int63 i = i
+
+
   let unquote_char trm =
     let (h,args) = app_full trm [] in
     if constr_equall h tAscii then
@@ -336,7 +339,7 @@ struct
 
 
   let inspect_term (t:Constr.t)
-  : (Constr.t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj) structure_of_term =
+  : (Constr.t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term =
     let (h,args) = app_full t [] in
     if constr_equall h tRel then
       match args with

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -73,7 +73,11 @@ struct
       false
     else not_supported_verb trm "from_bool"
 
-  let unquote_int63 i = i
+  let unquote_int63 trm =
+    match Constr.kind trm with 
+    | Constr.Int i -> i
+    | _ -> not_supported_verb trm "unquote_int63"
+  
 
 
   let unquote_char trm =

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -33,6 +33,7 @@ struct
 
   let mkRel i = constr_mkApp (tRel, [| i |])
   let mkVar id = constr_mkApp (tVar, [| id |])
+  let mkInt i = constr_mkApp (tInt, [| i |])
   let mkEvar n args = constr_mkApp (tEvar, [| n; to_coq_listl tTerm (Array.to_list args) |])
   let mkSort s = constr_mkApp (tSort, [| s |])
   let mkCast c k t = constr_mkApp (tCast, [| c ; k ; t |])
@@ -108,6 +109,8 @@ struct
 
   let quote_bool b =
     if b then Lazy.force ttrue else Lazy.force tfalse
+
+  let quote_int63 i = Lazy.force tInt
 
   let quote_char i =
     constr_mkApp (tAscii, Array.of_list (List.map (fun m -> quote_bool ((i land m) = m))

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -80,8 +80,8 @@ struct
   let mkProj kn t =
     constr_mkApp (tProj, [| kn; t |])
 
-  let mkInt i = constr_mkApp (tInt, [| i |])
-  let mkFloat f = constr_mkApp (tFloat, [| f |])
+  let mkInt i = i
+  let mkFloat f = f
 
   let quote_option ty = function
     | Some tm -> constr_mkApp (cSome, [|ty; tm|])

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -33,7 +33,6 @@ struct
 
   let mkRel i = constr_mkApp (tRel, [| i |])
   let mkVar id = constr_mkApp (tVar, [| id |])
-  let mkInt i = constr_mkApp (tInt, [| i |])
   let mkEvar n args = constr_mkApp (tEvar, [| n; to_coq_listl tTerm (Array.to_list args) |])
   let mkSort s = constr_mkApp (tSort, [| s |])
   let mkCast c k t = constr_mkApp (tCast, [| c ; k ; t |])
@@ -81,6 +80,9 @@ struct
   let mkProj kn t =
     constr_mkApp (tProj, [| kn; t |])
 
+  let mkInt i = constr_mkApp (tInt, [| i |])
+  let mkFloat f = constr_mkApp (tFloat, [| f |])
+
   let quote_option ty = function
     | Some tm -> constr_mkApp (cSome, [|ty; tm|])
     | None -> constr_mkApp (cNone, [|ty|])
@@ -110,7 +112,9 @@ struct
   let quote_bool b =
     if b then Lazy.force ttrue else Lazy.force tfalse
 
-  let quote_int63 i = Lazy.force tInt
+  let quote_int63 i = constr_mkApp (tInt, [| Constr.mkInt i |])
+
+  let quote_float64 f = constr_mkApp (tFloat, [| Constr.mkFloat f |])
 
   let quote_char i =
     constr_mkApp (tAscii, Array.of_list (List.map (fun m -> quote_bool ((i land m) = m))

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -6,7 +6,7 @@ struct
 
   type quoted_ident = Constr.t (* of type Ast.ident *)
   type quoted_int = Constr.t (* of type nat *)
-  type quoted_int63 = Uint63.t (* of type nat *)
+  type quoted_int63 = Constr.t (* of type int63 *)
   type quoted_bool = Constr.t (* of type bool *)
   type quoted_name = Constr.t (* of type BasicAst.name *)
   type quoted_aname = Constr.t (* of type BasicAst.aname (names with relevance) *)
@@ -139,11 +139,11 @@ struct
   let tmkInd = ast "mkInd"
   let tmkdecl = ast "mkdecl"
   let (tTerm,tRel,tVar,tEvar,tSort,tCast,tProd,
-       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj) =
+       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj,tInt) =
     (ast "term", ast "tRel", ast "tVar", ast "tEvar",
      ast "tSort", ast "tCast", ast "tProd", ast "tLambda",
      ast "tLetIn", ast "tApp", ast "tCase", ast "tFix",
-     ast "tConstruct", ast "tConst", ast "tInd", ast "tCoFix", ast "tProj")
+     ast "tConstruct", ast "tConst", ast "tInd", ast "tCoFix", ast "tProj", ast "tInt")
   let tkername = ast "kername"
   let tmodpath = ast "modpath"
   let tMPfile = ast "MPfile"

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -6,7 +6,6 @@ struct
 
   type quoted_ident = Constr.t (* of type Ast.ident *)
   type quoted_int = Constr.t (* of type nat *)
-  type quoted_int63 = Constr.t (* of type int63 *)
   type quoted_bool = Constr.t (* of type bool *)
   type quoted_name = Constr.t (* of type BasicAst.name *)
   type quoted_aname = Constr.t (* of type BasicAst.aname (names with relevance) *)
@@ -16,8 +15,8 @@ struct
   type quoted_kernel_name = Constr.t (* of type Ast.kername *)
   type quoted_inductive = Constr.t (* of type Ast.inductive *)
   type quoted_proj = Constr.t (* of type Ast.projection *)
-  type quoted_prim_int = Constr.t (* of type UInt63.t *)
-  type quoted_prim_float = Constr.t (* of type Float64.t *)
+  type quoted_int63 = Constr.t (* of type UInt63.t *)
+  type quoted_float64 = Constr.t (* of type Float64.t *)
   type quoted_global_reference = Constr.t (* of type Ast.global_reference *)
 
   type quoted_sort_family = Constr.t (* of type Ast.sort_family *)
@@ -141,11 +140,11 @@ struct
   let tmkInd = ast "mkInd"
   let tmkdecl = ast "mkdecl"
   let (tTerm,tRel,tVar,tEvar,tSort,tCast,tProd,
-       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj,tInt) =
+       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj,tInt,tFloat) =
     (ast "term", ast "tRel", ast "tVar", ast "tEvar",
      ast "tSort", ast "tCast", ast "tProd", ast "tLambda",
      ast "tLetIn", ast "tApp", ast "tCase", ast "tFix",
-     ast "tConstruct", ast "tConst", ast "tInd", ast "tCoFix", ast "tProj", ast "tInt")
+     ast "tConstruct", ast "tConst", ast "tInd", ast "tCoFix", ast "tProj", ast "tInt", ast "tFloat")
   let tkername = ast "kername"
   let tmodpath = ast "modpath"
   let tMPfile = ast "MPfile"

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -6,6 +6,7 @@ struct
 
   type quoted_ident = Constr.t (* of type Ast.ident *)
   type quoted_int = Constr.t (* of type nat *)
+  type quoted_int63 = Uint63.t (* of type nat *)
   type quoted_bool = Constr.t (* of type bool *)
   type quoted_name = Constr.t (* of type BasicAst.name *)
   type quoted_aname = Constr.t (* of type BasicAst.aname (names with relevance) *)
@@ -77,17 +78,17 @@ struct
   let cZ0 = resolve "metacoq.Z.zero"
   let cZpos = resolve "metacoq.Z.pos"
   let cZneg = resolve "metacoq.Z.neg"
-  
+
   let tpos = resolve "metacoq.pos.type"
   let cposzero = resolve "metacoq.pos.xH"
   let cposI = resolve "metacoq.pos.xI"
   let cposO = resolve "metacoq.pos.xO"
-  
+
   let cSome_instance = resolve "metacoq.option_instance.some"
   let cNone_instance = resolve "metacoq.option_instance.none"
 
   let unit_tt = resolve "metacoq.unit.intro"
-  
+
   let tAscii = resolve "metacoq.ascii.intro"
   let tlist = resolve "metacoq.list.type"
   let c_nil = resolve "metacoq.list.nil"
@@ -223,7 +224,7 @@ struct
   let cMonomorphic_entry = ast "Monomorphic_entry"
   let cPolymorphic_entry = ast "Polymorphic_entry"
 
-  let (tcbv, tcbn, thnf, tall, tlazy, tunfold) = 
+  let (tcbv, tcbn, thnf, tall, tlazy, tunfold) =
     (template "cbv", template "cbn", template "hnf", template "all", template "lazy", template "unfold")
 
 

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -16,6 +16,8 @@ struct
   type quoted_kernel_name = Constr.t (* of type Ast.kername *)
   type quoted_inductive = Constr.t (* of type Ast.inductive *)
   type quoted_proj = Constr.t (* of type Ast.projection *)
+  type quoted_prim_int = Constr.t (* of type UInt63.t *)
+  type quoted_prim_float = Constr.t (* of type Float64.t *)
   type quoted_global_reference = Constr.t (* of type Ast.global_reference *)
 
   type quoted_sort_family = Constr.t (* of type Ast.sort_family *)

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -13,8 +13,8 @@ sig
   val unquote_evar : Environ.env -> Evd.evar_map -> quoted_int -> Constr.t list -> Evd.evar_map * Constr.t
   val unquote_int : quoted_int -> int
   val unquote_bool : quoted_bool -> bool
-  val unquote_int63 : quoted_prim_int -> Uint63.t
-  val unquote_int63 : quoted_prim_float -> Float64.t
+  val unquote_int63 : quoted_int63 -> Uint63.t
+  val unquote_float64 : quoted_float64 -> Float64.t
   (* val unquote_sort : quoted_sort -> Sorts.t *)
   (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)
   val unquote_cast_kind : quoted_cast_kind -> Constr.cast_kind
@@ -25,7 +25,9 @@ sig
   val unquote_universe : Evd.evar_map -> quoted_sort -> Evd.evar_map * Univ.Universe.t
   val unquote_universe_instance: Evd.evar_map -> quoted_univ_instance -> Evd.evar_map * Univ.Instance.t
   (* val representsIndConstuctor : quoted_inductive -> Term.constr -> bool *)
-  val inspect_term : t -> (t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term
+  val inspect_term : t -> (t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, 
+    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, 
+    quoted_int63, quoted_float64) structure_of_term
 
 end
 

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -13,6 +13,8 @@ sig
   val unquote_evar : Environ.env -> Evd.evar_map -> quoted_int -> Constr.t list -> Evd.evar_map * Constr.t
   val unquote_int : quoted_int -> int
   val unquote_bool : quoted_bool -> bool
+  val unquote_int63 : quoted_prim_int -> Uint63.t
+  val unquote_int63 : quoted_prim_float -> Float64.t
   (* val unquote_sort : quoted_sort -> Sorts.t *)
   (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)
   val unquote_cast_kind : quoted_cast_kind -> Constr.cast_kind
@@ -23,7 +25,7 @@ sig
   val unquote_universe : Evd.evar_map -> quoted_sort -> Evd.evar_map * Univ.Universe.t
   val unquote_universe_instance: Evd.evar_map -> quoted_univ_instance -> Evd.evar_map * Univ.Instance.t
   (* val representsIndConstuctor : quoted_inductive -> Term.constr -> bool *)
-  val inspect_term : t -> (t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj) structure_of_term
+  val inspect_term : t -> (t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, quoted_int63) structure_of_term
 
 end
 
@@ -139,7 +141,9 @@ struct
          let p' = Names.Projection.make (Projection.Repr.make ind' ~proj_npars ~proj_arg l) false in
          let evm, t' = aux env evm t in
          evm, Constr.mkProj (p', t')
-      
+      | ACoq_tInt x -> evm, Constr.mkInt (D.unquote_int63 x)
+      | ACoq_tFloat x -> evm, Constr.mkFloat (D.unquote_float64 x)
+
     in aux env evm trm
 
 end

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -58,6 +58,7 @@ sig
   val mkProj : quoted_proj -> t -> t
   val mkFix : (quoted_int array * quoted_int) * (quoted_aname array * t array * t array) -> t
   val mkCoFix : quoted_int * (quoted_aname array * t array * t array) -> t
+  val mkInt : quoted_int63 -> t
 
   val mkBindAnn : quoted_name -> quoted_relevance -> quoted_aname
   val mkName : quoted_ident -> quoted_name
@@ -68,6 +69,7 @@ sig
   val quote_aname : Name.t Context.binder_annot -> quoted_aname
   val quote_relevance : Sorts.relevance -> quoted_relevance
   val quote_int : int -> quoted_int
+  val quote_int63 : Uint63.t -> quoted_int63
   val quote_bool : bool -> quoted_bool
   val quote_sort : Sorts.t -> quoted_sort
   val quote_sort_family : Sorts.family -> quoted_sort_family
@@ -262,7 +264,7 @@ struct
          let t', acc = quote_term acc env c in
          (Q.mkProj p' t', add_inductive (Projection.inductive p) acc)
       | Constr.Meta _ -> failwith "Meta not supported by TemplateCoq"
-      | Constr.Int _ -> failwith "Native integers not supported by TemplateCoq"
+      | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
       | Constr.Float _ -> failwith "Native floating point numbers not supported by TemplateCoq"
       in
       let in_prop, env' = env in

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -78,6 +78,10 @@ sig
   val quote_inductive : quoted_kernel_name * quoted_int -> quoted_inductive
   val quote_proj : quoted_inductive -> quoted_int -> quoted_int -> quoted_proj
 
+  (* Primitive objects *)
+  val quote_prim_int : Uint63.t -> quoted_prim_int
+  val quote_prim_float : Float64.t -> quoted_prim_float
+
   val quote_constraint_type : Univ.constraint_type -> quoted_constraint_type
   val quote_univ_constraint : Univ.univ_constraint -> quoted_univ_constraint
   val quote_univ_instance : Univ.Instance.t -> quoted_univ_instance
@@ -229,7 +233,7 @@ struct
 
       | Constr.Const (c,pu) ->
         let kn = Constant.canonical c in
-	(Q.mkConst (Q.quote_kn kn) (Q.quote_univ_instance pu), add_constant kn acc)
+        (Q.mkConst (Q.quote_kn kn) (Q.quote_univ_instance pu), add_constant kn acc)
 
       | Constr.Construct ((mind,c),pu) ->
          (Q.mkConstruct (quote_inductive' mind, Q.quote_int (c - 1)) (Q.quote_univ_instance pu),
@@ -263,9 +267,9 @@ struct
          let p' = Q.quote_proj ind pars arg in
          let t', acc = quote_term acc env c in
          (Q.mkProj p' t', add_inductive (Projection.inductive p) acc)
+      | Constr.Int i -> (Q.quote_prim_int i, acc)
+      | Constr.Float f -> (Q.quote_prim_float f, acc)
       | Constr.Meta _ -> failwith "Meta not supported by TemplateCoq"
-      | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
-      | Constr.Float _ -> failwith "Native floating point numbers not supported by TemplateCoq"
       in
       let in_prop, env' = env in
       if is_cast_prop () && not in_prop then

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -59,6 +59,7 @@ sig
   val mkFix : (quoted_int array * quoted_int) * (quoted_aname array * t array * t array) -> t
   val mkCoFix : quoted_int * (quoted_aname array * t array * t array) -> t
   val mkInt : quoted_int63 -> t
+  val mkFloat : quoted_float64 -> t
 
   val mkBindAnn : quoted_name -> quoted_relevance -> quoted_aname
   val mkName : quoted_ident -> quoted_name
@@ -69,7 +70,6 @@ sig
   val quote_aname : Name.t Context.binder_annot -> quoted_aname
   val quote_relevance : Sorts.relevance -> quoted_relevance
   val quote_int : int -> quoted_int
-  val quote_int63 : Uint63.t -> quoted_int63
   val quote_bool : bool -> quoted_bool
   val quote_sort : Sorts.t -> quoted_sort
   val quote_sort_family : Sorts.family -> quoted_sort_family
@@ -79,8 +79,8 @@ sig
   val quote_proj : quoted_inductive -> quoted_int -> quoted_int -> quoted_proj
 
   (* Primitive objects *)
-  val quote_prim_int : Uint63.t -> quoted_prim_int
-  val quote_prim_float : Float64.t -> quoted_prim_float
+  val quote_int63 : Uint63.t -> quoted_int63
+  val quote_float64 : Float64.t -> quoted_float64
 
   val quote_constraint_type : Univ.constraint_type -> quoted_constraint_type
   val quote_univ_constraint : Univ.univ_constraint -> quoted_univ_constraint
@@ -267,8 +267,8 @@ struct
          let p' = Q.quote_proj ind pars arg in
          let t', acc = quote_term acc env c in
          (Q.mkProj p' t', add_inductive (Projection.inductive p) acc)
-      | Constr.Int i -> (Q.quote_prim_int i, acc)
-      | Constr.Float f -> (Q.quote_prim_float f, acc)
+      | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
+      | Constr.Float f -> (Q.mkFloat (Q.quote_float64 f), acc)
       | Constr.Meta _ -> failwith "Meta not supported by TemplateCoq"
       in
       let in_prop, env' = env in

--- a/template-coq/src/reification.ml
+++ b/template-coq/src/reification.ml
@@ -5,6 +5,7 @@ sig
 
   type quoted_ident
   type quoted_int
+  type quoted_int63
   type quoted_bool
   type quoted_name
   type quoted_aname

--- a/template-coq/src/reification.ml
+++ b/template-coq/src/reification.ml
@@ -5,7 +5,6 @@ sig
 
   type quoted_ident
   type quoted_int
-  type quoted_int63
   type quoted_bool
   type quoted_name
   type quoted_aname
@@ -15,8 +14,8 @@ sig
   type quoted_kernel_name
   type quoted_inductive
   type quoted_proj
-  type quoted_prim_int
-  type quoted_prim_float
+  type quoted_int63
+  type quoted_float64
 
   type quoted_global_reference
 

--- a/template-coq/src/reification.ml
+++ b/template-coq/src/reification.ml
@@ -15,6 +15,9 @@ sig
   type quoted_kernel_name
   type quoted_inductive
   type quoted_proj
+  type quoted_prim_int
+  type quoted_prim_float
+
   type quoted_global_reference
 
   type quoted_sort_family

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -68,7 +68,7 @@ type ('term, 'name, 'nat) adef = { adname : 'name; adtype : 'term; adbody : 'ter
 
 type ('term, 'name, 'nat) amfixpoint = ('term, 'name, 'nat) adef list
 
-type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'relevance, 'universe_instance, 'projection, 'int63) structure_of_term =
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'relevance, 'universe_instance, 'projection, 'int63, 'float64) structure_of_term =
   | ACoq_tRel of 'nat
   | ACoq_tVar of 'ident
   | ACoq_tEvar of 'nat * 'term list
@@ -86,4 +86,5 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | ACoq_tFix of ('term, 'name, 'nat) amfixpoint * 'nat
   | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
   | ACoq_tInt of 'int63
+  | ACoq_tFloat of 'float64
 

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -51,7 +51,7 @@ let not_supported trm =
 
 let not_supported_verb trm rs =
   let env = Global.env () in
-  CErrors.user_err (str "Not Supported raised at " ++ str rs ++ str ":" ++ spc () ++ 
+  CErrors.user_err (str "Not Supported raised at " ++ str rs ++ str ":" ++ spc () ++
     Printer.pr_constr_env env (Evd.from_env env) trm)
 
 let bad_term trm =
@@ -68,7 +68,7 @@ type ('term, 'name, 'nat) adef = { adname : 'name; adtype : 'term; adbody : 'ter
 
 type ('term, 'name, 'nat) amfixpoint = ('term, 'name, 'nat) adef list
 
-type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'relevance, 'universe_instance, 'projection) structure_of_term =
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'relevance, 'universe_instance, 'projection, 'int63) structure_of_term =
   | ACoq_tRel of 'nat
   | ACoq_tVar of 'ident
   | ACoq_tEvar of 'nat * 'term list
@@ -85,4 +85,5 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | ACoq_tProj of 'projection * 'term
   | ACoq_tFix of ('term, 'name, 'nat) amfixpoint * 'nat
   | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
+  | ACoq_tInt of 'int63
 

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils Environment.
 From MetaCoq.Template Require Export Universes.
-
+From Coq Require Int63.
 
 (** * AST of Coq kernel terms and kernel data structures
 
@@ -50,7 +50,8 @@ Inductive term : Type :=
         (discr:term) (branches : list (nat * term))
 | tProj (proj : projection) (t : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
-| tCoFix (mfix : mfixpoint term) (idx : nat).
+| tCoFix (mfix : mfixpoint term) (idx : nat)
+| tInt (i : Int63.int).
 
 (** This can be used to represent holes, that, when unquoted, turn into fresh existential variables. 
     The fresh evar will depend on the whole context at this point in the term, despite the empty instance.
@@ -124,7 +125,8 @@ Inductive wf : term -> Prop :=
 | wf_tProj p t : wf t -> wf (tProj p t)
 | wf_tFix mfix k : Forall (fun def => wf def.(dtype) /\ wf def.(dbody) /\ isLambda def.(dbody) = true) mfix ->
                    wf (tFix mfix k)
-| wf_tCoFix mfix k : Forall (fun def => wf def.(dtype) /\ wf def.(dbody)) mfix -> wf (tCoFix mfix k).
+| wf_tCoFix mfix k : Forall (fun def => wf def.(dtype) /\ wf def.(dbody)) mfix -> wf (tCoFix mfix k)
+| wf_tInt i : wf (tInt i).
 
 (** ** Entries
 

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -61,12 +61,6 @@ Inductive term : Type :=
 *)
 Definition hole := tEvar fresh_evar_id [].
 
-(** This can be used to represent holes, that, when unquoted, turn into fresh existential variables. 
-    The fresh evar will depend on the whole context at this point in the term, despite the empty instance.
-    Denotation will call Coq's Typing.solve_evars to try and fill these holes using typing information.
-*)
-Definition hole := tEvar fresh_evar_id [].
-
 Definition mkApps t us :=
   match us with
   | nil => t

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -7,8 +7,9 @@ Require Import ZArith.
 
 (** Raw term printing *)
 
-Definition string_of_prim_int n :=
-  string_of_Z (Numbers.Cyclic.Int63.Int63.to_Z n).
+Definition string_of_prim_int (i:Int63.int) : string := 
+  (* Better? DecimalString.NilZero.string_of_uint (BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). ? *)
+  string_of_Z (Numbers.Cyclic.Int63.Int63.to_Z i).
 
 Definition string_of_float (f : PrimFloat.float) :=
   "<float>".

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -42,6 +42,7 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
+  | tInt i => "Int(" ^ string_of_int i ^ ")"
   end.
 
 Definition decompose_app (t : term) :=

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -1,8 +1,17 @@
+(* For primitive integers and floats  *)
+From Coq Require Numbers.Cyclic.Int63.Int63 Floats.PrimFloat.
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils BasicAst Ast.
 Require Import ssreflect.
+Require Import ZArith.
 
 (** Raw term printing *)
+
+Definition string_of_prim_int n :=
+  string_of_Z (Numbers.Cyclic.Int63.Int63.to_Z n).
+
+Definition string_of_float (f : PrimFloat.float) :=
+  "<float>".
 
 Fixpoint string_of_term (t : term) :=
   match t with
@@ -42,7 +51,8 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  | tInt i => "Int(" ^ string_of_int i ^ ")"
+  | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
+  | tFloat f => "Float(" ^ string_of_float f ^ ")"
   end.
 
 Definition decompose_app (t : term) :=

--- a/template-coq/theories/BasicAst.v
+++ b/template-coq/theories/BasicAst.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils.
+From Coq Require Import Floats.SpecFloat.
 
 (** ** Reification of names ** *)
 
@@ -27,6 +28,8 @@ From MetaCoq.Template Require Import utils.
     - constructor => [inductive * nat]
     - Projection.t => [projection]
     - GlobRef.t => global_reference
+
+    Finally, we define the models of primitive types (uint63 and floats64).
 *)
 
 Definition ident   := string. (* e.g. nat *)
@@ -382,3 +385,21 @@ Ltac close_All :=
   | H : All2 _ _ _ |- All _ _ =>
     (apply (All2_All_left H) || apply (All2_All_right H)); clear H; simpl
   end.
+
+(** Primitive types models (axiom free) *)
+
+(** Model of unsigned integers *)   
+Definition uint_size := 63.
+Definition uint_wB := (2 ^ (Z.of_nat uint_size))%Z.
+Definition uint63_model := { z : Z | ((0 <=? z) && (z <? uint_wB))%Z }.
+
+Definition string_of_uint63_model (i : uint63_model) := string_of_Z (proj1_sig i).
+
+(** Model of floats *)
+Definition prec := 53%Z.
+Definition emax := 1024%Z.
+(** We consider valid binary encordings of floats as our model *)
+Definition float64_model := sig (valid_binary prec emax).
+
+Definition string_of_float64_model (i : float64_model) := 
+  "<float>".

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -167,6 +167,7 @@ Register MetaCoq.Template.Ast.tCase as metacoq.ast.tCase.
 Register MetaCoq.Template.Ast.tProj as metacoq.ast.tProj.
 Register MetaCoq.Template.Ast.tFix as metacoq.ast.tFix.
 Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tCoFix.
+Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tInt.
 
 (* Local and global declarations *)
 Register MetaCoq.Template.Ast.parameter_entry as metacoq.ast.parameter_entry.

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -168,6 +168,7 @@ Register MetaCoq.Template.Ast.tProj as metacoq.ast.tProj.
 Register MetaCoq.Template.Ast.tFix as metacoq.ast.tFix.
 Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tCoFix.
 Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
+Register MetaCoq.Template.Ast.tFloat as metacoq.ast.tFloat.
 
 (* Local and global declarations *)
 Register MetaCoq.Template.Ast.parameter_entry as metacoq.ast.parameter_entry.

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -167,7 +167,7 @@ Register MetaCoq.Template.Ast.tCase as metacoq.ast.tCase.
 Register MetaCoq.Template.Ast.tProj as metacoq.ast.tProj.
 Register MetaCoq.Template.Ast.tFix as metacoq.ast.tFix.
 Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tCoFix.
-Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tInt.
+Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
 
 (* Local and global declarations *)
 Register MetaCoq.Template.Ast.parameter_entry as metacoq.ast.parameter_entry.

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils Ast Reflect Induction.
-Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
-
+Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *).
+From Coq Require Extraction.
 (** * Extraction setup for template-coq.
 
     Any extracted code planning to link with the plugin's OCaml reifier
@@ -20,7 +20,7 @@ Extract Inductive Equations.Init.sigma => "( * )" ["(,)"].
 Extract Constant Equations.Init.pr1 => "fst".
 Extract Constant Equations.Init.pr2 => "snd".
 Extraction Inline Equations.Init.pr1 Equations.Init.pr2.
- 
+
 Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
            UnivSubst Typing Checker Retyping OrderedType Logic Common Equality UnivSubst.
 Set Warnings "-extraction-opaque-accessed".
@@ -30,6 +30,8 @@ Cd "gen-src".
 
 From MetaCoq.Template Require Import TemplateMonad.Extractable config Induction
      LiftSubst UnivSubst Pretty.
+Import Init.Nat.
+Locate Nat.
 
 Recursive Extraction Library Extractable.
 Extraction Library MCPrelude.

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -1,7 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import utils Ast Reflect Induction.
-Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *)
-    ExtrOCamlFloats.
+From MetaCoq.Template Require Import utils Ast Reflect Induction MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *).
+From Coq Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlFloats.
 From Coq Require Extraction.
 (** * Extraction setup for template-coq.
 

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils Ast Reflect Induction.
-Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *).
+Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt MC_ExtrOCamlInt63 (*b/c nameclash with `comparion` *)
+    ExtrOCamlFloats.
 From Coq Require Extraction.
 (** * Extraction setup for template-coq.
 
@@ -33,6 +34,15 @@ From MetaCoq.Template Require Import TemplateMonad.Extractable config Induction
 Import Init.Nat.
 Locate Nat.
 
+(* Floats *)
+(* Extraction Library Zeven.
+Extraction Library Zeven.
+Extraction Library ZArith_dec.
+Extraction Library Sumbool.
+Extraction Library Zbool.
+Extraction Library SpecFloat. *)
+Separate Extraction FloatOps.Prim2SF.
+
 Recursive Extraction Library Extractable.
 Extraction Library MCPrelude.
 Extraction Library MCOption.
@@ -43,6 +53,7 @@ Extraction Library Induction.
 Extraction Library LiftSubst.
 Extraction Library UnivSubst.
 Extraction Library BasicAst.
+
 Extraction Library Reflect.
 Extraction Library Pretty.
 Extraction Library config.

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -99,37 +99,37 @@ Proof.
     intros; try solve [match goal with
                  H : _ |- _ => apply H
               end; auto].
-  apply H2. inv H19.
+  apply H2. inv H18.
   auto using lift_to_wf_list.
 
+  - inv H19; auto.
+  - inv H19; auto.
+  - inv H19; auto.
   - inv H20; auto.
-  - inv H20; auto.
-  - inv H20; auto.
-  - inv H21; auto.
-  - inv H20; auto.
+  - inv H19; auto.
     apply H8; auto.
     auto using lift_to_wf_list.
 
-  - inv H20; apply H12; auto.
+  - inv H19; apply H12; auto.
     red. red in X.
     induction X.
     + constructor.
-    + constructor. inv H23; auto. apply IHX. inv H23; auto.
-
-  - inv H19; auto.
+    + constructor. inv H22; auto. apply IHX. inv H22; auto.
 
   - inv H18; auto.
+
+  - inv H16; auto.
     apply H14. red. red in X.
     induction X; constructor.
-    + split; inv H19; intuition.
-    + apply IHX. now inv H19.
+    + split; inv H18; intuition.
+    + apply IHX. now inv H18.
     + eapply Forall_impl; tea. clear; intros; cbn in *; intuition.
 
-  - inv H18; auto.
+  - inv H16; auto.
     apply H15. red. red in X.
     induction X; constructor.
-    + split; inv H19; intuition.
-    + apply IHX. now inv H19.
+    + split; inv H18; intuition.
+    + apply IHX. now inv H18.
 Qed.
 
 Definition tCaseBrsType {A} (P : A -> Type) (l : list (nat * A)) :=

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -30,6 +30,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
+    (forall (i : Int63.int), P (tInt i)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -87,16 +88,17 @@ Lemma term_wf_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> Forall (fun def => isLambda (dbody def) = true) m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
+    (forall (i : Int63.int), P (tInt i)) ->
     forall t : term, wf t -> P t.
 Proof.
-  pose proof I as H1.  (* can go away, to avoid renaming everything... *)
-  intros until t. revert t.
+  pose proof I as H1.   (* can go away, to avoid renaming everything... *)
+  intros until t. revert t. rename H16 into H16'.
   apply (term_forall_list_ind (fun t => wf t -> P t));
     intros; try solve [match goal with
                  H : _ |- _ => apply H
               end; auto].
   apply H2. inv H17.
-  auto using lift_to_wf_list.
+  { auto using lift_to_wf_list. }
 
   - inv H18; auto.
   - inv H18; auto.
@@ -155,6 +157,7 @@ Lemma term_forall_list_rect :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tCoFix m n)) ->
+    (forall (i : Int63.int), P (tInt i)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -30,7 +30,8 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall (i : Int63.int), P (tInt i)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->    
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -88,7 +89,8 @@ Lemma term_wf_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> Forall (fun def => isLambda (dbody def) = true) m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall (i : Int63.int), P (tInt i)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, wf t -> P t.
 Proof.
   pose proof I as H1.   (* can go away, to avoid renaming everything... *)
@@ -97,37 +99,37 @@ Proof.
     intros; try solve [match goal with
                  H : _ |- _ => apply H
               end; auto].
-  apply H2. inv H17.
-  { auto using lift_to_wf_list. }
+  apply H2. inv H19.
+  auto using lift_to_wf_list.
 
-  - inv H18; auto.
-  - inv H18; auto.
-  - inv H18; auto.
-  - inv H19; auto.
-  - inv H18; auto.
+  - inv H20; auto.
+  - inv H20; auto.
+  - inv H20; auto.
+  - inv H21; auto.
+  - inv H20; auto.
     apply H8; auto.
     auto using lift_to_wf_list.
 
-  - inv H18; apply H12; auto.
+  - inv H20; apply H12; auto.
     red. red in X.
     induction X.
     + constructor.
-    + constructor. inv H21; auto. apply IHX. inv H21; auto.
+    + constructor. inv H23; auto. apply IHX. inv H23; auto.
 
-  - inv H17; auto.
+  - inv H19; auto.
 
-  - inv H16; auto.
+  - inv H18; auto.
     apply H14. red. red in X.
     induction X; constructor.
-    + split; inv H17; intuition.
-    + apply IHX. now inv H17.
+    + split; inv H19; intuition.
+    + apply IHX. now inv H19.
     + eapply Forall_impl; tea. clear; intros; cbn in *; intuition.
 
-  - inv H16; auto.
+  - inv H18; auto.
     apply H15. red. red in X.
     induction X; constructor.
-    + split; inv H17; intuition.
-    + apply IHX. now inv H17.
+    + split; inv H19; intuition.
+    + apply IHX. now inv H19.
 Qed.
 
 Definition tCaseBrsType {A} (P : A -> Type) (l : list (nat * A)) :=
@@ -157,7 +159,8 @@ Lemma term_forall_list_rect :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tCoFix m n)) ->
-    (forall (i : Int63.int), P (tInt i)) ->
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->    
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -67,6 +67,7 @@ Section print_term.
       | Some body => substring 0 1 (body.(ind_name))
       | None => "X"
       end
+    | tInt _ => "i"
     | _ => "U"
     end.
 
@@ -201,6 +202,7 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ binder_name ∘ dname) l) n)
+  | tInt i => "Int(" ^ string_of_int i ^ ")"
   end.
 
 End print_term.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -202,7 +202,8 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ binder_name ∘ dname) l) n)
-  | tInt i => "Int(" ^ string_of_int i ^ ")"
+  | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
+  | tFloat f => "Float(" ^ string_of_float f ^ ")"
   end.
 
 End print_term.

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -496,6 +496,8 @@ Proof.
         subst. inversion e1. subst.
         destruct (eq_dec rarg rarg0) ; nodec.
         subst. left. reflexivity.
+  - destruct (Int63.eqs i i0) ; nodec.
+    subst. left. reflexivity.
 Defined.
 
 Instance reflect_term : ReflectEq term :=

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -149,11 +149,12 @@ Qed.
  
 Derive NoConfusion EqDec for SpecFloat.spec_float.
 
-Arguments eqb : simpl never.
+Local Obligation Tactic := idtac.
 #[program] 
 Instance reflect_prim_float : ReflectEq PrimFloat.float :=
   { eqb x y := eqb (ReflectEq := EqDec_ReflectEq SpecFloat.spec_float) (FloatOps.Prim2SF x) (FloatOps.Prim2SF y) }.
 Next Obligation.
+  intros. cbn -[eqb].
   destruct (eqb_spec (ReflectEq := EqDec_ReflectEq SpecFloat.spec_float) (FloatOps.Prim2SF x) (FloatOps.Prim2SF y)); constructor.
   now apply FloatAxioms.Prim2SF_inj.
   intros e; apply n. rewrite e.

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -523,6 +523,8 @@ Proof.
         subst. left. reflexivity.
   - destruct (Int63.eqs i i0) ; nodec.
     subst. left. reflexivity.
+  - destruct (eq_dec f f0) ; nodec.
+    subst. left. reflexivity.
 Defined.
 
 Instance reflect_term : ReflectEq term :=

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -1,4 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
+(* For primitive integers and floats  *)
+From Coq Require Numbers.Cyclic.Int63.Int63 Floats.PrimFloat Floats.FloatAxioms.
 From MetaCoq.Template Require Import utils AstUtils BasicAst Ast Induction.
 Require Import ssreflect.
 From Equations Require Import Equations.
@@ -134,6 +136,29 @@ Defined.
 Instance reflect_nat : ReflectEq nat := {
   eqb_spec := Nat.eqb_spec
 }.
+
+#[program] 
+Instance reflect_prim_int : ReflectEq Numbers.Cyclic.Int63.Int63.int :=
+  { eqb := Numbers.Cyclic.Int63.Int63.eqb
+}.
+Next Obligation.
+  destruct (Int63.eqb x y) eqn:eq; constructor.
+  now apply (Numbers.Cyclic.Int63.Int63.eqb_spec x y) in eq.
+  now apply (Numbers.Cyclic.Int63.Int63.eqb_false_spec x y) in eq.
+Qed.
+ 
+Derive NoConfusion EqDec for SpecFloat.spec_float.
+
+Arguments eqb : simpl never.
+#[program] 
+Instance reflect_prim_float : ReflectEq PrimFloat.float :=
+  { eqb x y := eqb (ReflectEq := EqDec_ReflectEq SpecFloat.spec_float) (FloatOps.Prim2SF x) (FloatOps.Prim2SF y) }.
+Next Obligation.
+  destruct (eqb_spec (ReflectEq := EqDec_ReflectEq SpecFloat.spec_float) (FloatOps.Prim2SF x) (FloatOps.Prim2SF y)); constructor.
+  now apply FloatAxioms.Prim2SF_inj.
+  intros e; apply n. rewrite e.
+  reflexivity.
+Qed.
 
 Definition eq_level l1 l2 :=
   match l1, l2 with

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -509,7 +509,10 @@ Inductive eq_term_upto_univ (Re Rle : Universe.t -> Universe.t -> Prop) : term -
     eq_term_upto_univ Re Rle (tCoFix mfix idx) (tCoFix mfix' idx)
 
 | eq_Int i :
-    eq_term_upto_univ Re Rle (tInt i) (tInt i).
+    eq_term_upto_univ Re Rle (tInt i) (tInt i)
+
+ | eq_Float f :
+    eq_term_upto_univ Re Rle (tFloat f) (tFloat f).
 
 Definition eq_term `{checker_flags} φ :=
   eq_term_upto_univ (eq_universe φ) (eq_universe φ).

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -9,7 +9,7 @@ From MetaCoq.Template Require Import config utils Ast AstUtils LiftSubst UnivSub
 
  *)
 
- 
+
 Definition isSort T :=
   match T with
   | tSort u => True
@@ -506,7 +506,10 @@ Inductive eq_term_upto_univ (Re Rle : Universe.t -> Universe.t -> Prop) : term -
       eq_term_upto_univ Re Re x.(dbody) y.(dbody) ×
       x.(rarg) = y.(rarg)
     ) mfix mfix' ->
-    eq_term_upto_univ Re Rle (tCoFix mfix idx) (tCoFix mfix' idx).
+    eq_term_upto_univ Re Rle (tCoFix mfix idx) (tCoFix mfix' idx)
+
+| eq_Int i :
+    eq_term_upto_univ Re Rle (tInt i) (tInt i).
 
 Definition eq_term `{checker_flags} φ :=
   eq_term_upto_univ (eq_universe φ) (eq_universe φ).
@@ -536,7 +539,7 @@ Fixpoint strip_casts t :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def strip_casts strip_casts) mfix in
     tCoFix mfix' idx
-  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => t
+  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ | tInt _ => t
   end.
 
 Definition eq_term_nocast `{checker_flags} (φ : ConstraintSet.t) (t u : term) :=
@@ -758,14 +761,14 @@ Definition build_case_predicate_type ind mdecl idecl params u ps : option term :
          decl_type := mkApps (tInd ind u) (map (lift0 #|X.1|) params ++ to_extended_list X.1) |} in
   ret (it_mkProd_or_LetIn (X.1 ,, inddecl) (tSort ps)).
 
-Definition wf_universe Σ s := 
+Definition wf_universe Σ s :=
   match s with
-  | Universe.lProp 
+  | Universe.lProp
   | Universe.lSProp => True
-  | Universe.lType u => 
+  | Universe.lType u =>
     forall l, UnivExprSet.In l u -> LevelSet.In (UnivExpr.get_level l) (global_ext_levels Σ)
   end.
-  
+
 
 Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term -> term -> Type :=
 | type_Rel n decl :
@@ -1475,7 +1478,7 @@ Proof.
         remember (fix_context mfix) as mfixcontext. clear Heqmfixcontext.
 
         induction a1; econstructor; eauto.
-        ++ split; auto. 
+        ++ split; auto.
           eapply (X _ (typing_wf_local (fst p)) _ _ (fst p)). simpl. lia.
         ++ eapply IHa1. intros.
           eapply (X _ X0 _ _ Hty). simpl; lia.
@@ -1511,9 +1514,9 @@ Proof.
            clear X14 X13.
            clear e decl a0.
            remember (fix_context mfix) as mfixcontext. clear Heqmfixcontext.
-   
+
            induction a1; econstructor; eauto.
-           ++ split; auto. 
+           ++ split; auto.
              eapply (X _ (typing_wf_local p) _ _ p). simpl. lia.
            ++ eapply IHa1. intros.
              eapply (X _ X0 _ _ Hty). simpl; lia.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -539,7 +539,8 @@ Fixpoint strip_casts t :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def strip_casts strip_casts) mfix in
     tCoFix mfix' idx
-  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ | tInt _ => t
+  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ 
+  | tInt _ | tFloat _ => t
   end.
 
 Definition eq_term_nocast `{checker_flags} (φ : ConstraintSet.t) (t u : term) :=

--- a/template-coq/theories/UnivSubst.v
+++ b/template-coq/theories/UnivSubst.v
@@ -10,7 +10,7 @@ From MetaCoq Require Import utils Ast AstUtils Induction LiftSubst.
 Instance subst_instance_constr : UnivSubst term :=
   fix subst_instance_constr u c {struct c} : term :=
   match c with
-  | tRel _ | tVar _  => c
+  | tRel _ | tVar _  | tInt _ => c
   | tEvar ev args => tEvar ev (List.map (subst_instance_constr u) args)
   | tSort s => tSort (subst_instance_univ u s)
   | tConst c u' => tConst c (subst_instance_instance u u')

--- a/template-coq/theories/UnivSubst.v
+++ b/template-coq/theories/UnivSubst.v
@@ -10,7 +10,7 @@ From MetaCoq Require Import utils Ast AstUtils Induction LiftSubst.
 Instance subst_instance_constr : UnivSubst term :=
   fix subst_instance_constr u c {struct c} : term :=
   match c with
-  | tRel _ | tVar _  | tInt _ => c
+  | tRel _ | tVar _  | tInt _ | tFloat _ => c
   | tEvar ev args => tEvar ev (List.map (subst_instance_constr u) args)
   | tSort s => tSort (subst_instance_univ u s)
   | tConst c u' => tConst c (subst_instance_instance u u')

--- a/template-coq/theories/WfInv.v
+++ b/template-coq/theories/WfInv.v
@@ -14,7 +14,7 @@ Fixpoint wf_Inv (t : term) :=
   | tLambda na t b => wf t /\ wf b
   | tLetIn na t b b' => wf t /\ wf b /\ wf b'
   | tApp t u => isApp t = false /\ u <> nil /\ wf t /\ Forall wf u
-  | tConst _ _ | tInd _ _ | tConstruct _ _ _ | tInt _ => True
+  | tConst _ _ | tInd _ _ | tConstruct _ _ _ => True
   | tCase ci p c brs => wf p /\ wf c /\ Forall (wf ∘ snd) brs
   | tProj p t => wf t
   | tFix mfix k => Forall (fun def => wf def.(dtype) /\ wf def.(dbody) /\ isLambda def.(dbody) = true) mfix
@@ -69,7 +69,7 @@ Fixpoint wf_term (t : term) : bool :=
   | tLambda na t b => wf_term t && wf_term b
   | tLetIn na t b b' => wf_term t && wf_term b && wf_term b'
   | tApp t u => ~~ isApp t && ~~ is_empty u && wf_term t && forallb wf_term u
-  | tConst _ _ | tInd _ _ | tConstruct _ _ _ | tInt _ => true
+  | tConst _ _ | tInd _ _ | tConstruct _ _ _ => true
   | tCase ci p c brs => wf_term p && wf_term c && forallb (wf_term ∘ snd) brs
   | tProj p t => wf_term t
   | tFix mfix k =>

--- a/template-coq/theories/WfInv.v
+++ b/template-coq/theories/WfInv.v
@@ -14,7 +14,7 @@ Fixpoint wf_Inv (t : term) :=
   | tLambda na t b => wf t /\ wf b
   | tLetIn na t b b' => wf t /\ wf b /\ wf b'
   | tApp t u => isApp t = false /\ u <> nil /\ wf t /\ Forall wf u
-  | tConst _ _ | tInd _ _ | tConstruct _ _ _ => True
+  | tConst _ _ | tInd _ _ | tConstruct _ _ _ | tInt _ => True
   | tCase ci p c brs => wf p /\ wf c /\ Forall (wf ∘ snd) brs
   | tProj p t => wf t
   | tFix mfix k => Forall (fun def => wf def.(dtype) /\ wf def.(dbody) /\ isLambda def.(dbody) = true) mfix
@@ -69,7 +69,7 @@ Fixpoint wf_term (t : term) : bool :=
   | tLambda na t b => wf_term t && wf_term b
   | tLetIn na t b b' => wf_term t && wf_term b && wf_term b'
   | tApp t u => ~~ isApp t && ~~ is_empty u && wf_term t && forallb wf_term u
-  | tConst _ _ | tInd _ _ | tConstruct _ _ _ => true
+  | tConst _ _ | tInd _ _ | tConstruct _ _ _ | tInt _ => true
   | tCase ci p c brs => wf_term p && wf_term c && forallb (wf_term ∘ snd) brs
   | tProj p t => wf_term t
   | tFix mfix k =>

--- a/template-coq/theories/WfInv.v
+++ b/template-coq/theories/WfInv.v
@@ -7,7 +7,7 @@ From MetaCoq.Template Require Import config utils Ast AstUtils.
 
 Fixpoint wf_Inv (t : term) :=
   match t with
-  | tRel _ | tVar _ | tSort _ => True
+  | tRel _ | tVar _ | tSort _ | tInt _ | tFloat _ => True
   | tEvar n l => Forall wf l
   | tCast t k t' => wf t /\ wf t'
   | tProd na t b => wf t /\ wf b
@@ -61,7 +61,7 @@ Qed.
 
 Fixpoint wf_term (t : term) : bool :=
   match t with
-  | tRel _ | tVar _ => true
+  | tRel _ | tVar _ | tInt _ | tFloat _ => true
   | tEvar n l => forallb wf_term l
   | tSort u => true
   | tCast t k t' => wf_term t && wf_term t'

--- a/template-coq/theories/utils/MCString.v
+++ b/template-coq/theories/utils/MCString.v
@@ -25,83 +25,10 @@ Definition print_list {A} (f : A -> string) (sep : string) (l : list A) : string
 Definition parens (top : bool) (s : string) :=
   if top then s else "(" ++ s ++ ")".
 
-(* TODO: reuse the Decimal support for parsing and printing numbers in Coq *)  
 Definition string_of_nat n : string :=
   DecimalString.NilEmpty.string_of_uint (Nat.to_uint n).
-(* match n with
-  | 0 => "0"
-  | 1 => "1"
-  | 2 => "2"
-  | 3 => "3"
-  | 4 => "4"
-  | 5 => "5"
-  | 6 => "6"
-  | 7 => "7"
-  | 8 => "8"
-  | 9 => "9"
-  | 10 => "10"
-  | 11 => "11"
-  | 12 => "12"
-  | 13 => "13"
-  | 14 => "14"
-  | 15 => "15"
-  | 16 => "16"
-  | 17 => "17"
-  | 18 => "18"
-  | 19 => "19"
-  | 20 => "20"
-  | 21 => "21"
-  | 22 => "22"
-  | 23 => "23"
-  | 24 => "24"
-  | 25 => "25"
-  | 26 => "26"
-  | 27 => "27"
-  | 28 => "28"
-  | 29 => "29"
-  | 30 => "30"
-  | 31 => "31"
-  | 32 => "32"
-  | 33 => "33"
-  | 34 => "34"
-  | 35 => "35"
-  | 36 => "36"
-  | 37 => "37"
-  | 38 => "38"
-  | 39 => "39"
-  | 40 => "40"
-  | 41 => "41"
-  | 42 => "42"
-  | 43 => "43"
-  | 44 => "44"
-  | 45 => "45"
-  | 46 => "46"
-  | 47 => "47"
-  | 48 => "48"
-  | 49 => "49"
-  | _ => "todo string_of_nat"
-  end. *)
-
-
-(* Definition string_of_nat n : string := DecimalString.NilZero.string_of_uint (Nat.to_uint n). *)
-(* Definition string_of_int (i:Int63.int) : string := BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). *)
-(* Definition string_of_int (i:Int63.int) : string := 
-  (if Int63.ltb i 8
-  then
-    if Int63.ltb i 4
-    then
-      if Int63.ltb i 2
-      then if Int63.ltb i 1 then "0" else "1"
-      else if Int63.ltb i 3 then "2" else "3"
-    else
-      if Int63.ltb i 6
-      then if Int63.ltb i 5 then "4" else "5"
-      else if Int63.ltb i 7 then "6" else "7"
-  else if Int63.eqb i 42 then "42" else "todo string_of_int")%int63. *)
 
 Hint Resolve String.string_dec : eq_dec.
-
-
 
 Definition string_of_positive p := 
   string_of_nat (Pos.to_nat p).

--- a/template-coq/theories/utils/MCString.v
+++ b/template-coq/theories/utils/MCString.v
@@ -1,5 +1,4 @@
-From Coq Require Import String.
-From Coq.Numbers Require Import (* DecimalString *) Int63.
+From Coq Require Import String Decimal DecimalString ZArith.
 From MetaCoq.Template Require Import MCCompare.
 
 Local Open Scope string_scope.
@@ -26,8 +25,10 @@ Definition print_list {A} (f : A -> string) (sep : string) (l : list A) : string
 Definition parens (top : bool) (s : string) :=
   if top then s else "(" ++ s ++ ")".
 
+(* TODO: reuse the Decimal support for parsing and printing numbers in Coq *)  
 Definition string_of_nat n : string :=
-  match n with
+  DecimalString.NilEmpty.string_of_uint (Nat.to_uint n).
+(* match n with
   | 0 => "0"
   | 1 => "1"
   | 2 => "2"
@@ -79,12 +80,12 @@ Definition string_of_nat n : string :=
   | 48 => "48"
   | 49 => "49"
   | _ => "todo string_of_nat"
-  end.
+  end. *)
 
 
 (* Definition string_of_nat n : string := DecimalString.NilZero.string_of_uint (Nat.to_uint n). *)
 (* Definition string_of_int (i:Int63.int) : string := BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). *)
-Definition string_of_int (i:Int63.int) : string := 
+(* Definition string_of_int (i:Int63.int) : string := 
   (if Int63.ltb i 8
   then
     if Int63.ltb i 4
@@ -96,10 +97,21 @@ Definition string_of_int (i:Int63.int) : string :=
       if Int63.ltb i 6
       then if Int63.ltb i 5 then "4" else "5"
       else if Int63.ltb i 7 then "6" else "7"
-  else if Int63.eqb i 42 then "42" else "todo string_of_int")%int63.
+  else if Int63.eqb i 42 then "42" else "todo string_of_int")%int63. *)
 
 Hint Resolve String.string_dec : eq_dec.
 
+
+
+Definition string_of_positive p := 
+  string_of_nat (Pos.to_nat p).
+
+Definition string_of_Z (z : Z) : string := 
+  match z with
+  | Z0 => "0"
+  | Zpos p => string_of_positive p
+  | Zneg p => "-" ++ string_of_positive p
+  end.
 
 Definition eq_string s s' :=
   match string_compare s s' with

--- a/template-coq/theories/utils/MCString.v
+++ b/template-coq/theories/utils/MCString.v
@@ -1,4 +1,5 @@
 From Coq Require Import String.
+From Coq.Numbers Require Import (* DecimalString *) Int63.
 From MetaCoq.Template Require Import MCCompare.
 
 Local Open Scope string_scope.
@@ -79,6 +80,23 @@ Definition string_of_nat n : string :=
   | 49 => "49"
   | _ => "todo string_of_nat"
   end.
+
+
+(* Definition string_of_nat n : string := DecimalString.NilZero.string_of_uint (Nat.to_uint n). *)
+(* Definition string_of_int (i:Int63.int) : string := BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). *)
+Definition string_of_int (i:Int63.int) : string := 
+  (if Int63.ltb i 8
+  then
+    if Int63.ltb i 4
+    then
+      if Int63.ltb i 2
+      then if Int63.ltb i 1 then "0" else "1"
+      else if Int63.ltb i 3 then "2" else "3"
+    else
+      if Int63.ltb i 6
+      then if Int63.ltb i 5 then "4" else "5"
+      else if Int63.ltb i 7 then "6" else "7"
+  else if Int63.eqb i 42 then "42" else "todo string_of_int")%int63.
 
 Hint Resolve String.string_dec : eq_dec.
 

--- a/template-coq/theories/utils/MC_ExtrOCamlInt63.v
+++ b/template-coq/theories/utils/MC_ExtrOCamlInt63.v
@@ -1,0 +1,56 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Extraction to OCaml of native 63-bit machine integers. *)
+
+From Coq Require Int63 Extraction.
+
+(** Basic data types used by some primitive operators. *)
+
+Extract Inductive bool => bool [ true false ].
+Extract Inductive prod => "( * )" [ "" ].
+(* Extract Inductive comparison => int [ "0" "(-1)" "1" ]. *)
+Extract Inductive DoubleType.carry => "Uint63.carry" [ "Uint63.C0" "Uint63.C1" ].
+
+(** Primitive types and operators. *)
+Extract Constant Int63.int => "Uint63.t".
+Extraction Inline Int63.int.
+(* Otherwise, the name conflicts with the primitive OCaml type [int] *)
+
+Extract Constant Int63.lsl => "Uint63.l_sl".
+Extract Constant Int63.lsr => "Uint63.l_sr".
+Extract Constant Int63.land => "Uint63.l_and".
+Extract Constant Int63.lor => "Uint63.l_or".
+Extract Constant Int63.lxor => "Uint63.l_xor".
+
+Extract Constant Int63.add => "Uint63.add".
+Extract Constant Int63.sub => "Uint63.sub".
+Extract Constant Int63.mul => "Uint63.mul".
+Extract Constant Int63.mulc => "Uint63.mulc".
+Extract Constant Int63.div => "Uint63.div".
+Extract Constant Int63.mod => "Uint63.rem".
+
+Extract Constant Int63.eqb => "Uint63.equal".
+Extract Constant Int63.ltb => "Uint63.lt".
+Extract Constant Int63.leb => "Uint63.le".
+
+Extract Constant Int63.addc => "Uint63.addc".
+Extract Constant Int63.addcarryc => "Uint63.addcarryc".
+Extract Constant Int63.subc => "Uint63.subc".
+Extract Constant Int63.subcarryc => "Uint63.subcarryc".
+
+Extract Constant Int63.diveucl => "Uint63.diveucl".
+Extract Constant Int63.diveucl_21 => "Uint63.div21".
+Extract Constant Int63.addmuldiv => "Uint63.addmuldiv".
+
+Extract Constant Int63.compare => "fun _x _y -> failwith ""not yet implemented""".
+
+Extract Constant Int63.head0 => "Uint63.head0".
+Extract Constant Int63.tail0 => "Uint63.tail0".

--- a/template-coq/update_plugin.sh
+++ b/template-coq/update_plugin.sh
@@ -4,7 +4,7 @@ TOCOPY="ast_denoter.ml ast_quoter.ml denoter.ml plugin_core.ml plugin_core.mli r
 
 # Test is gen-src is older than src
 if [[ "gen-src" -ot "src" || ! -f "gen-src/denoter.ml" || ! -f "gen-src/metacoq_template_plugin.cmxs" ||
-  "gen-src/extractable.ml" -nt "gen-src/metacoq_template_plugin.cmxs" ]]
+  "gen-src/extractable.ml" -nt "gen-src/metacoq_template_plugin.cmxs" || "$1" = "force" ]]
 then
     echo "Updating gen-src from src"
     mkdir -p build
@@ -12,9 +12,10 @@ then
     for x in ${TOCOPY}; do rm -f gen-src/$x; cp src/$x gen-src/$x; done
     echo "Renaming files to camelCase"
     (cd gen-src; ./to-lower.sh)
-    rm -f gen-src/*.d
+    rm -f gen-src/*.d gen-src/*.cm*
     # Fix an extraction bug: wrong type annotation on eq_equivalence
     patch -N -p0 < extraction.patch
+    patch -N -p0 < specFloat.patch
     exit 0
 else
     echo "Extracted code is up-to-date"

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -46,3 +46,4 @@ univ.v
 vs.v
 tmVariable.v
 order_rec.v
+primitive.v

--- a/test-suite/int.v
+++ b/test-suite/int.v
@@ -1,0 +1,14 @@
+Require Import MetaCoq.Template.Loader.
+Require Import Int63.
+
+Definition n : Int63.int := 42.
+Import List.ListNotations.
+Definition ns : list Int63.int := [n]%list.
+
+
+MetaCoq Quote Recursively Definition q_n := n.
+MetaCoq Unquote Definition n' := (snd q_n).
+
+MetaCoq Quote Recursively Definition q_ns := ns.
+MetaCoq Unquote Definition ns' := (snd q_ns).
+

--- a/test-suite/primitive.v
+++ b/test-suite/primitive.v
@@ -1,0 +1,37 @@
+From Coq Require Import String.
+From MetaCoq.Template Require Import monad_utils All.
+From Coq.Numbers.Cyclic Require Import Int63.
+
+Local Open Scope string_scope.
+Import MonadNotation.
+
+Definition bigint : Int63.int := 542985047%int63.
+
+Notation eval_hnf := (tmEval hnf).
+Notation eval := (tmEval all).
+
+MetaCoq Run (eval_hnf bigint >>= 
+            (fun x => tmQuote (x + 1)%int63) >>= 
+            tmMkDefinition "foo").
+
+Print foo.
+
+MetaCoq Run (eval_hnf bigint >>= 
+            (fun x => tmQuote (x + 1)%int63 >>= fun q =>
+            tmUnquoteTyped int q >>= fun unq =>
+            tmPrint unq >>= fun _ =>
+            tmLemma "foo'" (bigint + 1 = unq)%int63 >>= 
+            fun x => tmPrint x)).
+
+From Coq Require Import Int63 PrimFloat.
+
+Definition f := (of_int63 bigint / 3)%float.
+Eval lazy in f.
+MetaCoq Run (tmEval lazy f >>= 
+            (fun x => tmQuote (x + 1)%float) >>= 
+            tmMkDefinition "fplus1").
+
+MetaCoq Run (tmUnquoteTyped float (tFloat f) >>= 
+  (fun x : float => tmPrint x >>= 
+   fun _ => tmQuote x >>= tmMkDefinition "somefloat")).
+   Print somefloat.

--- a/translations/param_binary.v
+++ b/translations/param_binary.v
@@ -141,6 +141,7 @@ Fixpoint tsl_rec1_app (app : list term) (E : tsl_table) (t : term) : term :=
   | tFix _ _ | tCoFix _ _ => todo "tsl"
   | tVar _ | tEvar _ _ => todo "tsl"
   | tLambda _ _ _ => tVar "impossible"
+  | tInt _ | tFloat _ => todo "impossible"
   end
   in apply app t1
   end.

--- a/translations/param_original.v
+++ b/translations/param_original.v
@@ -103,6 +103,7 @@ Fixpoint tsl_rec1_app (app : option term) (E : tsl_table) (t : term) : term :=
   | tFix _ _ | tCoFix _ _ => todo "tsl"
   | tVar _ | tEvar _ _ => todo "tsl"
   | tLambda _ _ _ => tVar "impossible"
+  | tInt _ | tFloat _ => todo "impossible"
   end in
   match app with Some t' => mkApp t1 (t' {3 := tRel 1} {2 := tRel 0})
                | None => t1 end


### PR DESCRIPTION
This adds support of primitive integers and floats to template-coq, including the extractable monad, where we bind to native ocaml implementations. We need to update the rest of the development to them.