### PR TITLE
Adapt to coq/coq#15071 (namegen doesn't avoid names from imported modules)

### DIFF
--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -1162,21 +1162,21 @@ Lemma erases_mutual {Σ mdecl m} :
   declared_minductive Σ mdecl m ->
   erases_mutual_inductive_body m (erase_mutual_inductive_body m).
 Proof.
-  destruct m; constructor; simpl; auto.
+  destruct m as [??? ind_bodies ??]; constructor; simpl; auto.
   eapply on_declared_minductive in H; auto. simpl in H. clear X.
   eapply onInductives in H; simpl in *.
   assert (Alli (fun i oib => 
-    match destArity [] oib.(ind_type) with Some _ => True | None => False end) 0 ind_bodies0).
+    match destArity [] oib.(ind_type) with Some _ => True | None => False end) 0 ind_bodies).
   { eapply Alli_impl; eauto.
     simpl. intros n x []. simpl in *. rewrite ind_arity_eq.
     rewrite !destArity_it_mkProd_or_LetIn /= //. } clear H.
   induction X; constructor; auto.
-  destruct hd; constructor; simpl; auto.
+  destruct hd as [????? ind_ctors ind_projs ?]; constructor; simpl; auto.
   clear.
-  induction ind_ctors0; constructor; auto.
+  induction ind_ctors; constructor; auto.
   cbn in *.
   intuition auto.
-  induction ind_projs0; constructor; auto.
+  induction ind_projs; constructor; auto.
   destruct a; auto.
   unfold isPropositionalArity.
   destruct destArity as [[? ?]|] eqn:da; auto.

--- a/pcuic/theories/PCUICAstUtils.v
+++ b/pcuic/theories/PCUICAstUtils.v
@@ -232,16 +232,16 @@ Proof.
     exact (List.map string_of_aname names).
     exact (List.map LocalAssum types).
   - refine (List.map _ decl.(ind_bodies)).
-    intros [].
-    refine {| mind_entry_typename := ind_name0;
-              mind_entry_arity := remove_arity decl.(ind_npars) ind_type0;
+    intros [ind_name ?? ind_type ? ind_ctors].
+    refine {| mind_entry_typename := ind_name;
+              mind_entry_arity := remove_arity decl.(ind_npars) ind_type;
               mind_entry_template := false;
               mind_entry_consnames := _;
               mind_entry_lc := _;
             |}.
-    refine (List.map (fun x => cstr_name x) ind_ctors0).
+    refine (List.map (fun x => cstr_name x) ind_ctors).
     refine (List.map (fun x => remove_arity decl.(ind_npars)
-                                                (cstr_type x)) ind_ctors0).
+                                                (cstr_type x)) ind_ctors).
 Defined.
 
 Fixpoint decompose_prod_assum (Γ : context) (t : term) : context * term :=

--- a/pcuic/theories/PCUICClosed.v
+++ b/pcuic/theories/PCUICClosed.v
@@ -677,7 +677,7 @@ Proof.
   intros X X0.
   simpl in *. induction X0; constructor; auto.
   clear IHX0. destruct d; simpl.
-  - destruct c; simpl. destruct cst_body0; simpl in *; now eapply X.
+  - destruct c as [? [] ?]; simpl in *; now eapply X.
   - red in o. simpl in *.
     destruct o0 as [onI onP onNP].
     constructor; auto.
@@ -1227,7 +1227,7 @@ Proof.
   - rewrite closedn_subst_instance.
     eapply lookup_on_global_env in X0; eauto.
     destruct X0 as [Σ' [HΣ' IH]].
-    repeat red in IH. destruct decl, cst_body0. simpl in *.
+    repeat red in IH. destruct decl as [? [] ?]. simpl in *.
     rewrite -> andb_and in IH. intuition auto.
     eauto using closed_upwards with arith.
     simpl in *.

--- a/pcuic/theories/PCUICGlobalEnv.v
+++ b/pcuic/theories/PCUICGlobalEnv.v
@@ -98,28 +98,24 @@ Proof.
        -- inversion HΣ; subst.
           destruct H2 as [HH1 [HH HH3]].
           subst udecl. destruct d as [decl|decl]; simpl in *.
