### PR TITLE
Better treatment of `MonadNonation` module 

### DIFF
--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -13,7 +13,7 @@ From MetaCoq.Erasure Require Import EAstUtils EArities Extract Prelim ErasureCor
 
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
-Import MonadNotation.
+Import MCMonadNotation.
 
 From Equations Require Import Equations.
 Set Equations Transparent.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -13,7 +13,7 @@ From MetaCoq.Erasure Require Import EAstUtils EArities Extract Prelim EDeps Eras
 
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
-Import MonadNotation.
+Import MCMonadNotation.
 
 From Equations Require Import Equations.
 Set Equations Transparent.

--- a/examples/add_constructor.v
+++ b/examples/add_constructor.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (* **************************************************** *)
 (* In this file we define a small plugin which allow to *)

--- a/examples/add_constructor.v
+++ b/examples/add_constructor.v
@@ -1,6 +1,8 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 
+Import MonadNotation.
+
 (* **************************************************** *)
 (* In this file we define a small plugin which allow to *)
 (* add a constructor to an inductive without rewriting  *)

--- a/examples/demo.v
+++ b/examples/demo.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (** This is just printing **)
 MetaCoq Test Quote (fun x : nat => x).

--- a/examples/demo.v
+++ b/examples/demo.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 
+Import MonadNotation.
 
 (** This is just printing **)
 MetaCoq Test Quote (fun x : nat => x).

--- a/examples/metacoq_tour.v
+++ b/examples/metacoq_tour.v
@@ -3,7 +3,7 @@ From MetaCoq.Template Require config utils All.
 From MetaCoq.Template Require Import TemplateMonad.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICReduction PCUICCumulativity PCUICTyping PCUICSafeLemmata.
 
