### PR TITLE
Adapting to Coq PR #14686: define parameter_entry as a record type

### DIFF
--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -95,9 +95,13 @@ let tmDefinition (nm : ident) ?poly:(poly=false) ?opaque:(opaque=false) (typ : t
 
 let tmAxiom (nm : ident) ?poly:(poly=false) (typ : term) : kername tm =
   fun ~st env evm success _fail ->
+    let open Entries in
     let param =
-      let entry = Evd.univ_entry ~poly evm
-       in Declare.ParameterEntry (None, (typ, entry), None)
+      let entry = { parameter_entry_secctx = None;
+                    parameter_entry_type = typ;
+                    parameter_entry_universes = Evd.univ_entry ~poly evm;
+                    parameter_entry_inline_code = None }
+       in Declare.ParameterEntry entry
     in
     let n =
       Declare.declare_constant ~name:nm
@@ -190,8 +194,10 @@ let _constant_entry_of_cb (cb : Declarations.constant_body) =
     const_entry_opaque = opaque;
     const_entry_inline_code = cb.const_inline_code }
   in
-  let parameter inline =
-    (secctx, (cb.const_type, universes_entry_of_decl cb.const_universes), inline)
+  let parameter inline = { parameter_entry_secctx = secctx;
+    parameter_entry_type = cb.const_type;
+    parameter_entry_universes = universes_entry_of_decl cb.const_universes;
+    parameter_entry_inline_code = inline }
   in
   match cb.const_body with
   | Def b -> DefinitionEntry (with_body_opaque (Mod_subst.force_constr b) false)

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -360,7 +360,11 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
       let name = unquote_ident (reduce_all env evm name) in
       let evm, typ = (match unquote_option s with Some s -> let red = unquote_reduction_strategy env evm s in Plugin_core.reduce env evm red typ | None -> evm, typ) in
       let univs = Evd.univ_entry ~poly evm in
-      let param = Declare.ParameterEntry (None, (typ, univs), None) in
+      let entry = { parameter_entry_secctx = None;
+                    parameter_entry_type = typ;
+                    parameter_entry_universes = univs;
+                    parameter_entry_inline_code = None } in
+      let param = Declare.ParameterEntry entry in
       let n = Declare.declare_constant ~name ~kind:Decls.(IsDefinition Definition) param in
       let env = Global.env () in
       k ~st env evm (Constr.mkConst n)


### PR DESCRIPTION
We consequently adapt a few occurrences, hopefully trying to respect the local indentation style (tell me if different wishes).

This has to be merged synchrounously with coq/coq#14686.