### PR TITLE
Adapt to Coq PR #14234: add scope on ?= to avoid collision with Strin…

### DIFF
--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -106,7 +106,7 @@ Section optimize.
     induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto; 
       try solve [f_equal; eauto; ELiftSubst.solve_all].
     
-    - destruct (k ?= n); auto.
+    - destruct (k ?= n)%nat; auto.
     - f_equal; eauto. rewrite !map_map_compose; eauto.
       solve_all.
     - destruct ETyping.is_propositional_ind as [[|]|] => /= //.


### PR DESCRIPTION
Hi @TheoWinterhalter, I'm sorry, there is another place to modify metacoq for coq/coq#14234. It is in `erasure/theories/EOptimizePropDiscr.v`. Here, I added a `%nat` to prevent a collision on `(k ?= n)`. Don't know if it would have been better to control the order of imports of `String` and `Arith`. This is anyway backwards compatible and can be merged as soon as now.
