### PR TITLE
Adapt to Coq PR #14234: need Nat.leb to be distinguished from String.leb

### DIFF
--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -239,7 +239,7 @@ Lemma trans_subst xs k t:
 Proof.
   induction t in k |- * using PCUICInduction.term_forall_list_ind.
   all: cbn;try congruence.
-  - destruct leb;trivial.
+  - destruct Nat.leb;trivial.
     rewrite nth_error_map.
     destruct nth_error;cbn.
     2: now rewrite map_length.


### PR DESCRIPTION
Hi, coq/coq#14234 adds `String.leb` which collides with `leb` on `nat` which is used in `PCUICToTemplateCorrectness.v`. This PR qualifies `Nat.leb` to avoid the collision. This is backwards compatible and can be merged as soon as now.