### PR TITLE
CI for master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Test compilation
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [ local, opam ]
+
+    steps:
+
+      # - name: Try to restore opam cache
+      #   id: opam-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: "~/.opam"
+      #     key: opam-${{github.base_ref}}-${{github.ref}} 
+      #     restore-keys: |
+      #       opam--refs/heads/${{github.base_ref}}
+
+      - name: Install OCaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: 4.07.1
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - run: opam repo add coq-released https://coq.inria.fr/opam/released
+      - run: opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev
+      - run: opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
+      - run: opam install . --deps-only --with-doc --with-test
+
+      - run: opam exec -- ./configure.sh ${{matrix.target}}
+      - run: opam exec -- make -j 2 ci-${{matrix.target}}

--- a/coq-metacoq-checker.opam
+++ b/coq-metacoq-checker.opam
@@ -21,6 +21,7 @@ build: [
 install: [
   [make "-C" "checker" "install"]
 ]
+version: "dev"
 depends: [
   "ocaml" {>= "4.07.1" & < "4.12~"}
   "coq" { = "dev" }

--- a/coq-metacoq-erasure.opam
+++ b/coq-metacoq-erasure.opam
@@ -21,6 +21,7 @@ build: [
 install: [
   [make "-C" "erasure" "install"]
 ]
+version: "dev"            
 depends: [
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/coq-metacoq-pcuic.opam
+++ b/coq-metacoq-pcuic.opam
@@ -21,6 +21,7 @@ build: [
 install: [
   [make "-C" "pcuic" "install"]
 ]
+version: "dev"
 depends: [
   "coq-equations" {= "dev" }
   "coq-metacoq-template" {= version}

--- a/coq-metacoq-safechecker.opam
+++ b/coq-metacoq-safechecker.opam
@@ -21,6 +21,7 @@ build: [
 install: [
   [make "-C" "safechecker" "install"]
 ]
+version: "dev"
 depends: [
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/coq-metacoq-template.opam
+++ b/coq-metacoq-template.opam
@@ -21,6 +21,7 @@ build: [
 install: [
   [make "-C" "template-coq" "install"]
 ]
+version: "dev"
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" { = "dev" }

--- a/coq-metacoq-translations.opam
+++ b/coq-metacoq-translations.opam
@@ -17,6 +17,7 @@ build: [
 install: [
   [make "-C" "translations" "install"]
 ]
+version: "dev"
 depends: [
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/coq-metacoq.opam
+++ b/coq-metacoq.opam
@@ -1,4 +1,4 @@
-opam-version: "2.0"
+opam-version: "2.0"              
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
@@ -14,6 +14,7 @@ authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
           "Théo Winterhalter <theo.winterhalter@inria.fr>"
 ]
 license: "MIT"
+version: "dev"
 depends: [
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}


### PR DESCRIPTION
I copy-pasted the CI scripts and disabled caching because we always want to build against the newest Coq `dev` package. I would guess this part is fairly uncontroversial. We have a CI time of around 50 minutes now, which is quite a lot, but not really avoidable if we build against `master`.

But in order to make this work, I had to add `version: dev` in all `.opam` files. The `version` was used frequently there, and it is never set explicitly. I don't understand how exactly the `opam` packages work in this regard, so likely it makes sense if somebody double-checks (@mattam82).