### PR TITLE
Adapt to coq/coq#14819

### DIFF
--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -20,7 +20,7 @@ Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(
 Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
 Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
-           UnivSubst Typing Checker Retyping OrderedType Logic Common Equality Classes Numeral
+           UnivSubst Typing Checker Retyping OrderedType Logic Common Equality Classes Number
            Uint63.
 Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".

--- a/pcuic/theories/Extraction.v
+++ b/pcuic/theories/Extraction.v
@@ -13,7 +13,7 @@ Require Import FSets ssreflect ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt.
    https://github.com/coq/coq/issues/7017. *)
 Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-Extract Inductive Numeral.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
+Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
 Extraction Blacklist Classes config uGraph universes Ast String List Logic Logic0 Nat Int
            UnivSubst Typing Checker Retyping OrderedType Classes equality.

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -83,7 +83,7 @@ Extract Constant Z.abs_N => "Pervasives.abs".
    https://github.com/coq/coq/issues/7017. *)
 Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-Extract Inductive Numeral.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
+Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
 Extract Constant ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".

--- a/safechecker/theories/PCUICWfReduction.v
+++ b/safechecker/theories/PCUICWfReduction.v
@@ -195,13 +195,13 @@ Section fix_sigma.
         eapply Acc_no_loop in X0. eauto.
         eapply @normalisation; eauto.
       * split. exists t'. split; eauto.
-    Grab Existential Variables.
-    - eapply red_welltyped; sq.
-      3:eapply Relation_Properties.clos_rtn1_rt in r; eassumption. all:eauto.
+    Unshelve.
+    - eapply red_welltyped; eauto; sq; eauto.
     - eapply red_welltyped in H; eauto. all:sq; eauto.
       eapply redp_red in redt'.
       now transitivity t''.
-    - eapply red_welltyped; eauto; sq; eauto.
+    - eapply red_welltyped; sq.
+      3:eapply Relation_Properties.clos_rtn1_rt in r; eassumption. all:eauto.
   Qed.
 
   Global Instance wf_hnf_subterm : WellFounded hnf_subterm_rel.
@@ -250,7 +250,7 @@ Section fix_sigma.
       destruct (term_subterm_redp X0) as [t'' [[redt' [tst' Htst']]]].
       eapply IH. eapply cored_redp. sq. eassumption. red.
       sq. right. exists tst'. now rewrite Htst'.
-    Grab Existential Variables.
+    Unshelve.
     - eapply redp_red in redt'; eapply red_welltyped; sq; eauto.
   Qed.
 

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -123,8 +123,8 @@ gen-src/mSetProperties.ml
 gen-src/mSetProperties.mli
 gen-src/nat0.ml
 gen-src/nat0.mli
-gen-src/number.ml
-gen-src/number.mli
+gen-src/number0.ml
+gen-src/number0.mli
 gen-src/orderedType0.ml
 gen-src/orderedType0.mli
 gen-src/ordersFacts.ml

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -3,7 +3,7 @@ Bool
 Equalities
 Decimal
 Hexadecimal
-Numeral0
+Number0
 Nat0
 List0
 PeanoNat

--- a/template-coq/src/monad_extraction.mlpack
+++ b/template-coq/src/monad_extraction.mlpack
@@ -15,7 +15,7 @@ Common
 Datatypes
 Decimal
 Hexadecimal
-Numeral
+Number
 Equalities
 Extractable
 List0

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -108,7 +108,7 @@ Extract Constant Equations.Init.pr2 => "snd".
 Extraction Inline Equations.Init.pr1 Equations.Init.pr2.
 
 Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
-           UnivSubst Typing Checker Retyping OrderedType Logic Common Equality UnivSubst Numeral
+           UnivSubst Typing Checker Retyping OrderedType Logic Common Equality UnivSubst Number
            Uint63.
 Set Warnings "-extraction-opaque-accessed".
 Set Warnings "-extraction-reserved-identifier".


### PR DESCRIPTION
Numeral.v was replaced by Number.v in Coq 8.13.
