### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -788,7 +788,7 @@ Proof.
         2:eapply PCUICWeakeningEnv.weaken_env_prop_typing.
         unfold on_constant_decl in isdecl'. rewrite e in isdecl'. red in isdecl'.
         unfold declared_constant in isdecl''.
-        now eapply typing_subst_instance_decl with (Σ0 := Σ) (Γ := []); eauto.
+        now eapply @typing_subst_instance_decl with (Σ := Σ) (Γ := []); eauto.
       * assert (isdecl'' := isdecl').
         eapply PCUICWeakeningEnv.declared_constant_inv in isdecl'; [| |now eauto|now apply wfΣ].
         unfold on_constant_decl in isdecl'. rewrite e in isdecl'. cbn in *.

--- a/pcuic/theories/PCUICNameless.v
+++ b/pcuic/theories/PCUICNameless.v
@@ -1229,9 +1229,9 @@ Proof.
       rewrite global_ext_levels_nlg global_ext_constraints_nlg; assumption.
   - destruct cdecl as [[id t] n]. cbn.
     rewrite nl_inds.
-    eapply type_Construct with (idecl0:=nl_one_inductive_body idecl)
-                               (mdecl0:=nl_mutual_inductive_body mdecl)
-                               (cdecl:=(id, nl t, n))
+    eapply @type_Construct with (idecl:=nl_one_inductive_body idecl)
+                                (mdecl:=nl_mutual_inductive_body mdecl)
+                                (cdecl:=(id, nl t, n))
     ; eauto using nlg_wf_local.
     + destruct isdecl as [[H1 H2] H3]. repeat split.
       * eapply lookup_env_nlg in H1. eapply H1.
@@ -1242,10 +1242,10 @@ Proof.
     + unfold consistent_instance_ext.
       rewrite global_ext_levels_nlg global_ext_constraints_nlg; assumption.
   - rewrite nl_mkApps map_app map_skipn. cbn.
-    eapply type_Case with  (mdecl0:=nl_mutual_inductive_body mdecl)
-                           (idecl0:=nl_one_inductive_body idecl)
-                           (btys0:=map (on_snd nl) btys)
-                           (u0:=u)
+    eapply @type_Case with  (mdecl:=nl_mutual_inductive_body mdecl)
+                            (idecl:=nl_one_inductive_body idecl)
+                            (btys:=map (on_snd nl) btys)
+                            (u:=u)
     ; tea.
     + destruct isdecl as [HH1 HH2]. split.
       * eapply lookup_env_nlg in HH1. eapply HH1.
@@ -1323,9 +1323,9 @@ Proof.
       destruct s as [s [Hs IH]] ; exists s; eauto.
   - destruct pdecl as [pdecl1 pdecl2]; simpl.
     rewrite map_rev.
-    eapply type_Proj with (mdecl0:=nl_mutual_inductive_body mdecl)
-                          (idecl0:=nl_one_inductive_body idecl)
-                          (pdecl:=(pdecl1, nl pdecl2)).
+    eapply @type_Proj with (mdecl:=nl_mutual_inductive_body mdecl)
+                           (idecl:=nl_one_inductive_body idecl)
+                           (pdecl:=(pdecl1, nl pdecl2)).
     + destruct isdecl as [[H1 H2] [H3 H4]]. repeat split.
       * eapply lookup_env_nlg in H1. eapply H1.
       * replace (ind_bodies (nl_mutual_inductive_body mdecl)) with

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -297,7 +297,7 @@ Proof.
     2-3: rewrite lift_subst_instance_constr lift_closed; cbnr; apply H'.
     eapply weakening; tea.
     now rewrite app_context_nil_l.
-    eapply typing_subst_instance_decl with (Γ0:=[]); tea.
+    eapply @typing_subst_instance_decl with (Γ:=[]); tea.
 
   - (* iota reduction *)
     subst npar.

--- a/pcuic/theories/PCUICUnivSubstitution.v
+++ b/pcuic/theories/PCUICUnivSubstitution.v
@@ -1603,9 +1603,9 @@ Proof.
            X2 H1 X3 notCoFinite X4 btys H2 X5 u0 univs X6 HSub H4.
     rewrite subst_instance_constr_mkApps in *.
     rewrite map_app. cbn. rewrite map_skipn.
-    eapply type_Case with (u1:=subst_instance_instance u0 u)
-                          (ps0 :=subst_instance_univ u0 ps)
-                          (btys0:=map (on_snd (subst_instance_constr u0)) btys);
+    eapply @type_Case with (u:=subst_instance_instance u0 u)
+                           (ps :=subst_instance_univ u0 ps)
+                           (btys:=map (on_snd (subst_instance_constr u0)) btys);
       eauto.
     + clear -H0. rewrite firstn_map. unfold build_case_predicate_type. simpl.
       rewrite <- subst_instance_constr_two, <- subst_instance_context_two.

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -624,7 +624,7 @@ Section Typecheck.
         eapply PCUICInductives.isType_it_mkProd_or_LetIn_inv in typ_p; eauto.
         apply isType_wf_universes in typ_p; auto.
         now exact (elimT wf_universe_reflect typ_p). }
-    eapply type_Case with (pty0:=pty'); tea.
+    eapply @type_Case with (pty:=pty'); tea.
     - reflexivity.
     - symmetry; eassumption.
     - destruct isCoFinite; auto.


### PR DESCRIPTION
Should be backwards compatible.