### PR TITLE
Disable warning 60 of ocaml >= 4.10 (unused functor argument)

### DIFF
--- a/safechecker/Makefile.plugin.local
+++ b/safechecker/Makefile.plugin.local
@@ -3,3 +3,4 @@ CAMLFLAGS+=-w -33 # Unused opens
 CAMLFLAGS+=-w -32 # Unused values
 CAMLFLAGS+=-w -34 # Unused types
 CAMLFLAGS+=-w -39 # Unused rec flags
+CAMLFLAGS+=-w -60 # Unused module in functor


### PR DESCRIPTION
This should allow metacoq to compile with recent ocaml versions.