### PR TITLE
Adapt to coq/coq#14705 (hints.ml has its own locality type instead of reusing option locality)

### DIFF
--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -229,7 +229,7 @@ let tmInductive (mi : mutual_inductive_entry) : unit tm =
 let tmExistingInstance (gr : Names.GlobRef.t) : unit tm =
   fun ~st env evd success _fail ->
     let q = Libnames.qualid_of_path (Nametab.path_of_global gr) in
-    Classes.existing_instance Goptions.OptGlobal q None;
+    Classes.existing_instance Hints.Local q None;
     success ~st env evd ()
 
 let tmInferInstance (typ : term) : term option tm =

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -490,7 +490,7 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
     let gr = reduce_all env evm gr in
     let gr = unquote_global_reference gr in
     let q = Libnames.qualid_of_path (Nametab.path_of_global gr) in
-    Classes.existing_instance Goptions.OptGlobal q None;
+    Classes.existing_instance Hints.SuperGlobal q None;
     k ~st env evm (Lazy.force unit_tt)
   | TmInferInstance (s, typ) ->
     begin


### PR DESCRIPTION
Why do these 2 TmExistingInstance versions have different localities?