### PR TITLE
Adapting to Coq PR #14692: UContext now includes the names by default

### DIFF
--- a/safechecker/src/g_metacoq_safechecker.mlg
+++ b/safechecker/src/g_metacoq_safechecker.mlg
@@ -69,7 +69,7 @@ let retypecheck_term_dependencies env gr =
     let fake_inst = Univ.Instance.of_array (Array.mapi fake_level names) in
     let cu = (c, fake_inst) in
     let cbody, ctype, cstrs = Environ.constant_value_and_type env cu in
-    let env' = Environ.push_context (Univ.UContext.make (fake_inst, cstrs)) env in
+    let env' = Environ.push_context (Univ.UContext.make names (fake_inst, cstrs)) env in
     typecheck env' ctype;
     Option.iter (typecheck env') cbody
   in

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -166,8 +166,8 @@ Section Typecheck.
     := match uctx with
        | Monomorphic_ctx _ =>
          check_eq_nat #|u| 0 (Msg "monomorphic instance should be of length 0")
-       | Polymorphic_ctx (inst, cstrs) =>
-         let '(inst, cstrs) := AUContext.repr (inst, cstrs) in
+       | Polymorphic_ctx (inst, cstrs)  =>
+         let '(_, (inst, cstrs)) := AUContext.repr (inst, cstrs)  in
          check_eq_true (forallb (fun l => LevelSet.mem l (uGraph.wGraph.V G)) u)
                        (Msg "undeclared level in instance") ;;
          X <- check_eq_nat #|u| #|inst|

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -190,9 +190,10 @@ struct
     | Univ.Variance.Invariant -> Universes0.Variance.Invariant
 
   let quote_univ_context (uctx : Univ.UContext.t) : quoted_univ_context =
+    let names = CArray.map_to_list quote_name (Univ.UContext.names uctx)  in
     let levels = Univ.UContext.instance uctx  in
     let constraints = Univ.UContext.constraints uctx in
-    (quote_univ_instance levels, quote_univ_constraints constraints)
+    (names, (quote_univ_instance levels, quote_univ_constraints constraints))
 
   let quote_univ_contextset (uctx : Univ.ContextSet.t) : quoted_univ_contextset =
     (* CHECKME: is is safe to assume that there will be no Prop or SProp? *)
@@ -373,7 +374,7 @@ struct
        let k = (quote_int (k - 1)) in
        ConstructRef (quote_inductive (kn,n), k)
 
-  let mkPolymorphic_entry names c = Universes0.Polymorphic_entry (names, c)
+  let mkPolymorphic_entry c = Universes0.Polymorphic_entry c
   let mkMonomorphic_entry c = Universes0.Monomorphic_entry c
 
 end

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -183,6 +183,7 @@ struct
   let cMonomorphic_ctx = ast "Monomorphic_ctx"
   let cPolymorphic_ctx = ast "Polymorphic_ctx"
   let tUContext = ast "UContext.t"
+  let tUContextmake' = ast "UContext.make'"
   let tAUContext = ast "AUContext.t"
   let tUContextmake = ast "UContext.make"
   let tAUContextmake = ast "AUContext.make"

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -92,7 +92,7 @@ sig
   val quote_abstract_univ_context : Univ.AUContext.t -> quoted_abstract_univ_context
 
   val mkMonomorphic_entry : quoted_univ_contextset -> quoted_universes_entry
-  val mkPolymorphic_entry : quoted_name list -> quoted_univ_context -> quoted_universes_entry
+  val mkPolymorphic_entry : quoted_univ_context -> quoted_universes_entry
 
   val mkMonomorphic_ctx : quoted_univ_contextset -> quoted_universes_decl
   val mkPolymorphic_ctx : quoted_abstract_univ_context -> quoted_universes_decl
@@ -154,8 +154,7 @@ struct
 
   let quote_universes_entry = function
     | Monomorphic_entry ctx -> Q.mkMonomorphic_entry (Q.quote_univ_contextset ctx)
-    | Polymorphic_entry (names, ctx) ->
-      Q.mkPolymorphic_entry (CArray.map_to_list Q.quote_name names) (Q.quote_univ_context ctx)
+    | Polymorphic_entry ctx -> Q.mkPolymorphic_entry (Q.quote_univ_context ctx)
 
   let quote_universes_decl = function
     | Monomorphic ctx -> Q.mkMonomorphic_ctx (Q.quote_univ_contextset ctx)
@@ -541,8 +540,7 @@ since  [absrt_info] is a private type *)
   let quote_constant_entry bypass env evm cd =
     let (ty, body) = quote_constant_body_aux bypass env evm cd in
     let uctx = match cd.const_universes with
-      | Polymorphic auctx ->
-        Polymorphic_entry (Univ.AUContext.names auctx, Univ.AUContext.repr auctx)
+      | Polymorphic auctx -> Polymorphic_entry (Univ.AUContext.repr auctx)
       | Monomorphic ctx -> Monomorphic_entry ctx
     in
     let univs = quote_universes_entry uctx in

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -155,11 +155,13 @@ let denote_names evm trm : _ * Name.t array =
 
 let denote_ucontext evm trm (* of type UContext.t *) : _ * UContext.t =
   let l, c = unquote_pair trm in
