### PR TITLE
Move PCUIC tactics to a library

### DIFF
--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1210,7 +1210,6 @@ Proof.
         eapply (assumption_context_cstr_branch_context d).
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval; eauto. constructor. econstructor; eauto.
-    + apply wfΣ.
   - pose (Hty' := Hty).
     eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?); [|easy].
     invs He.

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -19,6 +19,7 @@ theories/Syntax/PCUICOnFreeVars.v
 theories/Syntax/PCUICRenameDef.v
 theories/Syntax/PCUICInstDef.v
 theories/Syntax/PCUICLiftSubst.v
+theories/Syntax/PCUICTactics.v
 theories/Syntax/PCUICContextRelation.v
 theories/Syntax/PCUICUnivSubst.v
 theories/Syntax/PCUICClosed.v

--- a/pcuic/theories/Conversion/PCUICInstConv.v
+++ b/pcuic/theories/Conversion/PCUICInstConv.v
@@ -507,9 +507,8 @@ Proof.
         assert (n + (i - n - #|s|) - n = (i - n - #|s|)) as -> by lia.
         apply inst_ext => k.
         rewrite nth_error_idsn_None //; try lia.
-        destruct nth_error eqn:hnth'.
-        + eapply nth_error_Some_length in hnth'. len in hnth'. lia.
-        + simpl. lia_f_equal.
+        destruct nth_error eqn:hnth'; simpl; len.
+        eapply nth_error_Some_length in hnth'. len in hnth'.
 Qed.
 
 Lemma inst_context_subst_k f s k Γ :
@@ -976,7 +975,7 @@ Proof.
   have hlen := nth_error_Some_length hnth. len in hlen.
   simpl in hlen.
   destruct (nth_error (List.rev (_ ++ inst_context _ _)) _) eqn:hnth'.
-  2:{ eapply nth_error_None in hnth'. len in hnth'. simpl in hnth'. lia. }
+  2:{ eapply nth_error_None in hnth'. len in hnth'. }
   rewrite nth_error_rev_inv in hnth; len; auto.
   len in hnth. simpl in hnth.
   rewrite nth_error_rev_inv in hnth'; len; auto; try lia.

--- a/pcuic/theories/Conversion/PCUICNamelessConv.v
+++ b/pcuic/theories/Conversion/PCUICNamelessConv.v
@@ -972,7 +972,7 @@ Lemma nl_expand_lets_k Γ k t :
   expand_lets_k (nlctx Γ) k (nl t).
 Proof.
   rewrite /expand_lets_k.
-  now rewrite nl_subst nl_extended_subst nl_lift; len.
+  now rewrite nl_subst nl_extended_subst nl_lift; len; autorewrite with len.
 Qed.
 
 Lemma nl_expand_lets Γ t : 
@@ -1039,7 +1039,7 @@ Lemma nl_expand_lets_ctx Γ Δ :
   expand_lets_ctx (nlctx Γ) (nlctx Δ).
 Proof.
   rewrite /expand_lets_ctx /expand_lets_k_ctx.
-  now rewrite nl_subst_context nl_extended_subst nl_lift_context; len.
+  now rewrite nl_subst_context nl_extended_subst nl_lift_context nl_context_assumptions; len.
 Qed.
 
 Lemma nl_inds ind puinst bodies :
@@ -1297,7 +1297,7 @@ Proof.
     rewrite -/(inst_case_branch_context _ _).
     eapply red_iota => //.
     * rewrite H1 H //.
-    * len; eauto.
+    * rewrite nl_context_assumptions; len; eauto.
   - rewrite !nl_mkApps. cbn. eapply red_fix with (narg:=narg).
     + unfold unfold_fix in *. rewrite nth_error_map.
       destruct (nth_error mfix idx). 2: discriminate.

--- a/pcuic/theories/Conversion/PCUICRenameConv.v
+++ b/pcuic/theories/Conversion/PCUICRenameConv.v
@@ -65,16 +65,6 @@ Proof.
     simpl in *. f_equal. all: easy.
 Qed.
 
-Lemma rename_context_length :
-  forall σ Γ,
-    #|rename_context σ Γ| = #|Γ|.
-Proof.
-  intros σ Γ. unfold rename_context.
-  apply fold_context_k_length.
-Qed.
-#[global]
-Hint Rewrite rename_context_length : sigma wf.
-
 Lemma rename_context_snoc0 :
   forall f Γ d,
     rename_context f (d :: Γ) =

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -2224,7 +2224,7 @@ Section PredRed.
     intros x px. rewrite {1}/ids /=. split => //.
     split => //. eapply pred1_refl_gen => //.
     assert (#|Δ| = #|Δ'|).
-    { apply pred1_pred1_ctx in pred. eapply All2_fold_length in pred. len in pred. lia. }
+    { apply pred1_pred1_ctx in pred. eapply All2_fold_length in pred. len in pred. }
     move=> [na [b|] ty] => /= //.
     destruct (leb_spec_Set (S x) #|Δ|).
     - rewrite !nth_error_app_lt; try lia.
@@ -2265,12 +2265,11 @@ Section PredRed.
     apply X.
     pose proof (All2_fold_length predctx). len in H.
     red. split => //. split => //.
-    relativize #|Γ ,,, Δ|; [erewrite on_free_vars_ctx_on_ctx_free_vars|] => //.
-    len. lia.
+    relativize #|Γ ,,, Δ|; [erewrite on_free_vars_ctx_on_ctx_free_vars|] => //; len. 
     intros x px. rewrite {1}/ids /=. split => //.
     split => //. eapply pred1_refl_gen => //.
     assert (#|Δ| = #|Δ'|).
-    { apply pred1_pred1_ctx in pred. eapply All2_fold_length in pred. len in pred. lia. }
+    { apply pred1_pred1_ctx in pred. eapply All2_fold_length in pred. len in pred. }
     move=> [na [b|] ty] => /= //.
     destruct (leb_spec_Set (S x) #|Δ|).
     - rewrite !nth_error_app_lt; try lia.

--- a/pcuic/theories/PCUICContextReduction.v
+++ b/pcuic/theories/PCUICContextReduction.v
@@ -327,7 +327,7 @@ Section CtxReduction.
   Proof.
     intros r.
     eapply All2_fold_app_inv => //.
-    move: (All2_fold_length r). len. lia.
+    move: (All2_fold_length r). len.
   Qed.
     
   (* 

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -21,12 +21,6 @@ Implicit Types (cf : checker_flags) (Σ : global_env_ext).
 #[global]
 Hint Rewrite Nat.add_0_r : len.
 
-Lemma context_assumptions_expand_lets_ctx Γ Δ :
-  context_assumptions (expand_lets_ctx Γ Δ) = context_assumptions Δ.
-Proof. now rewrite /expand_lets_ctx /expand_lets_k_ctx; len. Qed.
-#[global]
-Hint Rewrite context_assumptions_expand_lets_ctx : len.
-
 Lemma smash_context_subst_empty s n Γ : 
   smash_context [] (subst_context s n Γ) =
   subst_context s n (smash_context [] Γ).
@@ -559,7 +553,6 @@ Lemma expand_lets_smash_context Γ Δ Δ' :
 Proof.
   rewrite /expand_lets_ctx /expand_lets_k_ctx.
   rewrite -smash_context_lift -smash_context_subst /=; len.
-  lia_f_equal.
 Qed.
 
 Lemma expand_lets_k_ctx_nil Γ k : expand_lets_k_ctx Γ k [] = [].
@@ -620,7 +613,7 @@ Proof.
   rewrite simpl_lift; len; try lia.
   rewrite subst_lift_above. now len.
   change (context_assumptions Δ) with (0 + context_assumptions Δ).
-  rewrite subst_lift_above. len. lia. now rewrite lift0_id.
+  rewrite subst_lift_above. len. now rewrite lift0_id.
 Qed.
 
 Lemma subslet_lift {cf} {Σ} {wfΣ : wf Σ} (Γ Δ : context) s Δ' :

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -3486,7 +3486,7 @@ Section CumulSubst.
     rewrite - !app_length.
     relativize #|Δ'0 ++ Γ''|; [apply (substitution_equality_subst_conv (le:=le') hs hs' eqs)|] => //.
     1:rewrite app_context_assoc //.
-    len. now rewrite len.
+    len.
   Qed. 
 
   Lemma weaken_context_equality_rel {le Γ Γ' Δ Δ'} :

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -3072,7 +3072,6 @@ Proof.
   f_equal.
   { relativize #|cstr_args cdecl|. erewrite expand_lets_lift_cancel. 2:rewrite case_branch_context_length_args //.
     rewrite case_branch_context_assumptions //. 
-    rewrite context_assumptions_map.
     rewrite (trans_lift _ (shiftnP #|Γ| xpred0)).
     { rewrite /ptm on_free_vars_it_mkLambda_or_LetIn.
       apply/andP; split.
@@ -3122,16 +3121,16 @@ Proof.
     rewrite on_free_vars_ctx_subst_instance. eapply on_free_vars_ctx_impl.
     2:{ eapply closedn_ctx_on_free_vars. eapply (declared_inductive_closed_params declc). }
     { intros i'. rewrite shiftnP0 //. }
+    { len in fvssi. now len. }
     rewrite -map_rev.
     rewrite -(trans_subst (shiftnP (context_assumptions (cstr_args cdecl) + context_assumptions (ind_params mdecl))
       xpred0) (shiftnP #|Γ| xpred0)).
-    { rewrite context_assumptions_map.
-      relativize (context_assumptions (ind_params mdecl)).
+    { relativize (context_assumptions (ind_params mdecl)).
       eapply on_free_vars_expand_lets_k => //.
       rewrite on_free_vars_ctx_subst_instance; eauto with pcuic.
       2:now len.
       rewrite shiftnP_add in fvssi. len in fvssi. len.
-      rewrite Nat.add_comm context_assumptions_map in fvssi => //. }
+      rewrite Nat.add_comm => //. }
     { rewrite forallb_rev. eapply forallb_All in onps. solve_all. }
     f_equal.
     rewrite /case_branch_context /case_branch_context_gen.
@@ -3141,7 +3140,7 @@ Proof.
     rewrite /pre_case_branch_context_gen /inst_case_context.
     relativize #|cstr_args cdecl|.
     erewrite expand_lets_subst_comm. 2:now len.
-    rewrite !context_assumptions_map !context_assumptions_subst_instance.
+    rewrite !context_assumptions_subst_instance.
     rewrite cstr_branch_context_assumptions Nat.add_0_r.
     f_equal.
     rewrite /cstr_branch_context; len.
@@ -3159,7 +3158,6 @@ Proof.
     len. rewrite on_free_vars_subst_instance. 
     eapply closedn_on_free_vars. rewrite Nat.add_assoc //. }
   cbn. f_equal.
-  rewrite context_assumptions_map.
   rewrite -(trans_smash_context (shiftnP (#|ind_bodies mdecl| + #|ind_params mdecl|) xpred0) []) //.
   rewrite expand_lets_mkApps /= map_app trans_mkApps /=.
   f_equal. f_equal; rewrite map_app. f_equal.
@@ -5043,7 +5041,7 @@ Proof.
       destruct (lt_dec n (context_assumptions Γ)); revgoals.
       { intros hnth.
         have hn : n = context_assumptions Γ.
-        { apply nth_error_Some_length in hnth. len in hnth. lia. }
+        { apply nth_error_Some_length in hnth. len in hnth. }
         move: hnth.
         subst n. rewrite nth_error_app_ge; len => //.
         cbn. rewrite Nat.sub_diag /=. intros [= <-].

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -422,7 +422,7 @@ Proof.
   { len.
     rewrite -(Nat.add_0_r (#|cstr_args cdecl| + #|ind_params mdecl|)).
     eapply closedn_ctx_subst. len.
-    rewrite -(subst_instance_assumptions u).
+    rewrite -(context_assumptions_subst_instance u).
     eapply closedn_ctx_expand_lets. eapply closedn_ctx_upwards; eauto. lia.
     len. eapply closedn_ctx_upwards; eauto. lia.
     rewrite forallb_rev.
@@ -682,7 +682,7 @@ Proof.
   split=> //. split=> //.
   split; auto. split => //.
   now len in Hu.
-  now rewrite Hargslen context_assumptions_app !context_assumptions_subst !subst_instance_assumptions; lia.
+  now rewrite Hargslen context_assumptions_app !context_assumptions_subst !context_assumptions_subst_instance; lia.
 
   exists (skipn #|cdecl.(cstr_args)| isubst), (firstn #|cdecl.(cstr_args)| isubst).
   apply make_context_subst_spec in Hisubst.
@@ -690,7 +690,7 @@ Proof.
   rewrite List.rev_involutive.
   move/context_subst_app.
   rewrite !subst_context_length !subst_instance_length.
-  rewrite context_assumptions_subst subst_instance_assumptions -H.
+  rewrite context_assumptions_subst context_assumptions_subst_instance -H.
   move=>  [argsub parsub].
   rewrite closed_ctx_subst in parsub.
   now rewrite closedn_subst_instance_context.
@@ -2703,14 +2703,14 @@ Proof.
       rewrite !subst_instance_extended_subst.
       rewrite (subst_context_subst_context (inds  _ u _)); len.
       rewrite (subst_context_subst_context (inds  _ u' _)); len.
-      rewrite -(subst_instance_assumptions u).
+      rewrite -(context_assumptions_subst_instance u).
       rewrite -(subst_extended_subst).
       rewrite (closed_ctx_subst (inds _ _ _)) //.
-      rewrite (subst_instance_assumptions u).
-      rewrite -(subst_instance_assumptions u').
+      rewrite (context_assumptions_subst_instance u).
+      rewrite -(context_assumptions_subst_instance u').
       rewrite -(subst_extended_subst).
       rewrite (closed_ctx_subst (inds _ u' _)) //.
-      rewrite (subst_instance_assumptions u').
+      rewrite (context_assumptions_subst_instance u').
       rewrite (subst_context_subst_context (List.rev pars)) /=; len.
       rewrite -(spine_subst_extended_subst spu).
       rewrite !subst_instance_lift_context. len.
@@ -2800,8 +2800,8 @@ Proof.
         now rewrite -context_assumptions_app in clx *. }
       len in cxy. autorewrite with substu in cxy.
       rewrite -context_assumptions_app in cxy.
-      rewrite -{1}(subst_instance_assumptions u (_ ++ _)) in cxy.
-      rewrite -{1}(subst_instance_assumptions u' (_ ++ _)) in cxy.
+      rewrite -{1}(context_assumptions_subst_instance u (_ ++ _)) in cxy.
+      rewrite -{1}(context_assumptions_subst_instance u' (_ ++ _)) in cxy.
       rewrite -(expand_lets_subst_comm' _ _ 0) in cxy.
       { len. substu; cbn.
         rewrite -context_assumptions_app in clx.
@@ -2825,7 +2825,7 @@ Proof.
       rewrite -/(expand_lets_ctx _ _).
       rewrite !subst_instance_subst_context !subst_instance_lift_context subst_instance_smash /=.
       rewrite subst_instance_extended_subst.
-      rewrite -(subst_instance_assumptions u).
+      rewrite -(context_assumptions_subst_instance u).
       rewrite -(subst_instance_length u).
       rewrite -/(expand_lets_k_ctx (ind_params mdecl)@[u] 0 (smash_context [] (cstr_args cdecl)@[u])).
       rewrite subst_context_expand_lets_k //.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -836,7 +836,7 @@ Lemma lift_context_lift_context n k k' Γ :
   lift_context n (k + k') (lift_context k' k Γ) = lift_context (n + k') k Γ.
 Proof.
   rewrite - !rename_context_lift_context.
-  rewrite /PCUICRenameDef.rename_context fold_context_k_compose.
+  rewrite /rename_context fold_context_k_compose.
   apply fold_context_k_ext => i x.
   rewrite !rename_inst !shiftn_lift_renaming !ren_lift_renaming.
   sigma. apply inst_ext.
@@ -1730,7 +1730,7 @@ Proof.
   eapply arity_typing_spine in tyargs as [argslen leqs [instsubst [wfdom wfcodom cs subs]]] => //.
   apply context_subst_app in cs as [argsubst parsubst].
   eexists _, _. move=> parctx argctx.
-  rewrite subst_instance_assumptions in argsubst, parsubst.
+  rewrite context_assumptions_subst_instance in argsubst, parsubst.
   rewrite declm.(onNpars) in argsubst, parsubst.
   eapply subslet_app_inv in subs as [subp suba].
   rewrite subst_instance_length in subp, suba.
@@ -1775,7 +1775,7 @@ Proof.
   apply context_subst_app in cs as [argsubst parsubst].
   eexists (firstn (ind_npars mdecl) args), (skipn (ind_npars mdecl) args), _, _.
   move=> parctx argctx.
-  rewrite subst_instance_assumptions in argsubst, parsubst.
+  rewrite context_assumptions_subst_instance in argsubst, parsubst.
   rewrite declm.(onNpars) in argsubst, parsubst.
   eapply subslet_app_inv in subs as [subp suba].
   rewrite subst_instance_length in subp, suba.

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -6,8 +6,6 @@ From MetaCoq.PCUIC Require Import PCUICUtils PCUICOnOne PCUICAst PCUICAstUtils P
      PCUICSigmaCalculus PCUICWeakeningEnvConv PCUICInduction
      PCUICRenameDef PCUICRenameConv PCUICInstDef PCUICInstConv PCUICOnFreeVars 
      PCUICContextRelation PCUICWeakeningConv PCUICWeakeningTyp PCUICSubstitution.
-
-     (* PCUICWeakening  PCUICSubstitution. *)
      
 Require Import ssreflect ssrbool.
 From Equations Require Import Equations.
@@ -115,21 +113,6 @@ Section All2_fold.
     induction H; constructor; auto. eapply All_decls_impl; tea. eauto.
   Qed.
 
-  Global Instance on_contexts_has_length P (l l' : context) : 
-    HasLen (All2_fold P l l') #|l| #|l'|.
-  Proof. red. apply on_contexts_length. Qed.
-  Hint Extern 20 (#|?X| = #|?Y|) =>
-    match goal with
-      [ H : All2_fold _ ?X ?Y |- _ ] => apply (All2_fold_length H)
-    | [ H : All2_fold _ ?Y ?X |- _ ] => symmetry; apply (All2_fold_length H)
-    | [ H : on_contexts_over _ _ _ ?X ?Y |- _ ] => apply (on_contexts_length H)
-    | [ H : on_contexts_over _ _ _ ?Y ?X |- _ ] => symmetry; apply (on_contexts_length H)
-    end : pcuic.
-
-  Ltac pcuic := eauto with pcuic.
-
-  Derive Signature for All2_fold.
-
   Lemma on_contexts_app':
     forall P (Γ Γ' Γ'' : context),
       on_contexts P (Γ ,,, Γ') Γ'' ->
@@ -169,7 +152,7 @@ Section All2_fold.
   Proof.
     intros * a hl.
     apply: All2_fold_app_inv => //.
-    apply All2_fold_length in a. len in a. lia.
+    apply All2_fold_length in a. len in a.
   Qed.
   
   Lemma nth_error_pred1_ctx {P} {Γ Δ} i body' :
@@ -1873,7 +1856,7 @@ Section ParallelSubstitution.
       rewrite nth_error_app_lt //. lia.
       eapply simpl_pred; revgoals. 3:reflexivity.
       econstructor. eapply on_contexts_app => //.
-      rewrite nth_error_app_lt. len. len in l. lia.
+      rewrite nth_error_app_lt. len. len in l. 
       rewrite /inst_context nth_error_fold_context_k option_map_two /=.
       destruct (nth_error Δ1 x) => //. noconf eqb.
       cbn. rewrite H /= //.

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -3612,7 +3612,7 @@ Section Rho.
     now rewrite -> shiftnP_xpredT in onpctx.
     eapply pred1_subst_consn; tea; eauto with fvs.
     - len. now rewrite (All2_length a).
-    - len. now rewrite (All2_length a).
+    - len. rewrite context_assumptions_fake_params. now rewrite (All2_length a).
     - now eapply All2_rev.
   Qed.
 
@@ -4034,8 +4034,10 @@ Section Rho.
       now eapply pred1_refl_gen.
 
     - simpl in *. simp rho; simpl.
-      destruct (lookup_env Σ c) eqn:Heq; pcuic. destruct g; pcuic.
-      destruct cst_body eqn:Heq'; pcuic.
+      destruct (lookup_env Σ c) eqn:Heq. 2:{ constructor; auto. }
+      destruct g. 2:{ constructor; auto. }
+      destruct c0. destruct cst_body0 eqn:Heq'. pcuic.
+      constructor; auto.
       
     - simpl in *. inv_on_free_vars. rewrite rho_app_proj.
       rewrite decompose_app_mkApps; auto.
@@ -4222,7 +4224,7 @@ Section Rho.
         econstructor. 1-2:tea.
         * erewrite nth_error_map, hbr. instantiate (1 := rho_br Γ'0 (rho_predicate Γ'0 p0) b).
           reflexivity.
-        * len. eauto.  
+        * len.
         * solve_all.
         * solve_all. eapply All2_map_right_inv in hbrs. solve_all.
           eapply on_contexts_app_inv => //. rewrite -heq_puinst.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -30,7 +30,7 @@ Arguments Nat.sub : simpl nomatch.
 Arguments Universe.sort_of_product : simpl nomatch.
 
 #[global]
-Hint Rewrite subst_instance_assumptions projs_length : len.
+Hint Rewrite context_assumptions_subst_instance projs_length : len.
 
 (* Preservation of wf_*fixpoint *)  
 
@@ -2547,7 +2547,7 @@ Proof.
     rewrite !subst_instance_it_mkProd_or_LetIn !subst_it_mkProd_or_LetIn in tyargs, Hty.
     eapply typing_spine_inv in tyargs as [arg_sub [spargs sp]]; eauto.
     2:{ rewrite !context_assumptions_fold.
-        rewrite subst_instance_assumptions. rewrite H2.
+        rewrite context_assumptions_subst_instance. rewrite H2.
         apply onNpars in onmind. lia. }
     rewrite closed_ctx_subst in spargs.
     { eapply closed_wf_local; eauto. eapply on_minductive_wf_params; eauto. }
@@ -2556,7 +2556,7 @@ Proof.
     rewrite subst_it_mkProd_or_LetIn in sp.
     rewrite !subst_instance_mkApps !subst_mkApps in sp.
     eapply typing_spine_nth_error in sp; eauto.
-    2:{ rewrite !context_assumptions_fold. rewrite subst_instance_assumptions.
+    2:{ rewrite !context_assumptions_fold. rewrite context_assumptions_subst_instance.
         clear sp. eapply nth_error_Some_length in H.
         rewrite List.skipn_length in H. lia. }
     destruct sp as [decl [Hnth Hu0]].

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -118,7 +118,11 @@ Fixpoint rename f t : term :=
 
 Notation rename_predicate := (map_predicate_shift rename shiftn id).
 Notation rename_branches f := (map_branches_shift rename f).
-
+Definition rename_context f (Γ : context) : context :=
+  fold_context_k (fun i => rename (shiftn i f)) Γ.
+Definition rename_decl f d := map_decl (rename f) d.
+Definition rename_telescope r Γ :=
+  mapi (fun i => map_decl (rename (shiftn i r))) Γ.
 
 Lemma shiftn_ext n f f' : (forall i, f i = f' i) -> forall t, shiftn n f t = shiftn n f' t.
 Proof.
@@ -2220,3 +2224,13 @@ Qed.
 
 #[global]
 Hint Rewrite ren_lift_renaming subst_consn_compose : sigma.
+
+Lemma rename_context_length :
+  forall σ Γ,
+    #|rename_context σ Γ| = #|Γ|.
+Proof.
+  intros σ Γ. unfold rename_context.
+  apply fold_context_k_length.
+Qed.
+#[global]
+Hint Rewrite rename_context_length : sigma wf.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -817,7 +817,7 @@ Proof.
   move: E chopm.
   rewrite chop_n_app ?map_length. {
     rewrite <- H1. apply onNpars in onmind.
-    now rewrite subst_instance_assumptions. }
+    now rewrite context_assumptions_subst_instance. }
   move=> [= <- <-] chopm.
   move: {chopm}(chopm _ (subst n (#|cs'.(cstr_args)| + k))).
   rewrite map_app.
@@ -1118,6 +1118,7 @@ Proof.
       replace #|Γ''| with ((#|Γ''| - S n) + S n) at 2 by lia.
       set (k := S n).
       sigma. apply inst_ext.
+      rewrite /rshiftk. rewrite (ren_shiftk (S n)).
       rewrite -shiftn_Upn - !Upn_Upn. intros i; lia_f_equal.
   - move: hnth.
     case: (nth_error_app_context Γ Γ' _) => // x' hnth hn' [=] eq; subst x'.
@@ -1167,7 +1168,7 @@ Proof.
     split; auto.
     * rewrite Upn_eq /subst_consn idsn_lt //.
     * rewrite nth_error_app_lt; len => //.
-      change (fun m => S (n + m)) with (lift_renaming (S n) 0).
+      change (rshiftk (S n)) with (lift_renaming (S n) 0).
       rewrite nth_error_subst_context /= hnth /=. split; eauto.
       rewrite /= hb /=. f_equal.
       rewrite subst_inst. rewrite Nat.add_0_r.

--- a/pcuic/theories/Syntax/PCUICClosed.v
+++ b/pcuic/theories/Syntax/PCUICClosed.v
@@ -9,16 +9,6 @@ From Equations Require Import Equations.
 
 (** * Lemmas about the [closedn] predicate *)
 
-Lemma subst_instance_assumptions u ctx :
-  context_assumptions (subst_instance u ctx) = context_assumptions ctx.
-Proof.
-  induction ctx; cbnr.
-  destruct (decl_body a); cbn; now rewrite IHctx.
-Qed.
-#[global]
-Hint Rewrite subst_instance_assumptions : len.
-
-
 Lemma lift_decl_closed n k d : closed_decl k d -> lift_decl n k d = d.
 Proof.
   case: d => na [body|] ty; rewrite /test_decl /lift_decl /map_decl /=; unf_term.

--- a/pcuic/theories/Syntax/PCUICContextRelation.v
+++ b/pcuic/theories/Syntax/PCUICContextRelation.v
@@ -1,12 +1,8 @@
 From Equations Require Import Equations.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICLiftSubst.
-
+From MetaCoq.PCUIC Require Export PCUICTactics.
 From Coq Require Import CRelationClasses.
-
-Ltac pcuic :=
-  try repeat red; cbn in *;
-   try (solve [ intuition auto; eauto with pcuic || (try lia || congruence) ]).
 
 Lemma All2_fold_impl_onctx (P : context -> context -> context_decl -> context_decl -> Type) P' Γ Δ Q :  
   onctx Q Γ ->

--- a/pcuic/theories/Syntax/PCUICRenameDef.v
+++ b/pcuic/theories/Syntax/PCUICRenameDef.v
@@ -17,16 +17,6 @@ Set Keyed Unification.
 
 Set Default Goal Selector "!".
 
-
-Definition rename_context f (Γ : context) : context :=
-  fold_context_k (fun i => rename (shiftn i f)) Γ.
-
-Definition rename_decl f d := map_decl (rename f) d.
-
-Definition rename_telescope r Γ :=
-  mapi (fun i => map_decl (rename (shiftn i r))) Γ.
-
-
 Section Renaming.
 
 Context `{cf : checker_flags}.

--- a/pcuic/theories/Syntax/PCUICTactics.v
+++ b/pcuic/theories/Syntax/PCUICTactics.v
@@ -1,0 +1,57 @@
+
+From Coq Require Import ssreflect.
+From MetaCoq.Template Require Import config utils BasicAst.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCases PCUICLiftSubst
+  PCUICSigmaCalculus.
+
+#[global] Hint Extern 20 (#|?X| = #|?Y|) =>
+  match goal with
+  [ H : All2_fold _ ?X ?Y |- _ ] => apply (All2_fold_length H)
+  | [ H : All2_fold _ ?Y ?X |- _ ] => symmetry; apply (All2_fold_length H)
+  | [ H : on_contexts_over _ _ _ ?X ?Y |- _ ] => apply (All2_fold_length H)
+  | [ H : on_contexts_over _ _ _ ?Y ?X |- _ ] => symmetry; apply (All2_fold_length H)
+   end : pcuic.
+
+Ltac pcuic_core :=
+  try (solve [ intuition auto; eauto with pcuic || (try lia || congruence) ]).
+
+Ltac pcuic :=
+  pcuic_core || ltac:(try (red; repeat red; cbn in *; pcuic_core)).
+
+Definition lengths := 
+  (@context_assumptions_expand_lets_ctx, 
+   @context_assumptions_subst_context,
+   context_assumptions_fold, 
+   @context_assumptions_app,
+   @context_assumptions_map,
+   @context_assumptions_mapi,
+   @context_assumptions_mapi_context,
+   @context_assumptions_smash_context,
+   @context_assumptions_subst_instance, 
+   @context_assumptions_lift_context,
+   @inst_case_context_assumptions,
+    @expand_lets_ctx_length, @subst_context_length,
+    @subst_instance_length, @expand_lets_k_ctx_length, @inds_length, @lift_context_length,
+    @app_length, @List.rev_length, @extended_subst_length, @reln_length,
+    Nat.add_0_r, @app_nil_r, @rev_map_length, @rev_length, @unfold_length,
+    @map_length, @mapi_length, @mapi_rec_length, @map_InP_length,
+    @fold_context_k_length, @cofix_subst_length, @fix_subst_length,
+    fix_context_length, 
+    @smash_context_length,
+    @arities_context_length,
+    @forget_types_length,
+    @PCUICCases.ind_predicate_context_length,
+    @PCUICCases.cstr_branch_context_length,
+    @PCUICCases.inst_case_branch_context_length,
+    @PCUICCases.inst_case_predicate_context_length,
+    @inst_case_context_length,
+    @ind_predicate_context_length,
+    @map_context_length, @skipn_map_length,
+    @mapi_context_length, idsn_length, ren_ids_length).
+
+Ltac len ::= 
+  repeat (rewrite !lengths /= //); try solve [lia_f_equal].
+  
+Tactic Notation "len" "in" hyp(id) :=
+  repeat (rewrite !lengths /= // in id);
+  try solve [lia_f_equal].

--- a/pcuic/theories/Typing/PCUICInstTyp.v
+++ b/pcuic/theories/Typing/PCUICInstTyp.v
@@ -775,7 +775,7 @@ Proof.
       eapply inst_ext_closed.
       intros x Hx.
       rewrite subst_consn_lt /=; len; try lia.
-      (rewrite Upn_comp; try now repeat len); [].
+      rewrite Upn_comp; try now repeat len. 2:cbn; len.
       rewrite subst_consn_lt /=; len; try lia.
       now rewrite map_rev.
   - intros Σ wfΣ Γ wfΓ mfix n decl types hguard hnth htypes hmfix ihmfix wffix Δ σ hΔ hσ.

--- a/pcuic/theories/Typing/PCUICRenameTyp.v
+++ b/pcuic/theories/Typing/PCUICRenameTyp.v
@@ -142,7 +142,7 @@ Proof.
       rewrite (Nat.add_comm _ (context_assumptions _)) rename_shiftnk.
       f_equal. rewrite Nat.add_comm rename_subst.
       rewrite rename_inds. f_equal.
-      rewrite shiftn_add. len. lia_f_equal.
+      rewrite shiftn_add. now len.
     ++ unfold id. f_equal. f_equal.
        rewrite map_app map_map_compose.
        rewrite map_map_compose.
@@ -919,7 +919,7 @@ Proof.
     eapply (Hs P (Δ' ,,, rename_context f Γ0) (shiftn #|Γ0| f)).
     split => //.
     eapply urenaming_ext.
-    { len. now rewrite -shiftnP_add. }
+    { now rewrite app_length -shiftnP_add. }
     { reflexivity. } now eapply urenaming_context.
   - destruct t0 as [s Hs]. red in t1.
     rewrite rename_context_snoc /=. constructor; auto.
@@ -927,11 +927,11 @@ Proof.
       apply (Hs P (Δ' ,,, rename_context f Γ0) (shiftn #|Γ0| f)).
       split => //.
       eapply urenaming_ext.
-      { len; now rewrite -shiftnP_add. }
+      { now rewrite app_length -shiftnP_add. }
       { reflexivity. } now eapply urenaming_context.
     * red. apply (t1 P). split => //.
       eapply urenaming_ext.
-      { len; now rewrite -shiftnP_add. }
+      { now rewrite app_length -shiftnP_add. }
       { reflexivity. } now eapply urenaming_context.
 Qed.
 
@@ -996,7 +996,7 @@ Proof.
   pose proof (nth_error_Some_length hnth). len in H.
   simpl in H.
   destruct (nth_error (List.rev (rename_context _ _)) _) eqn:hnth'.
-  2:{ eapply nth_error_None in hnth'. len in hnth'. simpl in hnth'. lia. }
+  2:{ eapply nth_error_None in hnth'. len in hnth'. }
   rewrite nth_error_rev_inv in hnth; len; auto.
   len in hnth. simpl in hnth.
   rewrite nth_error_rev_inv in hnth'; len; auto.
@@ -1187,9 +1187,9 @@ Proof.
         split.
         ++ apply All_local_env_app_inv in IHpredctx as [].
           eapply wf_local_app_renaming; eauto. apply a0.
-        ++ rewrite /predctx.
+        ++ rewrite /predctx app_length.
            eapply urenaming_ext.
-           { len. now rewrite -shiftnP_add. }
+           { now rewrite -shiftnP_add. }
            { reflexivity. }
           relativize #|pcontext p|; [eapply urenaming_context|].
           { apply Hf. }

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -422,8 +422,8 @@ Proof.
       rewrite fix_context_length ?map_length in X0, X1, X3.
       rewrite (map_dtype _ (subst_instance u) x) in X3.
       rewrite subst_instance_app in X3.
-      rewrite <- (fix_context_subst_instance u mfix). len.
-      eapply X3.
+      rewrite <- (fix_context_subst_instance u mfix). 
+      now len.
     + red; rewrite <- wffix.
       unfold wf_fixpoint.
       rewrite map_map_compose.
@@ -447,8 +447,8 @@ Proof.
         rewrite fix_context_length ?map_length in X0, X1, X3.
         rewrite (map_dtype _ (subst_instance u) x) in X3.
         rewrite subst_instance_app in X3.
-        rewrite <- (fix_context_subst_instance u mfix). len.
-        eapply X3.
+        rewrite <- (fix_context_subst_instance u mfix). 
+        now len.
       + red; rewrite <- wffix.
         unfold wf_cofixpoint.
         rewrite map_map_compose.

--- a/pcuic/theories/utils/PCUICAstUtils.v
+++ b/pcuic/theories/utils/PCUICAstUtils.v
@@ -1066,3 +1066,9 @@ Proof.
   - now rewrite context_assumptions_fold.
   - rewrite context_assumptions_app /=. lia.
 Qed. 
+
+Lemma context_assumptions_expand_lets_ctx Γ Δ :
+  context_assumptions (expand_lets_ctx Γ Δ) = context_assumptions Δ.
+Proof. now rewrite /expand_lets_ctx /expand_lets_k_ctx; len. Qed.
+#[global]
+Hint Rewrite context_assumptions_expand_lets_ctx : len.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -681,10 +681,10 @@ Qed.
     destruct infer as []; cbn.
     destruct wt as [T' HT'].
     sq. split.
-    eapply BDToPCUIC.infering_typing in s; pcuic. apply hΣ.
+    eapply BDToPCUIC.infering_typing in s; pcuic.
     intros T'' HT''.
     apply typing_infering in HT'' as [P [HP HP']].
-    eapply infering_checking;tea. 1-2: pcuic. apply hΣ. fvs.
+    eapply infering_checking;tea. 1-2: pcuic. fvs.
     econstructor; tea. now eapply equality_forget in HP'.
   Qed.
     


### PR DESCRIPTION
We also avoid redefining the tactics at arbitrary places, and to consistently use ssr's autorewrite (fast) instead of standard autorewrite (slow) for `len`. 