### PR TITLE
Optimize let expansion to not needlessly expand branches

### DIFF
--- a/pcuic/theories/PCUICExpandLets.v
+++ b/pcuic/theories/PCUICExpandLets.v
@@ -8,11 +8,13 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCases PCUICTyping.
 *)
 
 Definition trans_branch p (br : branch term) :=
-  {| bcontext := smash_context [] br.(bcontext); 
-     bbody := 
-      expand_lets 
-        (subst_context (List.rev p.(pparams)) 0 br.(bcontext)@[p.(puinst)]) 
-        br.(bbody) |}.
+  if is_assumption_context br.(bcontext) then br
+  else
+    {| bcontext := smash_context [] br.(bcontext); 
+       bbody := 
+        expand_lets 
+          (subst_context (List.rev p.(pparams)) 0 br.(bcontext)@[p.(puinst)]) 
+          br.(bbody) |}.
 
 Fixpoint trans (t : term) : term :=
   match t with

--- a/test-suite/erasure_test.v
+++ b/test-suite/erasure_test.v
@@ -47,4 +47,3 @@ MetaCoq Erase bignat.
 
 From MetaCoq.TestSuite Require Import vs.
 MetaCoq Erase main.
-(* let-expansion adds a ~25% overhead *)


### PR DESCRIPTION
When a constructor branch does not have let-bindings, `expand_lets` is an expensive variant of the identity. 
This solves the performance issue identified previously. Only took ~1hr to update the proof :)