+  let evm, names = denote_names evm l in
+  let l, c = unquote_pair c in
   let l = unquote_list l in
   let evm, vars = map_evm unquote_level evm l in
-  let vars = Instance.of_array (Array.of_list vars) in
   let evm, c = unquote_constraints evm c in
-  evm, (UContext.make (vars, c))
+  let inst = Instance.of_array (Array.of_list vars) in
+  evm, (UContext.make names (inst, c))
 
 let denote_aucontext evm trm (* of type AUContext.t *) : _ * AUContext.t =
   let i, c = unquote_pair trm in
@@ -167,7 +169,7 @@ let denote_aucontext evm trm (* of type AUContext.t *) : _ * AUContext.t =
   let vars = List.mapi (fun i l -> Level.var i) l in
   let vars = Instance.of_array (Array.of_list vars) in
   let evm, c = unquote_constraints evm c in
-  evm, snd (abstract_universes (CArray.map_of_list unquote_name l) (UContext.make (vars, c)))
+  evm, snd (abstract_universes (UContext.make (CArray.map_of_list unquote_name l) (vars, c)))
 
 
 let denote_variance evm trm (* of type Variance.t list *) : _ * Variance.t array =
@@ -187,7 +189,7 @@ type universe_context_type =
 
 let _to_entry_inductive_universes = function
   | Monomorphic_uctx ctx -> Monomorphic_entry ctx
-  | Polymorphic_uctx ctx -> Polymorphic_entry (AUContext.names ctx, AUContext.repr ctx)
+  | Polymorphic_uctx ctx -> Polymorphic_entry (AUContext.repr ctx)
 
 let _denote_universes_decl evm trm (* of type universes_decl *) : _ * universe_context_type =
   let (h, args) = app_full trm [] in
@@ -208,15 +210,11 @@ let denote_universes_entry evm trm (* of type universes_entry *) : _ * Entries.u
   | ctx :: [] -> if constr_equall h cMonomorphic_entry then
                    let evm, ctx = denote_ucontextset evm ctx in
                    evm, Monomorphic_entry ctx
+                 else if constr_equall h cPolymorphic_entry then
+                   let evm, ctx = denote_ucontext evm ctx in
+                   evm, Polymorphic_entry ctx
                  else
                    not_supported_verb trm "denote_universes_entry"
-  | names :: ctx :: [] ->
-     if constr_equall h cPolymorphic_entry then
-       let evm, names = denote_names evm names in
-       let evm, ctx = denote_ucontext evm ctx in
-        evm, Polymorphic_entry (names, ctx)
-     else
-      not_supported_verb trm "denote_universes_entry"
   | _ -> bad_term_verb trm "denote_universes_entry"
 
 

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -124,7 +124,7 @@ Fixpoint lookup_mind_decl (id : kername) (decls : global_env)
 
 Definition universes_entry_of_decl (u : universes_decl) : universes_entry :=
   match u with
-  | Polymorphic_ctx ctx => Polymorphic_entry (fst ctx) (Universes.AUContext.repr ctx)
+  | Polymorphic_ctx ctx => Polymorphic_entry (Universes.AUContext.repr ctx)
   | Monomorphic_ctx ctx => Monomorphic_entry ctx
   end.
 

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -623,7 +623,7 @@ Section Typecheck.
   Definition polymorphic_constraints u :=
     match u with
     | Monomorphic_ctx _ => ConstraintSet.empty
-    | Polymorphic_ctx ctx => snd (AUContext.repr ctx)
+    | Polymorphic_ctx ctx => snd (snd (AUContext.repr ctx))
     end.
 
   Definition lookup_constant_type cst u :=

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -138,6 +138,7 @@ Register MetaCoq.Template.Universes.ConstraintSet.add as metacoq.ast.ConstraintS
 
 Register MetaCoq.Template.Universes.UContext.t as metacoq.ast.UContext.t.
 Register MetaCoq.Template.Universes.UContext.make as metacoq.ast.UContext.make.
+Register MetaCoq.Template.Universes.UContext.make' as metacoq.ast.UContext.make'.
 Register MetaCoq.Template.Universes.AUContext.t as metacoq.ast.AUContext.t.
 Register MetaCoq.Template.Universes.AUContext.make as metacoq.ast.AUContext.make.
 

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -1239,16 +1239,18 @@ Module Instance.
 End Instance.
 
 Module UContext.
-  Definition t := Instance.t × ConstraintSet.t.
+  Definition t := list name × (Instance.t × ConstraintSet.t).
 
-  Definition make : Instance.t -> ConstraintSet.t -> t := pair.
+  Definition make' : Instance.t -> ConstraintSet.t -> Instance.t × ConstraintSet.t := pair.
 
