### PR TITLE
Overlay for Coq PR 14224

### DIFF
--- a/template-coq/src/g_template_coq.mlg
+++ b/template-coq/src/g_template_coq.mlg
@@ -13,7 +13,7 @@ let ltac_lcall tac args =
   let (location, name) = Loc.tag (Names.Id.of_string tac)
     (* Loc.tag @@ Names.Id.of_string tac *)
   in
-  Tacexpr.TacArg(CAst.make ?loc:location (Tacexpr.TacCall
+  CAst.make ?loc:location (Tacexpr.TacArg(Tacexpr.TacCall
                               (CAst.make (Locus.ArgVar (CAst.make ?loc:location name),args))))
 
 open Tacexpr


### PR DESCRIPTION
Not sure why I get this error.  `pCUICSafeChecker.ml` is compiled.

```
CAMLOPT -c -for-pack Metacoq_safechecker_plugin src/g_metacoq_safechecker.ml
File "src/g_metacoq_safechecker.mlg", line 10, characters 5-21:
Error: Unbound module PCUICSafeChecker
Command exited with non-zero status 2
```