### PR TITLE
Implement a `infer_univs` mode for mkInductive

### DIFF
--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -179,9 +179,18 @@ struct
       with Not_found ->
         CErrors.user_err ~hdr:"unquote_level" (str ("Level "^s^" is not a declared level."))
 
+  let is_fresh_level evm trm h args =
+    if constr_equall h tLevel then
+      match args with
+      | s :: [] -> debug (fun () -> str "Unquoting level " ++ Printer.pr_constr_env (Global.env ()) evm trm);
+        let s = (unquote_string s) in
+        s = "__metacoq_fresh_level__"
+      | _ -> bad_term_verb trm "unquote_level" 
+    else false
+
   let unquote_level evm trm (* of type level *) : Evd.evar_map * Univ.Level.t =
     let (h,args) = app_full trm [] in
-    if constr_equall h lfresh_level then
+    if is_fresh_level evm trm h args then
       if !strict_unquote_universe_mode then
         CErrors.user_err ~hdr:"unquote_level" (str "It is not possible to unquote a fresh level in Strict Unquote Universe Mode.")
       else
@@ -216,14 +225,7 @@ struct
 
   let unquote_universe evm trm (* of type universe *)  =
     let (h,args) = app_full trm [] in
-    if constr_equall h lfresh_universe then
-      if !strict_unquote_universe_mode then
-        CErrors.user_err ~hdr:"unquote_universe" (str "It is not possible to unquote a fresh universe in Strict Unquote Universe Mode.")
-      else
-        let evm, u = Evd.new_univ_variable (Evd.UnivFlexible false) evm in
-        debug (fun () -> str"Fresh universe " ++ Univ.Universe.pr u ++ str" was added to the context.");
-        evm, u
-    else if constr_equall h lSProp then
+    if constr_equall h lSProp then
       match args with
          | [] -> evm, Univ.Universe.sprop
          | _ -> bad_term_verb trm "unquote_univ_expr"
@@ -236,22 +238,23 @@ struct
       | [x] ->
          let (h,args) = app_full x [] in
          if constr_equall h tBuild_Universe then
-                     match args with
-                       x :: _ :: [] -> (let (h,args) = app_full x [] in
-                                        if constr_equall h tMktUnivExprSet then
-                                          match args with
-                                          | x :: _ :: [] ->
-                                             (match unquote_list x with
-                                              | [] -> assert false
-                                              | e::q -> List.fold_left (fun (evm,u) e ->
-                                                            let evm, u' = unquote_univ_expr evm e
-                                                            in evm, Univ.Universe.sup u u')
-                                                          (unquote_univ_expr evm e) q)
-                                          | _ -> bad_term_verb trm "unquote_universe 0"
-                                        else
-                                          not_supported_verb trm "unquote_universe 0")
-                     | _ -> bad_term_verb trm "unquote_universe 1"
-               else  not_supported_verb trm "unquote_universe 2"
+            match args with
+              x :: _ :: [] -> 
+              (let (h,args) = app_full x [] in
+              if constr_equall h tMktUnivExprSet then
+                match args with
+                | x :: _ :: [] ->
+                    (match unquote_list x with
+                    | [] -> assert false
+                    | e::q -> List.fold_left (fun (evm,u) e ->
+                                  let evm, u' = unquote_univ_expr evm e
+                                  in evm, Univ.Universe.sup u u')
+                                (unquote_univ_expr evm e) q)
+                | _ -> bad_term_verb trm "unquote_universe 0"
+              else
+                not_supported_verb trm "unquote_universe 0")
+            | _ -> bad_term_verb trm "unquote_universe 1"
+      else  not_supported_verb trm "unquote_universe 2"
       | _ -> bad_term_verb trm "unquote_universe 3"
     else bad_term_verb trm "unquote_universe 4"
 

--- a/template-coq/src/g_template_coq.mlg
+++ b/template-coq/src/g_template_coq.mlg
@@ -133,7 +133,7 @@ VERNAC COMMAND EXTEND TemplateCoq_Make_Inductive CLASSIFIED AS SIDEFF STATE prog
         let (evm, def) = Constrintern.interp_open_constr env evm def in
         let (evm, pgm) = EConstr.fresh_global env evm (Lazy.force Template_monad.ptmMkInductive) in
         let pgm = Constr.mkApp (EConstr.to_constr evm pgm, 
-          [|to_constr_evars evm def|]) in
+          [|Constr_quoter.quote_bool false; to_constr_evars evm def|]) in
         run_template_program env evm ~poly pgm }
 END
 

