### PR TITLE
Fix "equiv" notation level for compat with other developments

### DIFF
--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -1466,9 +1466,9 @@ Qed.
 
 Definition upto_names := eq_term_upto_univ [] eq eq.
 
-Infix "≡" := upto_names (at level 60).
+Infix "≡" := upto_names (at level 70).
 
-Infix "≡'" := (eq_term_upto_univ [] eq eq) (at level 60).
+Infix "≡'" := (eq_term_upto_univ [] eq eq) (at level 70).
 Notation upto_names' := (eq_term_upto_univ [] eq eq).
 
 Instance upto_names_ref : Reflexive upto_names.


### PR DESCRIPTION
Reported here: https://coq.zulipchat.com/#narrow/stream/237658-MetaCoq/topic/Notation.20clash.20with.20Int63