### PR TITLE
Adapt to coq/coq#14050 (removal of universe remote counter)

### DIFF
--- a/safechecker/src/g_metacoq_safechecker.mlg
+++ b/safechecker/src/g_metacoq_safechecker.mlg
@@ -53,7 +53,7 @@ let retypecheck_term_dependencies env gr =
     let names = Univ.AUContext.names auctx in
     let dp = Names.DirPath.make [Names.Id.of_string "MetaCoq"; Names.Id.of_string "Retypecheck"] in
     let fake_level i _ =
-     Univ.Level.make (Univ.Level.UGlobal.make dp i)
+     Univ.Level.make (Univ.Level.UGlobal.make dp "" i)
     in
     let fake_inst = Univ.Instance.of_array (Array.mapi fake_level names) in
     let cu = (c, fake_inst) in

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -164,7 +164,8 @@ struct
       let last, dp = CList.sep_last comps in
       let dp = DirPath.make (List.map Id.of_string comps) in
       let idx = int_of_string last in
-      Univ.Level.make (Univ.Level.UGlobal.make dp idx)
+      (* TODO handle universes from workers *)
+      Univ.Level.make (Univ.Level.UGlobal.make dp "" idx)
     | Universes0.Level.Var n -> Univ.Level.var (unquote_int n)
 
   let unquote_level_expr (trm : Universes0.Level.t * Datatypes.nat) : Univ.Universe.t =

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -152,7 +152,8 @@ struct
       | n :: dp ->
         let num = int_of_string n in
         let dp = DirPath.make (List.map Id.of_string dp) in
-        let l = Univ.Level.make (Univ.Level.UGlobal.make dp num) in
+        (* TODO handle univs created in workers *)
+        let l = Univ.Level.make (Univ.Level.UGlobal.make dp "" num) in
         try
           let evm = Evd.add_global_univ evm l in
           if !strict_unquote_universe_mode then


### PR DESCRIPTION
Universe levels now have a additional string component, which is empty
when the universe was created in the master process.

Handling universes from workers is left to a followup (they come from
`par:` tactics and delegated Qed proofs).