-  Definition empty : t := (Instance.empty, ConstraintSet.empty).
+  Definition make (ids : list name) (inst_ctrs : Instance.t × ConstraintSet.t) : t := (ids, inst_ctrs).
 
-  Definition instance : t -> Instance.t := fst.
-  Definition constraints : t -> ConstraintSet.t := snd.
+  Definition empty : t := (nil, (Instance.empty, ConstraintSet.empty)).
 
-  Definition dest : t -> Instance.t * ConstraintSet.t := fun x => x.
+  Definition instance : t -> Instance.t := fun x => fst (snd x).
+  Definition constraints : t -> ConstraintSet.t := fun x => snd (snd x).
+
+  Definition dest : t -> list name × (Instance.t * ConstraintSet.t) := fun x => x.
 End UContext.
 
 Module AUContext.
@@ -1257,10 +1259,10 @@ Module AUContext.
   Definition make (ids : list name) (ctrs : ConstraintSet.t) : t := (ids, ctrs).
   Definition repr (x : t) : UContext.t :=
     let (u, cst) := x in
-    (mapi (fun i _ => Level.Var i) u, cst).
+    (u, (mapi (fun i _ => Level.Var i) u, cst)).
 
   Definition levels (uctx : t) : LevelSet.t :=
-    LevelSetProp.of_list (fst (repr uctx)).
+    LevelSetProp.of_list (fst (snd (repr uctx))).
 End AUContext.
 
 Module ContextSet.
@@ -1313,7 +1315,7 @@ Definition levels_of_udecl u :=
 Definition constraints_of_udecl u :=
   match u with
   | Monomorphic_ctx ctx => snd ctx
-  | Polymorphic_ctx ctx => snd (AUContext.repr ctx)
+  | Polymorphic_ctx ctx => snd (snd (AUContext.repr ctx))
   end.
 
 Definition univ_le_n {cf:checker_flags} n u u' := 
@@ -1859,19 +1861,19 @@ Definition string_of_universe_instance u :=
 
 Inductive universes_entry :=
 | Monomorphic_entry (ctx : ContextSet.t)
-| Polymorphic_entry (names : list name) (ctx : UContext.t).
+| Polymorphic_entry (ctx : UContext.t).
 Derive NoConfusion for universes_entry.
 
 Definition universes_entry_of_decl (u : universes_decl) : universes_entry :=
   match u with
-  | Polymorphic_ctx ctx => Polymorphic_entry (fst ctx) (Universes.AUContext.repr ctx)
+  | Polymorphic_ctx ctx => Polymorphic_entry (Universes.AUContext.repr ctx)
   | Monomorphic_ctx ctx => Monomorphic_entry ctx
   end.
 
 Definition polymorphic_instance uctx :=
   match uctx with
   | Monomorphic_ctx c => Instance.empty
-  | Polymorphic_ctx c => fst (AUContext.repr c)
+  | Polymorphic_ctx c => fst (snd (AUContext.repr c))
   end.
 
 

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -90,7 +90,7 @@ Set Printing Universes.
 Definition clean_universes_entry e :=
   match e with
   | Monomorphic_entry e => Monomorphic_entry e
-  | Polymorphic_entry names e => Polymorphic_entry (map (fun x => nAnon) names) e
+  | Polymorphic_entry (names, e) => Polymorphic_entry (map (fun x => nAnon) names, e)
   end.
 
 Definition clean_universes_decl (m : mutual_inductive_entry) : mutual_inductive_entry :=


### PR DESCRIPTION
Coq PR #14692 makes a small change to data types used to represent universes in the kernel, namely `UContext`, and, indirectly, `universes_entry`.

I realized that the template_coq part of MetaCoq had a reflection in Coq of `UContext` and `universes_entry` with ability to quote/unquote them. I also realized that the safechecker part of MetaCoq was itself relying on this reflection in Coq of `UContext` and `universes_entry` to reformulate this part of the Coq kernel in Coq.

This is an impressive and fascinating work which made me wonder about the status to give to my PR. We seemed to be arrived at a stage where the current OCaml code of the kernel and the work on a certified type-checker are intimately intertwined and that a change to one cannot be done without a change to the other.

How do you see things in the future? Are there plans to use MetaCoq as the "master" source for the kernel, and eventually, to turn Coq `univ.ml` and `entries.ml`, or part of them, into extracted modules, so as to keep them synchronous? Or do you consider MetaCoq as still too experimental and you would prefer that such PRs are still first made to Coq, with MetaCoq adapting only afterwards? Etc.

In any case if ever your view is that the current status is that the kernel of Coq, at least until further notice, is the primary source for the code, the PR has to be merged synchrounously with coq/coq#14692.

Regarding the change itself. I would say that it makes the code rather nicer in Coq, but that the benefit in MetaCoq is limited to a better symmetry between `Polymorphic_entry` and `Monomorphic_entry`. That would certainly be interesting to understand what would be the optimal representations of the pcuic data structures which make the code of both Coq and MetaCoq nice.