### PR TITLE
Introduce ci-local-noclean

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - 'dev'
         ocaml_version:
           - '4.07-flambda'
-        target: [ local, opam ]
+        target: [ local-and-clean, opam ]
       fail-fast: true
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - 'dev'
         ocaml_version:
           - '4.07-flambda'
-        target: [ local-and-clean, opam ]
+        target: [ local, opam ]
       fail-fast: true
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ cleanplugins:
 ci-local:
 	./configure.sh local
 	$(MAKE) all test-suite TIMED=pretty-timed
-	$(MAKE) clean
-	
+
+ci-local-and-clean: ci-local
+  $(MAKE) clean
+
 ci-opam:
 	# Use -v so that regular output is produced
 	opam install -v -y .

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ ci-local-noclean:
 	$(MAKE) all test-suite TIMED=pretty-timed
 
 ci-local: ci-local-noclean
-  $(MAKE) clean
+	$(MAKE) clean
 
 ci-opam:
-	# Use -v so that regular output is produced
+# Use -v so that regular output is produced
 	opam install -v -y .
 	opam remove -y coq-metacoq coq-metacoq-template

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,11 @@ cleanplugins:
 	$(MAKE) -C safechecker cleanplugin
 	$(MAKE) -C erasure cleanplugin
 
-ci-local:
+ci-local-noclean:
 	./configure.sh local
 	$(MAKE) all test-suite TIMED=pretty-timed
 
-ci-local-and-clean: ci-local
+ci-local: ci-local-noclean
   $(MAKE) clean
 
 ci-opam:

--- a/template-coq/Makefile
+++ b/template-coq/Makefile
@@ -9,7 +9,7 @@ coq: Makefile.coq
 template-coq: coq Makefile.template
 # Force building the ML code before the .v's requiring them.
 	$(MAKE) -f Makefile.template optfiles
-	cp src/template_coq.cm* build/
+	cp -a src/template_coq.cm* build/
 	$(MAKE) -f Makefile.template
 	# rm gen-src/uint63.*
 

--- a/template-coq/Makefile.plugin.local
+++ b/template-coq/Makefile.plugin.local
@@ -11,4 +11,4 @@ CAMLFLAGS+=-bin-annot # For merlin
 INSTALLDEFAULTROOT=MetaCoq/Template
 
 post-all::
-	cp gen-src/metacoq_template_plugin.cm* build/
+	cp -a gen-src/metacoq_template_plugin.cm* build/

--- a/template-coq/update_plugin.sh
+++ b/template-coq/update_plugin.sh
@@ -9,7 +9,7 @@ then
     echo "Updating gen-src from src"
     mkdir -p build
     echo "Copying from src to gen-src"
-    for x in ${TOCOPY}; do rm -f gen-src/$x; cp src/$x gen-src/$x; done
+    for x in ${TOCOPY}; do rm -f gen-src/$x; cp -a src/$x gen-src/$x; done
     echo "Renaming files to camelCase"
     (cd gen-src; ./to-lower.sh)
     rm -f gen-src/*.d gen-src/*.cm*


### PR DESCRIPTION
This PR introduces a `ci-local-noclean` target which can be used by Coq's CI, and consistently uses `cp -a` to copy around files.

This should hopefully suffice to fix #563.