-          ++ destruct decl; simpl in *.
-             destruct cst_universes0 ; [
-               eapply (HH (l, ct, l') Hctr)
+          ++ destruct decl as [?? []]; simpl in *;
+             [ eapply (HH (l, ct, l') Hctr)
              | apply ConstraintSetFact.empty_iff in Hctr ; contradiction
              ].
-          ++ destruct decl. simpl in *.
-             destruct ind_universes0 ; [
-               eapply (HH (l, ct, l') Hctr)
+          ++ destruct decl as [???? [] ?]; simpl in *;
+             [ eapply (HH (l, ct, l') Hctr)
              | apply ConstraintSetFact.empty_iff in Hctr; contradiction
              ].
        -- inversion HΣ. subst.
           destruct H2 as [HH1 [HH HH3]].
           subst udecl. destruct d as [decl|decl].
           all: simpl in *.
-          ++ destruct decl. simpl in *.
-             destruct cst_universes0 ; [
-               eapply (HH (l, ct, l') Hctr)
+          ++ destruct decl as [?? []]; simpl in *;
+             [ eapply (HH (l, ct, l') Hctr)
              | apply ConstraintSetFact.empty_iff in Hctr; contradiction
              ].
-          ++ destruct decl. simpl in *.
-             destruct ind_universes0; [
-               eapply (HH (l, ct, l') Hctr)
+          ++ destruct decl as [???? [] ?]; simpl in *;
+             [ eapply (HH (l, ct, l') Hctr)
              | apply ConstraintSetFact.empty_iff in Hctr; contradiction
              ].
      * inversion HΣ. subst.
@@ -157,9 +153,9 @@ Proof.
     apply ConstraintSet.union_spec in Hc. destruct Hc.
     apply ConstraintSet.union_spec; simpl.
     + left. destruct d.
-      destruct c, cst_universes0. assumption.
+      destruct c as [?? []]. assumption.
       apply ConstraintSetFact.empty_iff in H; contradiction.
-      destruct m, ind_universes0. assumption.
+      destruct m as [???? [] ?]. assumption.
       apply ConstraintSetFact.empty_iff in H; contradiction.
     + apply ConstraintSet.union_spec; simpl.
       now right.

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -426,15 +426,15 @@ Proof.
     rewrite inds_spec.
     rewrite map_rev.
     rewrite map_mapi.
-    destruct mdecl.
+    destruct mdecl as [? ? ? ind_bodies].
     cbn.
     f_equal.
     remember 0 as k.
-    induction ind_bodies0 in k |- *.
+    induction ind_bodies in k |- *.
     + reflexivity.
     + cbn.
       f_equal.
-      apply IHind_bodies0.
+      apply IHind_bodies.
   - rewrite trans_subst_instance.
     f_equal.
 Qed.
@@ -1332,7 +1332,7 @@ Proof.
     
   - rewrite trans_subst_instance. econstructor.
     apply (trans_declared_constant _ c decl H).
-    destruct decl. now simpl in *; subst cst_body0.
+    destruct decl as [? cst_body ?]; now simpl in *; subst cst_body.
 
   - rewrite trans_mkApps; eauto with wf.
     simpl. constructor; now rewrite nth_error_map H.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -816,8 +816,7 @@ Proof.
       apply IH'; auto.
     * simpl. simpl in *.
       destruct d; simpl.
-      + destruct c; simpl in *.
-        destruct cst_body0; simpl in *.
+      + destruct c as [? [] ?]; simpl in *.
         simpl.
         red in Xg; simpl in Xg. intros. red. simpl.
         specialize (IH (existT _ (Σ, udecl) (existT _ X (existT _ [] (existT _ _ (existT _ _ Xg)))))).

--- a/pcuic/theories/PCUICWeakening.v
+++ b/pcuic/theories/PCUICWeakening.v
@@ -331,10 +331,10 @@ Lemma lift_declared_constant `{checker_flags} Σ cst decl n k :
   decl = map_constant_body (lift n k) decl.
 Proof.
   intros wf declc.
-  rewrite /map_constant_body; destruct decl; simpl; f_equal; rewrite ?lift_rename.
+  rewrite /map_constant_body; destruct decl as [? cst_body ?]; simpl; f_equal; rewrite ?lift_rename.
   - eapply declared_constant_closed_type in declc; eauto.
     now rewrite rename_closed.
-  - destruct cst_body0 eqn:cb => /= //.
+  - destruct cst_body eqn:cb => /= //.
     f_equal.
     eapply declared_constant_closed_body in declc; simpl; eauto.
     now rewrite lift_rename rename_closed.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -575,7 +575,7 @@ Proof.
   intros HPΣ wfΣ' Hext Hdecl.
   destruct decl.
   1:{
-    destruct c. destruct cst_body0.
+    destruct c as [? [] ?].
     - simpl in *.
       red in Hdecl |- *. simpl in *.
       eapply HPΣ; eauto.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -2897,11 +2897,11 @@ Proof.
     change (Typing.wf Σ) in X0.
     have wfdecl := on_global_decl_wf (Σ := (Σ, udecl)) X0 o0.
     destruct d; simpl in *.
-    * destruct c; simpl. destruct cst_body0; simpl in *.
+    * destruct c as [cst_typ [] cst_univs]; simpl in *.
       red in o |- *. simpl in *. 
-      apply (X (Σ, cst_universes0) [] t (Some cst_type0)); auto.
+      apply (X (Σ, cst_univs) [] t (Some cst_typ)); auto.
       red in o0 |- *. simpl in *.
-      now apply (X (Σ, cst_universes0) [] cst_type0 None).
+      now apply (X (Σ, cst_univs) [] cst_typ None).
     * destruct o0 as [onI onP onNP].
       constructor; auto.
       -- have wfpars := on_global_inductive_wf_params wfdecl.
@@ -3025,8 +3025,8 @@ Proof.
               eapply trans_cstr_respects_variance => //.
             + destruct lets_in_constructor_types.
               ++ red in on_lets_in_type. red. rewrite <- on_lets_in_type.
-                 destruct x. clear. cbn.
-                 induction cstr_args0.
+                 destruct x as [? cstr_args]. clear. cbn.
+                 induction cstr_args.
                  +++ reflexivity.
                  +++ cbn. destruct (decl_body a); cbn; eauto.
               ++ eauto.

--- a/safechecker/theories/PCUICConsistency.v
+++ b/safechecker/theories/PCUICConsistency.v
@@ -103,9 +103,8 @@ Proof.
   induction t; intros axfree_args all_true; cbn; auto.
   - destruct lookup_env eqn:find; auto.
     destruct g; auto.
-    destruct c; auto.
-    apply axfree in find; cbn in *.
-    now destruct cst_body0.
+    destruct c as [? [] ?]; auto.
+    now apply axfree in find; cbn in *.
   - destruct nth_error; auto.
     rewrite nth_nth_error.
     destruct nth_error eqn:nth; auto.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -2106,8 +2106,8 @@ Section CheckEnv.
     assert (eq: monomorphic_constraints_decl g
                 = constraints_of_udecl (universes_decl_of_decl g)). {
       destruct g.
-      destruct c, cst_universes0; try discriminate; reflexivity.
-      destruct m, ind_universes0; try discriminate; reflexivity. }
+      destruct c as [?? []]; try discriminate; reflexivity.
+      destruct m as [???? [] ?]; try discriminate; reflexivity. }
     rewrite eq; clear eq. 
     case_eq (gc_of_constraints (global_constraints Σ));
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
@@ -2117,8 +2117,8 @@ Section CheckEnv.
     subst G. unfold global_ext_levels; simpl.
     assert (eq: monomorphic_levels_decl g
                 = levels_of_udecl (universes_decl_of_decl g)). {
-      destruct g. destruct c, cst_universes0; try discriminate; reflexivity.
-      destruct m, ind_universes0; try discriminate; reflexivity. }
+      destruct g. destruct c as [?? []]; try discriminate; reflexivity.
+      destruct m as [???? [] ?]; try discriminate; reflexivity. }
     rewrite eq. simpl. rewrite add_uctx_make_graph.
     apply graph_eq; try reflexivity.
     simpl. now rewrite H1.
@@ -2128,12 +2128,12 @@ Section CheckEnv.
     split; sq. 2: constructor; tas.
     unfold global_uctx; simpl.
     assert (eq1: monomorphic_levels_decl g = LevelSet.empty). {
-      destruct g. destruct c, cst_universes0; try discriminate; reflexivity.
-      destruct m, ind_universes0; try discriminate; reflexivity. }
+      destruct g. destruct c as [?? []]; try discriminate; reflexivity.
+      destruct m as [???? [] ?]; try discriminate; reflexivity. }
     rewrite eq1; clear eq1.
     assert (eq1: monomorphic_constraints_decl g = ConstraintSet.empty). {
-      destruct g. destruct c, cst_universes0; try discriminate; reflexivity.
-      destruct m, ind_universes0; try discriminate; reflexivity. }
+      destruct g. destruct c as [?? []]; try discriminate; reflexivity.
+      destruct m as [???? [] ?]; try discriminate; reflexivity. }
     rewrite eq1; clear eq1.
     now rewrite LevelSet_union_empty CS_union_empty.
   Qed.

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -218,14 +218,14 @@ apply (List.firstn decl.(ind_npars)) in names.
 apply (List.firstn decl.(ind_npars)) in types.
   refine (map (fun '(x, ty) => vass x ty) (combine names types)).
   - refine (List.map _ decl.(ind_bodies)).
-    intros [].
-    refine {| mind_entry_typename := ind_name0;
-              mind_entry_arity := remove_arity decl.(ind_npars) ind_type0;
+    intros [ind_name ?? ind_type ? ind_ctors].
+    refine {| mind_entry_typename := ind_name;
+              mind_entry_arity := remove_arity decl.(ind_npars) ind_type;
               mind_entry_consnames := _;
               mind_entry_lc := _;
             |}.
-    refine (List.map (fun x => cstr_name x) ind_ctors0).
-    refine (List.map (fun x => remove_arity decl.(ind_npars) (cstr_type x)) ind_ctors0).
+    refine (List.map (fun x => cstr_name x) ind_ctors).
+    refine (List.map (fun x => remove_arity decl.(ind_npars) (cstr_type x)) ind_ctors).
 Defined.
 
 Fixpoint strip_casts t :=

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -986,7 +986,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
     assert (X' := fun Γ t T => X (Σ, udecl0) Γ t T wfΣ X0 IHX0); clear X.
     rename X' into X.
     clear IHX0. destruct d; simpl.
-    - destruct c; simpl. destruct cst_body0; simpl in *; now eapply X.
+    - destruct c as [?[]]; simpl in *; now eapply X.
     - red in o. simpl in *.
       destruct o0 as [onI onP onNP].
       constructor; auto.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -1265,8 +1265,8 @@ Proof.
     apply IH'; auto.
   - simpl. simpl in *.
     destruct d.
-    + destruct c; simpl in *.
-      destruct cst_body0; simpl in *.
+    + destruct c as [? cst_body ?]; simpl in *.
+      destruct cst_body; simpl in *.
       simpl.
       intros. red in Xg. simpl in Xg.
       specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Xg)))))).

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -44,7 +44,7 @@ Lemma on_global_decl_impl `{checker_flags} Σ P Q kn d :
 Proof.
   intros X X0 o.
   destruct d; simpl.
-  - destruct c; simpl. destruct cst_body0; simpl in *.
+  - destruct c as [? cst_body ?]; simpl. destruct cst_body; simpl in *.
     red in o |- *. simpl in *. now eapply X.
     red in o |- *. simpl in *. now eapply X.
   - simpl in *.
@@ -755,8 +755,8 @@ Section WfRed.
     - apply wf_subst_instance.
       unfold declared_constant in H.
       eapply lookup_on_global_env in H as [Σ' [onΣ' [ext prf]]]; eauto.
-      destruct decl; simpl in *.
-      subst cst_body0; simpl in *; unfold on_constant_decl in prf; cbn in prf.
+      destruct decl as [? cst_body ?]; simpl in *.
+      subst cst_body; simpl in *; unfold on_constant_decl in prf; cbn in prf.
       unfold wf_decl_pred in prf. intuition eauto using wf_extends.
     - apply wf_mkApps_inv in X.
       eapply nth_error_all in X; eauto.
@@ -962,7 +962,7 @@ Section TypingWf.
       apply wf_subst. now destruct p0. destruct p. now inv w.
     - split. wf. apply wf_subst_instance. wf.
       destruct (lookup_on_global_env X H) as [Σ' [wfΣ' [ext prf]]]; eauto.
-      red in prf. destruct decl; destruct cst_body0; red in prf; simpl in *; wf.
+      red in prf. destruct decl as [? [] ?]; red in prf; simpl in *; wf.
       destruct prf. wf.
 
     - split. wf. apply wf_subst_instance.

--- a/template-coq/theories/WfAst.v
+++ b/template-coq/theories/WfAst.v
@@ -252,6 +252,7 @@ Proof.
   induction u in t |- *; simpl.
   - intuition.
   - intros Happ H; destruct t; try solve [inv H; intuition auto].
+    try rename t into t0. (* compat: variable is t0 before coq 8.15 but t after *)
     specialize (IHu (tApp t0 (u ++ [a]))).
     forward IHu.
     induction u; trivial. discriminate.
@@ -263,6 +264,7 @@ Proof.
   induction u in t |- *; simpl.
   - intuition.
   - intros H; destruct t; try solve [inv H; intuition auto].
+    try rename t into t0. (* compat: variable is t0 before coq 8.15 but t after *)
     specialize (IHu (tApp t0 (args ++ [a]))).
     forward IHu.
     induction u; trivial.
@@ -281,7 +283,9 @@ Lemma wf_subst_instance Σ u c :
   wf Σ c -> wf Σ (subst_instance u c).
 Proof.
   induction 1 using term_wf_forall_list_ind; simpl; try solve [ cbn; constructor; auto using All_map; solve_all ].
-  - cbn. constructor; auto. destruct t0; simpl in *; try congruence.
+  - cbn. constructor; auto.
+    try rename t into t0. (* compat: variable is t0 before coq 8.15 but t after *)
+    destruct t0; simpl in *; try congruence.
     destruct l; simpl in *; congruence.
     now apply All_map.
   - cbn; econstructor; eauto; simpl; solve_all.

--- a/template-coq/theories/common/uGraph.v
+++ b/template-coq/theories/common/uGraph.v
@@ -1087,9 +1087,9 @@ Section CheckLeq.
       -> gc_leq_universe_n n uctx.2 (Universe.lType (Universe.make' e1)) u.
   Proof.
     unfold leqb_expr_univ_n, gc_leq_universe_n; cbn.
-    intros H v Hv. destruct u; try discriminate;cbn in *.
+    intros H v Hv. destruct u as [| |u];try discriminate;cbn in *.
     rewrite val_fold_right.
-    destruct (Universe.exprs t0) as [e u'] eqn:Ht0;cbn in *.
+    destruct (Universe.exprs u) as [e u'] eqn:Ht0;cbn in *.
     rewrite <- !fold_left_rev_right in H; cbn in *.
     induction (List.rev u'); cbn in *.
     - apply leqb_expr_n_spec0; tas.
@@ -1468,14 +1468,14 @@ Section CheckLeq.
   Proof.
     split; [apply leqb_expr_univ_n_spec0|].
     unfold leqb_expr_univ_n; intro HH.
-    destruct u.
+    destruct u as [| |u].
     - (*contradiction *)
       cbn in *. destruct HC as [v Hv];specialize (HH v Hv); cbn in HH.
       auto.
     - (*contradiction *)
       cbn in *. destruct HC as [v Hv];specialize (HH v Hv); cbn in HH.
       destruct lt; simpl in *; lled;lia.
-    - case_eq (Universe.exprs t0). intros e u' ee.
+    - case_eq (Universe.exprs u). intros e u' ee.
       assert (Hu': gc_expr_declared e /\ Forall gc_expr_declared u'). {
       split. apply Hu. apply Universe.In_exprs. left. now rewrite ee.
       apply Forall_forall. intros e' He'. apply Hu.
@@ -1545,7 +1545,7 @@ Section CheckLeq.
   Proof.
     unfold leqb_universe_n, gc_leq_universe_n.
     move/orP: (trichotomy u1) => [/orP [issp1|isp1]|diff];
-    destruct u1 eqn:Hu1;cbn;intros H v Hv; try discriminate.
+    destruct u1 as [| |u1l] eqn:Hu1;cbn;intros H v Hv; try discriminate.
     - move/orP: (trichotomy u2) => [/orP [issp|isp]|].
       * rewrite issp /= andb_true_r in H.
         apply is_sprop_val with (v:=v) in issp; rewrite issp; cbn.
@@ -1570,7 +1570,7 @@ Section CheckLeq.
         eapply val_is_sprop in vu2. now rewrite vu2 in issp.
         now rewrite H.
     - unfold val, Universe.Evaluable'.
-      destruct (Universe.exprs t0) as [e1 u1'] eqn:Hu1'.
+      destruct (Universe.exprs u1l) as [e1 u1'] eqn:Hu1'.
       subst u1.
       rewrite <- fold_left_rev_right in *; cbn in *.
       induction (List.rev u1'); cbn in *.
@@ -1699,7 +1699,7 @@ Section CheckLeq.
         (Hu2  : levels_declared u2)
     : check_eqb_universe u1 u2 <-> gc_eq_universe uctx.2 u1 u2.
   Proof.
-    destruct u1, u2; simpl; rewrite ?check_eqb_universe_exprs_spec; auto; cbn; unfold check_eqb_universe; 
+    destruct u1 as [| |u1], u2 as [| |u2]; simpl; rewrite ?check_eqb_universe_exprs_spec; auto; cbn; unfold check_eqb_universe;
     repeat rewrite ?orb_true_r ?orb_false_r ?andb_true_r ?andb_false_r; cbn.
     9:reflexivity.
     all:unfold gc_eq_universe; destruct check_univs eqn:cu; cbn; try split; auto; try discriminate.
@@ -1707,9 +1707,9 @@ Section CheckLeq.
     all:try solve [intros Hgc; destruct HC as [v Hv]; specialize (Hgc v Hv); simpl in Hgc; try discriminate].
     rewrite !andb_true_r in v.
     intros Hgc.
-    destruct (Universe.exprs t0).
+    destruct (Universe.exprs u2).
     now rewrite fold_left_false andb_false_r in v.
-    destruct (Universe.exprs t0).
+    destruct (Universe.exprs u1).
     now rewrite fold_left_false /= in v.
   Qed.
 
@@ -2129,7 +2129,7 @@ Section AddLevelsCstrs.
   Proof.
     unfold gc_of_constraints.
     rewrite ConstraintSet.fold_spec.
-    destruct fold_left eqn:eq.
+    destruct fold_left as [t|] eqn:eq.
     - constructor.
       + intros.
         setoid_rewrite ConstraintSetFact.elements_iff; setoid_rewrite InA_In_eq at 2.
@@ -2139,7 +2139,7 @@ Section AddLevelsCstrs.
         2:gcsets.
         revert eq.
         generalize (GCS.empty).
-        induction (ConstraintSet.elements s) in t0 |- *; simpl in *.
+        induction (ConstraintSet.elements s) in t |- *; simpl in *.
         intros ? [= ->]. firstorder auto.
         intros t' Ht'.
         pose proof (add_gc_of_constraint_spec a t').
@@ -2161,7 +2161,7 @@ Section AddLevelsCstrs.
         setoid_rewrite ConstraintSetFact.elements_iff; setoid_rewrite InA_In_eq at 1.
         revert eq.
         generalize (GCS.empty).
-        induction (ConstraintSet.elements s) in t0 |- *; simpl in *.
+        induction (ConstraintSet.elements s) in t |- *; simpl in *.
         intros ? [= ->]. firstorder auto.
         intros t' Ht'.
         pose proof (add_gc_of_constraint_spec a t').


### PR DESCRIPTION
Should be backwards compatible.