--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -215,9 +215,16 @@ let tmQuoteConstant (kn : kername) (bypass : bool) : Opaqueproof.opaque Declarat
     with
       Not_found -> fail ~st Pp.(str "constant not found " ++ Names.KerName.print kn)
 
-let tmInductive (mi : mutual_inductive_entry) : unit tm =
+let tmInductive (infer_univs : bool) (mie : mutual_inductive_entry) : unit tm =
   fun ~st env evd success _fail ->
-    ignore (DeclareInd.declare_mutual_inductive_with_eliminations mi Names.Id.Map.empty []) ;
+    let mie = 
+      if infer_univs then
+        let ctx = Tm_util.RetypeMindEntry.infer_mentry_univs env Univ.ContextSet.empty mie in
+        DeclareUctx.declare_universe_context ~poly:false ctx; mie
+      else mie
+    in
+    let names = Names.Id.Map.empty in
+    ignore (DeclareInd.declare_mutual_inductive_with_eliminations mie names []) ;
     success ~st (Global.env ()) evd ()
 
 let tmExistingInstance (gr : Names.GlobRef.t) : unit tm =

--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -219,7 +219,8 @@ let tmInductive (infer_univs : bool) (mie : mutual_inductive_entry) : unit tm =
   fun ~st env evd success _fail ->
     let mie = 
       if infer_univs then
-        let ctx = Tm_util.RetypeMindEntry.infer_mentry_univs env Univ.ContextSet.empty mie in
+        let evm = Evd.from_env env in
+        let ctx, mie = Tm_util.RetypeMindEntry.infer_mentry_univs env evm mie in
         DeclareUctx.declare_universe_context ~poly:false ctx; mie
       else mie
     in

--- a/template-coq/src/plugin_core.mli
+++ b/template-coq/src/plugin_core.mli
@@ -61,7 +61,7 @@ val tmQuoteInductive : kername -> (Names.MutInd.t * mutual_inductive_body) optio
 val tmQuoteUniverses : UGraph.t tm
 val tmQuoteConstant : kername -> bool -> constant_body tm
 
