### PR TITLE
Fix hardcoded dependency on /bin/bash

### DIFF
--- a/dependency-graph/generate-depgraph.sh
+++ b/dependency-graph/generate-depgraph.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/erasure/clean_extraction.sh
+++ b/erasure/clean_extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/pcuic/clean_extraction.sh
+++ b/pcuic/clean_extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/safechecker/clean_extraction.sh
+++ b/safechecker/clean_extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SED=`which gsed || which sed`
 

--- a/template-coq/update_plugin.sh
+++ b/template-coq/update_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TOCOPY="ast_denoter.ml ast_quoter.ml denoter.ml plugin_core.ml plugin_core.mli reification.ml quoter.ml run_extractable.ml run_extractable.mli tm_util.ml"
 


### PR DESCRIPTION
On systems like NixOS, there is no `/bin/bash`, making the opam installation fail.