### PR TITLE
Adapt to Coq PR #14846: references to inductive types in the type of constructors are directly Ind rather than Rel nodes

### DIFF
--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -330,6 +330,7 @@ struct
       in
       let envind = push_rel_context (List.rev indtys) env in
       let ref_name = Q.quote_kn (MutInd.canonical t) in
+      let ntyps = Array.length mib.mind_packets in
       let (ls,acc) =
         List.fold_left (fun (ls,acc) oib ->
           let named_ctors =
@@ -344,6 +345,7 @@ struct
             List.fold_left (fun (ls,acc) (nm,ty,ar) ->
               debug (fun () -> Pp.(str "opt_hnf_ctor_types:" ++ spc () ++
                                   bool !opt_hnf_ctor_types)) ;
+              let ty = Inductive.abstract_constructor_type_relatively_to_inductive_types_context ntyps t ty in
               let ty = if !opt_hnf_ctor_types then hnf_type (snd envind) ty else ty in
               let (ty,acc) = quote_term acc envind ty in
               ((Q.quote_ident nm, ty, Q.quote_int ar) :: ls, acc))

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -53,6 +53,7 @@ let of_mib (env : Environ.env) (t : Names.MutInd.t) (mib : Plugin_core.mutual_in
          (Context.Rel.Declaration.LocalAssum (Context.annotR (Names.Name oib.mind_typename), ty))) mib.mind_packets)
   in
   let envind = Environ.push_rel_context (List.rev indtys) env in
+  let ntyps = Array.length mib.mind_packets in
   let (ls,acc) =
     List.fold_left (fun (ls,acc) oib ->
     let named_ctors =
@@ -67,6 +68,7 @@ let of_mib (env : Environ.env) (t : Names.MutInd.t) (mib : Plugin_core.mutual_in
       List.fold_left (fun (ls,acc) (nm,ty,ar) ->
           Tm_util.debug (fun () -> Pp.(str "opt_hnf_ctor_types:" ++ spc () ++
                                       bool !Quoter.opt_hnf_ctor_types)) ;
+          let ty = Inductive.abstract_constructor_type_relatively_to_inductive_types_context ntyps t ty in
           let ty = if !Quoter.opt_hnf_ctor_types then Quoter.hnf_type envind ty else ty in
           let ty = quote_term acc ty in
           ((quote_ident nm, ty, quote_int ar) :: ls, acc))


### PR DESCRIPTION
We insert a translation function which emulates the previous behavior.

This is to be merged synchronously with coq/coq#14846.