### PR TITLE
Adapt to the removal of first argument of PrivatePolymorphic in Coq #14727

### DIFF
--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -443,7 +443,7 @@ struct
                   let c, univs = Global.force_proof Library.indirect_accessor lc in
                   let () = match univs with
                   | Opaqueproof.PrivateMonomorphic () -> ()
-                  | Opaqueproof.PrivatePolymorphic (n, csts) -> if not (Univ.ContextSet.is_empty csts && Int.equal n 0) then 
+                  | Opaqueproof.PrivatePolymorphic csts -> if not (Univ.ContextSet.is_empty csts) then
                     CErrors.user_err Pp.(str "Private polymorphic universes not supported by TemplateCoq")
                   in Some c
                 else None

--- a/test-suite/safechecker_test.v
+++ b/test-suite/safechecker_test.v
@@ -568,8 +568,7 @@ MetaCoq SafeCheck @issect'.
 MetaCoq SafeCheck @ap_pp.
 MetaCoq CoqCheck ap_pp.
 
-(* FIXME TODO Private polymorphic universes *)
-Fail MetaCoq SafeCheck @isequiv_adjointify.
+MetaCoq SafeCheck @isequiv_adjointify.
 MetaCoq CoqCheck isequiv_adjointify.
 
 MetaCoq SafeCheck @IsEquiv.


### PR DESCRIPTION
The first argument of PrivatePolymorphic happened to be useless. It is removed as a side product of the reworking of cooking in #14727. To be merged synchronously.

A side effect of removing the first argument of PrivatePolymorphic is that the test which failed with coq/coq#14903 does not fail anymore. I did not investigate why and a confirmation that it is expected (or not) would be nice. See @ppedrot's https://github.com/coq/coq/pull/14903#issuecomment-924024025 about the failing test.