### PR TITLE
Adapt to coq/coq#15294 (comparison is no longer extracted to int)

### DIFF
--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -6,12 +6,10 @@ From MetaCoq.Template Require Import utils.
 
     Any extracted code planning to link with the plugin
     should use these same directives for consistency.
-
-    ExtrOCamlInt63 extracts comparison to int (-1, 0, 1), so one might need to adapt code accordingly.
 *)
 
 Extract Constant ascii_compare =>
- "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
+ "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt".
 
 (* Ignore [Decimal.int] before the extraction issue is solved:
    https://github.com/coq/coq/issues/7017. *)

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -42,9 +42,9 @@ Extract Constant Pos.mul => "( * )".
 Extract Constant Pos.min => "Pervasives.min".
 Extract Constant Pos.max => "Pervasives.max".
 Extract Constant Pos.compare =>
-    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+    "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 Extract Constant Pos.compare_cont =>
-    "fun c x y -> if x=y then c else if x<y then -1 else 1".
+    "fun c x y -> if x=y then c else if x<y then Lt else Gt".
 
 
 Extract Constant N.add => "(+)".
@@ -57,7 +57,7 @@ Extract Constant N.max => "Pervasives.max".
 Extract Constant N.div => "fun a b -> if b=0 then 0 else a/b".
 Extract Constant N.modulo => "fun a b -> if b=0 then a else a mod b".
 Extract Constant N.compare =>
-    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+    "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 
 
 Extract Constant Z.add => "(+)".
@@ -70,7 +70,7 @@ Extract Constant Z.abs => "Pervasives.abs".
 Extract Constant Z.min => "Pervasives.min".
 Extract Constant Z.max => "Pervasives.max".
 Extract Constant Z.compare =>
-    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+    "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 
 Extract Constant Z.of_N => "fun p -> p".
 Extract Constant Z.abs_N => "Pervasives.abs".
@@ -86,7 +86,7 @@ Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(
 Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
 Extract Constant ascii_compare =>
- "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
+ "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt".
 
 Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int Init
            UnivSubst Typing Checker Retyping OrderedType Logic Common Equality Classes

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -56,9 +56,9 @@ Extract Constant Pos.mul => "( * )".
 Extract Constant Pos.min => "Pervasives.min".
 Extract Constant Pos.max => "Pervasives.max".
 Extract Constant Pos.compare =>
- "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+ "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 Extract Constant Pos.compare_cont =>
- "fun c x y -> if x=y then c else if x<y then -1 else 1".
+ "fun c x y -> if x=y then c else if x<y then Lt else Gt".
 
 
 Extract Constant N.add => "(+)".
@@ -71,7 +71,7 @@ Extract Constant N.max => "Pervasives.max".
 Extract Constant N.div => "fun a b -> if b=0 then 0 else a/b".
 Extract Constant N.modulo => "fun a b -> if b=0 then a else a mod b".
 Extract Constant N.compare =>
- "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+ "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 
 
 Extract Constant Z.add => "(+)".
@@ -84,7 +84,7 @@ Extract Constant Z.abs => "Pervasives.abs".
 Extract Constant Z.min => "Pervasives.min".
 Extract Constant Z.max => "Pervasives.max".
 Extract Constant Z.compare =>
- "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+ "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 
 Extract Constant Z.of_N => "fun p -> p".
 Extract Constant Z.abs_N => "Pervasives.abs".
@@ -100,7 +100,7 @@ Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(
 Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
 Extract Constant ascii_compare =>
- "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
+ "fun x y -> match Char.compare x y with 0 -> Eq | x when x < 0 -> Lt | _ -> Gt".
 
 Extract Inductive Equations.Init.sigma => "( * )" ["(,)"].
 Extract Constant Equations.Init.pr1 => "fst".

--- a/template-coq/theories/utils/MC_ExtrOCamlInt63.v
+++ b/template-coq/theories/utils/MC_ExtrOCamlInt63.v
@@ -16,7 +16,6 @@ From Coq Require Uint63 Sint63 Extraction.
 
 Extract Inductive bool => bool [ true false ].
 Extract Inductive prod => "( * )" [ "" ].
-Extract Inductive comparison => int [ "0" "(-1)" "1" ].
 Extract Inductive DoubleType.carry => "MCUint63.carry" [ "MCUint63.C0" "MCUint63.C1" ].
 
 (** Primitive types and operators. *)
@@ -56,8 +55,10 @@ Extract Constant Uint63.diveucl => "MCUint63.diveucl".
 Extract Constant Uint63.diveucl_21 => "MCUint63.div21".
 Extract Constant Uint63.addmuldiv => "MCUint63.addmuldiv".
 
-Extract Constant Uint63.compare => "MCUint63.compare".
-Extract Constant Sint63.compare => "MCUint63.compares".
+Extract Constant Uint63.compare =>
+  "fun x y -> match MCUint63.compare x y with 0 -> Eq | c when c < 0 -> Lt | _ -> Gt".
+Extract Constant Sint63.compare =>
+  "fun x y -> match MCUint63.compares x y with 0 -> Eq | c when c < 0 -> Lt | _ -> Gt".
 
 Extract Constant Uint63.head0 => "MCUint63.head0".
 Extract Constant Uint63.tail0 => "MCUint63.tail0".


### PR DESCRIPTION
Not backwards compatible. Wait for upstream to merge.