-Import MonadNotation.
+Import MCMonadNotation.
 Local Open Scope string_scope.
 
 (** MetaCoq is: 

--- a/examples/metacoq_tour.v
+++ b/examples/metacoq_tour.v
@@ -3,6 +3,7 @@ From MetaCoq.Template Require config utils All.
 From MetaCoq.Template Require Import TemplateMonad.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICReduction PCUICCumulativity PCUICTyping PCUICSafeLemmata.
 
+Import MonadNotation.
 Local Open Scope string_scope.
 
 (** MetaCoq is: 

--- a/examples/metacoq_tour_prelude.v
+++ b/examples/metacoq_tour_prelude.v
@@ -4,7 +4,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICLiftSu
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICTypeChecker PCUICSafeChecker.
 From Equations Require Import Equations.
 
-Import MonadNotation.
+Import MCMonadNotation.
 Existing Instance default_checker_flags.
 
 (* ********************************************************* *)

--- a/examples/metacoq_tour_prelude.v
+++ b/examples/metacoq_tour_prelude.v
@@ -4,6 +4,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICLiftSu
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICTypeChecker PCUICSafeChecker.
 From Equations Require Import Equations.
 
+Import MonadNotation.
 Existing Instance default_checker_flags.
 
 (* ********************************************************* *)

--- a/examples/tauto.v
+++ b/examples/tauto.v
@@ -7,7 +7,7 @@ Definition banon := {| binder_name := nAnon; binder_relevance := Relevant |}.
 Definition bnamed n := {| binder_name := nNamed n; binder_relevance := Relevant |}.
 
 Local Existing Instance config.default_checker_flags.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Definition var := nat.
 

--- a/examples/tauto.v
+++ b/examples/tauto.v
@@ -7,6 +7,7 @@ Definition banon := {| binder_name := nAnon; binder_relevance := Relevant |}.
 Definition bnamed n := {| binder_name := nNamed n; binder_relevance := Relevant |}.
 
 Local Existing Instance config.default_checker_flags.
+Import MonadNotation.
 
 Definition var := nat.
 

--- a/examples/typing_correctness.v
+++ b/examples/typing_correctness.v
@@ -5,6 +5,8 @@ From MetaCoq.SafeChecker Require Import PCUICErrors PCUICTypeChecker PCUICSafeCh
 From Equations Require Import Equations.
 Existing Instance default_checker_flags.
 
+Import MonadNotation.
+
 (* ********************************************************* *)
 (* In this file we define a small plugin which proves        *)
 (* the identity theorem for any sort using the safe checker. *)

--- a/examples/typing_correctness.v
+++ b/examples/typing_correctness.v
@@ -5,7 +5,7 @@ From MetaCoq.SafeChecker Require Import PCUICErrors PCUICTypeChecker PCUICSafeCh
 From Equations Require Import Equations.
 Existing Instance default_checker_flags.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (* ********************************************************* *)
 (* In this file we define a small plugin which proves        *)

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -4,7 +4,7 @@ From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction
      PCUICReflect PCUICEquality PCUICLiftSubst.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.

--- a/pcuic/theories/PCUICPosition.v
+++ b/pcuic/theories/PCUICPosition.v
@@ -4,6 +4,8 @@ From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction
      PCUICReflect PCUICEquality PCUICLiftSubst.
 
+Import MonadNotation.
+
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
 

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -13,6 +13,8 @@ Set Warnings "+notation_overridden".
 
 Require Import PCUICToTemplate.
 
+Import MonadNotation.
+
 Implicit Types cf : checker_flags. (* Use {cf} to parameterize by checker_flags where needed *)
 
 (* from Checker Generation to avoid dependencies *)

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -13,7 +13,7 @@ Set Warnings "+notation_overridden".
 
 Require Import PCUICToTemplate.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Implicit Types cf : checker_flags. (* Use {cf} to parameterize by checker_flags where needed *)
 

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -5,6 +5,8 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
   PCUICPosition.
 From MetaCoq.PCUIC Require Export PCUICReduction PCUICCumulativity.
 
+Import MonadNotation.
+
 (* TODO: remove this export *)
 From MetaCoq Require Export LibHypsNaming.
 

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -5,7 +5,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
   PCUICPosition.
 From MetaCoq.PCUIC Require Export PCUICReduction PCUICCumulativity.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (* TODO: remove this export *)
 From MetaCoq Require Export LibHypsNaming.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -21,6 +21,8 @@ Require Import ssreflect ssrbool.
 Local Set Keyed Unification.
 Set Equations Transparent.
 
+Import MonadNotation.
+
 (** It otherwise tries [auto with *], very bad idea. *)
 Ltac Coq.Program.Tactics.program_solve_wf ::= 
   match goal with 

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -21,7 +21,7 @@ Require Import ssreflect ssrbool.
 Local Set Keyed Unification.
 Set Equations Transparent.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (** It otherwise tries [auto with *], very bad idea. *)
 Ltac Coq.Program.Tactics.program_solve_wf ::= 

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -13,7 +13,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICArities PCUICInduc
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICSafeReduce.
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
-Import monad_utils.MonadNotation.
+Import monad_utils.MCMonadNotation.
 
 Hint Constructors assumption_context : pcuic.
 

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -21,6 +21,8 @@ Require Import ssreflect ssrbool.
 Local Set Keyed Unification.
 Set Equations Transparent.
 
+Import MonadNotation.
+
 (** It otherwise tries [auto with *], very bad idea. *)
 Ltac Coq.Program.Tactics.program_solve_wf ::= 
   match goal with 

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -21,7 +21,7 @@ Require Import ssreflect ssrbool.
 Local Set Keyed Unification.
 Set Equations Transparent.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (** It otherwise tries [auto with *], very bad idea. *)
 Ltac Coq.Program.Tactics.program_solve_wf ::= 

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -6,7 +6,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping
      TemplateToPCUIC.
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICSafeChecker.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Program Definition infer_template_program {cf : checker_flags} (p : Ast.program) φ Hφ
   : EnvCheck (∑ A, ∥ (trans_global_decls p.1, φ) ;;; [] |- trans p.2 : A ∥) :=

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -6,6 +6,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping
      TemplateToPCUIC.
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICSafeChecker.
 
+Import MonadNotation.
 
 Program Definition infer_template_program {cf : checker_flags} (p : Ast.program) φ Hφ
   : EnvCheck (∑ A, ∥ (trans_global_decls p.1, φ) ;;; [] |- trans p.2 : A ∥) :=

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config Ast AstUtils utils
      LiftSubst UnivSubst uGraph Typing.
-Import MonadNotation.
+Import MCMonadNotation.
 
 (** * Coq type-checker for kernel terms
 

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config Ast AstUtils utils
      LiftSubst UnivSubst uGraph Typing.
+Import MonadNotation.
 
 (** * Coq type-checker for kernel terms
 

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -2,6 +2,7 @@
 From MetaCoq.Template Require Import utils Ast AstUtils Common.
 
 Local Set Universe Polymorphism.
+Import MonadNotation.
 
 (** * The Template Monad
 

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -2,7 +2,7 @@
 From MetaCoq.Template Require Import utils Ast AstUtils Common.
 
 Local Set Universe Polymorphism.
-Import MonadNotation.
+Import MCMonadNotation.
 
 (** * The Template Monad
 
@@ -62,7 +62,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option_instance A)
 .
 
-(** This allow to use notations of MonadNotation *)
+(** This allow to use notations of MCMonadNotation *)
 Instance TemplateMonad_Monad : Monad TemplateMonad :=
   {| ret := @tmReturn ; bind := @tmBind |}.
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -5,7 +5,7 @@ From Coq Require Import ssreflect Wellfounded Relation_Operators CRelationClasse
 From MetaCoq.Template Require Import config utils Ast AstUtils LiftSubst UnivSubst
      EnvironmentTyping Reflect TermEquality.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 (** * Typing derivations
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -5,6 +5,8 @@ From Coq Require Import ssreflect Wellfounded Relation_Operators CRelationClasse
 From MetaCoq.Template Require Import config utils Ast AstUtils LiftSubst UnivSubst
      EnvironmentTyping Reflect TermEquality.
 
+Import MonadNotation.
+
 (** * Typing derivations
 
   Inductive relations for reduction, conversion and typing of CIC terms.

--- a/template-coq/theories/common/uGraph.v
+++ b/template-coq/theories/common/uGraph.v
@@ -6,6 +6,8 @@ From Equations Require Import Equations.
 Require Import ssreflect ssrbool.
 Import ConstraintType.
 
+Import MonadNotation.
+
 Arguments Z.add : simpl nomatch.
 Arguments Nat.leb : simpl nomatch.
 Arguments Nat.eqb : simpl nomatch.

--- a/template-coq/theories/common/uGraph.v
+++ b/template-coq/theories/common/uGraph.v
@@ -6,7 +6,7 @@ From Equations Require Import Equations.
 Require Import ssreflect ssrbool.
 Import ConstraintType.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Arguments Z.add : simpl nomatch.
 Arguments Nat.leb : simpl nomatch.

--- a/template-coq/theories/monad_utils.v
+++ b/template-coq/theories/monad_utils.v
@@ -21,7 +21,7 @@ Class MonadExc E (m : Type -> Type) : Type :=
 }.
 
 
-Module MonadNotation.
+Module MCMonadNotation.
   Declare Scope monad_scope.
   Delimit Scope monad_scope with monad.
 
@@ -42,9 +42,9 @@ Module MonadNotation.
 
   Notation "e1 ;; e2" := (_ <- e1%monad ;; e2%monad)%monad
     (at level 100, right associativity) : monad_scope.
-End MonadNotation.
+End MCMonadNotation.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Instance option_monad : Monad option :=
   {| ret A a := Some a ;

--- a/template-coq/theories/utils.v
+++ b/template-coq/theories/utils.v
@@ -30,5 +30,3 @@ Notation "A * B" := (prod A B) : type_scope2.
 Global Open Scope type_scope2.
 
 Global Open Scope metacoq_scope.
-
-Export MonadNotation.

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -7,6 +7,7 @@ From Coq Require Import String.
 Local Open Scope string_scope.
 
 From MetaCoq.Template Require Import utils.
+Import MonadNotation.
 
 Definition test (p : Ast.program) : string :=
   erase_and_print_template_program p.

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -7,7 +7,7 @@ From Coq Require Import String.
 Local Open Scope string_scope.
 
 From MetaCoq.Template Require Import utils.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Definition test (p : Ast.program) : string :=
   erase_and_print_template_program p.

--- a/test-suite/issue28.v
+++ b/test-suite/issue28.v
@@ -2,7 +2,7 @@ Require Import MetaCoq.Template.All.
 Require Export String List.
 Open Scope string.
 Import ListNotations.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Inductive test (X : Type) := test_T : test X -> test X.
 

--- a/test-suite/modules_sections.v
+++ b/test-suite/modules_sections.v
@@ -1,5 +1,5 @@
 From MetaCoq.Template Require Import utils All.
-Import MonadNotation.
+Import MCMonadNotation.
 
 
 Module Type A.

--- a/test-suite/modules_sections.v
+++ b/test-suite/modules_sections.v
@@ -1,4 +1,5 @@
 From MetaCoq.Template Require Import utils All.
+Import MonadNotation.
 
 
 Module Type A.

--- a/test-suite/opaque.v
+++ b/test-suite/opaque.v
@@ -1,7 +1,7 @@
 From Coq Require Import String List Nat.
 From MetaCoq.Template Require Import All.
 
-Import MonadNotation String ListNotations.
+Import MCMonadNotation String ListNotations.
 
 Definition foo : nat. exact 0. Qed.
 

--- a/test-suite/primitive.v
+++ b/test-suite/primitive.v
@@ -3,7 +3,7 @@ From MetaCoq.Template Require Import monad_utils All.
 From Coq.Numbers.Cyclic Require Import Int63.
 
 Local Open Scope string_scope.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Definition bigint : Int63.int := 542985047%int63.
 

--- a/test-suite/run_in_tactic.v
+++ b/test-suite/run_in_tactic.v
@@ -1,5 +1,5 @@
 From MetaCoq.Template Require Import utils All.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Goal True.
   let k x := pose (y := x) in

--- a/test-suite/run_in_tactic.v
+++ b/test-suite/run_in_tactic.v
@@ -1,4 +1,5 @@
 From MetaCoq.Template Require Import utils All.
+Import MonadNotation.
 
 Goal True.
   let k x := pose (y := x) in

--- a/test-suite/sprop_tests.v
+++ b/test-suite/sprop_tests.v
@@ -1,7 +1,7 @@
 Require Import String List.
 Require Import MetaCoq.Template.All.
 
-Import ListNotations MonadNotation.
+Import ListNotations MCMonadNotation.
 
 Open Scope string.
 

--- a/test-suite/tmExistingInstance.v
+++ b/test-suite/tmExistingInstance.v
@@ -1,4 +1,5 @@
 From MetaCoq.Template Require Import utils All.
+Import MonadNotation.
 
 MetaCoq Run (tmLocate1 "I" >>= tmDefinition "qI").
 

--- a/test-suite/tmExistingInstance.v
+++ b/test-suite/tmExistingInstance.v
@@ -1,5 +1,5 @@
 From MetaCoq.Template Require Import utils All.
-Import MonadNotation.
+Import MCMonadNotation.
 
 MetaCoq Run (tmLocate1 "I" >>= tmDefinition "qI").
 

--- a/test-suite/tmFreshName.v
+++ b/test-suite/tmFreshName.v
@@ -1,6 +1,6 @@
 Require Import List Arith String.
 Require Import MetaCoq.Template.All.
-Import ListNotations MonadNotation.
+Import ListNotations MCMonadNotation.
 
 
 MetaCoq Run (x <- tmFreshName ("x" ++ "y")%string ;;

--- a/test-suite/tmInferInstance.v
+++ b/test-suite/tmInferInstance.v
@@ -1,7 +1,7 @@
 Require Import MetaCoq.Template.All.
 Require Export String List.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Existing Class True.
 Existing Instance I.

--- a/test-suite/tmVariable.v
+++ b/test-suite/tmVariable.v
@@ -1,4 +1,5 @@
 From MetaCoq.Template Require Import utils All.
+Import MonadNotation.
 
 Section test.
 

--- a/test-suite/tmVariable.v
+++ b/test-suite/tmVariable.v
@@ -1,5 +1,5 @@
 From MetaCoq.Template Require Import utils All.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Section test.
 

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -1,6 +1,6 @@
 From MetaCoq.Template Require Import All.
 Require Import String List Arith.
-Import ListNotations MonadNotation.
+Import ListNotations MCMonadNotation.
 Open Scope string.
 
 Notation "'unfolded' d" :=
@@ -149,7 +149,7 @@ Polymorphic Inductive foo3@{i j k l} (A : Type@{i}) (B : Type@{j}) : Type@{k} :=
 MetaCoq Quote Recursively Definition qfoo3 := foo3.
 Compute qfoo3.
 
-Require Import MetaCoq.Template.monad_utils. Import MonadNotation.
+Require Import MetaCoq.Template.monad_utils. Import MCMonadNotation.
 Require Import MetaCoq.Template.TemplateMonad.Core.
 
 MetaCoq Run (tmQuoteInductive (cp "foo") >>= tmPrint).

--- a/translations/param_binary.v
+++ b/translations/param_binary.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Local Infix "<=" := Nat.leb.
 

--- a/translations/param_binary.v
+++ b/translations/param_binary.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils.
-
+Import MonadNotation.
 
 Local Infix "<=" := Nat.leb.
 

--- a/translations/param_cheap_packed.v
+++ b/translations/param_cheap_packed.v
@@ -2,7 +2,7 @@
 From MetaCoq.Template Require Import utils All Checker.
 From MetaCoq.Translations Require Import translation_utils sigma.
 
-Import MonadNotation.
+Import MCMonadNotation.
 Local Existing Instance config.default_checker_flags.
 Local Existing Instance default_fuel.
 

--- a/translations/param_cheap_packed.v
+++ b/translations/param_cheap_packed.v
@@ -2,6 +2,7 @@
 From MetaCoq.Template Require Import utils All Checker.
 From MetaCoq.Translations Require Import translation_utils sigma.
 
+Import MonadNotation.
 Local Existing Instance config.default_checker_flags.
 Local Existing Instance default_fuel.
 

--- a/translations/param_generous_packed.v
+++ b/translations/param_generous_packed.v
@@ -2,7 +2,7 @@
 From MetaCoq.Template Require Import utils Checker All.
 From MetaCoq.Translations Require Import translation_utils MiniHoTT_paths.
 
-Import MonadNotation.
+Import MCMonadNotation.
 
 Reserved Notation "'tsl_ty_param'".
 

--- a/translations/param_generous_packed.v
+++ b/translations/param_generous_packed.v
@@ -2,6 +2,7 @@
 From MetaCoq.Template Require Import utils Checker All.
 From MetaCoq.Translations Require Import translation_utils MiniHoTT_paths.
 
+Import MonadNotation.
 
 Reserved Notation "'tsl_ty_param'".
 

--- a/translations/param_original.v
+++ b/translations/param_original.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Local Infix "<=" := Nat.leb.
 

--- a/translations/param_original.v
+++ b/translations/param_original.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils.
-
+Import MonadNotation.
 
 Local Infix "<=" := Nat.leb.
 

--- a/translations/sigma.v
+++ b/translations/sigma.v
@@ -2,7 +2,7 @@
 From MetaCoq.Template Require Import utils All.
 
 Local Set Primitive Projections.
-Import MonadNotation.
+Import MCMonadNotation.
 
 #[universes(template)]
 Record sigma A B :=

--- a/translations/sigma.v
+++ b/translations/sigma.v
@@ -2,6 +2,7 @@
 From MetaCoq.Template Require Import utils All.
 
 Local Set Primitive Projections.
+Import MonadNotation.
 
 #[universes(template)]
 Record sigma A B :=

--- a/translations/standard_model.v
+++ b/translations/standard_model.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils sigma.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Infix "<=" := Nat.leb.
 

--- a/translations/standard_model.v
+++ b/translations/standard_model.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils sigma.
-
+Import MonadNotation.
 
 Infix "<=" := Nat.leb.
 

--- a/translations/times_bool_fun.v
+++ b/translations/times_bool_fun.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All Checker.
 From MetaCoq.Translations Require Import translation_utils MiniHoTT.
-
+Import MonadNotation.
 
 Unset Strict Unquote Universe Mode.
 

--- a/translations/times_bool_fun.v
+++ b/translations/times_bool_fun.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All Checker.
 From MetaCoq.Translations Require Import translation_utils MiniHoTT.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Unset Strict Unquote Universe Mode.
 

--- a/translations/times_bool_fun2.v
+++ b/translations/times_bool_fun2.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils times_bool_fun MiniHoTT.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Unset Strict Unquote Universe Mode.
 Unset Universe Checking.

--- a/translations/times_bool_fun2.v
+++ b/translations/times_bool_fun2.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
 From MetaCoq.Translations Require Import translation_utils times_bool_fun MiniHoTT.
+Import MonadNotation.
 
 Unset Strict Unquote Universe Mode.
 Unset Universe Checking.

--- a/translations/translation_utils.v
+++ b/translations/translation_utils.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils Checker All.
-Import MonadNotation.
+Import MCMonadNotation.
 
 (* Should be in AstUtils probably *)
 Fixpoint subst_app (t : term) (us : list term) : term :=

--- a/translations/translation_utils.v
+++ b/translations/translation_utils.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils Checker All.
+Import MonadNotation.
 
 (* Should be in AstUtils probably *)
 Fixpoint subst_app (t : term) (us : list term) : term :=


### PR DESCRIPTION
This PR

- removes all exports on the `MonadNotation` module and adds imports in the files using monad notation
- renames the module to `MCMonadNotation`

This minimises clashes with `coq-ext-lib`, from where our monad notations are copy-pasted. The two changes are in separate commits. In case we merge this, I'd hope that the commits can be cherry-picked to other branches.