### PR TITLE
Fix reify/quote of predicate and branches binding name contexts 

### DIFF
--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -273,9 +273,9 @@ struct
     let info = { ci_ind = ind; ci_npar = npar; ci_relevance = r } in
     let pred = { pparams = Array.to_list pars; 
                  puinst = univs; 
-                 pcontext = Array.to_list pctx;
+                 pcontext = List.rev (Array.to_list pctx);
                  preturn = pret } in
-    let branches = List.map (fun (bctx, br) -> { bcontext = Array.to_list bctx; bbody = br }) brs in
+    let branches = List.map (fun (bctx, br) -> { bcontext = List.rev (Array.to_list bctx); bbody = br }) brs in
     Coq_tCase (info,pred,c,branches)
 
   let mkProj p c = Coq_tProj (p,c)

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -74,10 +74,10 @@ struct
 
   let mk_predicate (uinst, pars, pctx, pret) =
     let pars = to_coq_listl tTerm (Array.to_list pars) in
-    let pctx = to_coq_listl taname (Array.to_list pctx) in
+    let pctx = to_coq_listl taname (List.rev (Array.to_list pctx)) in
     constr_mkApp (tmk_predicate, [| Lazy.force tTerm; uinst; pars; pctx; pret |])
   let mk_branch (bctx, bbody) =
-    let bctx = to_coq_listl taname (Array.to_list bctx) in
+    let bctx = to_coq_listl taname (List.rev (Array.to_list bctx)) in
     constr_mkApp (tmk_branch, [| Lazy.force tTerm; bctx; bbody |])
 
   let mk_case_info (ind, npar, relevance) =

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -112,12 +112,12 @@ struct
         let evm, puinst = D.unquote_universe_instance evm p.auinst in
         let evm, pars = map_evm (aux env) evm p.apars in
         let pars = Array.of_list pars in
-        let napctx = CArray.map_of_list D.unquote_aname p.apcontext in
+        let napctx = CArray.map_of_list D.unquote_aname (List.rev p.apcontext) in
         let pctx = CaseCompat.case_predicate_context env ci puinst pars napctx in 
         let evm, pret = aux (Environ.push_rel_context pctx env) evm p.apreturn in
         let evm, c = aux env evm c in
         let brs = List.map (fun { abcontext = bctx; abbody = bbody } ->
-          let nabctx = CArray.map_of_list D.unquote_aname bctx in
+          let nabctx = CArray.map_of_list D.unquote_aname (List.rev bctx) in
           (nabctx, bbody)) brs in
         let brs = CaseCompat.case_branches_contexts env ci puinst pars (Array.of_list brs) in
         let denote_br evm (nas, bctx, bbody) = 


### PR DESCRIPTION
These are in the unnatural order in Coq for typechecking purposes.