-val tmInductive : mutual_inductive_entry -> unit tm
+val tmInductive : bool -> mutual_inductive_entry -> unit tm
 
 val tmExistingInstance : global_reference -> unit tm
 val tmInferInstance : term -> term option tm

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -230,8 +230,8 @@ let rec interp_tm (t : 'a coq_TM) : 'a tm =
   | Coq_tmQuoteConstant (kn, b) ->
     tmBind (tmQuoteConstant (unquote_kn kn) b)
            (fun x -> Obj.magic (tmOfConstantBody x))
-  | Coq_tmInductive i ->
-    tmMap (fun _ -> Obj.magic ()) (tmInductive (to_mie i))
+  | Coq_tmInductive (inferu, i) ->
+    tmMap (fun _ -> Obj.magic ()) (tmInductive (unquote_bool inferu) (to_mie i))
   | Coq_tmExistingInstance k ->
     Obj.magic (tmExistingInstance (unquote_global_reference k))
   | Coq_tmInferInstance t ->

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -288,11 +288,17 @@ let unquote_mutual_inductive_entry env evm trm (* of type mutual_inductive_entry
   else
     not_supported_verb trm "unquote_mutual_inductive_entry"
 
-
-let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (mind: Constr.t) : unit =
+let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (infer_univs : bool) (mind: Constr.t) : unit =
   let mind = reduce_all env evm mind in
   let evm, mind = unquote_mutual_inductive_entry env evm mind in
-  ignore (DeclareInd.declare_mutual_inductive_with_eliminations mind Names.Id.Map.empty [])
+  let mind = 
+    if infer_univs then
+      let ctx, mind = Tm_util.RetypeMindEntry.infer_mentry_univs env ctx mind in
+      DeclareUctx.declare_universe_context ~poly:false ctx; mind
+    else mind
+  in
+  let names = Evd.universe_binders evm in
+  ignore (DeclareInd.declare_mutual_inductive_with_eliminations mind names [])
 
 let not_in_tactic s =
   CErrors.user_err  (str ("You can not use " ^ s ^ " in a tactic."))
@@ -451,8 +457,9 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
     let evm,trm = denote_term env evm (reduce_all env evm trm) in
     Plugin_core.run ~st (Plugin_core.tmEval red trm) env evm
       (fun ~st env evm trm -> k ~st env evm (quote_term env trm))
-  | TmMkInductive mind ->
-    declare_inductive env evm mind;
+  | TmMkInductive (b, mind) ->
+    let infer_univs = unquote_bool (reduce_all env evm b) in
+    declare_inductive env evm infer_univs mind;
     let env = Global.env () in
     k ~st env evm (Lazy.force unit_tt)
   | TmUnquote t ->

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -290,14 +290,15 @@ let unquote_mutual_inductive_entry env evm trm (* of type mutual_inductive_entry
 
 let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (infer_univs : bool) (mind: Constr.t) : unit =
   let mind = reduce_all env evm mind in
-  let evm, mind = unquote_mutual_inductive_entry env evm mind in
+  let evm' = Evd.from_env env in
+  let evm', mind = unquote_mutual_inductive_entry env evm' mind in
   let mind = 
     if infer_univs then
-      let ctx, mind = Tm_util.RetypeMindEntry.infer_mentry_univs env ctx mind in
+      let ctx, mind = Tm_util.RetypeMindEntry.infer_mentry_univs env evm' mind in
       DeclareUctx.declare_universe_context ~poly:false ctx; mind
     else mind
   in
-  let names = Evd.universe_binders evm in
+  let names = Evd.universe_binders evm' in
   ignore (DeclareInd.declare_mutual_inductive_with_eliminations mind names [])
 
 let not_in_tactic s =

--- a/template-coq/src/run_template_monad.mli
+++ b/template-coq/src/run_template_monad.mli
@@ -1,4 +1,4 @@
-val declare_inductive : Environ.env -> Evd.evar_map -> Constr.t -> unit
+val declare_inductive : Environ.env -> Evd.evar_map -> bool -> Constr.t -> unit
 
 val run_template_program_rec :
     poly:bool ->

--- a/template-coq/src/run_template_monad.mli
+++ b/template-coq/src/run_template_monad.mli
@@ -1,4 +1,4 @@
-val declare_inductive : Environ.env -> Evd.evar_map -> bool -> Constr.t -> unit
+val declare_inductive : Environ.env -> Evd.evar_map -> bool -> Constr.t -> Evd.evar_map
 
 val run_template_program_rec :
     poly:bool ->

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -156,7 +156,7 @@ type template_monad =
   | TmLemmaTerm of Constr.t * Constr.t
   | TmAxiom of Constr.t * Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
-  | TmMkInductive of Constr.t
+  | TmMkInductive of Constr.t * Constr.t
   | TmVariable of Constr.t * Constr.t
 
   | TmFreshName of Constr.t
@@ -339,7 +339,7 @@ let next_action env evd (pgm : constr) : template_monad * _ =
 
   else if eq_gr ptmMkInductive then
     match args with
-    | mind::[] -> (TmMkInductive mind, universes)
+    | inferu :: mind :: [] -> (TmMkInductive (inferu, mind), universes)
     | _ -> monad_failure "tmMkInductive" 1
   else if eq_gr ptmVariable then
     match args with
@@ -347,7 +347,7 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     | _ -> monad_failure "tmVariable" 2
   else if eq_gr ttmInductive then
     match args with
-    | mind::[] -> (TmMkInductive mind, universes)
+    | inferu :: mind::[] -> (TmMkInductive (inferu, mind), universes)
     | _ -> monad_failure "tmInductive" 1
   else if eq_gr ptmUnquote then
     match args with

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -28,7 +28,7 @@ type template_monad =
   | TmLemmaTerm of Constr.t * Constr.t
   | TmAxiom of Constr.t * Constr.t * Constr.t
   | TmAxiomTerm of Constr.t * Constr.t
-  | TmMkInductive of Constr.t
+  | TmMkInductive of Constr.t * Constr.t
   | TmVariable of Constr.t * Constr.t
 
   | TmFreshName of Constr.t

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -221,28 +221,23 @@ module RetypeMindEntry =
     in
     evm, mind
 
-  let infer_mentry_univs env ctx mind = 
-    let evm = Evd.from_env env in
+  let infer_mentry_univs env evm mind = 
     let evm = 
       match mind.mind_entry_universes with
-      | Entries.Monomorphic_ind_entry ->
-        evm
-      | Entries.Template_ind_entry ctx ->
+      | Entries.Monomorphic_entry ctx ->
         Evd.merge_context_set (UState.UnivFlexible false) evm ctx
-      | Entries.Polymorphic_ind_entry uctx ->
+      | Entries.Polymorphic_entry (names, uctx) ->
         let uctx' = ContextSet.of_context uctx in
         Evd.merge_context_set (UState.UnivFlexible false) evm uctx'
     in
     let evm, mind = infer_mentry_univs env evm mind in
     let ctx, mind = 
       match mind.mind_entry_universes with
-      | Entries.Monomorphic_ind_entry ->
-        Evd.universe_context_set evm, mind
-      | Entries.Template_ind_entry ctx ->
-        Univ.ContextSet.empty, { mind with mind_entry_universes = Entries.Template_ind_entry (Evd.universe_context_set evm) }
-      | Entries.Polymorphic_ind_entry uctx ->
+      | Entries.Monomorphic_entry ctx ->
+        Univ.ContextSet.empty, { mind with mind_entry_universes = Entries.Monomorphic_entry (Evd.universe_context_set evm) }
+      | Entries.Polymorphic_entry (names, uctx) ->
         let uctx' = Evd.to_universe_context evm in
-        Univ.ContextSet.empty, { mind with mind_entry_universes = Entries.Polymorphic_ind_entry uctx' }
+        Univ.ContextSet.empty, { mind with mind_entry_universes = Entries.Polymorphic_entry (names, uctx') }
     in ctx, mind
 end 
 

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -117,6 +117,7 @@ Module PrintTermTree.
 
   Section env.
   Context (Σ : global_env_ext).
+  Context (with_universes : bool).
 
   Definition print_def {A} (f : A -> t) (g : A -> t) (def : def A) :=
     string_of_name (binder_name (dname def)) ^ " { struct " ^ string_of_nat (rarg def) ^ " }" ^
@@ -128,6 +129,17 @@ Module PrintTermTree.
     let ctx' := fix_context defs in
     print_list (print_def (print_term Γ true) (print_term (fresh_names Σ Γ ctx') true))
                (nl ^ " with ") defs.
+  Definition print_universe u :=
+    match u with
+    | Universe.lProp => "Prop"
+    | Universe.lSProp => "SProp"
+    | Universe.lType l =>
+      if with_universes then
+        ("Type(" ++
+           MCString.string_of_list string_of_level_expr (UnivExprSet.elements l) ++
+          ")")%bs
+       else "Type"
+    end.
 
   (* TODO: SPROP: we ignore relevance on printing, maybe add print config? *)
   Fixpoint print_term (Γ : list ident) (top : bool) (t : term) {struct t} : Tree.t :=
@@ -139,7 +151,7 @@ Module PrintTermTree.
     end
   | tVar n => "Var(" ^ n ^ ")"
   | tEvar ev args => "Evar(" ^ string_of_nat ev ^ "[]" (* TODO *)  ^ ")"
-  | tSort s => string_of_sort s
+  | tSort s => print_universe s
   | tCast c k t => parens top (print_term Γ true c ^ ":"  ^ print_term Γ true t)
   | tProd na dom codom =>
     let na' := (fresh_name Σ Γ na.(binder_name) (Some dom)) in
@@ -279,9 +291,41 @@ Module PrintTermTree.
     oib.(ind_name) ^ spars ^ sinds ^ print_term Γinds true (tSort oib.(ind_sort)) ^ ":=" ^ nl ^
     if short then "..."
     else print_list (print_one_cstr Γpars mib) nl oib.(ind_ctors).
+  
+  Definition print_one_cstr_entry Γ (mie : mutual_inductive_entry) (c : ident × term) : t :=
+    c.1 ^ " : " ^ print_term Γ true c.2.
+    
+  Definition print_one_ind_entry (short : bool) Γ (mie : mutual_inductive_entry) (oie : one_inductive_entry) : t :=
+    let '(Γpars, spars) := print_context Γ mie.(mind_entry_params) in
+    oie.(mind_entry_typename) ^ spars ^ print_term Γpars true oie.(mind_entry_arity) ^ ":=" ^ nl ^
+    if short then "..."
+    else print_list (print_one_cstr_entry Γpars mie) nl (combine oie.(mind_entry_consnames) oie.(mind_entry_lc)).
   End env.
 
-  Fixpoint print_env_aux (short : bool) (prefix : nat) (Σ : global_env) (acc : t) : t := 
+  Definition universes_decl_of_universes_entry e :=
+    match e with
+    | Monomorphic_entry ctx => Monomorphic_ctx
+    | Polymorphic_entry names uctx => Polymorphic_ctx (names, UContext.constraints uctx)
+    end.
+
+  Definition print_mib Σ with_universes (short : bool) (mib : mutual_inductive_body) : t :=
+    let Σ' := (Σ, mib.(ind_universes)) in
+    let names := fresh_names Σ' [] (arities_context mib.(ind_bodies)) in
+      ("Inductive " ^ 
+      print_list (print_one_ind Σ' with_universes short names mib) nl mib.(ind_bodies) ^ "." ^ nl).
+
+  Definition mie_arities_context mie := 
+    rev_map (fun ind => vass (mkBindAnn (nNamed ind.(mind_entry_typename)) Relevant) 
+      (it_mkProd_or_LetIn mie.(mind_entry_params) ind.(mind_entry_arity))) 
+      mie.(mind_entry_inds).
+    
+  Definition print_mie Σ with_universes (short : bool) (mie : mutual_inductive_entry) : t :=
+    let Σ' := (Σ, universes_decl_of_universes_entry mie.(mind_entry_universes)) in
+    let names := fresh_names Σ' [] (mie_arities_context mie) in
+      ("Inductive " ^ 
+      print_list (print_one_ind_entry Σ' with_universes short names mie) nl mie.(mind_entry_inds) ^ "." ^ nl).
+    
+  Fixpoint print_env_aux with_universes (short : bool) (prefix : nat) (Σ : global_env) (acc : t) : t := 
     match prefix with 
     | 0 => match Σ.(declarations) with [] => acc | _ => ("..." ^ nl ^ acc) end
     | S n => 
@@ -289,40 +333,39 @@ Module PrintTermTree.
       match Σ.(declarations) with
       | [] => acc
       | (kn, InductiveDecl mib) :: Σ => 
-        let Σ' := ({| Env.universes := univs; declarations := Σ |}, mib.(ind_universes)) in
-        let names := fresh_names Σ' [] (arities_context mib.(ind_bodies)) in
-        print_env_aux short n Σ'.1
-          ("Inductive " ^ 
-          print_list (print_one_ind Σ' short names mib) nl mib.(ind_bodies) ^ "." ^ 
-          nl ^ acc)
+        let Σ := {| Env.universes := univs; declarations := Σ |} in
+        print_env_aux with_universes short n Σ (print_mib Σ with_universes short mib ^ acc)
       | (kn, ConstantDecl cb) :: Σ =>
         let Σ' := ({| Env.universes := univs; declarations := Σ |}, cb.(cst_universes)) in
-        print_env_aux short n Σ'.1
+        print_env_aux with_universes short n Σ'.1
           ((match cb.(cst_body) with 
             | Some _ => "Definition "
             | None => "Axiom "
-          end) ^ string_of_kername kn ^ " : " ^ print_term Σ' nil true cb.(cst_type) ^
+          end) ^ string_of_kername kn ^ " : " ^ print_term Σ' with_universes nil true cb.(cst_type) ^
           match cb.(cst_body) with
           | Some b => 
             if short then ("..." ^ nl)
-            else (" := " ^ nl ^ print_term Σ' nil true b ^ "." ^ nl)
+            else (" := " ^ nl ^ print_term Σ' with_universes nil true b ^ "." ^ nl)
           | None => "."
           end ^ acc)
       end
     end.
 
-  Definition print_env (short : bool) (prefix : nat) Σ := 
-    print_env_aux short prefix Σ (Tree.string "").
+  Definition print_env with_universes (short : bool) (prefix : nat) Σ := 
+    print_env_aux with_universes short prefix Σ (Tree.string "").
 
-  Definition print_program (short : bool) (prefix : nat) (p : program) : t := 
-    print_env short prefix (fst p) ^ nl ^ print_term (empty_ext (fst p)) nil true (snd p). 
+  Definition print_program with_universes (short : bool) (prefix : nat) (p : program) : t := 
+    print_env with_universes short prefix (fst p) ^ nl ^ print_term (empty_ext (fst p)) with_universes nil true (snd p). 
 
 End PrintTermTree.
 
-Definition print_term Σ Γ top := Tree.to_string ∘ PrintTermTree.print_term Σ Γ top.
+Definition print_mie Σ with_universes short := Tree.to_string ∘ PrintTermTree.print_mie Σ with_universes short.
+Definition print_mib Σ with_universes short := Tree.to_string ∘ PrintTermTree.print_mib Σ with_universes short.
+
+Definition print_term Σ Γ top := Tree.to_string ∘ PrintTermTree.print_term Σ true Γ top.
 
 Definition print_env (short : bool) (prefix : nat) Σ := 
-  Tree.to_string (PrintTermTree.print_env short prefix Σ).
+  Tree.to_string (PrintTermTree.print_env true short prefix Σ).
 
 Definition print_program (short : bool) (prefix : nat) (p : program) : string := 
-  Tree.to_string (PrintTermTree.print_program short prefix p).
+  Tree.to_string (PrintTermTree.print_program true short prefix p).

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -40,7 +40,7 @@ Record TMInstance@{t u r} :=
 ; tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_body
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)
-; tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
+; tmMkInductive : bool (* infer universes? *) -> mutual_inductive_entry -> TemplateMonad unit
 (* Typeclass registration and querying for an instance *)
 ; tmExistingInstance : global_reference -> TemplateMonad unit
 }.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -52,7 +52,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_body
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)
-| tmMkInductive : mutual_inductive_entry -> TemplateMonad unit
+| tmMkInductive : bool -> mutual_inductive_entry -> TemplateMonad unit
 | tmUnquote : Ast.term  -> TemplateMonad typed_term@{u}
 | tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
 
@@ -80,7 +80,7 @@ Definition fail_nf {A} (msg : string) : TemplateMonad A
   := tmEval all msg >>= tmFail.
 
 Definition tmMkInductive' (mind : mutual_inductive_body) : TemplateMonad unit
-  := tmMkInductive (mind_body_to_entry mind).
+  := tmMkInductive false (mind_body_to_entry mind).
 
 Definition tmAxiom id := tmAxiomRed id None.
 Definition tmDefinition id {A} t := @tmDefinitionRed_ false id None A t.

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -53,7 +53,7 @@ Cumulative Inductive TM@{t} : Type@{t} -> Type :=
 
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)
-| tmInductive : mutual_inductive_entry -> TM unit
+| tmInductive : bool -> mutual_inductive_entry -> TM unit
 
 (* Typeclass registration and querying for an instance *)
 | tmExistingInstance : global_reference -> TM unit
@@ -87,7 +87,7 @@ Definition tmDefinition (nm : ident)
 
 
 Definition tmInductive' (mind : mutual_inductive_body) : TM unit
-  := tmInductive (mind_body_to_entry mind).
+  := tmInductive false (mind_body_to_entry mind).
 
 Definition tmLemmaRed (i : ident) (rd : reductionStrategy)
            (ty : Ast.term) :=

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -1707,11 +1707,10 @@ Section Univ.
 
 End Univ.
 
-(* This universe is a hack used in plugings to generate fresh universes *)
-Definition fresh_universe : Universe.t. exact Universe.type0. Qed.
 (* This level is a hack used in plugings to generate fresh levels *)
-Definition fresh_level : Level.t. exact Level.lzero. Qed.
-
+Definition fresh_level : Level.t := Level.Level "__metacoq_fresh_level__".
+(* This universe is a hack used in plugins to generate fresh universes *)
+Definition fresh_universe : Universe.t := Universe.make fresh_level.
 
 (** * Universe substitution
 

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -43,3 +43,5 @@ univ.v
 tmVariable.v
 order_rec.v
 # primitive.v
+inferind.v
+inferindunivs.v

--- a/test-suite/extractable.v
+++ b/test-suite/extractable.v
@@ -51,9 +51,8 @@ MetaCoq Run
 
 Definition nAnon := {| binder_name := nAnon; binder_relevance := Relevant |}.
 
-
 MetaCoq Run
-    (tmInductive {| mind_entry_record := None
+    (tmInductive true {| mind_entry_record := None
                   ; mind_entry_finite := Finite
                   ; mind_entry_params := nil
                   ; mind_entry_inds :=

--- a/test-suite/inferind.v
+++ b/test-suite/inferind.v
@@ -1,0 +1,86 @@
+From Coq Require Import List.
+From MetaCoq.Template Require Import All.
+
+Import ListNotations.
+Import MCMonadNotation.
+Open Scope bs_scope.
+Definition qlist := Eval compute in match <% list %> with 
+    | tInd ind _ => ind.(inductive_mind)
+    | _ => (MPfile nil, ""%bs)
+    end.
+
+
+Definition refresh_sort t :=
+  match t with
+  | tSort s => 
+      match s with
+      | Universe.lProp => tSort Universe.lProp
+      | Universe.lSProp => tSort Universe.lSProp
+      | Universe.lType _ => tSort Universes.fresh_universe
+      end
+  | _ => t
+  end.
+
+Definition refresh_arity s := 
+  let (ctx, concl) := decompose_prod_assum [] s in
+  it_mkProd_or_LetIn ctx (refresh_sort concl).
+
+  Definition mind_body_to_entry :=
+  fun decl : mutual_inductive_body =>
+  {|
+  mind_entry_record := None;
+  mind_entry_finite := Finite;
+  mind_entry_params :=
+      match hd_error (ind_bodies decl) with
+      | Some i0 =>
+          List.rev
+          (let typ := decompose_prod (ind_type i0) in
+              let (a, b) := typ in
+              (fun p : list aname × list term =>
+              let (a0, b0) := p in
+              (fun (names : list aname) (types : list term) (_ : term) =>
+              let names0 := firstn (ind_npars decl) names in
+              let types0 := firstn (ind_npars decl) types in
+              map (fun '(x, ty) => vass x ty) (combine names0 types0)) a0 b0)
+              a b)
+      | None => []
+      end;
+  mind_entry_inds :=
+      map
+      (fun X : one_inductive_body =>
+          match X with
+          | {|
+              ind_name := ind_name;
+              ind_indices := ind_indices;
+              ind_sort := ind_sort;
+              ind_type := ind_type;
+              ind_kelim := ind_kelim;
+              ind_ctors := ind_ctors;
+              ind_projs := ind_projs;
+              ind_relevance := ind_relevance
+          |} =>
+              {|
+              mind_entry_typename := ind_name;
+              mind_entry_arity := refresh_arity (remove_arity (ind_npars decl) ind_type);
+              mind_entry_consnames :=
+                  map (fun x : constructor_body => cstr_name x) ind_ctors;
+              mind_entry_lc :=
+                  map
+                  (fun x : constructor_body =>
+                      remove_arity (ind_npars decl) (cstr_type x)) ind_ctors
+              |}
+          end) (ind_bodies decl);
+  mind_entry_universes := universes_entry_of_decl (ind_universes decl);
+  mind_entry_template := false;
+  mind_entry_variance := option_map (map Some) (ind_variance decl);
+  mind_entry_private := None
+  |}.
+      
+      
+
+Unset MetaCoq Strict Unquote Universe Mode.
+MetaCoq Run (tmQuoteInductive qlist >>= fun mib =>
+  let entry := mind_body_to_entry mib in 
+  entry <- tmEval all entry;;
+  tmPrint entry ;;
+  tmMkInductive true entry).

--- a/test-suite/inferindunivs.v
+++ b/test-suite/inferindunivs.v
@@ -1,0 +1,68 @@
+From Coq Require Import List String.
+From MetaCoq.Template Require Import Ast AstUtils monad_utils Loader Core.
+Import Ast.Env.
+Import ListNotations.
+Import MCMonadNotation.
+
+Local Open Scope string_scope.
+
+Definition bnamed n := {| binder_name := nNamed n; binder_relevance := Relevant |}.
+
+MetaCoq Quote Definition rid := @id.
+
+Universe u.
+MetaCoq Quote Definition qu := Type@{u}.
+Universe v.
+MetaCoq Quote Definition qv := Type@{v}.
+
+Universe w.
+MetaCoq Quote Definition qw := Type@{w}.
+
+Definition update_mutual_inductive_entry_inds (mie : mutual_inductive_entry) inds' :=
+ {| mind_entry_record := mie.(mind_entry_record);
+	mind_entry_finite := mie.(mind_entry_finite);
+    mind_entry_params := mie.(mind_entry_params);
+    mind_entry_inds := inds';
+    mind_entry_universes := mie.(mind_entry_universes);
+    mind_entry_template := mie.(mind_entry_template);
+    mind_entry_variance := mie.(mind_entry_variance);
+    mind_entry_private := mie.(mind_entry_private) |}.
+
+Definition add_cstr_univs (mie : mutual_inductive_entry) := 
+  let inds := mie.(mind_entry_inds) in
+  let add_cstr oie :=
+    let cstrs := oie.(mind_entry_lc) in
+    let cstr' := 
+      it_mkProd_or_LetIn mie.(mind_entry_params)
+        (tProd (bnamed "newty"%string) qv
+          (tProd (bnamed "new") (mkApps rid [qu; tRel 0])
+            (mkApps (tRel (2 + List.length (mie.(mind_entry_params))))
+              (to_extended_list mie.(mind_entry_params)))))
+    in 
+    let prime_cstrs := List.map (fun s => s ++ "'") oie.(mind_entry_consnames) in
+    {| mind_entry_typename := (oie.(mind_entry_typename) ++ "'")%string;
+       mind_entry_arity := (*oie.(mind_entry_arity)*) qw; 
+       mind_entry_lc := cstr' :: cstrs;
+       mind_entry_consnames := "newcons" :: prime_cstrs |}
+  in
+  let inds' := List.map add_cstr inds in
+  update_mutual_inductive_entry_inds mie inds'.
+
+Inductive foo : Set := 
+ | bar : foo.
+
+Definition fooref := (MPfile ["inferindunivs"], "foo").
+
+MetaCoq Run (tmQuoteInductive fooref >>= fun mib =>
+    let mie := mind_body_to_entry mib in
+    let mie := add_cstr_univs mie in
+    tmMkInductive true mie).
+
+Set Printing Universes.
+Set Printing All.
+
+Print foo'.
+
+
+
+

--- a/test-suite/inferindunivs.v
+++ b/test-suite/inferindunivs.v
@@ -1,10 +1,10 @@
-From Coq Require Import List String.
-From MetaCoq.Template Require Import Ast AstUtils monad_utils Loader Core.
+From Coq Require Import List.
+From MetaCoq.Template Require Import All Loader.
 Import Ast.Env.
 Import ListNotations.
 Import MCMonadNotation.
 
-Local Open Scope string_scope.
+Local Open Scope bs_scope.
 
 Definition bnamed n := {| binder_name := nNamed n; binder_relevance := Relevant |}.
 
@@ -34,13 +34,13 @@ Definition add_cstr_univs (mie : mutual_inductive_entry) :=
     let cstrs := oie.(mind_entry_lc) in
     let cstr' := 
       it_mkProd_or_LetIn mie.(mind_entry_params)
-        (tProd (bnamed "newty"%string) qv
+        (tProd (bnamed "newty"%bs) qv
           (tProd (bnamed "new") (mkApps rid [qu; tRel 0])
             (mkApps (tRel (2 + List.length (mie.(mind_entry_params))))
               (to_extended_list mie.(mind_entry_params)))))
     in 
     let prime_cstrs := List.map (fun s => s ++ "'") oie.(mind_entry_consnames) in
-    {| mind_entry_typename := (oie.(mind_entry_typename) ++ "'")%string;
+    {| mind_entry_typename := (oie.(mind_entry_typename) ++ "'");
        mind_entry_arity := (*oie.(mind_entry_arity)*) qw; 
        mind_entry_lc := cstr' :: cstrs;
        mind_entry_consnames := "newcons" :: prime_cstrs |}

--- a/test-suite/inferindunivs.v
+++ b/test-suite/inferindunivs.v
@@ -51,7 +51,7 @@ Definition add_cstr_univs (mie : mutual_inductive_entry) :=
 Inductive foo : Set := 
  | bar : foo.
 
-Definition fooref := (MPfile ["inferindunivs"], "foo").
+Definition fooref := (MPfile ["inferindunivs"; "TestSuite"; "MetaCoq"], "foo").
 
 MetaCoq Run (tmQuoteInductive fooref >>= fun mib =>
     let mie := mind_body_to_entry mib in
@@ -62,7 +62,3 @@ Set Printing Universes.
 Set Printing All.
 
 Print foo'.
-
-
-
-

--- a/test-suite/sprop_tests.v
+++ b/test-suite/sprop_tests.v
@@ -47,7 +47,7 @@ Module foo.
   MetaCoq Run (t <- tmQuoteInductive (MPfile ["sprop_tests"; "TestSuite"; "MetaCoq"], "sle") ;;
               t <- tmEval all (mind_body_to_entry t) ;;
               tmPrint t ;;
-              tmMkInductive t
+              tmMkInductive false t
              ).
 
   Print sle.

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -107,7 +107,7 @@ Module to.
  MetaCoq Run (t <- tmQuoteInductive (cp "list") ;;
               t <- tmEval all (mind_body_to_entry t) ;;
               tmPrint t ;;
-              tmMkInductive (clean_universes_decl t)).
+              tmMkInductive false (clean_universes_decl t)).
 
  Print list.
 End to.

--- a/translations/param_generous_unpacked.v
+++ b/translations/param_generous_unpacked.v
@@ -1,8 +1,8 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils All.
-Require Import Translations.translation_utils.
+From MetaCoq.Translations Require Import translation_utils.
 Require Import ssreflect.
-
+(* Import BasicAst. *)
 
 Reserved Notation "'tsl_ty_param'".
 
@@ -219,7 +219,7 @@ Definition tTranslate (ΣE : tsl_context) (id : ident)
       tmPrint d' ;;
       let entries := map mind_body_to_entry (snd d') in
       (* print_nf entries ;; *)
-      monad_fold_left (fun _ e => tmMkInductive e) entries tt ;;
+      monad_fold_left (fun _ e => tmMkInductive true e) entries tt ;;
       let decl := InductiveDecl kn d in
       print_nf  (id ^ " has been translated as " ^ id') ;;
       ret (Some (decl :: fst ΣE, E ++ snd ΣE))


### PR DESCRIPTION
This allows to let Coq infer the universe constraints associated to an unquoted inductive. It also allows to introduce unregistered universes during the unquoting.