### PR TITLE
Use parameterization by Conv/Cumul everywhere

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -199,7 +199,7 @@ Proof.
       rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r subst_mkApps /= in sp.
       apply (X (subst_context [t] 0 Γ0) ltac:(len; reflexivity) _ _ sp).
       eapply isType_apply in i; tea.
-      eapply (type_equality (le:=false)); tea. 2:now symmetry.
+      eapply (type_equality (pb:=Conv)); tea. 2:now symmetry.
       now eapply isType_tProd in i as [].
 Qed.
 

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -228,7 +228,7 @@ Proof.
   intros. induction Γ2.
   - cbn; eauto.
   - destruct a. destruct decl_body.
-    + cbn. econstructor. inv X0. eauto. econstructor.
-      depelim X0; reflexivity. reflexivity. reflexivity.
-    + cbn. econstructor. inv X0. eauto. now econstructor.
+    + cbn. econstructor. inv X0. apply IHΓ2. eauto.
+      depelim X0; econstructor; reflexivity.
+    + cbn. econstructor. inv X0. apply IHΓ2. eauto. now econstructor.
 Qed.

--- a/pcuic/theories/Bidirectional/BDToPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDToPCUIC.v
@@ -440,7 +440,7 @@ Section BDToPCUICTyping.
     - red ; intros.
       destruct X3.
       econstructor ; eauto.
-      eapply (cumulAlgo_cumulSpec _ (le := true)), into_equality ; tea.
+      eapply (cumulAlgo_cumulSpec _ (pb := Cumul)), into_equality ; tea.
       + fvs. 
       + now eapply type_is_open_term.
       + now eapply subject_is_open_term. 

--- a/pcuic/theories/Conversion/PCUICNamelessConv.v
+++ b/pcuic/theories/Conversion/PCUICNamelessConv.v
@@ -383,8 +383,8 @@ Lemma nl_compare_term {cf:checker_flags} le Σ:
     compare_term le (nl_global_env Σ) φ (nl t) (nl t').
 Proof.
   destruct le; intros.
-  - apply nl_leq_term. assumption.
   - apply nl_eq_term. assumption.
+  - apply nl_leq_term. assumption.
 Qed.
 
 Corollary eq_term_nl_eq :
@@ -793,8 +793,8 @@ Qed.
 
 Lemma nl_eq_decl {cf:checker_flags} :
   forall le Σ φ d d',
-    eq_decl le Σ φ d d' ->
-    eq_decl le (nl_global_env Σ) φ (map_decl nl d) (map_decl nl d').
+    compare_decl le Σ φ d d' ->
+    compare_decl le (nl_global_env Σ) φ (map_decl nl d) (map_decl nl d').
 Proof.
   intros le Σ φ d d' []; constructor; destruct le; 
   intuition auto using nl_eq_term, nl_leq_term.
@@ -802,8 +802,8 @@ Qed.
 
 Lemma nl_eq_decl' {cf:checker_flags} :
   forall le Σ φ d d',
-    eq_decl le Σ φ d d' ->
-    eq_decl le (nl_global_env Σ) φ (map_decl_anon nl d) (map_decl_anon nl d').
+    compare_decl le Σ φ d d' ->
+    compare_decl le (nl_global_env Σ) φ (map_decl_anon nl d) (map_decl_anon nl d').
 Proof.
   intros le Σ φ d d' []; constructor; destruct le;
   intuition auto using nl_eq_term, nl_leq_term.
@@ -811,8 +811,8 @@ Qed.
 
 Lemma nl_eq_context {cf:checker_flags} :
   forall le Σ φ Γ Γ',
-    eq_context le Σ φ Γ Γ' ->
-    eq_context le (nl_global_env Σ) φ (nlctx Γ) (nlctx Γ').
+    compare_context le Σ φ Γ Γ' ->
+    compare_context le (nl_global_env Σ) φ (nlctx Γ) (nlctx Γ').
 Proof.
   intros le Σ φ Γ Γ' h.
   unfold eq_context, nlctx.

--- a/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
+++ b/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
@@ -10,6 +10,8 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICOnOne PCUICAstUtils PCUICInducti
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
 
+Implicit Types (cf : checker_flags).
+
 (** * Universe Substitution lemmas for typing derivations. *)
 
 Local Set Keyed Unification.
@@ -241,6 +243,12 @@ Proof.
   - eapply H.
     eapply Universe.map_spec.
     exists e0; split; auto.
+Qed.
+
+#[global]
+Instance compare_universe_substu {cf} le Σ : SubstUnivPreserving (compare_universe le Σ).
+Proof.
+  destruct le; tc.
 Qed.
 
 Global Instance subst_instance_def {A} `(UnivSubst A) : UnivSubst (def A)
@@ -892,16 +900,13 @@ Proof.
 Qed.
 
 Lemma leq_term_subst_instance {cf : checker_flags} Σ : SubstUnivPreserved (leq_term Σ).
-Proof. exact _. Qed.
+Proof. apply eq_term_upto_univ_subst_preserved; cbn; apply _. Qed.
 
 Lemma eq_term_subst_instance {cf : checker_flags} Σ : SubstUnivPreserved (eq_term Σ).
-Proof. exact _. Qed.
+Proof. apply eq_term_upto_univ_subst_preserved; cbn; exact _. Qed.
 
-Lemma compare_term_subst_instance {cf : checker_flags} le Σ : SubstUnivPreserved (compare_term le Σ).
-Proof. destruct le; simpl; unfold compare_term. 
-  - apply leq_term_subst_instance.
-  - apply eq_term_subst_instance.
-Qed.
+Lemma compare_term_subst_instance {cf : checker_flags} pb Σ : SubstUnivPreserved (compare_term pb Σ).
+Proof. apply eq_term_upto_univ_subst_preserved; cbn; try destruct pb; exact _. Qed.
 
 (** Now routine lemmas ... *)
 
@@ -1495,16 +1500,16 @@ Proof.
   rewrite subst_instance_univ_val'; auto.
 Qed.
 
-Global Instance eq_decl_subst_instance {cf : checker_flags} le Σ : SubstUnivPreserved (eq_decl le Σ).
+Global Instance compare_decl_subst_instance {cf : checker_flags} pb Σ : SubstUnivPreserved (compare_decl pb Σ).
 Proof.
-  intros φ1 φ2 u HH ? ? [] => /=; destruct le; constructor; auto;
-   (eapply eq_term_subst_instance || eapply leq_term_subst_instance); tea.
+  intros φ1 φ2 u HH ? ? [] => /=; constructor; auto;
+   eapply compare_term_subst_instance; tea.
 Qed.
 
-Global Instance eq_context_subst_instance {cf : checker_flags} le Σ : SubstUnivPreserved (eq_context le Σ).
+Global Instance compare_context_subst_instance {cf : checker_flags} pb Σ : SubstUnivPreserved (compare_context pb Σ).
 Proof.
   intros φ φ' u HH Γ Γ' X. eapply All2_fold_map, All2_fold_impl; tea.
-  intros. eapply eq_decl_subst_instance; eassumption.
+  intros. eapply compare_decl_subst_instance; eassumption.
 Qed.
 
 Lemma subst_instance_destArity Γ A u :

--- a/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
+++ b/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
@@ -115,22 +115,21 @@ Lemma compare_term_subset {cf:checker_flags} le Σ φ φ' t t'
   : ConstraintSet.Subset φ φ'
     -> compare_term le Σ φ t t' -> compare_term le Σ φ' t t'.
 Proof.
-  destruct le; [apply leq_term_subset|apply eq_term_subset].
+  destruct le; [apply eq_term_subset|apply leq_term_subset].
 Qed.
 
-Lemma eq_decl_subset {cf:checker_flags} le Σ φ φ' d d'
+Lemma compare_decl_subset {cf:checker_flags} le Σ φ φ' d d'
   : ConstraintSet.Subset φ φ'
-    -> eq_decl le Σ φ d d' -> eq_decl le Σ φ' d d'.
+    -> compare_decl le Σ φ d d' -> compare_decl le Σ φ' d d'.
 Proof.
-  intros Hφ []; constructor; destruct le;
-  eauto using leq_term_subset, eq_term_subset.
+  intros Hφ []; constructor; eauto using compare_term_subset.
 Qed.
 
-Lemma eq_context_subset {cf:checker_flags} le Σ φ φ' Γ Γ'
+Lemma compare_context_subset {cf:checker_flags} le Σ φ φ' Γ Γ'
   : ConstraintSet.Subset φ φ'
-    -> eq_context le Σ φ Γ Γ' ->  eq_context le Σ φ' Γ Γ'.
+    -> compare_context le Σ φ Γ Γ' ->  compare_context le Σ φ' Γ Γ'.
 Proof.
-  intros Hφ. induction 1; constructor; auto; eapply eq_decl_subset; eassumption.
+  intros Hφ. induction 1; constructor; auto; eapply compare_decl_subset; eassumption.
 Qed.
 
 Ltac my_rename_hyp h th :=
@@ -334,7 +333,7 @@ Proof.
   induction 1; simpl.
   - econstructor. eapply eq_term_subset.
     + eapply global_ext_constraints_app.
-    + simpl in *. eapply eq_term_upto_univ_weaken_env in e; simpl; eauto.
+    + simpl in *. eapply eq_term_upto_univ_weaken_env in c; simpl; eauto.
       1:exists Σ''; eauto.
       all:typeclasses eauto.
   - econstructor 2; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
@@ -351,7 +350,7 @@ Proof.
   induction 1; simpl.
   - econstructor. eapply leq_term_subset.
     + eapply global_ext_constraints_app.
-    + simpl in *. eapply eq_term_upto_univ_weaken_env in e; simpl; eauto.
+    + simpl in *. eapply eq_term_upto_univ_weaken_env in c; simpl; eauto.
       1:exists Σ''; eauto.
       all:typeclasses eauto.
   - econstructor 2; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -252,12 +252,12 @@ Section Alpha.
     induction 1; constructor; auto.
   Qed.
 
-  Lemma All_decls_alpha_le_ws_decl {le P} {Γ : context} {d d'} :
+  Lemma All_decls_alpha_pb_ws_decl {le P} {Γ : context} {d d'} :
     (forall le t t', is_open_term Γ t -> is_open_term Γ t' -> upto_names' t t' -> P le t t') ->
     compare_decls upto_names' upto_names' d d' ->
     ws_decl Γ d ->
     ws_decl Γ d' ->
-    All_decls_alpha_le le P d d'.
+    All_decls_alpha_pb le P d d'.
   Proof.
     intros HP []; cbn. constructor; eauto.
     move/andP=> [] /= clb clT /andP[] => clb' clT'.
@@ -292,7 +292,7 @@ Section Alpha.
     rewrite onΓ a' /= => iscl.
     move: (on_free_vars_ctx_app xpred0 Γ Δ0).
     rewrite onΓ a /= => iscl'.
-    eapply All_decls_alpha_le_ws_decl; tea.
+    eapply All_decls_alpha_pb_ws_decl; tea.
     intros. apply equality_compare => //. now apply eq_term_compare_term, upto_names_impl_eq_term.
     rewrite app_length (All2_fold_length IH') -app_length //.
 
@@ -494,19 +494,19 @@ Section Alpha.
     induction eq; depelim a; cbn; try solve [constructor; auto];
     depelim r; subst; constructor; auto.
     - destruct l as [s Hs]. exists s.
-      eapply (closed_context_cumulativity _ (le:=false)); tea. apply IHeq. pcuic.
+      eapply (closed_context_cumulativity _ (pb:=Conv)); tea. apply IHeq. pcuic.
       eapply context_equality_rel_app.
       eapply eq_context_upto_conv_context_rel; fvs.
       eapply eq_context_gen_upto.
       now eapply All2_fold_All2 in eq.
     - destruct l as [s Hs]. exists s.
-      eapply (closed_context_cumulativity _ (le := false)); tea. apply IHeq. pcuic.
+      eapply (closed_context_cumulativity _ (pb:=Conv)); tea. apply IHeq. pcuic.
       eapply context_equality_rel_app.
       eapply eq_context_upto_conv_context_rel. 1-2:fvs.
       eapply eq_context_gen_upto.
       now eapply All2_fold_All2 in eq.
     - red. red in l0.
-      eapply (closed_context_cumulativity _ (le := false)); tea. apply IHeq. pcuic.
+      eapply (closed_context_cumulativity _ (pb:=Conv)); tea. apply IHeq. pcuic.
       eapply context_equality_rel_app.
       eapply eq_context_upto_conv_context_rel. 1-2:fvs.
       eapply eq_context_gen_upto.
@@ -634,10 +634,9 @@ Section Alpha.
         eapply validity. eapply ihB; eauto.
         constructor; auto. constructor ; auto. reflexivity.
       + apply eq_term_upto_univ_cumulSpec, eq_term_leq_term.
-        apply eq_term_sym.
-        constructor; auto.
+        symmetry. constructor; auto.
         all: try (eapply upto_names_impl_eq_term ; assumption).
-        all: eapply eq_term_refl.
+        all: reflexivity.
     - intros na b B t s1 A ih hB ihB hb ihb hA ihA Δ v e e'; invs e.
       specialize (ihB _ _ X0 e').
       specialize (ihb _ _ X e').
@@ -665,10 +664,9 @@ Section Alpha.
       + destruct X2. exists x.
         eapply eq_context_conversion; tea. eauto.
       + eapply eq_term_upto_univ_cumulSpec, eq_term_leq_term.
-        apply eq_term_sym.
-        constructor. assumption.
+        symmetry; constructor. assumption.
         all: try (eapply upto_names_impl_eq_term ; assumption).
-        all: eapply eq_term_refl.
+        all: reflexivity.
     - intros t na A B s u ih hty ihty ht iht hu ihu Δ v e e'; invs e.
       assert (isType Σ Γ (B {0 := s})).
       { eapply validity; econstructor; eauto. }
@@ -681,7 +679,7 @@ Section Alpha.
         * eapply ihty. reflexivity. auto.
       + destruct X1 as [s' Hs]. exists s'. eapply eq_context_conversion; tea. eauto.
       + eapply eq_term_upto_univ_cumulSpec, eq_term_leq_term.
-        apply eq_term_sym.
+        symmetry.
         eapply upto_names_impl_eq_term.
         eapply eq_term_upto_univ_subst ; now auto.
     - intros cst u decl ? ? hdecl hcons Δ v e e'; invs e.
@@ -763,7 +761,7 @@ Section Alpha.
         destruct (wf_local_app_inv X4) as [wfΔ _].
         assert (clΔ := (wf_local_closed_context wfΔ)).
         econstructor; tea; eauto. 2,3: constructor; tea ; eauto. 
-        * eapply (type_equality (le:=true)).
+        * eapply (type_equality (pb:=Cumul)).
           eapply IHc; eauto.
           eexists; eapply isType_mkApps_Ind; tea.
           unshelve eapply (ctx_inst_spine_subst _ ctxinst').
@@ -836,7 +834,7 @@ Section Alpha.
         econstructor ; eauto.
         eapply eq_context_conversion; tea; pcuic.
       + apply eq_term_upto_univ_cumulSpec, eq_term_leq_term.
-        apply eq_term_sym.
+        symmetry.
         eapply upto_names_impl_eq_term.
         eapply eq_term_upto_univ_substs ; auto; try reflexivity.
         * constructor ; auto.
@@ -991,11 +989,11 @@ Section Alpha.
         now symmetry.
 
     - intros t A B X wf ht iht har ihar hcu Δ v e e'.
-      eapply (type_equality (le:=true)).
+      eapply (type_equality (pb:=Cumul)).
       + eapply iht; tea.
       + exists X; eauto.
         specialize (wf _ e'). now eapply eq_context_conversion.
-      + eapply (equality_equality_ctx (le':=false)); tea.
+      + eapply (equality_equality_ctx (pb':=Conv)); tea.
         2:eapply PCUICInversion.into_ws_cumul; tea.
         specialize (wf _ e').
         apply wf_conv_context_closed => //.

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -136,7 +136,7 @@ Section WfEnv.
     | Some (ctx, s) =>
       ∑ T' ctx' s',
         [× Σ ;;; Γ ⊢ T ⇝ T', (destArity [] T' = Some (ctx', s')),
-          context_equality false Σ (Γ ,,, smash_context [] ctx) (Γ ,,, ctx') &
+          Σ ⊢ Γ ,,, smash_context [] ctx = Γ ,,, ctx' &
           leq_universe (global_ext_constraints Σ) s s']
     | None => unit
     end.
@@ -236,18 +236,18 @@ Section WfEnv.
     exists s'. now eapply (substitution (T:=tSort _)).
   Qed.
 
-  Lemma type_equality {le Γ t} T {U} :
+  Lemma type_equality {pb Γ t} T {U} :
     Σ ;;; Γ |- t : T ->
     isType Σ Γ U ->
-    Σ ;;; Γ ⊢ T ≤[le] U ->
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
     Σ ;;; Γ |- t : U.
   Proof.
     intros.
     eapply type_Cumul; tea. apply X0.π2.
-    destruct le.
-    - now eapply (cumulAlgo_cumulSpec Σ (le:=true)).
+    destruct pb.
     - eapply equality_eq_le in X1.
       now eapply cumulAlgo_cumulSpec in X1.
+    - now eapply cumulAlgo_cumulSpec.
   Qed.
 
   Lemma isType_tLetIn_red {Γ} (HΓ : wf_local Σ Γ) {na t A B}
@@ -258,7 +258,7 @@ Section WfEnv.
     exists s.
     assert (Hs := typing_wf_universe _ H).
     apply inversion_LetIn in H; tas. destruct H as [s1 [A' [HA [Ht [HB H]]]]].
-    eapply (type_equality (le:=true)) with (A' {0 := t}). eapply substitution_let in HB; eauto.
+    eapply (type_equality (pb:=Cumul)) with (A' {0 := t}). eapply substitution_let in HB; eauto.
     * econstructor; eauto with pcuic. econstructor; eauto.
     * eapply equality_Sort_r_inv in H as [s' [H H']].
       transitivity (tSort s'); eauto.
@@ -615,7 +615,7 @@ Section WfEnv.
       rewrite !subst_empty in t3.
       forward IHn.
       eapply type_Cumul. eapply t1. econstructor; intuition eauto using typing_wf_local with pcuic.
-      eapply (cumulAlgo_cumulSpec _ (le:=true)), e. rewrite {2}Hl in IHn.
+      eapply (cumulAlgo_cumulSpec _ (pb:=Cumul)), e. rewrite {2}Hl in IHn.
       now rewrite -subst_app_simpl -H0 firstn_skipn in IHn.
       
       intros Hs.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -262,7 +262,7 @@ Section Spines.
       eapply wf_local_rel_app_inv in wfty as [wfty _]. depelim wfty.
       eapply equality_Prod_Prod_inv in e as [eqna dom codom].
       assert (Σ ;;; Γ |- hd : ty).
-      { eapply (type_equality (le:=false)); pcuic. now symmetry. }
+      { eapply (type_equality (pb:=Conv)); pcuic. now symmetry. }
       eapply (substitution0_equality (t:=hd)) in codom; eauto.
       eapply typing_spine_strengthen in sp. 3:tea.
       rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in sp.
@@ -321,7 +321,7 @@ Section Spines.
         rewrite subst_app_simpl /=; len; rewrite H.
         now rewrite -(expand_lets_subst_comm _ _ _).
         eapply isType_apply in i; tea.
-        eapply (type_equality (le:=false)); tea. 2:now symmetry.
+        eapply (type_equality (pb:=Conv)); tea. 2:now symmetry.
         now eapply isType_tProd in i as [].
   Qed.
 
@@ -351,7 +351,7 @@ Section Spines.
         apply (H (subst_context [t] 0 Γ0) ltac:(len; reflexivity) _ _ sp).
         now len.
         eapply isType_apply in i; tea.
-        eapply (type_equality (le:=false)); tea. 2:now symmetry.
+        eapply (type_equality (pb:=Conv)); tea. 2:now symmetry.
         now eapply isType_tProd in i as [].
   Qed.
 
@@ -1133,7 +1133,7 @@ Section WeakNormalization.
       eapply IHHe3.
       rewrite (closed_subst a' 0 b); auto.
       rewrite /subst1 in t3. eapply t3.
-      eapply (type_equality (le:=false)); eauto.
+      eapply (type_equality (pb:=Conv)); eauto.
       eapply subject_reduction in IHHe2; eauto. now eexists.
       eapply equality_Prod_Prod_inv in e0 as [eqna dom codom]; eauto.
       now symmetry.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -36,15 +36,6 @@ Definition closed_red_ctx Σ Γ Γ' :=
 Notation "Σ ⊢ Γ ⇝ Δ" := (closed_red_ctx Σ Γ Δ) (at level 50, Γ, Δ at next level,
   format "Σ  ⊢  Γ  ⇝  Δ") : pcuic.
 
-Notation "Σ ⊢ Γ ≤[ le ] Δ" := (context_equality le Σ Γ Δ) (at level 50, Γ, Δ at next level,
-  format "Σ  ⊢  Γ  ≤[ le ]  Δ") : pcuic.
-
-Notation "Σ ⊢ Γ = Δ" := (context_equality false Σ Γ Δ) (at level 50, Γ, Δ at next level,
-  format "Σ  ⊢  Γ  =  Δ") : pcuic.
-
-Notation "Σ ⊢ Γ ≤ Δ" := (context_equality true Σ Γ Δ) (at level 50, Γ, Δ at next level,
-  format "Σ  ⊢  Γ  ≤  Δ") : pcuic.
-
 Lemma closed_red_ctx_red_ctx {Σ Γ Γ'} : 
   Σ ⊢ Γ ⇝ Γ' -> red_ctx Σ Γ Γ'.
 Proof.
@@ -386,39 +377,8 @@ Proof.
   now transitivity y.
 Qed.
 
-Definition compare_context {cf} le Σ := 
-  eq_context_upto Σ (eq_universe Σ) (compare_universe le Σ).
-
-#[global]
-Instance compare_universe_refl {cf} le Σ : RelationClasses.Reflexive (compare_universe le Σ).
-Proof.
-  destruct le; tc.
-Qed.
-
-#[global]
-Instance compare_universe_trans {cf} le Σ : RelationClasses.Transitive (compare_universe le Σ).
-Proof.
-  destruct le; tc.
-Qed.
-
-#[global]
-Instance compare_universe_substu {cf} le Σ : SubstUnivPreserving (compare_universe le Σ).
-Proof.
-  destruct le; tc.
-Qed.
-
-#[global]
-Instance compare_universe_subrel {cf} le Σ : RelationClasses.subrelation (eq_universe Σ) (compare_universe le Σ).
-Proof.
-  destruct le; tc.
-Qed.
-
-#[global]
-Instance compare_universe_preorder {cf} le Σ : RelationClasses.PreOrder (compare_universe le Σ).
-Proof.
-  destruct le; tc.
-Qed.
-
+Definition compare_context {cf} pb Σ := 
+  eq_context_upto Σ (eq_universe Σ) (compare_universe pb Σ).
 
 Section ContextConversion.
   Context {cf : checker_flags}.
@@ -481,40 +441,40 @@ Section ContextConversion.
   Qed.
   Hint Resolve red_ctx_closed_left red_ctx_closed_right : fvs.
 
-  Lemma red_compare_term_l {le Γ} {u v u' : term} :
-    compare_term le Σ Σ u u' ->
+  Lemma red_compare_term_l {pb Γ} {u v u' : term} :
+    compare_term pb Σ Σ u u' ->
     red Σ Γ u v -> 
-    ∑ v' : term, red Σ Γ u' v' × compare_term le Σ Σ v v'.
+    ∑ v' : term, red Σ Γ u' v' × compare_term pb Σ Σ v v'.
   Proof.
-    destruct le; cbn;
+    destruct pb; cbn;
     apply red_eq_term_upto_univ_l; tc.
   Qed.
 
-  Lemma red_compare_term_r {le Γ} {u v u' : term} :
-    compare_term le Σ Σ u u' ->
+  Lemma red_compare_term_r {pb Γ} {u v u' : term} :
+    compare_term pb Σ Σ u u' ->
     red Σ Γ u' v -> 
-    ∑ v' : term, red Σ Γ u v' × compare_term le Σ Σ v' v.
+    ∑ v' : term, red Σ Γ u v' × compare_term pb Σ Σ v' v.
   Proof.
-    destruct le; cbn;
+    destruct pb; cbn;
     apply red_eq_term_upto_univ_r; tc.
   Qed.
 
-  Lemma closed_red_compare_term_l {le Γ} {u v u' : term} :
+  Lemma closed_red_compare_term_l {pb Γ} {u v u' : term} :
     is_open_term Γ u' ->
-    compare_term le Σ Σ u u' ->
+    compare_term pb Σ Σ u u' ->
     Σ ;;; Γ ⊢ u ⇝ v -> 
-    ∑ v' : term, Σ ;;; Γ ⊢ u' ⇝ v' × compare_term le Σ Σ v v'.
+    ∑ v' : term, Σ ;;; Γ ⊢ u' ⇝ v' × compare_term pb Σ Σ v v'.
   Proof.
     intros isop comp [clΓ clu red].
     destruct (red_compare_term_l comp red) as [nf [r eq]].
     exists nf; repeat (split; eauto with fvs). 
   Qed.
 
-  Lemma closed_red_compare_term_r {le Γ} {u v u' : term} :
+  Lemma closed_red_compare_term_r {pb Γ} {u v u' : term} :
     is_open_term Γ u ->
-    compare_term le Σ Σ u u' ->
+    compare_term pb Σ Σ u u' ->
     Σ ;;; Γ ⊢ u' ⇝ v -> 
-    ∑ v' : term, Σ ;;; Γ ⊢ u ⇝ v' × compare_term le Σ Σ v' v.
+    ∑ v' : term, Σ ;;; Γ ⊢ u ⇝ v' × compare_term pb Σ Σ v' v.
   Proof.
     intros isop comp [clΓ clu red].
     destruct (red_compare_term_r comp red) as [nf [r eq]].
@@ -536,10 +496,10 @@ Section ContextConversion.
     rewrite -(length_of rctx); eauto with fvs.
   Qed.
 
-  Lemma equality_red {le} {Γ t u} :
-    Σ ;;; Γ ⊢ t ≤[le] u <~> 
+  Lemma equality_red {pb} {Γ t u} :
+    Σ ;;; Γ ⊢ t ≤[pb] u <~> 
     ∑ v v', [× Σ ;;; Γ ⊢ t ⇝ v, Σ ;;; Γ ⊢ u ⇝ v' &
-      compare_term le Σ (global_ext_constraints Σ) v v'].
+      compare_term pb Σ (global_ext_constraints Σ) v v'].
   Proof.    
     split.
     - move/equality_alt; intros (v & v' & [clΓ clt clu red red' leq]).
@@ -558,10 +518,10 @@ Section ContextConversion.
     cbn in *. exists v'; repeat split; eauto with fvs.
   Qed.
   
-  Lemma equality_red_ctx {le} {Γ Γ'} {T U} :
+  Lemma equality_red_ctx {pb} {Γ Γ'} {T U} :
     Σ ⊢ Γ ⇝ Γ' ->
-    Σ ;;; Γ ⊢ T ≤[le] U ->
-    Σ ;;; Γ' ⊢ T ≤[le] U.
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
+    Σ ;;; Γ' ⊢ T ≤[pb] U.
   Proof.
     intros Hctx H.
     apply equality_red in H as (v & v' & [redl redr leq]).
@@ -601,10 +561,10 @@ Section ContextConversion.
     rewrite -(All2_fold_length rc); eauto with fvs.
   Qed.
 
-  Lemma cumul_red_ctx_inv {le} {Γ Γ' : context} {T U : term} :
-    Σ ;;; Γ ⊢ T ≤[le] U ->
+  Lemma cumul_red_ctx_inv {pb} {Γ Γ' : context} {T U : term} :
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
     Σ ⊢ Γ' ⇝ Γ ->
-    Σ ;;; Γ' ⊢ T ≤[le] U.
+    Σ ;;; Γ' ⊢ T ≤[pb] U.
   Proof.
     intros H Hctx.
     apply equality_red in H as (v & v' & [redl redr leq]).
@@ -663,10 +623,10 @@ Section ContextConversion.
       eapply eq_term_upto_univ_trans with v''; auto; tc.
   Qed.
 
-  Lemma closed_red_eq_context_upto_l {le Γ Δ} {u} {v} :
+  Lemma closed_red_eq_context_upto_l {pb Γ Δ} {u} {v} :
     is_closed_context Δ ->
     Σ ;;; Γ ⊢ u ⇝ v ->
-    compare_context le Σ Γ Δ ->
+    compare_context pb Σ Γ Δ ->
     ∑ v', Σ ;;; Δ ⊢ u ⇝ v' × eq_term Σ Σ v v'.
   Proof.
     intros clΔ [onΓ onu r] c.
@@ -675,10 +635,10 @@ Section ContextConversion.
     now rewrite -(All2_fold_length c).
   Qed.
 
-  Lemma closed_red_eq_context_upto_r {le Γ Δ} {u} {v} :
+  Lemma closed_red_eq_context_upto_r {pb Γ Δ} {u} {v} :
     is_closed_context Γ ->
     Σ ;;; Δ ⊢ u ⇝ v ->
-    compare_context le Σ Γ Δ ->
+    compare_context pb Σ Γ Δ ->
     ∑ v', Σ ;;; Γ ⊢ u ⇝ v' × eq_term Σ Σ v v'.
   Proof.
     intros clΔ [onΓ onu r] c.
@@ -781,11 +741,11 @@ Section ContextConversion.
     now apply eq_term_leq_term.
   Qed.
 
-  Lemma equality_compare_context {le le' Γ Δ T U} :
-    compare_context le Σ Δ Γ ->
+  Lemma equality_compare_context {pb pb' Γ Δ T U} :
+    compare_context pb Σ Δ Γ ->
     is_closed_context Δ ->
-    Σ ;;; Γ ⊢ T ≤[le'] U ->
-    Σ ;;; Δ ⊢ T ≤[le'] U.
+    Σ ;;; Γ ⊢ T ≤[pb'] U ->
+    Σ ;;; Δ ⊢ T ≤[pb'] U.
   Proof.
     intros eqctx cl cum.
     eapply equality_red in cum as [nf [nf' [redl redr ?]]].
@@ -794,18 +754,19 @@ Section ContextConversion.
     destruct redl as [v' [redv' eqv']].
     destruct redr as [v'' [redv'' eqv'']].
     eapply equality_red. exists v', v''; split; auto.
-    destruct le'; cbn in *; transitivity nf.
-    apply eq_term_leq_term. now symmetry.
+    destruct pb'; cbn in *; transitivity nf.
+    now symmetry.
     transitivity nf' => //.
-    now apply eq_term_leq_term. now symmetry.
+    now apply eq_term_leq_term.
     transitivity nf'; auto.
+    now apply eq_term_leq_term.
   Qed.
   
-  Local Remark equality_compare_context_inv {le le' Γ Δ T U} :
-    compare_context le Σ Γ Δ ->
+  Local Remark equality_compare_context_inv {pb pb' Γ Δ T U} :
+    compare_context pb Σ Γ Δ ->
     is_closed_context Δ ->
-    Σ ;;; Γ ⊢ T ≤[le'] U ->
-    Σ ;;; Δ ⊢ T ≤[le'] U.
+    Σ ;;; Γ ⊢ T ≤[pb'] U ->
+    Σ ;;; Δ ⊢ T ≤[pb'] U.
   Proof.
     intros eqctx cl cum.
     eapply equality_red in cum as [nf [nf' [redl redr ?]]].
@@ -814,11 +775,12 @@ Section ContextConversion.
     destruct redl as [v' [redv' eqv']].
     destruct redr as [v'' [redv'' eqv'']].
     eapply equality_red. exists v', v''; split; auto.
-    destruct le'; cbn in *; transitivity nf.
-    apply eq_term_leq_term. now symmetry.
-    transitivity nf' => //.
-    now apply eq_term_leq_term. now symmetry.
-    transitivity nf'; auto.
+    destruct pb'; cbn in *; transitivity nf.
+    - now symmetry.
+    - transitivity nf'; auto.
+    - apply eq_term_leq_term. now symmetry.
+    - transitivity nf' => //.
+      now apply eq_term_leq_term. 
   Qed.
 
   (* Local Remark cumul_leq_context_upto_inv {Γ Δ T U} :
@@ -870,14 +832,14 @@ Section ContextConversion.
     eapply cumul_leq_context_upto; eauto.
   Qed.
 
-  Lemma equality_eq_context_upto {le Γ Δ T U} :
+  Lemma equality_eq_context_upto {pb Γ Δ T U} :
     eq_context_upto Σ (eq_universe Σ) (eq_universe Σ) Γ Δ ->
     is_closed_context Δ ->
-    Σ ;;; Γ ⊢ T ≤[le] U ->
-    Σ ;;; Δ ⊢ T ≤[le] U.
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
+    Σ ;;; Δ ⊢ T ≤[pb] U.
   Proof.
     intros eqctx cl cum. symmetry in eqctx.
-    eapply (equality_compare_context (le:=false)) in cum; tea.
+    eapply (equality_compare_context (pb:=Conv)) in cum; tea.
   Qed.
 
   Lemma conv_alt_red_ctx {Γ : closed_context} {Γ'} {T U : open_term Γ} :
@@ -940,10 +902,10 @@ Section ContextConversion.
     split. pcuic. auto.
   Qed.
 
-  Lemma equality_red_ctx_inv {le Γ Γ'} {T U} :
+  Lemma equality_red_ctx_inv {pb Γ Γ'} {T U} :
     Σ ⊢ Γ' ⇝ Γ ->
-    Σ ;;; Γ ⊢ T ≤[le] U ->
-    Σ ;;; Γ' ⊢ T ≤[le] U.
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
+    Σ ;;; Γ' ⊢ T ≤[pb] U.
   Proof.
     intros Hctx H.
     apply equality_red in H as [v [v' [redl redr leq]]].
@@ -978,10 +940,10 @@ Section ContextConversion.
     now apply on_free_vars_ctx_All_fold.
   Qed.
 
-  Lemma context_equality_red {le} {Γ Γ' : context} :
-    context_equality le Σ Γ Γ' ->
+  Lemma context_equality_red {pb} {Γ Γ' : context} :
+    context_equality pb Σ Γ Γ' ->
     ∑ Δ Δ', Σ ⊢ Γ ⇝ Δ × Σ ⊢ Γ' ⇝ Δ' ×
-      eq_context_upto Σ (eq_universe Σ) (compare_universe le Σ) Δ Δ'.
+      eq_context_upto Σ (eq_universe Σ) (compare_universe pb Σ) Δ Δ'.
   Proof.
     intros Hctx.
     induction Hctx.
@@ -990,51 +952,51 @@ Section ContextConversion.
       destruct p.
       { apply (equality_red_ctx redl) in eqt.
         eapply equality_red in eqt as (v & v' & [tv tv' com]).
-        destruct (closed_red_eq_context_upto_l (le:=le) (Δ := Δ') byfvs tv' eq) as [t'' [redt'' eq']].
+        destruct (closed_red_eq_context_upto_l (pb:=pb) (Δ := Δ') byfvs tv' eq) as [t'' [redt'' eq']].
         exists (vass na v :: Δ), (vass na' t'' :: Δ').
         intuition auto. constructor; auto. constructor; auto.
         eapply red_red_ctx_inv'; tea.
         constructor; auto. econstructor.
         eapply red_red_ctx_inv'; tea.
         constructor => //. constructor; auto.
-        destruct le; cbn in *.
-        * transitivity v' => //. now eapply eq_term_leq_term.
-        * transitivity v' => //. }
+        destruct pb; cbn in *.
+        * transitivity v' => //.
+        * transitivity v' => //. now eapply eq_term_leq_term. }
       { apply (equality_red_ctx redl) in eqb.
         eapply equality_red in eqb as (v & v' & [tv tv' com]).
-        destruct (closed_red_eq_context_upto_l (le:=le) (Δ := Δ') byfvs tv' eq) as [t'' [redt'' eq']].
+        destruct (closed_red_eq_context_upto_l (pb:=pb) (Δ := Δ') byfvs tv' eq) as [t'' [redt'' eq']].
         apply (equality_red_ctx redl) in eqt.
         eapply equality_red in eqt as (v0 & v0' & [tv0 tv0' com0]).
-        destruct (closed_red_eq_context_upto_l (le:=le) (Δ := Δ') byfvs tv0' eq) as [t0'' [redt0'' eq0']].
+        destruct (closed_red_eq_context_upto_l (pb:=pb) (Δ := Δ') byfvs tv0' eq) as [t0'' [redt0'' eq0']].
         exists (vdef na v v0 :: Δ), (vdef na' t'' t0'' :: Δ').
         intuition auto. constructor; auto. constructor; auto.
         1-2:eapply red_red_ctx_inv'; tea.
         constructor; auto. econstructor; eapply red_red_ctx_inv'; tea.
         constructor => //. constructor; auto.
         cbn in *. transitivity v' => //.
-        destruct le; cbn in *.
-        * transitivity v0' => //. now eapply eq_term_leq_term.
-        * transitivity v0' => //. }
+        destruct pb; cbn in *.
+        * transitivity v0' => //.
+        * transitivity v0' => //. now eapply eq_term_leq_term. }
   Qed.
 
-  Lemma equality_equality_ctx {le le'} {Γ Γ'} {T U} :
-    Σ ⊢ Γ' ≤[le'] Γ ->
-    Σ ;;; Γ ⊢ T ≤[le] U ->
-    Σ ;;; Γ' ⊢ T ≤[le] U.
+  Lemma equality_equality_ctx {pb pb'} {Γ Γ'} {T U} :
+    Σ ⊢ Γ' ≤[pb'] Γ ->
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
+    Σ ;;; Γ' ⊢ T ≤[pb] U.
   Proof.
     intros Hctx H.
     apply context_equality_red in Hctx => //.
     destruct Hctx as [Δ [Δ' [l [r elr]]]].
     eapply (equality_red_ctx r) in H.
-    destruct le'; cbn in *.
-    - eapply (equality_compare_context (le:=true) elr) in H. 2:eauto with fvs.
-      now eapply (equality_red_ctx_inv l) in H.
+    destruct pb'; cbn in *.
     - eapply (equality_eq_context_upto (symmetry elr)) in H. 2:eauto with fvs.
+      now eapply (equality_red_ctx_inv l) in H.
+    - eapply (equality_compare_context (pb:=Cumul) elr) in H. 2:eauto with fvs.
       now eapply (equality_red_ctx_inv l) in H.
   Qed.
 
   #[global]
-  Instance conv_context_sym : Symmetric (context_equality false Σ).
+  Instance conv_context_sym : Symmetric (context_equality Conv Σ).
   Proof.
     intros Γ Γ' conv.
     eapply All2_fold_sym; tea.
@@ -1058,7 +1020,7 @@ Section ContextConversion.
   Hint Resolve equality_eq_le : pcuic.
 
   Lemma conv_cumul_context {Γ Δ} : 
-    Σ ⊢ Γ ≤[false] Δ -> Σ ⊢ Γ ≤[true] Δ.
+    Σ ⊢ Γ ≤[Conv] Δ -> Σ ⊢ Γ ≤[Cumul] Δ.
   Proof.
     induction 1; constructor; auto.
     eapply conv_context_sym in X.
@@ -1071,53 +1033,45 @@ Section ContextConversion.
   (** This is provable as conversion is not relying on types of variables,
       and bodies of let-ins are convertible even for context cumulativity. *)
 
-  Local Remark equality_equality_ctx_inv {le le'} {Γ Γ'} {T U} :
-    Σ ⊢ Γ ≤[le'] Γ' ->
-    Σ ;;; Γ ⊢ T ≤[le] U ->
-    Σ ;;; Γ' ⊢ T ≤[le] U.
+  Local Remark equality_equality_ctx_inv {pb pb'} {Γ Γ'} {T U} :
+    Σ ⊢ Γ ≤[pb'] Γ' ->
+    Σ ;;; Γ ⊢ T ≤[pb] U ->
+    Σ ;;; Γ' ⊢ T ≤[pb] U.
   Proof.
     intros Hctx H.
     apply context_equality_red in Hctx => //.
     destruct Hctx as [Δ [Δ' [l [r elr]]]].
     eapply (equality_red_ctx_inv r).
-    destruct le'; cbn in *.
+    destruct pb'; cbn in *.
     - eapply (equality_red_ctx l) in H.
-      eapply (equality_compare_context_inv (le:=true) elr) in H => //. eauto with fvs.
+      eapply (equality_compare_context_inv (pb:=Conv) elr) in H => //. eauto with fvs.
     - eapply (equality_red_ctx l) in H.
-      eapply (equality_compare_context_inv (le:=false) elr) in H => //. eauto with fvs.
+      eapply (equality_compare_context_inv (pb:=Cumul) elr) in H => //. eauto with fvs.
   Qed.
 
-  Lemma equality_open_decls_equality_ctx {le le'} {Γ Γ'} {d d'} :
-    Σ ⊢ Γ' ≤[le'] Γ ->
-    equality_open_decls le Σ Γ d d' ->
-    equality_open_decls le Σ Γ' d d'.
+  Lemma equality_open_decls_equality_ctx {pb pb'} {Γ Γ'} {d d'} :
+    Σ ⊢ Γ' ≤[pb'] Γ ->
+    equality_open_decls pb Σ Γ d d' ->
+    equality_open_decls pb Σ Γ' d d'.
   Proof.
     intros Hctx H.
     destruct H; constructor; auto; eapply equality_equality_ctx; tea.
   Qed.
 
   #[global]
-  Instance context_equality_trans le : Transitive (context_equality le Σ).
+  Instance context_equality_trans pb : Transitive (context_equality pb Σ).
   Proof.
     eapply All2_fold_trans.
     intros.
     etransitivity; tea.
     now eapply (equality_open_decls_equality_ctx X).
   Qed.
-
-  #[global]
-  Instance conv_context_trans : Transitive (context_equality false Σ).
-  Proof. apply context_equality_trans. Qed.
-
-  #[global]
-  Instance cumul_context_trans : Transitive (context_equality true Σ).
-  Proof. apply context_equality_trans. Qed.
   
 End ContextConversion.
 
 #[global] Hint Resolve isType_open PCUICClosedTyp.wf_local_closed_context : fvs.
 #[global] Hint Resolve conv_ctx_refl' : pcuic.
-#[global] Hint Constructors conv_decls : pcuic.
+#[global] Hint Constructors All_decls_alpha_pb : pcuic.
 
 Lemma eq_context_upto_conv_context {cf:checker_flags} (Σ : global_env_ext) Re :
   RelationClasses.subrelation Re (eq_universe Σ) ->
@@ -1272,13 +1226,13 @@ Qed.
   eapply on_free_vars_decl_eq; [eassumption|len; lia] : fvs.
 
 Lemma context_equality_false_forget {cf} {Σ} {wfΣ : wf Σ} {Γ Γ'} : 
-  context_equality false Σ Γ Γ' -> conv_context Σ Γ Γ'.
+  context_equality Conv Σ Γ Γ' -> conv_context Σ Γ Γ'.
 Proof.
   apply: context_equality_forget.
 Qed.
 
 Lemma context_equality_true_forget {cf} {Σ} {wfΣ : wf Σ} {Γ Γ'} : 
-  context_equality true Σ Γ Γ' -> cumul_context Σ Γ Γ'.
+  context_equality Cumul Σ Γ Γ' -> cumul_context Σ Γ Γ'.
 Proof.
   apply: context_equality_forget.
 Qed.
@@ -1289,26 +1243,16 @@ Ltac exass H :=
     assert (H : A); [idtac|exists H]
   end.
 
-Lemma into_context_equality {cf:checker_flags} {le : bool} {Σ : global_env_ext} {wfΣ : wf Σ} 
+Lemma into_context_equality {cf:checker_flags} {pb : conv_pb} {Σ : global_env_ext} {wfΣ : wf Σ} 
   {Γ Γ' : context} :
   is_closed_context Γ ->
   is_closed_context Γ' ->
-  (if le then cumul_context Σ Γ Γ' else conv_context Σ Γ Γ') ->
-  context_equality le Σ Γ Γ'.
+  cumul_pb_context pb Σ Γ Γ' ->
+  context_equality pb Σ Γ Γ'.
 Proof.
   move/on_free_vars_ctx_All_fold => onΓ.
   move/on_free_vars_ctx_All_fold => onΓ'.
-  destruct le.
-  { intros cum.
-    eapply All2_fold_All_fold_mix in cum; tea.
-    eapply All2_fold_impl_ind; tea. clear -wfΣ.
-    cbn; intros. red.
-    eapply All2_fold_All_fold_mix_inv in X as [cum [onΓ onΔ]].
-    move/on_free_vars_ctx_All_fold: onΓ => onΓ.
-    move/on_free_vars_ctx_All_fold: onΔ => onΓ'.
-    destruct X1 as [wsd [wsd' cumd]].
-    eapply into_equality_open_decls; cbn; tea.
-    rewrite (All2_fold_length X0) //. } 
+  destruct pb.
   { intros cum.
     eapply All2_fold_All_fold_mix in cum; tea.
     eapply All2_fold_impl_ind; tea. clear -wfΣ.
@@ -1319,35 +1263,47 @@ Proof.
     destruct X1 as [wsd [wsd' cumd]].
     eapply into_equality_open_decls; cbn; tea.
     rewrite (All2_fold_length X0) //. }
+  { intros cum.
+    eapply All2_fold_All_fold_mix in cum; tea.
+    eapply All2_fold_impl_ind; tea. clear -wfΣ.
+    cbn; intros. red.
+    eapply All2_fold_All_fold_mix_inv in X as [cum [onΓ onΔ]].
+    move/on_free_vars_ctx_All_fold: onΓ => onΓ.
+    move/on_free_vars_ctx_All_fold: onΔ => onΓ'.
+    destruct X1 as [wsd [wsd' cumd]].
+    eapply into_equality_open_decls; cbn; tea.
+    rewrite (All2_fold_length X0) //. } 
 Qed.
 
-Lemma context_equality_refl {cf} {Σ} {wfΣ : wf Σ} {le} {Γ : context} :
-  is_closed_context Γ -> Σ ⊢ Γ ≤[le] Γ.
+Lemma context_equality_refl {cf} {Σ} {wfΣ : wf Σ} {pb} {Γ : context} :
+  is_closed_context Γ -> Σ ⊢ Γ ≤[pb] Γ.
 Proof.
   move/on_free_vars_ctx_All_fold.
   induction 1; constructor; auto.
   eapply (into_equality_open_decls _ Γ); tea; eauto with fvs.
-  destruct le; cbn; reflexivity.
+  destruct pb; cbn; reflexivity.
 Qed.
 
-Lemma context_equality_app_same {cf} {Σ} {wfΣ : wf Σ} {le} {Γ Γ' Δ : context} :
+Lemma context_equality_app_same {cf} {Σ} {wfΣ : wf Σ} {pb} {Γ Γ' Δ : context} :
   is_closed_context (Γ ,,, Δ) ->
-  Σ ⊢ Γ ≤[le] Γ' -> Σ ⊢ Γ,,, Δ ≤[le] Γ',,, Δ.
+  Σ ⊢ Γ ≤[pb] Γ' -> Σ ⊢ Γ,,, Δ ≤[pb] Γ',,, Δ.
 Proof.
   move=> iscl cum.
   eapply into_context_equality => //.
   eapply is_closed_context_cumul_app; tea; eauto with fvs.
   now rewrite (All2_fold_length cum).
-  destruct le. apply cumul_context_app_same.
-  now apply context_equality_true_forget.
-  apply conv_context_app_same.
-  now apply context_equality_false_forget.
+  destruct pb.
+  - apply conv_context_app_same.
+    now apply context_equality_false_forget.
+  - apply cumul_context_app_same.
+    now apply context_equality_true_forget.
+  
 Qed.
 
-Lemma context_cumulativity_app {cf:checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} {le Γ Γ' Δ Δ'} : 
+Lemma context_cumulativity_app {cf:checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} {pb Γ Γ' Δ Δ'} : 
   Σ ⊢ Γ' ≤ Γ ->
-  Σ ⊢ Γ ,,, Δ ≤[le] Γ ,,, Δ' ->
-  Σ ⊢ Γ' ,,, Δ ≤[le] Γ' ,,, Δ'.
+  Σ ⊢ Γ ,,, Δ ≤[pb] Γ ,,, Δ' ->
+  Σ ⊢ Γ' ,,, Δ ≤[pb] Γ' ,,, Δ'.
 Proof.
   intros cum conv.
   pose proof (length_of conv). len in H.

--- a/pcuic/theories/PCUICConvCumInversion.v
+++ b/pcuic/theories/PCUICConvCumInversion.v
@@ -15,8 +15,8 @@ Set Default Goal Selector "!".
 
 Implicit Types (cf : checker_flags) (Σ : global_env_ext).
 
-Definition conv_cum {cf:checker_flags} leq Σ Γ u v :=
-  ∥ Σ ;;; Γ ⊢ u ≤[conv_pb_dir leq] v ∥.
+Definition conv_cum {cf:checker_flags} pb Σ Γ u v :=
+  ∥ Σ ;;; Γ ⊢ u ≤[pb] v ∥.
 
 Lemma eq_term_eq_termp {cf:checker_flags} leq (Σ : global_env_ext) x y :
   eq_term Σ Σ x y ->
@@ -44,7 +44,7 @@ Lemma red_ctx_rel_par_conv {cf Σ Γ Γ0 Γ0' Γ1 Γ1'} {wfΣ : wf Σ} :
   red_ctx_rel Σ Γ Γ0 Γ0' ->
   red_ctx_rel Σ Γ Γ1 Γ1' ->
   eq_context_upto Σ (eq_universe Σ) (eq_universe Σ) Γ0' Γ1' ->
-  context_equality_rel false Σ Γ Γ0 Γ1.
+  context_equality_rel Conv Σ Γ Γ0 Γ1.
 Proof.
   intros clΓ0 clΓ1 r0 r1 eq.
   apply red_ctx_rel_red_context_rel, red_context_app_same_left in r0; auto.
@@ -54,12 +54,12 @@ Proof.
   eapply red_ctx_red_context in r0; eapply red_ctx_red_context in r1.
   eapply into_closed_red_ctx in r0 => //.
   eapply into_closed_red_ctx in r1 => //.
-  eapply (red_ctx_context_equality (l:=false)) in r0.
-  eapply (red_ctx_context_equality (l:=false)) in r1.
+  eapply (red_ctx_context_equality (l:=Conv)) in r0.
+  eapply (red_ctx_context_equality (l:=Conv)) in r1.
   apply context_equality_rel_app. etransitivity; tea.
   symmetry. etransitivity; tea.
   eapply (eq_context_upto_cat _ _ _ Γ _ Γ) in eq. 2:reflexivity.
-  eapply (eq_context_upto_context_equality (le:=false)) in eq. 2-3:fvs.
+  eapply (eq_context_upto_context_equality (pb:=Conv)) in eq. 2-3:fvs.
   now symmetry.
 Qed.
 
@@ -167,8 +167,8 @@ Proof.
   assert (forall P Q, (P <~> Q) -> (∥P∥ <-> ∥Q∥)) by
       (intros P Q H; split; intros [p]; constructor; apply H in p; auto).
   destruct leq; cbn; apply H.
-  * eapply (equality_alt_closed (le:=false)).
-  * eapply (equality_alt_closed (le:=true)).
+  * eapply (equality_alt_closed (pb:=Conv)).
+  * eapply (equality_alt_closed (pb:=Cumul)).
 Qed.
 
 Lemma conv_conv_cum_l {cf:checker_flags} :
@@ -378,7 +378,7 @@ Section fixed.
             eapply on_ctx_free_vars_inst_case_context; auto.
             1:now rewrite test_context_k_closed_on_free_vars_ctx.
             now erewrite -> on_free_vars_ctx_on_ctx_free_vars. }
-      eapply (equality_equality_ctx (Γ := Γ ,,, inst_case_predicate_context p') (le':=false)) => //.
+      eapply (equality_equality_ctx (Γ := Γ ,,, inst_case_predicate_context p') (pb':=Conv)) => //.
       symmetry. eapply red_equality.
       eapply into_closed_red; eauto. 1:fvs.
       len. now setoid_rewrite shiftnP_add in p1.

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -712,7 +712,7 @@ Lemma red_conv_prop {Σ Γ T U} {wfΣ : wf_ext Σ} :
   Σ ;;; Γ ⊢ T ⇝ U ->
   Σ ;;; Γ |- T ~~ U.
 Proof.
-  move/(red_equality (le:=false)).
+  move/(red_equality (pb:=Conv)).
   now apply conv_cumul_prop.
 Qed.
 
@@ -948,7 +948,7 @@ Proof.
   eapply cumul_prop_alt. 
   assert(eq_context_upto Σ (eq_universe Σ) (eq_universe Σ) (Γ ,, vdef na d t) (Γ ,, vdef na' d' t')).
   { repeat constructor; pcuic. eapply eq_context_upto_refl; typeclasses eauto. }
-  eapply (closed_red_eq_context_upto_l (le:=false)) in redr; eauto.
+  eapply (closed_red_eq_context_upto_l (pb:=Conv)) in redr; eauto.
   2:{ eapply clrel_ctx in redl. rewrite !on_free_vars_ctx_snoc in redl |- *.
       move/andP: redl => [] -> /= /andP[] cld clt.
       eapply PCUICConfluence.eq_term_upto_univ_napp_on_free_vars in cld; tea.
@@ -1310,7 +1310,7 @@ Proof.
       now apply subject_is_open_term in dty. }
     { now eapply cumul_prop_is_open in cum as []. }
     eapply eq_term_eq_term_prop_impl; eauto.
-    now eapply eq_term_sym in a.
+    now symmetry in a.
   
   - eapply inversion_CoFix in X2 as (decl' & fixguard' & Hnth & types' & bodies & wfcofix & cum); auto.
     eapply cumul_cumul_prop in cum; eauto.
@@ -1322,7 +1322,7 @@ Proof.
       now apply subject_is_open_term in dty. }
     { now eapply cumul_prop_is_open in cum as []. }
     eapply eq_term_eq_term_prop_impl; eauto.
-    now eapply eq_term_sym in a.
+    now symmetry in a.
 Qed.
 
 End no_prop_leq_type.

--- a/pcuic/theories/PCUICCumulativity.v
+++ b/pcuic/theories/PCUICCumulativity.v
@@ -10,55 +10,48 @@ Set Default Goal Selector "!".
 
 (** * Definition of cumulativity and conversion relations *)
 
-Reserved Notation " Σ ;;; Γ |- t <=[ Rle ] u" (at level 50, Γ, t, u at next level,
-  format "Σ  ;;;  Γ  |-  t  <=[ Rle ] u").
+Reserved Notation " Σ ;;; Γ |- t <=[ pb ] u" (at level 50, Γ, t, u at next level,
+  format "Σ  ;;;  Γ  |-  t  <=[ pb ] u").
 
 Definition leq_term_ext `{checker_flags} (Σ : global_env_ext) Rle t u := eq_term_upto_univ Σ (eq_universe Σ) Rle t u.
 
-Notation " Σ ⊢ t <===[ Rle , napp ] u" := (eq_term_upto_univ Σ (eq_universe Σ) Rle t u) (at level 50, t, u at next level).
+Notation " Σ ⊢ t <===[ pb ] u" := (compare_term pb Σ Σ t u) (at level 50, t, u at next level).
 
 (** ** Cumulativity *)
 
-Inductive cumulAlgo0 `{checker_flags} (Σ : global_env_ext) Rle (Γ : context) : term -> term -> Type :=
-| cumul_refl t u : Σ ⊢ t <===[ Rle , 0] u -> Σ ;;; Γ |- t <=[Rle] u
-| cumul_red_l t u v : Σ ;;; Γ |- t ⇝ v -> Σ ;;; Γ |- v <=[Rle] u -> Σ ;;; Γ |- t <=[Rle] u
-| cumul_red_r t u v : Σ ;;; Γ |- t <=[Rle] v -> Σ ;;; Γ |- u ⇝ v -> Σ ;;; Γ |- t <=[Rle] u
-where " Σ ;;; Γ |- t <=[ Rle ] u " := (cumulAlgo0 Σ Rle Γ t u) : type_scope.
+Inductive cumulAlgo_gen `{checker_flags} (Σ : global_env_ext) (Γ : context) (pb : conv_pb) : term -> term -> Type :=
+| cumul_refl t u : Σ ⊢ t <===[ pb ] u -> Σ ;;; Γ |- t <=[pb] u
+| cumul_red_l t u v : Σ ;;; Γ |- t ⇝ v -> Σ ;;; Γ |- v <=[pb] u -> Σ ;;; Γ |- t <=[pb] u
+| cumul_red_r t u v : Σ ;;; Γ |- t <=[pb] v -> Σ ;;; Γ |- u ⇝ v -> Σ ;;; Γ |- t <=[pb] u
+where " Σ ;;; Γ |- t <=[ pb ] u " := (cumulAlgo_gen Σ Γ pb t u) : type_scope.
 
-Definition cumulAlgo `{checker_flags} Σ Γ t u := Σ ;;; Γ |- t <=[ leq_universe Σ ] u.
+Notation " Σ ;;; Γ |- t = u " := (cumulAlgo_gen Σ Γ Conv t u) (at level 50, Γ, t, u at next level) : type_scope.
+Notation " Σ ;;; Γ |- t <= u " := (cumulAlgo_gen Σ Γ Cumul t u) (at level 50, Γ, t, u at next level) : type_scope.
 
-Definition convAlgo `{checker_flags} Σ Γ t u := Σ ;;; Γ |- t <=[ eq_universe Σ ] u.
-
-Notation " Σ ;;; Γ |- t <= u " := (cumulAlgo Σ Γ t u) (at level 50, Γ, t, u at next level).
-Notation " Σ ;;; Γ |- t = u " := (convAlgo Σ Γ t u) (at level 50, Γ, t, u at next level).
+Notation cumulAlgo Σ Γ := (cumulAlgo_gen Σ Γ Cumul).
+Notation convAlgo Σ Γ := (cumulAlgo_gen Σ Γ Conv).
 
 #[global]
 Hint Resolve cumul_refl : pcuic.
 
 Module PCUICConversionParAlgo <: EnvironmentTyping.ConversionParSig PCUICTerm PCUICEnvironment PCUICEnvTyping.
-  Definition conv := @convAlgo.
-  Definition cumul := @cumulAlgo.
+  Definition cumul_gen := @cumulAlgo_gen.
 End PCUICConversionParAlgo.
 
 Module PCUICConversionAlgo := EnvironmentTyping.Conversion PCUICTerm PCUICEnvironment PCUICEnvTyping PCUICConversionParAlgo.
 Include PCUICConversionAlgo.
 
-Notation conv_context Σ Γ Γ' := (All2_fold (conv_decls Σ) Γ Γ').
-Notation cumul_context Σ Γ Γ' := (All2_fold (cumul_decls Σ) Γ Γ').
-
 #[global]
-Instance conv_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (conv_decls Σ Γ Γ').
+Instance cumul_pb_decls_refl {cf:checker_flags} pb Σ Γ Γ' : Reflexive (cumul_pb_decls pb Σ Γ Γ').
 Proof.
   intros x. destruct x as [na [b|] ty]; constructor; auto.
-  all:constructor; apply eq_term_refl.
+  all:constructor; reflexivity.
 Qed.
 
 #[global]
-Instance cumul_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (cumul_decls Σ Γ Γ').
-Proof.
-  intros x. destruct x as [na [b|] ty]; constructor; auto.
-  all:constructor; apply eq_term_refl || apply leq_term_refl.
-Qed.
+Instance conv_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (conv_decls Σ Γ Γ') := _.
+#[global]
+Instance cumul_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (cumul_decls Σ Γ Γ') := _.
 
 Lemma cumul_alt `{cf : checker_flags} Σ Γ t u :
   Σ ;;; Γ |- t <= u <~> { v & { v' & (red Σ Γ t v * red Σ Γ u v' * 
@@ -77,14 +70,14 @@ Proof.
     induction redv.
     * induction redv'.
     ** constructor; auto.
-    ** econstructor 3; eauto. eapply IHredv'; eauto. 
-    * econstructor 2; eauto. eapply IHredv; eauto.
+    ** econstructor 3; eauto.
+    * econstructor 2; eauto.
 Qed.
 
 #[global]
-Instance cumul_refl' {cf:checker_flags} Σ Γ : Reflexive (cumulAlgo Σ Γ).
+Instance cumul_refl' {cf:checker_flags} Σ Γ pb : Reflexive (cumulAlgo_gen Σ Γ pb).
 Proof.
-  intro; constructor. unfold leq_term_ext. reflexivity.
+  intro; constructor; reflexivity.
 Qed.
 
 #[global]
@@ -118,7 +111,7 @@ Lemma red_cumul_cumul `{cf : checker_flags} {Σ : global_env_ext} {Γ t u v} :
 Proof.
   intros. apply clos_rt_rt1n in X.
   induction X. 1: auto.
-  econstructor 2; eauto. eapply IHX; eauto.
+  econstructor 2; eauto.
 Qed.
 
 Lemma red_cumul_cumul_inv `{cf : checker_flags} {Σ : global_env_ext} {Γ t u v} :
@@ -224,7 +217,7 @@ Proof.
 Qed.
 
 #[global]
-Hint Resolve leq_term_refl cumul_refl' : core.
+Hint Resolve cumul_refl' : core.
 
 Lemma red_conv_conv `{cf : checker_flags} Σ Γ t u v :
   red (fst Σ) Γ t u -> Σ ;;; Γ |- u = v -> Σ ;;; Γ |- t = v.
@@ -247,7 +240,7 @@ Instance conv_sym `{cf : checker_flags} (Σ : global_env_ext) Γ :
   Symmetric (convAlgo Σ Γ).
 Proof.
   intros t u X. induction X.
-  - eapply eq_term_sym in e; now constructor.
+  - symmetry in c; now constructor.
   - eapply red_conv_conv_inv.
     + eapply red1_red in r. eauto.
     + eauto.
@@ -272,30 +265,16 @@ Proof.
     eapply red_conv_conv_inv; eauto. now constructor.
 Qed.
 
-Definition conv_pb_rel {cf:checker_flags} (pb : conv_pb) Σ :=
-  match pb with
-  | Conv => eq_universe Σ
-  | Cumul => leq_universe Σ
-  end.
+Definition eq_termp_napp {cf:checker_flags} (pb: conv_pb) (Σ : global_env_ext) napp :=
+  compare_term_napp pb Σ Σ napp.
 
-Definition conv_pb_dir (pb : conv_pb) :=
-  match pb with
-  | Conv => false
-  | Cumul => true
-  end.
+Notation eq_termp pb Σ := (compare_term pb Σ Σ).
 
-Coercion conv_pb_dir : conv_pb >-> bool.
-
-Definition eq_termp_napp {cf:checker_flags} (leq : conv_pb) (Σ : global_env_ext) napp :=
-  compare_term_napp leq Σ Σ napp.
-
-Notation eq_termp leq Σ := (compare_term (conv_pb_dir leq) Σ Σ).
-
-Lemma eq_term_eq_termp {cf:checker_flags} leq (Σ : global_env_ext) x y :
+Lemma eq_term_eq_termp {cf:checker_flags} pb (Σ : global_env_ext) x y :
   eq_term Σ Σ x y ->
-  eq_termp leq Σ x y.
+  eq_termp pb Σ x y.
 Proof.
-  destruct leq; [easy|].
+  destruct pb; [easy|].
   cbn.
   apply eq_term_upto_univ_leq; auto.
   typeclasses eauto.
@@ -310,7 +289,7 @@ Proof.
   induction h.
   - eapply cumul_refl. constructor.
     + apply leq_term_leq_term_napp. assumption.
-    + apply eq_term_refl.
+    + reflexivity.
   - eapply cumul_red_l ; try eassumption.
     econstructor. assumption.
   - eapply cumul_red_r ; try eassumption.

--- a/pcuic/theories/PCUICCumulativitySpec.v
+++ b/pcuic/theories/PCUICCumulativitySpec.v
@@ -7,240 +7,228 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICOnOne PCUICAstUtils PCUICEqualit
 
 Set Default Goal Selector "!".
 
+Implicit Types (cf : checker_flags).
+
 Definition cumul_predicate (cumul : context -> term -> term -> Type) Γ Re p p' :=
   All2 (cumul Γ) p.(pparams) p'.(pparams) *
   (R_universe_instance Re p.(puinst) p'.(puinst) *
   ((eq_context_gen eq eq p.(pcontext) p'.(pcontext)) *
     cumul (Γ ,,, inst_case_predicate_context p) p.(preturn) p'.(preturn))).
 
-Reserved Notation " Σ ;;; Γ ⊢ t ≤s[ Rle ] u" (at level 50, Γ, t, u at next level,
-  format "Σ  ;;;  Γ  ⊢  t  ≤s[ Rle ]  u").
+Reserved Notation " Σ ;;; Γ ⊢ t ≤s[ pb ] u" (at level 50, Γ, t, u at next level,
+  format "Σ  ;;;  Γ  ⊢  t  ≤s[ pb ]  u").
 
-Definition cumul_Ind_univ Σ Re Rle i napp :=
-  R_opt_variance Re Rle (global_variance Σ (IndRef i) napp).
+Definition cumul_Ind_univ {cf} (Σ : global_env_ext) pb i napp :=
+  R_opt_variance (eq_universe Σ) (compare_universe pb Σ) (global_variance Σ (IndRef i) napp).
 
-Definition cumul_Construct_univ Σ Re Rle i k napp :=
-  R_opt_variance Re Rle (global_variance Σ (ConstructRef i k) napp).
+Definition cumul_Construct_univ {cf} (Σ : global_env_ext) pb  i k napp :=
+  R_opt_variance (eq_universe Σ) (compare_universe pb Σ) (global_variance Σ (ConstructRef i k) napp).
 
 (** * Definition of cumulativity and conversion relations *)
 
-Inductive cumulSpec0 Σ (Re Rle : Universe.t -> Universe.t -> Prop) Γ : term -> term -> Type :=
+Inductive cumulSpec0 {cf : checker_flags} (Σ : global_env_ext) Γ (pb : conv_pb) : term -> term -> Type :=
 
 (* transitivity *)
 
 | cumul_Trans : forall t u v,
     is_closed_context Γ -> is_open_term Γ u -> 
-    Σ ;;; Γ ⊢ t ≤s[Rle] u ->
-    Σ ;;; Γ ⊢ u ≤s[Rle] v ->    
-    Σ ;;; Γ ⊢ t ≤s[Rle] v 
+    Σ ;;; Γ ⊢ t ≤s[pb] u ->
+    Σ ;;; Γ ⊢ u ≤s[pb] v ->    
+    Σ ;;; Γ ⊢ t ≤s[pb] v 
 
 (* symmetry *)
 
 | cumul_Sym : forall t u, 
-    Σ ;;; Γ ⊢ t ≤s[Re] u ->
-    Σ ;;; Γ ⊢ u ≤s[Rle] t  
+    Σ ;;; Γ ⊢ t ≤s[Conv] u ->
+    Σ ;;; Γ ⊢ u ≤s[pb] t  
 
 (* reflexivity *)
 
 | cumul_Refl : forall t,
-    Σ ;;; Γ ⊢ t ≤s[Rle] t
+    Σ ;;; Γ ⊢ t ≤s[pb] t
 
 (* Cumulativity rules *)
 
 | cumul_Ind : forall i u u' args args', 
-    cumul_Ind_univ Σ Re Rle i #|args| u u' ->
-    All2 (fun t u => Σ ;;; Γ ⊢ t ≤s[Re] u) args args' ->
-    Σ ;;; Γ ⊢ mkApps (tInd i u) args ≤s[Rle] mkApps (tInd i u') args'
+    cumul_Ind_univ Σ pb i #|args| u u' ->
+    All2 (fun t u => Σ ;;; Γ ⊢ t ≤s[Conv] u) args args' ->
+    Σ ;;; Γ ⊢ mkApps (tInd i u) args ≤s[pb] mkApps (tInd i u') args'
 
 | cumul_Construct : forall i k u u' args args',
-    cumul_Construct_univ Σ Re Rle i k #|args| u u' ->
-    All2 (fun t u => Σ ;;; Γ ⊢ t ≤s[Re] u) args args' ->
-    Σ ;;; Γ ⊢ mkApps (tConstruct i k u) args ≤s[Rle] mkApps (tConstruct i k u') args'
+    cumul_Construct_univ Σ pb i k #|args| u u' ->
+    All2 (fun t u => Σ ;;; Γ ⊢ t ≤s[Conv] u) args args' ->
+    Σ ;;; Γ ⊢ mkApps (tConstruct i k u) args ≤s[pb] mkApps (tConstruct i k u') args'
    
 | cumul_Sort : forall s s',
-    Rle s s' ->
-    Σ ;;; Γ ⊢ tSort s ≤s[Rle] tSort s'
+    compare_universe pb Σ s s' ->
+    Σ ;;; Γ ⊢ tSort s ≤s[pb] tSort s'
 
 | cumul_Const : forall c u u',
-    R_universe_instance Re u u' ->
-    Σ ;;; Γ ⊢ tConst c u ≤s[Rle] tConst c u'
+    R_universe_instance (compare_universe Conv Σ) u u' ->
+    Σ ;;; Γ ⊢ tConst c u ≤s[pb] tConst c u'
 
 (* congruence rules *)
 
 | cumul_Evar : forall e args args', 
-    All2 (fun t u => Σ ;;; Γ ⊢ t ≤s[Re] u) args args' ->
-    Σ ;;; Γ ⊢ tEvar e args ≤s[Rle] tEvar e args'
+    All2 (fun t u => Σ ;;; Γ ⊢ t ≤s[Conv] u) args args' ->
+    Σ ;;; Γ ⊢ tEvar e args ≤s[pb] tEvar e args'
 
 | cumul_App : forall t t' u u', 
-    Σ ;;; Γ ⊢ t ≤s[Rle] t' ->
-    Σ ;;; Γ ⊢ u ≤s[Re] u' ->
-    Σ ;;; Γ ⊢ tApp t u ≤s[Rle] tApp t' u'
+    Σ ;;; Γ ⊢ t ≤s[pb] t' ->
+    Σ ;;; Γ ⊢ u ≤s[Conv] u' ->
+    Σ ;;; Γ ⊢ tApp t u ≤s[pb] tApp t' u'
 
 | cumul_Lambda : forall na na' ty ty' t t',
     eq_binder_annot na na' ->
-    Σ ;;; Γ ⊢ ty ≤s[Re] ty' ->
-    Σ ;;; Γ ,, vass na ty ⊢ t ≤s[Rle] t' ->
-    Σ ;;; Γ ⊢ tLambda na ty t ≤s[Rle] tLambda na' ty' t'
+    Σ ;;; Γ ⊢ ty ≤s[Conv] ty' ->
+    Σ ;;; Γ ,, vass na ty ⊢ t ≤s[pb] t' ->
+    Σ ;;; Γ ⊢ tLambda na ty t ≤s[pb] tLambda na' ty' t'
 
 | cumul_Prod : forall na na' a a' b b',
     eq_binder_annot na na' ->
-    Σ ;;; Γ ⊢ a ≤s[Re] a' ->
-    Σ ;;; Γ ,, vass na a ⊢ b ≤s[Rle] b' ->
-    Σ ;;; Γ ⊢ tProd na a b ≤s[Rle] tProd na' a' b'
+    Σ ;;; Γ ⊢ a ≤s[Conv] a' ->
+    Σ ;;; Γ ,, vass na a ⊢ b ≤s[pb] b' ->
+    Σ ;;; Γ ⊢ tProd na a b ≤s[pb] tProd na' a' b'
 
 | cumul_LetIn : forall na na' t t' ty ty' u u', 
     eq_binder_annot na na' ->
-    Σ ;;; Γ ⊢ t ≤s[Re] t' ->
-    Σ ;;; Γ ⊢ ty ≤s[Re] ty' ->
-    Σ ;;; Γ ,, vdef na t ty ⊢ u ≤s[Rle] u' ->
-    Σ ;;; Γ ⊢ tLetIn na t ty u ≤s[Rle] tLetIn na' t' ty' u'
+    Σ ;;; Γ ⊢ t ≤s[Conv] t' ->
+    Σ ;;; Γ ⊢ ty ≤s[Conv] ty' ->
+    Σ ;;; Γ ,, vdef na t ty ⊢ u ≤s[pb] u' ->
+    Σ ;;; Γ ⊢ tLetIn na t ty u ≤s[pb] tLetIn na' t' ty' u'
 
 | cumul_Case indn : forall p p' c c' brs brs', 
-    cumul_predicate (fun Γ t u => Σ ;;; Γ ⊢ t ≤s[Re] u) Γ Re p p' ->
-    Σ ;;; Γ ⊢ c ≤s[Re] c' ->
+    cumul_predicate (fun Γ t u => Σ ;;; Γ ⊢ t ≤s[Conv] u) Γ (compare_universe Conv Σ) p p' ->
+    Σ ;;; Γ ⊢ c ≤s[Conv] c' ->
     All2 (fun br br' =>
       eq_context_gen eq eq (bcontext br) (bcontext br') × 
-      Σ ;;; Γ ,,, inst_case_branch_context p br ⊢ bbody br ≤s[Re] bbody br'
+      Σ ;;; Γ ,,, inst_case_branch_context p br ⊢ bbody br ≤s[Conv] bbody br'
     ) brs brs' ->
-    Σ ;;; Γ ⊢ tCase indn p c brs ≤s[Rle] tCase indn p' c' brs'
+    Σ ;;; Γ ⊢ tCase indn p c brs ≤s[pb] tCase indn p' c' brs'
 
 | cumul_Proj : forall p c c', 
-    Σ ;;; Γ ⊢ c ≤s[Re] c' ->
-    Σ ;;; Γ ⊢ tProj p c ≤s[Rle] tProj p c'
+    Σ ;;; Γ ⊢ c ≤s[Conv] c' ->
+    Σ ;;; Γ ⊢ tProj p c ≤s[pb] tProj p c'
 
 | cumul_Fix : forall mfix mfix' idx,
     All2 (fun x y =>
-      Σ ;;; Γ ⊢ x.(dtype) ≤s[Re] y.(dtype) ×
-      Σ ;;; Γ ,,, fix_context mfix ⊢ x.(dbody) ≤s[Re] y.(dbody) ×
+      Σ ;;; Γ ⊢ x.(dtype) ≤s[Conv] y.(dtype) ×
+      Σ ;;; Γ ,,, fix_context mfix ⊢ x.(dbody) ≤s[Conv] y.(dbody) ×
       (x.(rarg) = y.(rarg)) ×
       eq_binder_annot x.(dname) y.(dname)
     ) mfix mfix' ->
-    Σ ;;; Γ ⊢ tFix mfix idx ≤s[Rle] tFix mfix' idx
+    Σ ;;; Γ ⊢ tFix mfix idx ≤s[pb] tFix mfix' idx
 
 | cumul_CoFix : forall mfix mfix' idx,
     All2 (fun x y =>
-      Σ ;;; Γ ⊢ x.(dtype) ≤s[Re] y.(dtype) ×
-      Σ ;;; Γ ,,, fix_context mfix ⊢ x.(dbody) ≤s[Re] y.(dbody) ×
+      Σ ;;; Γ ⊢ x.(dtype) ≤s[Conv] y.(dtype) ×
+      Σ ;;; Γ ,,, fix_context mfix ⊢ x.(dbody) ≤s[Conv] y.(dbody) ×
       (x.(rarg) = y.(rarg)) ×
       eq_binder_annot x.(dname) y.(dname)
     ) mfix mfix' ->
-    Σ ;;; Γ ⊢ tCoFix mfix idx ≤s[Rle] tCoFix mfix' idx
+    Σ ;;; Γ ⊢ tCoFix mfix idx ≤s[pb] tCoFix mfix' idx
 
 (** Reductions *)
 
 (** Beta red *)
 | cumul_beta : forall na t b a,
-    Σ ;;; Γ ⊢ tApp (tLambda na t b) a ≤s[Rle] b {0 := a}
+    Σ ;;; Γ ⊢ tApp (tLambda na t b) a ≤s[pb] b {0 := a}
 
 (** Let *)
 | cumul_zeta : forall na b t b',
-    Σ ;;; Γ ⊢ tLetIn na b t b' ≤s[Rle] b' {0 := b}
+    Σ ;;; Γ ⊢ tLetIn na b t b' ≤s[pb] b' {0 := b}
 
 | cumul_rel i body :
     option_map decl_body (nth_error Γ i) = Some (Some body) ->
-    Σ ;;; Γ ⊢ tRel i ≤s[Rle] lift0 (S i) body
+    Σ ;;; Γ ⊢ tRel i ≤s[pb] lift0 (S i) body
 
 (** iota red *)
 | cumul_iota : forall ci c u args p brs br, 
     nth_error brs c = Some br ->
     #|args| = (ci.(ci_npar) + context_assumptions br.(bcontext))%nat ->
-    Σ ;;; Γ ⊢ tCase ci p (mkApps (tConstruct ci.(ci_ind) c u) args) brs  ≤s[Rle] iota_red ci.(ci_npar) p args br
+    Σ ;;; Γ ⊢ tCase ci p (mkApps (tConstruct ci.(ci_ind) c u) args) brs  ≤s[pb] iota_red ci.(ci_npar) p args br
 
 (** Fix unfolding, with guard *)
 | cumul_fix : forall mfix idx args narg fn,
     unfold_fix mfix idx = Some (narg, fn) ->
     is_constructor narg args = true ->
-    Σ ;;; Γ ⊢ mkApps (tFix mfix idx) args ≤s[Rle] mkApps fn args
+    Σ ;;; Γ ⊢ mkApps (tFix mfix idx) args ≤s[pb] mkApps fn args
 
 (** CoFix-case unfolding *)
 | cumul_cofix_case : forall ip p mfix idx args narg fn brs,
     unfold_cofix mfix idx = Some (narg, fn) ->
-    Σ ;;; Γ ⊢ tCase ip p (mkApps (tCoFix mfix idx) args) brs ≤s[Rle] tCase ip p (mkApps fn args) brs
+    Σ ;;; Γ ⊢ tCase ip p (mkApps (tCoFix mfix idx) args) brs ≤s[pb] tCase ip p (mkApps fn args) brs
 
 (** CoFix-proj unfolding *)
 | cumul_cofix_proj : forall p mfix idx args narg fn,
     unfold_cofix mfix idx = Some (narg, fn) ->
-    Σ ;;; Γ ⊢ tProj p (mkApps (tCoFix mfix idx) args) ≤s[Rle] tProj p (mkApps fn args)
+    Σ ;;; Γ ⊢ tProj p (mkApps (tCoFix mfix idx) args) ≤s[pb] tProj p (mkApps fn args)
 
 (** Constant unfolding *)
 | cumul_delta : forall c decl body (isdecl : declared_constant Σ c decl) u,
     decl.(cst_body) = Some body ->
-    Σ ;;; Γ ⊢ tConst c u ≤s[Rle] body@[u]
+    Σ ;;; Γ ⊢ tConst c u ≤s[pb] body@[u]
 
 (** Proj *)
 | cumul_proj : forall i pars narg args u arg,
     nth_error args (pars + narg) = Some arg ->
-    Σ ;;; Γ ⊢ tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args) ≤s[Rle] arg
+    Σ ;;; Γ ⊢ tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args) ≤s[pb] arg
 
-where " Σ ;;; Γ ⊢ t ≤s[ Rle ] u " := (cumulSpec0 Σ _ Rle Γ t u) : type_scope.
+where " Σ ;;; Γ ⊢ t ≤s[ pb ] u " := (@cumulSpec0 _ Σ Γ pb t u) : type_scope.
 
-Definition convSpec `{checker_flags} Σ :=
-  let φ := (global_ext_constraints Σ) in cumulSpec0 Σ.1 (eq_universe φ) (eq_universe φ).
+Definition convSpec `{checker_flags} (Σ : global_env_ext) Γ := cumulSpec0 Σ Γ Conv.
+Definition cumulSpec `{checker_flags} (Σ : global_env_ext) Γ := cumulSpec0 Σ Γ Cumul.
 
 (* ** Syntactic cumulativity up-to universes *)
-
-Definition cumulSpec `{checker_flags} Σ :=
-  let φ := (global_ext_constraints Σ) in cumulSpec0 Σ.1 (eq_universe φ) (leq_universe φ).
 
 Notation " Σ ;;; Γ |- t <=s u " := (@cumulSpec _ Σ Γ t u) (at level 50, Γ, t, u at next level).
 Notation " Σ ;;; Γ |- t =s u " := (@convSpec _ Σ Γ t u) (at level 50, Γ, t, u at next level).
   
 Module PCUICConversionParSpec <: EnvironmentTyping.ConversionParSig PCUICTerm PCUICEnvironment PCUICEnvTyping.
-  Definition conv := @convSpec.
-  Definition cumul := @cumulSpec.
+  Definition cumul_gen := @cumulSpec0.
 End PCUICConversionParSpec.
 
 Module PCUICConversionSpec := EnvironmentTyping.Conversion PCUICTerm PCUICEnvironment PCUICEnvTyping PCUICConversionParSpec.
 Include PCUICConversionSpec.
 
-Notation conv_context Σ Γ Γ' := (All2_fold (conv_decls Σ) Γ Γ').
-Notation cumul_context Σ Γ Γ' := (All2_fold (cumul_decls Σ) Γ Γ').
-
+Notation " Σ ⊢ Γ ≤s[ pb ] Δ " := (@cumul_pb_context _ pb Σ Γ Δ) (at level 50, Γ, Δ at next level) : type_scope.
+Notation " Σ ⊢ Γ ≤s Δ " := (@cumul_pb_context _ Cumul Σ Γ Δ) (at level 50, Γ, Δ at next level) : type_scope.
+Notation " Σ ⊢ Γ =s Δ " := (@cumul_pb_context _ Conv Σ Γ Δ) (at level 50, Γ, Δ at next level) : type_scope.
 
 #[global]
-Instance conv_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (conv_decls Σ Γ Γ').
+Instance cumul_spec_refl {cf:checker_flags} Σ Γ pb : Reflexive (cumulSpec0 Σ Γ pb).
+Proof. intro; constructor 3. Qed.
+
+#[global]
+Instance conv_refl' {cf:checker_flags} Σ Γ : Reflexive (convSpec Σ Γ) := _.
+
+#[global]
+Instance cumul_pb_decls_refl {cf:checker_flags} pb Σ Γ Γ' : Reflexive (cumul_pb_decls pb Σ Γ Γ').
 Proof.
-  intros x. destruct x as [na [b|] ty]; constructor; auto.
-  all:constructor; apply eq_term_refl.
+  intros x. destruct x as [na [b|] ty]; constructor; auto. 
+  all:constructor; reflexivity.
 Qed.
 
 #[global]
-Instance cumul_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (cumul_decls Σ Γ Γ').
-Proof.
-  intros x. destruct x as [na [b|] ty]; constructor; auto.
-  all:constructor; apply eq_term_refl || apply leq_term_refl.
-Qed.
-
+Instance conv_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (conv_decls Σ Γ Γ') := _.
 #[global]
-Instance cumul_refl' {cf:checker_flags} Σ Γ : Reflexive (cumulSpec Σ Γ).
-Proof.
-  intro. constructor 3.
-Qed.
-
-#[global]
-Instance conv_refl' {cf:checker_flags} Σ Γ : Reflexive (convSpec Σ Γ).
-Proof.
-  intro; constructor 3. 
-Qed.
+Instance cumul_decls_refl {cf:checker_flags} Σ Γ Γ' : Reflexive (cumul_decls Σ Γ Γ') := _.
 
 Section ContextConversion.
   Context {cf : checker_flags}.
   Context (Σ : global_env_ext).
 
-  Notation conv_context Γ Γ' := (All2_fold (conv_decls Σ) Γ Γ').
-  Notation cumul_context Γ Γ' := (All2_fold (cumul_decls Σ) Γ Γ').
+  Notation conv_context := (conv_context Σ). 
+  Notation cumul_context := (cumul_context Σ).
 
-  Global Instance conv_ctx_refl : Reflexive (All2_fold (conv_decls Σ)).
+  Global Instance cumul_pb_ctx_refl pb : Reflexive (cumul_pb_context pb Σ).
   Proof.
     intro Γ; induction Γ; try econstructor; auto.
     reflexivity.
   Qed.
 
-  Global Instance cumul_ctx_refl : Reflexive (All2_fold (cumul_decls Σ)).
-  Proof.
-    intro Γ; induction Γ; try econstructor; auto.
-    reflexivity. 
-  Qed.
+  Global Instance conv_ctx_refl : Reflexive (conv_context) := _.
+  Global Instance cumul_ctx_refl : Reflexive (cumul_context) := _.
 
   Definition conv_ctx_refl' Γ : conv_context Γ Γ
   := conv_ctx_refl Γ.
@@ -250,172 +238,169 @@ Section ContextConversion.
 
 End ContextConversion.
 
-
-Definition cumulSpec0_ctx Σ Re Rle := (OnOne2_local_env (on_one_decl (fun Δ t t' => cumulSpec0 Σ (Re) Rle Δ t t'))).
-Definition cumulSpec0_ctx_rel Σ Re Rle Γ := (OnOne2_local_env (on_one_decl (fun Δ t t' => cumulSpec0 Σ (Re) Rle (Γ ,,, Δ) t t'))).
-
 Lemma cumulSpec0_ind_all :
-  forall (Σ : global_env) (Re : Universe.t -> Universe.t -> Prop)
-         (P : (Universe.t -> Universe.t -> Prop) -> context -> term -> term -> Type),
+  forall {cf} (Σ : global_env_ext)
+         (P : conv_pb -> context -> term -> term -> Type),
 
         (* beta *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (na : aname) (t b a : term),
-        P Rle Γ (tApp (tLambda na t b) a) (b {0 := a})) ->
+       (forall (pb : conv_pb) (Γ : context) (na : aname) (t b a : term),
+        P pb Γ (tApp (tLambda na t b) a) (b {0 := a})) ->
 
         (* let *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (na : aname) (b t b' : term), P Rle  Γ (tLetIn na b t b') (b' {0 := b})) ->
+       (forall (pb : conv_pb) (Γ : context) (na : aname) (b t b' : term), P pb Γ (tLetIn na b t b') (b' {0 := b})) ->
 
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (i : nat) (body : term),
-        option_map decl_body (nth_error Γ i) = Some (Some body) -> P Rle  Γ (tRel i) ((lift0 (S i)) body)) ->
+       (forall (pb : conv_pb) (Γ : context) (i : nat) (body : term),
+        option_map decl_body (nth_error Γ i) = Some (Some body) -> P pb Γ (tRel i) ((lift0 (S i)) body)) ->
 
         (* iota *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (ci : case_info) (c : nat) (u : Instance.t) (args : list term)
+       (forall (pb : conv_pb) (Γ : context) (ci : case_info) (c : nat) (u : Instance.t) (args : list term)
           (p : predicate term) (brs : list (branch term)) br,
           nth_error brs c = Some br ->
           #|args| = (ci.(ci_npar) + context_assumptions br.(bcontext))%nat ->
-          P Rle  Γ (tCase ci p (mkApps (tConstruct ci.(ci_ind) c u) args) brs)
+          P pb Γ (tCase ci p (mkApps (tConstruct ci.(ci_ind) c u) args) brs)
               (iota_red ci.(ci_npar) p args br)) ->
 
         (* fix unfolding *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
+       (forall (pb : conv_pb) (Γ : context) (mfix : mfixpoint term) (idx : nat) (args : list term) (narg : nat) (fn : term),
         unfold_fix mfix idx = Some (narg, fn) ->
-        is_constructor narg args = true -> P Rle Γ (mkApps (tFix mfix idx) args) (mkApps fn args)) ->
+        is_constructor narg args = true -> P pb Γ (mkApps (tFix mfix idx) args) (mkApps fn args)) ->
 
       (* cofix unfolding *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) ci (p : predicate term) (mfix : mfixpoint term) (idx : nat)
+       (forall (pb : conv_pb) (Γ : context) ci (p : predicate term) (mfix : mfixpoint term) (idx : nat)
           (args : list term) (narg : nat) (fn : term) (brs : list (branch term)),
         unfold_cofix mfix idx = Some (narg, fn) ->
-        P Rle Γ (tCase ci p (mkApps (tCoFix mfix idx) args) brs) (tCase ci p (mkApps fn args) brs)) ->
+        P pb Γ (tCase ci p (mkApps (tCoFix mfix idx) args) brs) (tCase ci p (mkApps fn args) brs)) ->
 
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
+       (forall (pb : conv_pb) (Γ : context) (p : projection) (mfix : mfixpoint term) (idx : nat) (args : list term)
           (narg : nat) (fn : term),
-        unfold_cofix mfix idx = Some (narg, fn) -> P Rle Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
+        unfold_cofix mfix idx = Some (narg, fn) -> P pb Γ (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args))) ->
 
         (* constant unfolding *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) c (decl : constant_body) (body : term),
+       (forall (pb : conv_pb) (Γ : context) c (decl : constant_body) (body : term),
         declared_constant Σ c decl ->
-        forall u : Instance.t, cst_body decl = Some body -> P Rle Γ (tConst c u) (subst_instance u body)) ->
+        forall u : Instance.t, cst_body decl = Some body -> P pb Γ (tConst c u) (subst_instance u body)) ->
 
         (* Proj *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
+       (forall (pb : conv_pb) (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
          (arg : term),
            nth_error args (pars + narg) = Some arg ->
-           P Rle  Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
+           P pb Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
 
         (* transitivity *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (t u v : term),
+       (forall (pb : conv_pb) (Γ : context) (t u v : term),
           is_closed_context Γ -> is_open_term Γ u ->
-          cumulSpec0 Σ (Re) Rle Γ t u -> P Rle Γ t u ->
-          cumulSpec0 Σ (Re) Rle Γ u v -> P Rle Γ u v ->
-          P Rle Γ t v) ->
+          cumulSpec0 Σ Γ pb t u -> P pb Γ t u ->
+          cumulSpec0 Σ Γ pb u v -> P pb Γ u v ->
+          P pb Γ t v) ->
 
         (* symmetry *)
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (t u : term),
-        cumulSpec0 Σ (Re) Re Γ u t -> P Re Γ u t ->
-        P Rle Γ t u) ->
+       (forall (pb : conv_pb) (Γ : context) (t u : term),
+        cumulSpec0 Σ Γ Conv u t -> P Conv Γ u t ->
+         P pb Γ t u) ->
 
         (* reflexivity *)
-        (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (t : term),
-        P Rle Γ t t) ->
+        (forall (pb : conv_pb) (Γ : context) (t : term),
+        P pb Γ t t) ->
         
         (* congruence rules *)
 
-        (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (ev : nat) (l l' : list term),
-          All2 (Trel_conj (cumulSpec0 Σ (Re) Re Γ) (P Re Γ)) l l' -> P Rle Γ (tEvar ev l) (tEvar ev l')) ->
+        (forall (pb : conv_pb) (Γ : context) (ev : nat) (l l' : list term),
+          All2 (Trel_conj (cumulSpec0 Σ Γ Conv) (P Conv Γ)) l l' -> P pb Γ (tEvar ev l) (tEvar ev l')) ->
 
-        (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (t t' u u' : term), 
-          cumulSpec0 Σ (Re) Rle Γ t t' -> P Rle Γ t t' ->
-          cumulSpec0 Σ (Re) Re Γ u u' -> P Re Γ u u' ->
-          P Rle Γ (tApp t u) (tApp t' u')) ->
+        (forall (pb : conv_pb) (Γ : context) (t t' u u' : term), 
+          cumulSpec0 Σ Γ pb t t' -> P pb Γ t t' ->
+          cumulSpec0 Σ Γ Conv u u' -> P Conv Γ u u' ->
+          P pb Γ (tApp t u) (tApp t' u')) ->
 
-        (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (na na' : aname) (ty ty' t t' : term),
+        (forall (pb : conv_pb) (Γ : context) (na na' : aname) (ty ty' t t' : term),
           eq_binder_annot na na' ->  
-          cumulSpec0 Σ (Re )Re Γ ty ty' -> P Re Γ ty ty' -> 
-          cumulSpec0 Σ (Re) Rle (Γ ,, vass na ty) t t' -> P Rle (Γ ,, vass na ty) t t' -> 
-          P Rle Γ (tLambda na ty t) (tLambda na' ty' t')) ->
+          cumulSpec0 Σ Γ Conv ty ty' -> P Conv Γ ty ty' -> 
+          cumulSpec0 Σ (Γ ,, vass na ty) pb t t' -> P pb (Γ ,, vass na ty) t t' -> 
+          P pb Γ (tLambda na ty t) (tLambda na' ty' t')) ->
 
-        (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (na na' : binder_annot name) (a a' b b' : term), 
+        (forall (pb : conv_pb) (Γ : context) (na na' : binder_annot name) (a a' b b' : term), 
           eq_binder_annot na na' ->
-          cumulSpec0 Σ (Re) Re Γ a a' -> P Re Γ a a' ->
-          cumulSpec0 Σ (Re) Rle (Γ,, vass na a) b b' -> P Rle (Γ,, vass na a) b b' ->
-          P Rle Γ (tProd na a b) (tProd na' a' b')) ->
+          cumulSpec0 Σ Γ Conv a a' -> P Conv Γ a a' ->
+          cumulSpec0 Σ (Γ,, vass na a) pb b b' -> P pb (Γ,, vass na a) b b' ->
+          P pb Γ (tProd na a b) (tProd na' a' b')) ->
 
-     (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (na na' : binder_annot name) (t t' ty ty' u u' : term),
-        eq_binder_annot na na' ->  cumulSpec0 Σ (Re) Re Γ t t' -> P Re Γ t t' ->
-        cumulSpec0 Σ (Re) Re Γ ty ty' -> P Re Γ ty ty' ->
-        cumulSpec0 Σ (Re) Rle (Γ,, vdef na t ty) u u' -> P Rle (Γ,, vdef na t ty) u u' ->
-        P Rle Γ (tLetIn na t ty u) (tLetIn na' t' ty' u')) ->
+     (forall (pb : conv_pb) (Γ : context) (na na' : binder_annot name) (t t' ty ty' u u' : term),
+        eq_binder_annot na na' ->  cumulSpec0 Σ Γ Conv t t' -> P Conv Γ t t' ->
+        cumulSpec0 Σ Γ  Conv ty ty' -> P Conv Γ ty ty' ->
+        cumulSpec0 Σ (Γ,, vdef na t ty) pb u u' -> P pb (Γ,, vdef na t ty) u u' ->
+        P pb Γ (tLetIn na t ty u) (tLetIn na' t' ty' u')) ->
 
-      (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (indn : case_info) (p p' : predicate term)
+      (forall (pb : conv_pb) (Γ : context) (indn : case_info) (p p' : predicate term)
         (c c' : term) (brs brs' : list (branch term)),
-        cumul_predicate (fun Γ t u => cumulSpec0 Σ (Re) Re Γ t u × P Re Γ t u) Γ Re p p' -> 
-        cumulSpec0 Σ (Re) Re Γ c c' -> P Re Γ c c' ->
+        cumul_predicate (fun Γ t u => cumulSpec0 Σ Γ Conv t u × P Conv Γ t u) Γ 
+          (compare_universe Conv Σ) p p' -> 
+        cumulSpec0 Σ Γ Conv c c' -> P Conv Γ c c' ->
         All2
           (Trel_conj (fun br br' : branch term =>
                eq_context_gen eq eq (bcontext br) (bcontext br') *
-               cumulSpec0 Σ (Re) Re (Γ,,, inst_case_branch_context p br)
+               cumulSpec0 Σ (Γ,,, inst_case_branch_context p br) Conv
                  (bbody br) (bbody br')) 
-            (fun br br' => P Re (Γ,,, inst_case_branch_context p br) (bbody br) (bbody br'))) brs brs' -> 
-       P Rle Γ (tCase indn p c brs) (tCase indn p' c' brs')) ->
+            (fun br br' => P Conv (Γ,,, inst_case_branch_context p br) (bbody br) (bbody br'))) brs brs' -> 
+       P pb Γ (tCase indn p c brs) (tCase indn p' c' brs')) ->
 
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) 
+       (forall (pb : conv_pb) (Γ : context) 
           (p : projection) (c c' : term),
-        cumulSpec0 Σ (Re) Re Γ c c' -> P Re Γ c c' ->
-         P Rle Γ (tProj p c) (tProj p c')) ->
+        cumulSpec0 Σ Γ Conv c c' -> P Conv Γ c c' ->
+         P pb Γ (tProj p c) (tProj p c')) ->
 
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) 
+       (forall (pb : conv_pb) (Γ : context) 
           (mfix : mfixpoint term) (mfix' : list (def term)) (idx : nat),
           All2
             (fun x y : def term =>
-             ((cumulSpec0 Σ (Re) Re Γ (dtype x) (dtype y) × 
-                P Re Γ (dtype x) (dtype y)
-               × cumulSpec0 Σ (Re) Re (Γ,,, fix_context mfix) 
-                   (dbody x) (dbody y)) × P Re (Γ,,, fix_context mfix) 
-                   (dbody x) (dbody y) × rarg x = rarg y) *
+             ((cumulSpec0 Σ Γ Conv (dtype x) (dtype y) × 
+                P Conv Γ (dtype x) (dtype y)
+               × cumulSpec0 Σ (Γ,,, fix_context mfix) Conv
+                   (dbody x) (dbody y)) × 
+                P Conv (Γ,,, fix_context mfix) (dbody x) (dbody y) × rarg x = rarg y) *
              eq_binder_annot (dname x) (dname y)) mfix mfix' ->
-           P Rle Γ (tFix mfix idx) (tFix mfix' idx)) ->
+           P pb Γ (tFix mfix idx) (tFix mfix' idx)) ->
 
-       (forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) 
+       (forall (pb : conv_pb) (Γ : context) 
            (mfix : mfixpoint term) (mfix' : list (def term)) (idx : nat),
            All2
              (fun x y : def term =>
-              ((cumulSpec0 Σ (Re) Re Γ (dtype x) (dtype y) × 
-                 P Re Γ (dtype x) (dtype y)
-                × cumulSpec0 Σ (Re) Re (Γ,,, fix_context mfix) 
-                    (dbody x) (dbody y)) × P Re (Γ,,, fix_context mfix) 
+              ((cumulSpec0 Σ Γ Conv (dtype x) (dtype y) × 
+                 P Conv Γ (dtype x) (dtype y)
+                × cumulSpec0 Σ (Γ,,, fix_context mfix) Conv
+                    (dbody x) (dbody y)) × P Conv (Γ,,, fix_context mfix) 
                     (dbody x) (dbody y) × rarg x = rarg y) *
               eq_binder_annot (dname x) (dname y)) mfix mfix' ->
-            P Rle Γ (tCoFix mfix idx) (tCoFix mfix' idx)) ->
+            P pb Γ (tCoFix mfix idx) (tCoFix mfix' idx)) ->
  
       (* cumulativiity rules *)
       
-      (forall (Rle : Universe.t -> Universe.t -> Prop) 
+      (forall (pb : conv_pb) 
             (Γ : context) (i : inductive) (u u' : list Level.t)
             (args args' : list term), 
-      R_global_instance Σ Re Rle (IndRef i) #|args| u u' ->
-      All2 (Trel_conj (cumulSpec0 Σ (Re) Re Γ) (P Re Γ)) args args' ->
-      P Rle Γ (mkApps (tInd i u) args) (mkApps (tInd i u') args')) ->
+      R_global_instance Σ (eq_universe Σ) (compare_universe pb Σ) (IndRef i) #|args| u u' ->
+      All2 (Trel_conj (cumulSpec0 Σ Γ Conv) (P Conv Γ)) args args' ->
+      P pb Γ (mkApps (tInd i u) args) (mkApps (tInd i u') args')) ->
 
-    (forall (Rle : Universe.t -> Universe.t -> Prop) 
+    (forall (pb : conv_pb) 
       (Γ : context) (i : inductive) (k : nat) 
       (u u' : list Level.t) (args args' : list term), 
-      R_global_instance Σ Re Rle (ConstructRef i k) #|args| u u' ->
-      All2 (Trel_conj (cumulSpec0 Σ (Re) Re Γ) (P Re Γ)) args args' ->
-      P Rle Γ (mkApps (tConstruct i k u) args)
+      R_global_instance Σ (eq_universe Σ) (compare_universe pb Σ) (ConstructRef i k) #|args| u u' ->
+      All2 (Trel_conj (cumulSpec0 Σ Γ Conv) (P Conv Γ)) args args' ->
+      P pb Γ (mkApps (tConstruct i k u) args)
               (mkApps (tConstruct i k u') args')) ->
 
-      (forall (Rle : Universe.t -> Universe.t -> Prop) 
+      (forall (pb : conv_pb) 
           (Γ : context) (s s' : Universe.t),
-          Rle s s' -> P Rle Γ (tSort s) (tSort s')) ->
+          compare_universe pb Σ s s' -> P pb Γ (tSort s) (tSort s')) ->
 
-      (forall (Rle : Universe.t -> Universe.t -> Prop) 
+      (forall (pb : conv_pb) 
           (Γ : context) (c : kername) (u u' : list Level.t),
-          R_universe_instance Re u u' -> P Rle Γ (tConst c u) (tConst c u') ) ->
+          R_universe_instance (compare_universe Conv Σ) u u' -> P pb Γ (tConst c u) (tConst c u') ) ->
 
-       forall (Rle : Universe.t -> Universe.t -> Prop) (Γ : context) (t t0 : term), cumulSpec0 Σ (Re) Rle Γ t t0 -> P Rle Γ t t0.
+       forall (pb : conv_pb) (Γ : context) (t t0 : term), cumulSpec0 Σ Γ pb t t0 -> P pb Γ t t0.
 Proof.
-  intros. rename X24 into Xlast. revert Rle Γ t t0 Xlast.
-  fix aux 5. intros Rle Γ t u.
+  intros. rename X24 into Xlast. revert pb Γ t t0 Xlast.
+  fix aux 5. intros pb Γ t u.
   move aux at top.
   destruct 1.
   - eapply X8; eauto.
@@ -472,7 +457,7 @@ Proof.
 Defined.
 
 Lemma convSpec0_ind_all :
-  forall (Σ : global_env) (Re : Universe.t -> Universe.t -> Prop)
+  forall {cf} (Σ : global_env_ext)
          (P : context -> term -> term -> Type),
 
         (* beta *)
@@ -522,13 +507,13 @@ Lemma convSpec0_ind_all :
         (* transitivity *)
        (forall  (Γ : context) (t u v : term),
           is_closed_context Γ -> is_open_term Γ u ->
-          cumulSpec0 Σ (Re) Re Γ t u -> P Γ t u ->
-          cumulSpec0 Σ (Re) Re Γ u v -> P Γ u v ->
+          cumulSpec0 Σ Γ Conv t u -> P Γ t u ->
+          cumulSpec0 Σ Γ Conv u v -> P Γ u v ->
           P Γ t v) ->
 
         (* symmetry *)
        (forall  (Γ : context) (t u : term),
-        cumulSpec0 Σ (Re) Re Γ u t -> P Γ u t ->
+        cumulSpec0 Σ Γ Conv u t -> P Γ u t ->
         P Γ t u) ->
 
         (* reflexivity *)
@@ -538,55 +523,55 @@ Lemma convSpec0_ind_all :
         (* congruence rules *)
 
         (forall  (Γ : context) (ev : nat) (l l' : list term),
-          All2 (Trel_conj (cumulSpec0 Σ (Re) Re Γ) (P Γ)) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
+          All2 (Trel_conj (cumulSpec0 Σ Γ Conv) (P Γ)) l l' -> P Γ (tEvar ev l) (tEvar ev l')) ->
 
         (forall  (Γ : context) (t t' u u' : term), 
-          cumulSpec0 Σ (Re) Re Γ t t' -> P Γ t t' ->
-          cumulSpec0 Σ (Re) Re Γ u u' -> P Γ u u' ->
+          cumulSpec0 Σ Γ Conv t t' -> P Γ t t' ->
+          cumulSpec0 Σ Γ Conv u u' -> P Γ u u' ->
           P Γ (tApp t u) (tApp t' u')) ->
 
         (forall  (Γ : context) (na na' : aname) (ty ty' t t' : term),
           eq_binder_annot na na' ->  
-          cumulSpec0 Σ (Re) Re Γ ty ty' -> P Γ ty ty' -> 
-          cumulSpec0 Σ (Re) Re (Γ ,, vass na ty) t t' -> P (Γ ,, vass na ty) t t' -> 
+          cumulSpec0 Σ Γ Conv ty ty' -> P Γ ty ty' -> 
+          cumulSpec0 Σ (Γ ,, vass na ty) Conv t t' -> P (Γ ,, vass na ty) t t' -> 
           P Γ (tLambda na ty t) (tLambda na' ty' t')) ->
 
         (forall  (Γ : context) (na na' : binder_annot name) (a a' b b' : term), 
           eq_binder_annot na na' ->
-          cumulSpec0 Σ (Re) Re Γ a a' -> P Γ a a' ->
-          cumulSpec0 Σ (Re) Re (Γ,, vass na a) b b' -> P (Γ,, vass na a) b b' ->
+          cumulSpec0 Σ Γ Conv a a' -> P Γ a a' ->
+          cumulSpec0 Σ (Γ,, vass na a) Conv b b' -> P (Γ,, vass na a) b b' ->
           P Γ (tProd na a b) (tProd na' a' b')) ->
 
      (forall  (Γ : context) (na na' : binder_annot name) (t t' ty ty' u u' : term),
-        eq_binder_annot na na' ->  cumulSpec0 Σ (Re) Re Γ t t' -> P Γ t t' ->
-        cumulSpec0 Σ (Re) Re Γ ty ty' -> P Γ ty ty' ->
-        cumulSpec0 Σ (Re) Re (Γ,, vdef na t ty) u u' -> P (Γ,, vdef na t ty) u u' ->
+        eq_binder_annot na na' ->  cumulSpec0 Σ Γ Conv t t' -> P Γ t t' ->
+        cumulSpec0 Σ Γ Conv ty ty' -> P Γ ty ty' ->
+        cumulSpec0 Σ (Γ,, vdef na t ty) Conv u u' -> P (Γ,, vdef na t ty) u u' ->
         P Γ (tLetIn na t ty u) (tLetIn na' t' ty' u')) ->
 
       (forall  (Γ : context) (indn : case_info) (p p' : predicate term)
         (c c' : term) (brs brs' : list (branch term)),
-        cumul_predicate (fun Γ t u => cumulSpec0 Σ (Re) Re Γ t u * P Γ t u) Γ Re p p' -> 
-        cumulSpec0 Σ (Re) Re Γ c c' -> P Γ c c' ->
+        cumul_predicate (fun Γ t u => cumulSpec0 Σ Γ Conv t u * P Γ t u) Γ (compare_universe Conv Σ) p p' -> 
+        cumulSpec0 Σ Γ Conv c c' -> P Γ c c' ->
         All2
           (Trel_conj (fun br br' : branch term =>
                eq_context_gen eq eq (bcontext br) (bcontext br') *
-               cumulSpec0 Σ (Re) Re (Γ,,, inst_case_branch_context p br)
+               cumulSpec0 Σ (Γ,,, inst_case_branch_context p br) Conv
                  (bbody br) (bbody br')) 
             (fun br br' => P (Γ,,, inst_case_branch_context p br) (bbody br) (bbody br'))) brs brs' -> 
        P Γ (tCase indn p c brs) (tCase indn p' c' brs')) ->
 
        (forall  (Γ : context) 
           (p : projection) (c c' : term),
-        cumulSpec0 Σ (Re) Re Γ c c' -> P Γ c c' ->
+        cumulSpec0 Σ Γ Conv c c' -> P Γ c c' ->
          P Γ (tProj p c) (tProj p c')) ->
 
        (forall  (Γ : context) 
           (mfix : mfixpoint term) (mfix' : list (def term)) (idx : nat),
           All2
             (fun x y : def term =>
-             ((cumulSpec0 Σ (Re) Re Γ (dtype x) (dtype y) × 
+             ((cumulSpec0 Σ Γ Conv (dtype x) (dtype y) × 
                 P Γ (dtype x) (dtype y)
-               × cumulSpec0 Σ (Re) Re (Γ,,, fix_context mfix) 
+               × cumulSpec0 Σ (Γ,,, fix_context mfix) Conv
                    (dbody x) (dbody y)) × P (Γ,,, fix_context mfix) 
                    (dbody x) (dbody y) × rarg x = rarg y) *
              eq_binder_annot (dname x) (dname y)) mfix mfix' ->
@@ -596,9 +581,9 @@ Lemma convSpec0_ind_all :
            (mfix : mfixpoint term) (mfix' : list (def term)) (idx : nat),
            All2
              (fun x y : def term =>
-              ((cumulSpec0 Σ (Re) Re Γ (dtype x) (dtype y) × 
+              ((cumulSpec0 Σ Γ Conv (dtype x) (dtype y) × 
                  P Γ (dtype x) (dtype y)
-                × cumulSpec0 Σ (Re) Re (Γ,,, fix_context mfix) 
+                × cumulSpec0 Σ (Γ,,, fix_context mfix) Conv
                     (dbody x) (dbody y)) × P (Γ,,, fix_context mfix) 
                     (dbody x) (dbody y) × rarg x = rarg y) *
               eq_binder_annot (dname x) (dname y)) mfix mfix' ->
@@ -609,27 +594,27 @@ Lemma convSpec0_ind_all :
       (forall  
             (Γ : context) (i : inductive) (u u' : list Level.t)
             (args args' : list term), 
-      R_global_instance Σ Re Re (IndRef i) #|args| u u' ->
-      All2 (Trel_conj (cumulSpec0 Σ (Re) Re Γ) (P Γ)) args args' ->
+      R_global_instance Σ (eq_universe Σ) (eq_universe Σ) (IndRef i) #|args| u u' ->
+      All2 (Trel_conj (cumulSpec0 Σ Γ Conv) (P Γ)) args args' ->
       P Γ (mkApps (tInd i u) args) (mkApps (tInd i u') args')) ->
 
     (forall  
       (Γ : context) (i : inductive) (k : nat) 
       (u u' : list Level.t) (args args' : list term), 
-      R_global_instance Σ Re Re (ConstructRef i k) #|args| u u' ->
-      All2 (Trel_conj (cumulSpec0 Σ (Re) Re Γ) (P Γ)) args args' ->
+      R_global_instance Σ (eq_universe Σ) (eq_universe Σ) (ConstructRef i k) #|args| u u' ->
+      All2 (Trel_conj (cumulSpec0 Σ Γ Conv) (P Γ)) args args' ->
       P Γ (mkApps (tConstruct i k u) args)
               (mkApps (tConstruct i k u') args')) ->
 
       (forall  
           (Γ : context) (s s' : Universe.t),
-          Re s s' -> P Γ (tSort s) (tSort s')) ->
+          eq_universe Σ s s' -> P Γ (tSort s) (tSort s')) ->
 
       (forall  
           (Γ : context) (c : kername) (u u' : list Level.t),
-          R_universe_instance Re u u' -> P Γ (tConst c u) (tConst c u') ) ->
+          R_universe_instance (eq_universe Σ) u u' -> P Γ (tConst c u) (tConst c u') ) ->
 
-       forall  (Γ : context) (t t0 : term), cumulSpec0 Σ (Re) Re Γ t t0 -> P Γ t t0.
+       forall  (Γ : context) (t t0 : term), cumulSpec0 Σ Γ Conv t t0 -> P Γ t t0.
 Proof.
   intros. rename X24 into Xlast. revert Γ t t0 Xlast.
   fix aux 4. intros Γ t u.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -235,7 +235,7 @@ Proof.
       now rewrite /subst1 subst_it_mkProd_or_LetIn Nat.add_0_r in cum.
       unshelve eapply (isType_subst (Δ := [vass _ _]) [hd]) in i1; pcuic.
       now rewrite subst_it_mkProd_or_LetIn in i1.
-      eapply subslet_ass_tip. eapply (type_equality (le:=false)); tea. now symmetry.
+      eapply subslet_ass_tip. eapply (type_equality (pb:=Conv)); tea. now symmetry.
 Qed.
 
 Inductive All_local_assum (P : context -> term -> Type) : context -> Type :=
@@ -429,7 +429,7 @@ Proof.
         split.
         intros prs;eapply All_local_assum_app in prs as [prd prs].
         depelim prd.
-        eapply (type_equality (le:=false) _ (U:=ty)) in t0.
+        eapply (type_equality (pb:=Conv) _ (U:=ty)) in t0.
         2:{ destruct s0 as [s' [Hs' _]]. exists s'; auto. }
         2:now symmetry.
         destruct H as [H _].

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -365,15 +365,43 @@ where " Σ ⊢ t <==[ Rle , napp ] u " := (eq_term_upto_univ_napp Σ _ Rle napp 
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 
+(* ** Syntactic conparison up-to universes *)
+
+Definition compare_term_napp `{checker_flags} (pb : conv_pb) Σ φ napp (t u : term) :=
+  eq_term_upto_univ_napp Σ (eq_universe φ) (compare_universe pb φ) napp t u.
+  
+Definition compare_term `{checker_flags} (pb : conv_pb) Σ φ (t u : term) :=
+  eq_term_upto_univ Σ (eq_universe φ) (compare_universe pb φ) t u.
+
 (* ** Syntactic conversion up-to universes *)
 
-Definition eq_term `{checker_flags} Σ φ :=
-  eq_term_upto_univ Σ (eq_universe φ) (eq_universe φ).
+Notation eq_term := (compare_term Conv).
 
 (* ** Syntactic cumulativity up-to universes *)
 
-Definition leq_term `{checker_flags} Σ φ :=
-  eq_term_upto_univ Σ (eq_universe φ) (leq_universe φ).
+Notation leq_term := (compare_term Cumul).
+
+Definition compare_opt_term `{checker_flags} (pb : conv_pb) Σ φ (t u : option term) :=
+  match t, u with
+  | Some t, Some u => compare_term pb Σ φ t u
+  | None, None => True
+  | _, _ => False
+  end.
+
+Definition compare_decl `{checker_flags} pb Σ φ (d d' : context_decl) :=
+  compare_decls (compare_term Conv Σ φ) (compare_term pb Σ φ) d d'.
+
+Notation eq_decl := (compare_decl Conv).
+Notation leq_decl := (compare_decl Cumul).
+
+Definition compare_context `{checker_flags} pb Σ φ (Γ Δ : context) :=
+  eq_context_gen (compare_term Conv Σ φ) (compare_term pb Σ φ) Γ Δ.
+  
+Notation eq_context := (compare_context Conv).
+Notation leq_context := (compare_context Cumul).
+
+Notation eq_context_upto Σ Re Rle := 
+  (eq_context_gen (eq_term_upto_univ Σ Re Re) (eq_term_upto_univ Σ Re Rle)).
 
 Lemma R_global_instance_refl Σ Re Rle gr napp u : 
   RelationClasses.Reflexive Re ->
@@ -497,16 +525,8 @@ Proof.
 Qed.
 
 #[global]
-Polymorphic Instance eq_term_refl `{checker_flags} Σ φ : Reflexive (eq_term Σ φ).
-Proof.
-  apply eq_term_upto_univ_refl. all: exact _.
-Qed.
-
-#[global]
-Polymorphic Instance leq_term_refl `{checker_flags} Σ φ : Reflexive (leq_term Σ φ).
-Proof.
-  apply eq_term_upto_univ_refl; exact _.
-Qed.
+Instance compare_term_refl {cf} pb {Σ : global_env} φ : Reflexive (compare_term pb Σ φ).
+Proof. eapply eq_term_upto_univ_refl; tc. Qed.
 
 Derive Signature for eq_term_upto_univ_napp.
 
@@ -593,9 +613,9 @@ Proof.
 Qed.
 
 #[global]
-Instance eq_term_sym `{checker_flags} Σ φ : Symmetric (eq_term Σ φ).
+Instance compare_term_sym {cf} Σ φ : Symmetric (compare_term Conv Σ φ).
 Proof.
-  eapply eq_term_upto_univ_sym. all: exact _.
+  now intros t u; unfold compare_term; cbn; symmetry.
 Qed.
 
 #[global]
@@ -714,16 +734,8 @@ Proof.
 Qed.
 
 #[global]
-Polymorphic Instance eq_term_trans {cf:checker_flags} Σ φ : Transitive (eq_term Σ φ).
-Proof.
-  eapply eq_term_upto_univ_trans. all: exact _.
-Qed.
-
-#[global]
-Polymorphic Instance leq_term_trans {cf:checker_flags} Σ φ : Transitive (leq_term Σ φ).
-Proof.
-  eapply eq_term_upto_univ_trans ; exact _.
-Qed.
+Instance compare_term_trans {cf} pb Σ φ : Transitive (compare_term pb Σ φ).
+Proof. apply eq_term_upto_univ_trans; tc. Qed.
 
 #[global]
 Polymorphic Instance eq_term_upto_univ_equiv Σ Re (hRe : RelationClasses.Equivalence Re)
@@ -745,15 +757,12 @@ Proof.
 Qed.
 
 #[global]
-Polymorphic Instance eq_term_equiv {cf:checker_flags} Σ φ : Equivalence (eq_term Σ φ) :=
-  {| Equivalence_Reflexive := eq_term_refl _ _;
-     Equivalence_Symmetric := eq_term_sym _ _;
-     Equivalence_Transitive := eq_term_trans _ _ |}.
+Polymorphic Instance eq_term_equiv {cf:checker_flags} Σ φ : Equivalence (eq_term Σ φ).
+Proof. split; tc. Qed.
 
 #[global]
-Polymorphic Instance leq_term_preorder {cf:checker_flags} Σ φ : PreOrder (leq_term Σ φ) :=
-  {| PreOrder_Reflexive := leq_term_refl _ _;
-     PreOrder_Transitive := leq_term_trans _ _ |}.
+Polymorphic Instance leq_term_preorder {cf:checker_flags} Σ φ : PreOrder (leq_term Σ φ).
+Proof. split; tc. Qed. 
 
 #[global]
 Instance R_universe_instance_equiv R (hR : RelationClasses.Equivalence R)
@@ -1024,6 +1033,29 @@ Proof.
     solve_all. rewrite H. eauto.
 Qed.
 
+Lemma lift_compare_term `{checker_flags} pb Σ ϕ n k t t' :
+  compare_term pb Σ ϕ t t' -> compare_term pb Σ ϕ (lift n k t) (lift n k t').
+Proof.
+  now apply eq_term_upto_univ_lift.
+Qed.
+
+Lemma lift_compare_decls `{checker_flags} pb Σ ϕ n k d d' :
+  compare_decl pb Σ ϕ d d' -> compare_decl pb Σ ϕ (lift_decl n k d) (lift_decl n k d').
+Proof.
+  intros []; constructor; cbn; intuition auto using lift_compare_term.
+Qed.
+
+Lemma lift_compare_context `{checker_flags} pb Σ φ l l' n k :
+  compare_context pb Σ φ l l' ->
+  compare_context pb Σ φ (lift_context n k l) (lift_context n k l').
+Proof.
+  unfold compare_context.
+  induction 1; rewrite -> ?lift_context_snoc0. constructor.
+  constructor; auto. 
+  eapply lift_compare_decls in p.
+  now rewrite (All2_fold_length X).
+Qed.
+
 Lemma lift_eq_term {cf:checker_flags} Σ φ n k T U :
   eq_term Σ φ T U -> eq_term Σ φ (lift n k T) (lift n k U).
 Proof.
@@ -1035,7 +1067,6 @@ Lemma lift_leq_term {cf:checker_flags} Σ φ n k T U :
 Proof.
   apply eq_term_upto_univ_lift.
 Qed.
-
 
 Local Ltac sih :=
   lazymatch goal with
@@ -1301,9 +1332,6 @@ Qed.
 
 (** ** Equality on contexts ** *)
 
-Notation eq_context_upto Σ Re Rle := 
-  (eq_context_gen (eq_term_upto_univ Σ Re Re) (eq_term_upto_univ Σ Re Rle)).
-
 Inductive rel_option {A B} (R : A -> B -> Type) : option A -> option B -> Type :=
 | rel_some : forall a b, R a b -> rel_option R (Some a) (Some b)
 | rel_none : rel_option R None None.
@@ -1501,52 +1529,6 @@ Proof.
     assumption.
   - simpl in h. cbn in h. apply ih in h. inversion h. subst.
     assumption.
-Qed.
-
-Definition leq_rel {cf} (le : bool) :=
-  if le then leq_universe else eq_universe.
-
-Definition compare_term_napp `{checker_flags} (le : bool) Σ φ napp (t u : term) :=
-  eq_term_upto_univ_napp Σ (eq_universe φ) (leq_rel le φ) napp t u.
-  
-Definition compare_term `{checker_flags} (le : bool) Σ φ (t u : term) :=
-  eq_term_upto_univ Σ (eq_universe φ) (leq_rel le φ) t u.
-
-Lemma lift_compare_term `{checker_flags} le Σ ϕ n k t t' :
-  compare_term le Σ ϕ t t' -> compare_term le Σ ϕ (lift n k t) (lift n k t').
-Proof.
-  destruct le; intros. now apply lift_leq_term. now apply lift_eq_term.
-Qed.
-
-(* todo: unify *)
-Definition eq_opt_term `{checker_flags} (le : bool) Σ φ (t u : option term) :=
-  match t, u with
-  | Some t, Some u => compare_term le Σ φ t u
-  | None, None => True
-  | _, _ => False
-  end.
-
-Definition eq_decl `{checker_flags} le Σ φ (d d' : context_decl) :=
-  compare_decls (eq_term Σ φ) (if le then leq_term Σ φ else eq_term Σ φ) d d'.
-
-Definition eq_context `{checker_flags} le Σ φ (Γ Δ : context) :=
-  eq_context_gen (eq_term Σ φ) (if le then leq_term Σ φ else eq_term Σ φ) Γ Δ.
-
-Lemma lift_compare_decls `{checker_flags} le Σ ϕ n k d d' :
-  eq_decl le Σ ϕ d d' -> eq_decl le Σ ϕ (lift_decl n k d) (lift_decl n k d').
-Proof.
-  intros []; destruct le; constructor; cbn; intuition auto using lift_compare_term, lift_eq_term, lift_leq_term.
-Qed.
-
-Lemma lift_eq_context `{checker_flags} le Σ φ l l' n k :
-  eq_context le Σ φ l l' ->
-  eq_context le Σ φ (lift_context n k l) (lift_context n k l').
-Proof.
-  unfold eq_context.
-  induction 1; rewrite -> ?lift_context_snoc0. constructor.
-  constructor; auto. 
-  eapply lift_compare_decls in p.
-  now rewrite (All2_fold_length X).
 Qed.
 
 Lemma eq_term_upto_univ_mkApps_inv Σ Re Rle u l u' l' :

--- a/pcuic/theories/PCUICEqualityDec.v
+++ b/pcuic/theories/PCUICEqualityDec.v
@@ -765,14 +765,14 @@ Section EqualityDec.
     destruct hΣ, Hφ; now constructor.
   Defined.
 
-  Definition conv_pb_relb pb :=
+  Definition compare_universeb pb :=
     match pb with
     | Conv => check_eqb_universe G
     | Cumul => check_leqb_universe G
     end.
   
   Definition eqb_termp_napp pb napp :=
-    eqb_term_upto_univ_napp Σ (check_eqb_universe G) (conv_pb_relb pb) napp.
+    eqb_term_upto_univ_napp Σ (check_eqb_universe G) (compare_universeb pb) napp.
 
     Lemma eq_universeP u u' :
     wf_universe Σ u ->
@@ -815,7 +815,7 @@ Section EqualityDec.
   Lemma leq_relP (pb : conv_pb) u u' :
     wf_universe Σ u ->
     wf_universe Σ u' ->
-    reflect (leq_rel pb Σ u u') (conv_pb_relb pb u u').
+    reflect (compare_universe pb Σ u u') (compare_universeb pb u u').
   Proof.
     destruct pb.
     - cbn.
@@ -966,7 +966,7 @@ Section EqualityDec.
     end.
 
   Lemma eqb_opt_term_spec t u
-    : eqb_opt_term t u -> eq_opt_term false Σ (global_ext_constraints Σ) t u.
+    : eqb_opt_term t u -> compare_opt_term Conv Σ (global_ext_constraints Σ) t u.
   Proof.
     destruct t, u; try discriminate; cbn => //.
     apply eqb_term_spec; tea.
@@ -977,7 +977,7 @@ Section EqualityDec.
     eqb_opt_term d.(decl_body) d'.(decl_body) && eqb_term d.(decl_type) d'.(decl_type).
 
   Lemma eqb_decl_spec d d'
-    : eqb_decl d d' -> eq_decl false Σ (global_ext_constraints Σ) d d'.
+    : eqb_decl d d' -> eq_decl Σ (global_ext_constraints Σ) d d'.
   Proof.
     unfold eqb_decl, eq_decl.
     intro H. rtoProp. apply eqb_opt_term_spec in H1.
@@ -990,7 +990,7 @@ Section EqualityDec.
   Definition eqb_context (Γ Δ : context) := forallb2 eqb_decl Γ Δ.
 
   Lemma eqb_context_spec Γ Δ
-    : eqb_context Γ Δ -> eq_context false Σ (global_ext_constraints Σ) Γ Δ.
+    : eqb_context Γ Δ -> eq_context Σ (global_ext_constraints Σ) Γ Δ.
   Proof.
     unfold eqb_context, eq_context.
     intro HH. apply forallb2_All2 in HH.

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -789,15 +789,15 @@ Qed.
 
 Notation "⋆" := ltac:(solve [pcuic]) (only parsing).
 
-Notation decl_equality Σ Γ := (All_decls_alpha_le false
-  (fun (le : bool) (x0 y0 : term) => Σ ;;; Γ ⊢ x0 ≤[le] y0)).
+Notation decl_equality Σ Γ := (All_decls_alpha_pb Conv
+  (fun pb (x0 y0 : term) => Σ ;;; Γ ⊢ x0 ≤[pb] y0)).
 
 Lemma conv_decls_fix_context_gen {cf:checker_flags} Σ Γ mfix mfix1 :
   wf Σ.1 ->
   All2 (fun d d' => Σ ;;; Γ ⊢ d.(dtype) = d'.(dtype) × eq_binder_annot d.(dname) d'.(dname)) mfix mfix1 ->
   forall Γ' Γ'',
   Σ ⊢ Γ ,,, Γ' = Γ ,,, Γ'' ->
-  context_equality_rel false Σ (Γ ,,, Γ') (fix_context_gen #|Γ'| mfix) (fix_context_gen #|Γ''| mfix1).
+  context_equality_rel Conv Σ (Γ ,,, Γ') (fix_context_gen #|Γ'| mfix) (fix_context_gen #|Γ''| mfix1).
 Proof.    
   intros wfΣ a Γ' Γ'' convctx.
   split. eauto with fvs.
@@ -865,7 +865,7 @@ Proof.
 Qed.
 
 Lemma context_equality_rel_context_assumptions {cf:checker_flags} P Γ Δ Δ' :
-  context_equality_rel false P Γ Δ Δ' ->
+  context_equality_rel Conv P Γ Δ Δ' ->
   context_assumptions Δ = context_assumptions Δ'.
 Proof.
   move=> [] _. induction 1; auto.
@@ -1572,11 +1572,11 @@ Lemma positive_cstr_closed_args_subst_arities {cf} {Σ} {wfΣ : wf Σ} {u u' Γ}
            positive_cstr_arg mdecl ([] ,,, (smash_context [] (ind_params mdecl) ,,, Γ)) t)
       Γ ->
   assumption_context Γ ->
-  context_equality_rel true Σ (subst_instance u (ind_arities mdecl) ,,,
+  context_equality_rel Cumul Σ (subst_instance u (ind_arities mdecl) ,,,
       subst_instance u
         (smash_context [] (PCUICEnvironment.ind_params mdecl)))
    (subst_instance u Γ) (subst_instance u' Γ) -> 
-  context_equality_rel true Σ (subst_instance u (smash_context [] (PCUICEnvironment.ind_params mdecl)))
+  context_equality_rel Cumul Σ (subst_instance u (smash_context [] (PCUICEnvironment.ind_params mdecl)))
     (subst_context (ind_subst mdecl ind u) (context_assumptions (ind_params mdecl)) (subst_instance u Γ))
     (subst_context (ind_subst mdecl ind u') (context_assumptions (ind_params mdecl)) (subst_instance u' Γ)).
 Proof.
@@ -1621,7 +1621,7 @@ Lemma positive_cstr_closed_args {cf} {Σ} {wfΣ : wf Σ} {u u'}
   declared_constructor Σ ind mdecl idecl cdecl ->
   consistent_instance_ext Σ (ind_universes mdecl) u ->
   R_opt_variance (eq_universe Σ) (leq_universe Σ) (ind_variance mdecl) u u' ->
- context_equality_rel true Σ (subst_instance u (ind_arities mdecl) ,,,
+ context_equality_rel Cumul Σ (subst_instance u (ind_arities mdecl) ,,,
     subst_instance u
       (smash_context [] (PCUICEnvironment.ind_params mdecl)))
  (smash_context []
@@ -1633,7 +1633,7 @@ Lemma positive_cstr_closed_args {cf} {Σ} {wfΣ : wf Σ} {u u'}
        (expand_lets_ctx (PCUICEnvironment.ind_params mdecl)
           (cstr_args cdecl)))) ->
 
-  context_equality_rel true Σ (subst_instance u (smash_context [] (PCUICEnvironment.ind_params mdecl)))
+  context_equality_rel Cumul Σ (subst_instance u (smash_context [] (PCUICEnvironment.ind_params mdecl)))
       (subst_context (inds (inductive_mind ind.1) u (ind_bodies mdecl)) (context_assumptions (ind_params mdecl))
        (smash_context []
           (subst_instance u
@@ -2313,7 +2313,7 @@ Lemma cumul_ctx_relSpec_Algo {cf} {Σ} {wfΣ : wf Σ} {Γ Δ Δ'}
   (c : PCUICConversionSpec.cumul_ctx_rel Σ Γ Δ Δ') : 
   is_closed_context (Γ ,,, Δ) ->
   is_closed_context (Γ ,,, Δ') ->
-  context_equality_rel true Σ Γ Δ Δ'.
+  context_equality_rel Cumul Σ Γ Δ Δ'.
 Proof.
   intros wf wf'.
   eapply context_equality_rel_app.
@@ -2323,14 +2323,14 @@ Proof.
   move: wf; rewrite /= on_free_vars_ctx_snoc => /andP[] h0 h1.
   move: wf'; rewrite /= on_free_vars_ctx_snoc => /andP[] h2 h3.
   destruct p; constructor; inv_on_free_vars; auto.
-  - eapply cumulSpec_cumulAlgo_curry in c0; fvs.
-    constructor; auto. now eapply equality_forget in c0.
+  - eapply cumulSpec_cumulAlgo_curry in eqt; fvs.
+    constructor; auto. now eapply equality_forget in eqt.
     len. rewrite (All2_fold_length c). now len in h3.
-  - eapply cumulSpec_cumulAlgo_curry in c1; eauto.
-    eapply convSpec_convAlgo_curry in c0; eauto; fvs.
+  - eapply cumulSpec_cumulAlgo_curry in eqt; eauto.
+    eapply convSpec_convAlgo_curry in eqb; eauto; fvs.
     constructor; auto.
-    now apply equality_forget in c0.
-    now apply equality_forget in c1.
+    now apply equality_forget in eqb.
+    now apply equality_forget in eqt.
     len. rewrite (All2_fold_length c) //. now len in H.
     len. rewrite (All2_fold_length c) //. now len in H0.
 Qed.
@@ -2339,7 +2339,7 @@ Lemma into_context_equality_rel {cf} {Σ} {wfΣ : wf Σ} {Γ Δ Δ'}
   (c : cumul_ctx_rel Σ Γ Δ Δ') : 
   is_closed_context (Γ ,,, Δ) ->
   is_closed_context (Γ ,,, Δ') ->
-  context_equality_rel true Σ Γ Δ Δ'.
+  context_equality_rel Cumul Σ Γ Δ Δ'.
 Proof.
   intros wf wf'.
   eapply context_equality_rel_app.
@@ -2370,7 +2370,7 @@ Lemma inductive_cumulative_indices {cf} {Σ} {wfΣ : wf Σ} :
   let indctx' := subst_instance u' idecl.(ind_indices) in
   let pindctx := subst_context parsubst 0 indctx in
   let pindctx' := subst_context parsubst' 0 indctx' in
-  context_equality_rel true Σ Γ (smash_context [] pindctx) (smash_context [] pindctx').
+  context_equality_rel Cumul Σ Γ (smash_context [] pindctx) (smash_context [] pindctx').
 Proof.
   intros * decli.
   destruct (on_declared_inductive decli) as [onmind oib].
@@ -2606,7 +2606,7 @@ Lemma constructor_cumulative_indices {cf} {Σ} {wfΣ : wf Σ} :
   in
   let pargctx := subst_context parsubst 0 argctx in
   let pargctx' := subst_context parsubst' 0 argctx' in
-  context_equality_rel true Σ Γ (smash_context [] pargctx) (smash_context [] pargctx') *
+  context_equality_rel Cumul Σ Γ (smash_context [] pargctx) (smash_context [] pargctx') *
   equality_terms Σ (Γ ,,, smash_context [] pargctx)
     (map (subst parsubst (context_assumptions (cstr_args cdecl)))
       (map (expand_lets argctx) (map (subst_instance u) (cstr_indices cdecl))))
@@ -2893,7 +2893,7 @@ Proof.
         eapply subst_instance_context_equality.
         2:now symmetry.
         apply (on_minductive_wf_params declc cu'). }
-      eapply (equality_expand_lets_equality_ctx (le:=false)) => //.
+      eapply (equality_expand_lets_equality_ctx (pb:=Conv)) => //.
       apply into_equality.
       { constructor.
         eapply eq_term_upto_univ_subst_instance; eauto; typeclasses eauto. }

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -165,7 +165,7 @@ Section Principality.
       assert(Σ ;;; Γ ,, vass x1 A' ⊢ B' = B'').
       { transitivity x4 => //.
         - now eapply red_equality.
-        - symmetry. eapply (equality_equality_ctx (le:=false)); tea.
+        - symmetry. eapply (equality_equality_ctx (pb:=Conv)); tea.
           2:eapply red_equality; tea.
           constructor; auto. eapply context_equality_refl. fvs.
           constructor. reflexivity. now symmetry. }
@@ -175,11 +175,11 @@ Section Principality.
       have convctx : Σ ⊢ Γ ,, vass na' dom' = Γ ,, vass x1 A'.
       { constructor. apply context_equality_refl. fvs. constructor => //. transitivity A'' => //.
         now symmetry. now symmetry. }
-      transitivity B'' => //. eapply (equality_equality_ctx (le':=false)); tea.
+      transitivity B'' => //. eapply (equality_equality_ctx (pb':=Conv)); tea.
       now apply equality_eq_le.
       eapply type_App'. tea.
       eapply type_reduction; eauto. eapply redA.
-      eapply (type_equality (le:=true)); eauto.
+      eapply (type_equality (pb:=Cumul)); eauto.
       { eapply validity in t0; auto.
         eapply isType_red in t0; [|exact redA].
         eapply isType_tProd in t0 as [? ?]; eauto. }
@@ -502,7 +502,7 @@ Proof.
     { repeat constructor; pcuic. }
     specialize (X3 onu t0 B).
     forward X3 by eapply context_conversion; eauto; pcuic.
-    eapply (type_equality (le:=false)).
+    eapply (type_equality (pb:=Conv)).
     * econstructor. eauto. instantiate (1 := bty).
       eapply context_conversion; eauto; pcuic.
       constructor; pcuic. constructor; pcuic. symmetry; constructor; auto.
@@ -534,7 +534,7 @@ Proof.
       now instantiate (1 := b'_ty).
     * eapply PCUICValidity.validity; eauto.
       econstructor; eauto.
-    * eapply (equality_LetIn (leq:=false)); pcuic.
+    * eapply (equality_LetIn (pb:=Conv)); pcuic.
       constructor; auto; fvs.
       constructor; fvs.
       apply equality_refl; fvs.
@@ -576,7 +576,7 @@ Proof.
     eapply PCUICUnivSubstitutionConv.eq_term_upto_univ_subst_instance; eauto; typeclasses eauto.
 
   - eapply inversion_Construct in X1 as [decl' [idecl' [cdecl' [wf [declc [cu cum]]]]]]; auto.
-    eapply (type_equality (le:=false)); eauto.
+    eapply (type_equality (pb:=Conv)); eauto.
     econstructor; eauto.
     eapply validity; eauto.
     econstructor; eauto.
@@ -654,7 +654,7 @@ Proof.
     eapply eq_term_empty_eq_term in X4.
     assert (wf_ext Σ) by (split; assumption).
     pose proof (principal_type_ind X3 a0) as [Ruu' X3'].
-    eapply (type_equality (le:=false)).
+    eapply (type_equality (pb:=Conv)).
     * clear a0.
       econstructor; eauto.
       now rewrite (All2_length X3').

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -90,12 +90,12 @@ Section Alpha.
       destruct r as [u' [r e]].
       exists u'. split.
       * constructor. assumption.
-      * constructor. eapply eq_term_trans. 1: eauto.
-        eapply eq_term_sym. assumption.
-    - specialize IHr1 with (1 := eq_term_refl _ _ _) (2 := hv).
-      destruct IHr1 as [y' [h1 [e1]]].
-      specialize IHr2 with (1 := hu) (2 := eq_term_sym _ _ _ _ e1).
-      destruct IHr2 as [u' [h2 ?]].
+      * constructor. etransitivity. 1: eauto.
+        now symmetry.
+    - specialize (IHr1 y v).
+      destruct IHr1 as [y' [h1 [e1]]]; auto. reflexivity.
+      specialize (IHr2 u y').
+      destruct IHr2 as [u' [h2 ?]]; auto. now symmetry.
       exists u'. split.
       + eapply cored_trans'. all: eauto.
       + assumption.
@@ -110,8 +110,8 @@ Section Alpha.
     intros Γ u v v' h e.
     eapply cored'_postpone.
     exists u, v. intuition eauto.
-    - constructor. apply eq_term_refl.
-    - constructor. apply eq_term_sym. assumption.
+    - constructor. reflexivity.
+    - constructor. now symmetry.
   Qed.
 
   Lemma Acc_impl :
@@ -133,12 +133,12 @@ Section Alpha.
     intros Γ u h. induction h as [u h ih].
     intros u' e. constructor. intros v [v' [u'' [r [[e1] [e2]]]]].
     assert (ee : eq_term Σ Σ u'' u).
-    { eapply eq_term_sym. eapply eq_term_trans. all: eassumption. }
+    { symmetry. etransitivity. all: eassumption. }
     eapply cored_upto in r as hh. 2: exact ee.
     destruct hh as [v'' [r' [e']]].
     eapply ih.
     - eassumption.
-    - eapply eq_term_sym. eapply eq_term_trans. all: eassumption.
+    - symmetry; etransitivity; eassumption.
   Qed.
 
   Lemma normalisation_upto :
@@ -152,7 +152,7 @@ Section Alpha.
     2: assumption.
     eapply Acc_cored_cored'.
     - eassumption.
-    - apply eq_term_refl.
+    - reflexivity.
   Qed.
 
   (* TODO Maybe switch to eq_context *)
@@ -274,8 +274,8 @@ Section Alpha.
   Proof.
     intros Γ u v h.
     exists u, v. intuition eauto.
-    - constructor. eapply eq_term_refl.
-    - constructor. eapply eq_term_refl.
+    - constructor. reflexivity.
+    - constructor. reflexivity.
   Qed.
 
 End Alpha.

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -255,7 +255,7 @@ Lemma eq_context_alpha_conv {cf} {Σ} {wfΣ : wf Σ} Γ Δ Δ' :
   eq_context_upto_names Δ Δ' ->
   is_closed_context (Γ ,,, Δ) ->
   is_closed_context (Γ ,,, Δ') ->
-  context_equality_rel false Σ Γ Δ Δ'.
+  context_equality_rel Conv Σ Γ Δ Δ'.
 Proof.
   induction 1.
   - constructor; auto. constructor.
@@ -551,8 +551,8 @@ Qed.
 Lemma conv_ctx_set_binder_name {cf} {Σ : global_env_ext} {wfΣ : wf Σ} (Γ Δ Δ' : context) (nas : list aname) :
   All2 (fun x y => eq_binder_annot x y.(decl_name)) nas Δ ->
   All2 (fun x y => eq_binder_annot x y.(decl_name)) nas Δ' ->
-  context_equality_rel false Σ Γ Δ Δ' ->
-  context_equality_rel false Σ Γ (map2 set_binder_name nas Δ) (map2 set_binder_name nas Δ').
+  context_equality_rel Conv Σ Γ Δ Δ' ->
+  context_equality_rel Conv Σ Γ (map2 set_binder_name nas Δ) (map2 set_binder_name nas Δ').
 Proof.
   induction 1 in Δ' |- *; intros H; depelim H; intros [cl H']; split; auto;
   depelim H'. cbn. constructor; auto. eapply IHX; auto. split; auto.
@@ -565,7 +565,7 @@ Proof.
     apply eq_context_gen_eq_context_upto; tc.
     apply eq_binder_annots_eq_context_gen_ctx => //. }
   depelim a; cbn in *; constructor; auto;
-  eapply (equality_equality_ctx (le':=false)); tea.
+  eapply (equality_equality_ctx (pb':=Conv)); tea.
 Qed.
     
 Lemma OnOne2_All2_All2 {A B : Type} {l1 l2 : list A} {l3 : list B} {R1  : A -> A -> Type} {R2 R3 : A -> B -> Type} :
@@ -1274,7 +1274,7 @@ Proof.
 Qed.
   
 Lemma closed_red1_equality {cf} {Σ} {wfΣ : wf Σ} {Γ} {t u} : 
-  closed_red1 Σ Γ t u -> equality false Σ Γ t u.
+  closed_red1 Σ Γ t u -> equality Conv Σ Γ t u.
 Proof.
   intros cl. now eapply red_conv, closed_red1_red.
 Qed. 
@@ -1497,7 +1497,7 @@ Lemma type_Cumul_alt {cf} {Σ} {wfΣ : wf Σ} (Γ : context) (t T T' : term) :
   Σ;;; Γ |- T <= T' → Σ;;; Γ |- t : T'.
 Proof.
   intros Ht isty cum.
-  eapply (type_equality (le:=true)); tea.
+  eapply (type_equality (pb:=Cumul)); tea.
   eapply into_equality; fvs.
 Qed.
 
@@ -1540,7 +1540,7 @@ Proof.
       exact tu.
       red. depelim p. destruct s as [[red <-]|[red <-]]; subst.
       specialize (t2 _ red). eapply type_equality; tea.
-      exists tu.π1. apply t2. eapply (red_equality (le:=true)).
+      exists tu.π1. apply t2. eapply (red_equality (pb:=Cumul)).
       now eapply closed_red1_red.
       now eapply t1.
       
@@ -1812,7 +1812,7 @@ Proof.
         apply context_equality_rel_app. apply context_equality_eq_le. symmetry.
         etransitivity; tea. } 
     rewrite subst_context_nil -heq_ind_npars in hb *.
-    eapply (type_equality (le:=true)). exact hb. 3:auto.
+    eapply (type_equality (pb:=Cumul)). exact hb. 3:auto.
     assumption. clear hb.
     rewrite /case_branch_type.
     set cbtyg := (case_branch_type_gen _ _ _ _ _ _ _ _ _).
@@ -1820,7 +1820,7 @@ Proof.
     transitivity (subst0 (List.rev (skipn (ind_npars mdecl) args)) (expand_lets prebrctx cbtyg.2)).
     { eapply equality_eq_le.
       eapply (substitution_equality (Γ'' := [])). eapply spbrctx. 
-      symmetry. apply (equality_expand_lets_equality_ctx (le:=true)); tea. 
+      symmetry. apply (equality_expand_lets_equality_ctx (pb:=Cumul)); tea. 
       eapply wt_equality_refl.
       rewrite case_branch_type_fst in cbty.
       eapply closed_context_conversion in cbty. exact cbty.
@@ -2220,7 +2220,7 @@ Proof.
         eapply wf_local_closed_context.
         eapply wf_local_smash_end.
         apply weaken_wf_local => //. eapply on_minductive_wf_params; tea. eapply isdecl. }
-      eapply (type_equality (le:=false)); tea. 
+      eapply (type_equality (pb:=Conv)); tea. 
       + eapply closed_context_conversion; tea.
       + exists ps. exact wfcbcty'.
       + eapply equality_mkApps; tea.
@@ -2330,7 +2330,7 @@ Proof.
       split => //. split => //.
       eapply type_equality; tea.
       now exists ps.
-      eapply (equality_equality_ctx (le':=true)); tea.
+      eapply (equality_equality_ctx (pb':=Cumul)); tea.
       2:eapply closed_red1_equality, btyred.
       now apply context_equality_refl, wf_local_closed_context.
     * eapply equality_eq_le, equality_mkApps; tea.
@@ -2358,7 +2358,7 @@ Proof.
       eapply wt_equality_refl. eapply type_it_mkLambda_or_LetIn; tea.
       apply into_equality_terms.
       + eapply All2_app. apply All2_refl. reflexivity.
-        apply All2_tip. eapply (cumulAlgo_cumulSpec _ (le:=false)).
+        apply All2_tip. eapply (cumulAlgo_cumulSpec _ (pb:=Conv)).
         symmetry. now eapply closed_red1_equality.
       + now apply wf_local_closed_context.
       + eapply isType_open in X0.
@@ -2555,7 +2555,7 @@ Proof.
         rewrite List.skipn_length in H. lia. }
     destruct sp as [decl [Hnth Hu0]].
     simpl in on_projs. red in on_projs. len in Hnth. 
-    eapply type_equality; eauto.
+    eapply (type_equality (pb:=Cumul)); eauto.
     { rewrite firstn_skipn.
       eapply (isType_subst_instance_decl _ _ _ _ _ u wf isdecl.p1.p1.p1) in projty; eauto.
       destruct projty as [s' Hs].
@@ -2595,7 +2595,6 @@ Proof.
     set (argctxu1 := subst_context _ _ argsu1) in *.
     set (argctxu := subst_context _ _ argsu) in *.
     simpl.
-    instantiate (1:=true).
     set (pargctxu1 := subst_context cparsubst 0 argctxu1) in *.
     set (pargctxu := subst_context iparsubst 0 argctxu) in *.
     move=> [cumargs _]; eauto.
@@ -3166,7 +3165,7 @@ Section SRContext.
       - destruct p; subst. constructor.
         apply conv_ctx_refl.
         destruct s as [[red ->]|[red ->]].
-        constructor; pcuics. reflexivity. 
+        constructor; pcuics.
         now apply PCUICCumulativity.red_conv, red1_red.      
         constructor. pcuic. now apply PCUICCumulativity.red_conv, red1_red.
         reflexivity.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -664,7 +664,7 @@ Qed.*)
   Lemma spine_subst_conv {Γ inst insts Δ inst' insts' Δ'} :
     spine_subst Σ Γ inst insts Δ ->
     spine_subst Σ Γ inst' insts' Δ' ->
-    context_equality_rel false Σ Γ Δ Δ' ->
+    context_equality_rel Conv Σ Γ Δ Δ' ->
     equality_terms Σ Γ inst inst' -> 
     equality_terms Σ Γ insts insts'.
   Proof.
@@ -1713,7 +1713,7 @@ Section WfEnv.
         pose proof (PCUICWfUniverses.typing_wf_universe _ IHΔ) as wfts.
         eapply inversion_LetIn in IHΔ as [s' [? [? [? [? ?]]]]]; auto.
         splits; eauto.
-        eapply (type_equality (le:=true)). eapply t2. apply isType_Sort; now pcuic.
+        eapply (type_equality (pb:=Cumul)). eapply t2. apply isType_Sort; now pcuic.
         eapply equality_LetIn_l_inv in e; auto.
         eapply equality_Sort_r_inv in e as [u' [redu' cumu']]. 
         transitivity (tSort u').
@@ -1929,19 +1929,19 @@ Section WfEnv.
   Qed.
   Hint Resolve typing_spine_wf_local : pcuic.
   
-  Lemma substitution_equality_vass {le : bool} {Γ} {a na ty M N} :
+  Lemma substitution_equality_vass {pb : conv_pb} {Γ} {a na ty M N} :
     Σ ;;; Γ |- a : ty ->
-    Σ ;;; Γ,, vass na ty ⊢ M ≤[le] N ->
-    Σ ;;; Γ ⊢ M{0 := a} ≤[le]  N{0 := a}.
+    Σ ;;; Γ,, vass na ty ⊢ M ≤[pb] N ->
+    Σ ;;; Γ ⊢ M{0 := a} ≤[pb] N{0 := a}.
   Proof.
     intros ha hm.
     eapply (PCUICConversion.substitution_equality (Γ' := [vass na ty]) (s := [a]) (Γ'':=[])); eauto with pcuic.
   Qed.
 
-  Lemma substitution_equality_vdef {le : bool} {Γ} {a na ty M N} :
+  Lemma substitution_equality_vdef {pb : conv_pb} {Γ} {a na ty M N} :
     wf_local Σ (Γ ,, vdef na a ty) ->
-    Σ ;;; Γ,, vdef na a ty ⊢ M ≤[le] N ->
-    Σ ;;; Γ ⊢ M{0 := a} ≤[le]  N{0 := a}.
+    Σ ;;; Γ,, vdef na a ty ⊢ M ≤[pb] N ->
+    Σ ;;; Γ ⊢ M{0 := a} ≤[pb]  N{0 := a}.
   Proof.
     intros ha hm.
     eapply (PCUICConversion.substitution_equality (Γ' := [vdef na a ty]) (s := [a]) (Γ'':=[])); eauto with pcuic.
@@ -2008,7 +2008,7 @@ Section WfEnv.
         eapply equality_Prod_Prod_inv in e as [eqna conv cum]; auto.
         eapply (substitution_equality_vass (a:=a)) in cum; auto.
         assert (Σ ;;; Γ |- a : decl_type).
-        { eapply (type_equality (le:=false)); tea. 2:now symmetry.
+        { eapply (type_equality (pb:=Conv)); tea. 2:now symmetry.
           now eapply isType_tProd in i as []. }
         eapply isType_apply in i; tea.
         eapply typing_spine_strengthen in sp. 3:tea. 2:tas. 
@@ -2102,7 +2102,7 @@ Section WfEnv.
           split; auto. rewrite subst_empty.
           pose proof (isType_wf_local i).
           eapply equality_Prod_Prod_inv in e as [conv cum]; auto.
-          eapply (type_equality (le:=false)); eauto.
+          eapply (type_equality (pb:=Conv)); eauto.
           eapply isType_tProd in i as [dom codom]; auto. cbn in *.
           now symmetry.
         * move=> Hnth Hn'.
@@ -2110,7 +2110,7 @@ Section WfEnv.
           eapply isType_tProd in i as [dom' codom']; auto. cbn in *.
           eapply equality_Prod_Prod_inv in e as [conv cum]; auto. simpl in codom'.
           assert (Σ ;;; Γ |- hd : ty).
-          { eapply (type_equality (le:=false)); eauto. now symmetry. }
+          { eapply (type_equality (pb:=Conv)); eauto. now symmetry. }
           unshelve eapply (isType_subst (Δ:=[vass na ty]) [hd]) in codom'.
           2:{ now eapply subslet_ass_tip. }
           specialize (X (subst_context [hd] 0 Γ0) ltac:(autorewrite with len; lia)).
@@ -2362,11 +2362,11 @@ Section WfEnv.
       a spine for a context whose types are higher in the cumulativity relation.
   *)
 
-  Lemma subslet_cumul {le Δ args Γ Γ'} : 
+  Lemma subslet_cumul {pb Δ args Γ Γ'} : 
     assumption_context Γ -> assumption_context Γ' -> 
     wf_local Σ (Δ ,,, Γ) ->
     wf_local Σ (Δ ,,, Γ') ->
-    context_equality_rel le Σ Δ Γ Γ' ->
+    context_equality_rel pb Σ Δ Γ Γ' ->
     subslet Σ Δ args Γ -> subslet Σ Δ args Γ'.
   Proof.
     intros ass ass' wf wf' a2.
@@ -2393,7 +2393,7 @@ Section WfEnv.
     assumption_context Γ -> assumption_context Γ' -> 
     wf_local Σ (Δ ,,, Γ) ->
     wf_local Σ (Δ ,,, Γ') ->
-    context_equality_rel true Σ Δ Γ Γ' ->
+    context_equality_rel Cumul Σ Δ Γ Γ' ->
     spine_subst Σ Δ args (List.rev args) Γ -> 
     spine_subst Σ Δ args (List.rev args) Γ'.
   Proof.
@@ -2687,33 +2687,33 @@ Section WfEnv.
   Proof. apply context_assumptions_fold. Qed.
   Hint Rewrite @context_assumptions_lift @context_assumptions_subst : len.
 
-  Lemma context_equality_rel'_context_assumptions {le} {Γ} {Δ Δ'} : 
+  Lemma context_equality_rel'_context_assumptions {pb} {Γ} {Δ Δ'} : 
     All2_fold
       (fun Γ' _ : context =>
-        All_decls_alpha_le le
-          (fun (le : bool) (x y : term) => Σ ;;; Γ,,, Γ' ⊢ x ≤[le] y)) Δ Δ' ->
+        All_decls_alpha_pb pb
+          (fun pb (x y : term) => Σ ;;; Γ,,, Γ' ⊢ x ≤[pb] y)) Δ Δ' ->
     context_assumptions Δ = context_assumptions Δ'.
   Proof.
     induction 1; auto.
     depelim p; simpl; auto. lia.
   Qed.
 
-  Lemma context_equality_rel_context_assumptions {le} {Γ} {Δ Δ'} : 
-    context_equality_rel le Σ Γ Δ Δ' ->
+  Lemma context_equality_rel_context_assumptions {pb} {Γ} {Δ Δ'} : 
+    context_equality_rel pb Σ Γ Δ Δ' ->
     context_assumptions Δ = context_assumptions Δ'.
   Proof.
     intros []. now eapply context_equality_rel'_context_assumptions.
   Qed.
   
   (* Lemma subslet_subs {cf} {Σ} {wfΣ : wf Σ} {Γ i Δ Δ'} :
-  context_equality_rel le Σ Γ Δ Δ' ->
+  context_equality_rel pb Σ Γ Δ Δ' ->
   ctx_inst Σ Γ i (Li *)
 
-  Lemma equality_expand_lets_k {le} {Γ Δ Γ'} {T T'} : 
+  Lemma equality_expand_lets_k {pb} {Γ Δ Γ'} {T T'} : 
     wf_local Σ (Γ ,,, Δ) ->
-    Σ ;;; Γ ,,, Δ ,,, Γ' ⊢ T ≤[le] T' ->
+    Σ ;;; Γ ,,, Δ ,,, Γ' ⊢ T ≤[pb] T' ->
     Σ ;;; Γ ,,, smash_context [] Δ ,,, expand_lets_ctx Δ Γ' ⊢ 
-      expand_lets_k Δ #|Γ'| T ≤[le] expand_lets_k Δ #|Γ'| T'.
+      expand_lets_k Δ #|Γ'| T ≤[pb] expand_lets_k Δ #|Γ'| T'.
   Proof.
     intros wf cum.
     rewrite -app_context_assoc in cum.
@@ -2730,10 +2730,10 @@ Section WfEnv.
     eapply wf_local_smash_end in wf. eauto with fvs.
   Qed.
 
-  Lemma equality_expand_lets {le} {Γ} {Δ} {T T'} : 
+  Lemma equality_expand_lets {pb} {Γ} {Δ} {T T'} : 
     wf_local Σ (Γ ,,, Δ) ->
-    Σ ;;; Γ ,,, Δ ⊢ T ≤[le] T' ->
-    Σ ;;; Γ ,,, smash_context [] Δ ⊢ expand_lets Δ T ≤[le] expand_lets Δ T'.
+    Σ ;;; Γ ,,, Δ ⊢ T ≤[pb] T' ->
+    Σ ;;; Γ ,,, smash_context [] Δ ⊢ expand_lets Δ T ≤[pb] expand_lets Δ T'.
   Proof.
     intros wf cum.
     eapply (weakening_equality (Γ'' := smash_context [] Δ)) in cum; tea.
@@ -2758,15 +2758,15 @@ Section WfEnv.
     eapply (weakening_equality (Γ' := [])) => //.
   Qed.
 
-  Lemma equality_le_le {le Γ T T'} :
-    Σ ;;; Γ ⊢ T ≤[le] T' -> Σ ;;; Γ ⊢ T ≤ T'.
+  Lemma equality_le_le {pb Γ T T'} :
+    Σ ;;; Γ ⊢ T ≤[pb] T' -> Σ ;;; Γ ⊢ T ≤ T'.
   Proof.
-    destruct le; eauto.
+    destruct pb; eauto.
     eapply equality_eq_le.
   Qed.
 
-  Lemma context_equality_le_le {le Γ Γ'} : 
-    Σ ⊢ Γ ≤[le] Γ' -> Σ ⊢ Γ ≤ Γ'.
+  Lemma context_equality_le_le {pb Γ Γ'} : 
+    Σ ⊢ Γ ≤[pb] Γ' -> Σ ⊢ Γ ≤ Γ'.
   Proof.
     intros a; eapply All2_fold_impl; tea.
     cbn; intros.
@@ -2775,17 +2775,17 @@ Section WfEnv.
     now eapply equality_le_le.
   Qed.
 
-  Lemma context_equality_eq_le {le Γ Δ} :
-    Σ ⊢ Γ = Δ -> Σ ⊢ Γ ≤[le] Δ.
+  Lemma context_equality_eq_le {pb Γ Δ} :
+    Σ ⊢ Γ = Δ -> Σ ⊢ Γ ≤[pb] Δ.
   Proof.
-    destruct le; eauto.
+    destruct pb; eauto.
     apply context_equality_le_le.
   Qed.
 
-  Lemma subslet_context_equality {le} {Γ Γ' Δ Δ'} {s} :
+  Lemma subslet_context_equality {pb} {Γ Γ' Δ Δ'} {s} :
     wf_local Σ (Γ ,,, Δ) ->
     wf_local Σ (Γ ,,, Δ') ->
-    context_equality_rel le Σ Γ Δ' Δ ->
+    context_equality_rel pb Σ Γ Δ' Δ ->
     subslet Σ (Γ ,,, Δ) s Γ' ->
     subslet Σ (Γ ,,, Δ') s Γ'.
   Proof.
@@ -2803,12 +2803,12 @@ Section WfEnv.
 
   Arguments on_free_vars_ctx _ _ : simpl never.
 
-  Lemma context_equality_rel_conv_extended_subst {le} {Γ Δ Δ'} :
+  Lemma context_equality_rel_conv_extended_subst {pb} {Γ Δ Δ'} :
     wf_local Σ (Γ ,,, Δ) ->
     wf_local Σ (Γ ,,, Δ') ->
-    context_equality_rel le Σ Γ Δ Δ' ->
+    context_equality_rel pb Σ Γ Δ Δ' ->
     equality_terms Σ (Γ ,,, smash_context [] Δ) (extended_subst Δ 0) (extended_subst Δ' 0) ×
-    context_equality_rel le Σ Γ (smash_context [] Δ) (smash_context [] Δ').
+    context_equality_rel pb Σ Γ (smash_context [] Δ) (smash_context [] Δ').
   Proof.
     intros wfl wfr [clΓ cum].
     assert (is_closed_context (Γ ,,, smash_context [] Δ)).
@@ -2892,19 +2892,19 @@ Section WfEnv.
   Qed.
 
 
-  Lemma context_equality_rel_smash {le} {Γ Δ Δ'} :
+  Lemma context_equality_rel_smash {pb} {Γ Δ Δ'} :
     wf_local Σ (Γ ,,, Δ) ->
     wf_local Σ (Γ ,,, Δ') ->
-    context_equality_rel le Σ Γ Δ Δ' ->
-    context_equality_rel le Σ Γ (smash_context [] Δ) (smash_context [] Δ').
+    context_equality_rel pb Σ Γ Δ Δ' ->
+    context_equality_rel pb Σ Γ (smash_context [] Δ) (smash_context [] Δ').
   Proof.
     now intros; apply context_equality_rel_conv_extended_subst.
   Qed.
 
-  Lemma equality_terms_equality_ctx {le} {Γ Δ Δ'} {ts ts'} :
+  Lemma equality_terms_equality_ctx {pb} {Γ Δ Δ'} {ts ts'} :
     wf_local Σ (Γ ,,, Δ) ->
     wf_local Σ (Γ ,,, Δ') ->
-    context_equality_rel le Σ Γ Δ Δ' ->
+    context_equality_rel pb Σ Γ Δ Δ' ->
     equality_terms Σ (Γ ,,, Δ') ts ts' ->
     equality_terms Σ (Γ ,,, Δ) ts ts'.
   Proof.
@@ -2916,8 +2916,8 @@ Section WfEnv.
     assumption.
   Qed.
 
-  Lemma context_equality_rel_length {le Γ Δ Δ'} :
-    context_equality_rel le Σ Γ Δ Δ' ->
+  Lemma context_equality_rel_length {pb Γ Δ Δ'} :
+    context_equality_rel pb Σ Γ Δ Δ' ->
     #|Δ| = #|Δ'|.
   Proof. intros []. apply (length_of a). Qed.
 
@@ -2932,11 +2932,11 @@ Section WfEnv.
 
   Hint Resolve is_closed_context_smash_end : fvs.
 
-  Lemma equality_expand_lets_equality_ctx {le le'} {Γ} {Δ Δ'} {T T'} : 
+  Lemma equality_expand_lets_equality_ctx {pb le'} {Γ} {Δ Δ'} {T T'} : 
     wf_local Σ (Γ ,,, Δ) ->
     wf_local Σ (Γ ,,, Δ') ->
     Σ ;;; Γ ,,, Δ ⊢ T ≤[le'] T' ->
-    context_equality_rel le Σ Γ Δ Δ' ->
+    context_equality_rel pb Σ Γ Δ Δ' ->
     Σ ;;; Γ ,,, smash_context [] Δ ⊢ expand_lets Δ T ≤[le'] expand_lets Δ' T'.
   Proof.
     intros wfl wfr cum cumΓ.
@@ -2960,8 +2960,8 @@ Section WfEnv.
       eapply weakening_equality => //; eauto with fvs.
   Qed.
 
-  Lemma ctx_inst_cumul {le Γ i Δ Δ'} :
-    context_equality_rel le Σ Γ Δ Δ' ->
+  Lemma ctx_inst_cumul {pb Γ i Δ Δ'} :
+    context_equality_rel pb Σ Γ Δ Δ' ->
     ctx_inst Σ Γ i (List.rev Δ) ->
     wf_local_rel Σ Γ Δ ->
     wf_local_rel Σ Γ Δ' ->
@@ -3089,22 +3089,22 @@ Section WfEnv.
     rewrite List.rev_length Nat.add_0_r in le'; len; lia_f_equal.
   Qed.
 
-  Lemma context_equality_rel_trans {le Γ Δ Δ' Δ''} :
-    context_equality_rel le Σ Γ Δ Δ' ->
-    context_equality_rel le Σ Γ Δ' Δ'' ->
-    context_equality_rel le Σ Γ Δ Δ''.
+  Lemma context_equality_rel_trans {pb Γ Δ Δ' Δ''} :
+    context_equality_rel pb Σ Γ Δ Δ' ->
+    context_equality_rel pb Σ Γ Δ' Δ'' ->
+    context_equality_rel pb Σ Γ Δ Δ''.
   Proof.
     move/context_equality_rel_app => h /context_equality_rel_app h'.
     apply context_equality_rel_app.
     now etransitivity.
   Qed.
 
-  Lemma OnOne2_ctx_inst {le} {P} {Γ inst inst' Δ} :
+  Lemma OnOne2_ctx_inst {pb} {P} {Γ inst inst' Δ} :
     (forall Γ Δ' Δ s s', wf_local Σ (Γ ,,, Δ' ,,, Δ) ->
     subslet Σ Γ (List.rev s) Δ' ->
     subslet Σ Γ (List.rev s') Δ' ->
     OnOne2 (P Σ Γ) s s' ->
-    context_equality le Σ (Γ ,,, subst_context (List.rev s) 0 Δ)
+    context_equality pb Σ (Γ ,,, subst_context (List.rev s) 0 Δ)
       (Γ ,,, subst_context (List.rev s') 0 Δ)) ->
     wf_local Σ (Γ ,,, (List.rev Δ)) ->
     PCUICTyping.ctx_inst
@@ -3146,12 +3146,12 @@ Section WfEnv.
       eapply wf_local_app_inv in wf as [wf _]. now depelim wf.
   Qed.
 
-  Lemma All2_ctx_inst {le} {P} {Γ inst inst' Δ} :
+  Lemma All2_ctx_inst {pb} {P} {Γ inst inst' Δ} :
     (forall Γ Δ' Δ s s', wf_local Σ (Γ ,,, Δ' ,,, Δ) ->
     subslet Σ Γ (List.rev s) Δ' ->
     subslet Σ Γ (List.rev s') Δ' ->
     All2 (P Σ Γ) s s' ->
-    context_equality le Σ (Γ ,,, subst_context (List.rev s) 0 Δ)
+    context_equality pb Σ (Γ ,,, subst_context (List.rev s) 0 Δ)
       (Γ ,,, subst_context (List.rev s') 0 Δ)) ->
     wf_local Σ (Γ ,,, (List.rev Δ)) ->
     PCUICTyping.ctx_inst

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -1231,24 +1231,24 @@ Lemma subst_compare_term {cf:checker_flags} le Σ (φ : ConstraintSet.t) (l : li
   compare_term le Σ φ T U -> compare_term le Σ φ (subst l k T) (subst l k U).
 Proof.
   destruct le; simpl.
-  - apply subst_leq_term.
-  - apply subst_eq_term. 
+  - apply subst_eq_term.
+  - apply subst_leq_term. 
 Qed.
 
-Lemma subst_eq_decl `{checker_flags} {le Σ ϕ l k d d'} :
-  eq_decl le Σ ϕ d d' -> eq_decl le Σ ϕ (subst_decl l k d) (subst_decl l k d').
+Lemma subst_compare_decl `{checker_flags} {le Σ ϕ l k d d'} :
+  compare_decl le Σ ϕ d d' -> compare_decl le Σ ϕ (subst_decl l k d) (subst_decl l k d').
 Proof.
   intros []; constructor; auto; destruct le; 
     intuition eauto using subst_compare_term, subst_eq_term, subst_leq_term.
 Qed.
 
-Lemma subst_eq_context `{checker_flags} le Σ φ l l' n k :
-  eq_context le Σ φ l l' ->
-  eq_context le Σ φ (subst_context n k l) (subst_context n k l').
+Lemma subst_compare_context `{checker_flags} le Σ φ l l' n k :
+  compare_context le Σ φ l l' ->
+  compare_context le Σ φ (subst_context n k l) (subst_context n k l').
 Proof.
   induction 1; rewrite ?subst_context_snoc /=; constructor; auto.
   erewrite (All2_fold_length X). simpl.
-  apply (subst_eq_decl p).
+  apply (subst_compare_decl p).
 Qed.
 
 From Coq Require Import ssrbool.
@@ -1278,17 +1278,17 @@ Section CtxReduction.
   Qed.
 End CtxReduction.
 
-Record wt_equality (le : bool) {cf} Σ (Γ : context) T U := 
+Record wt_equality {cf} (c : conv_pb) Σ (Γ : context) T U := 
   { wt_equality_dom : isType Σ Γ T;
     wt_equality_codom : isType Σ Γ U;
-    wt_equality_eq : if le then Σ ;;; Γ |- T <= U else Σ ;;; Γ |- T = U }.
+    wt_equality_eq : cumulAlgo_gen Σ Γ c T U }.
 
-Arguments wt_equality_dom {le cf Σ Γ T U}.
-Arguments wt_equality_codom {le cf Σ Γ T U}.
-Arguments wt_equality_eq {le cf Σ Γ T U}.
+Arguments wt_equality_dom {cf c Σ Γ T U}.
+Arguments wt_equality_codom {cf c Σ Γ T U}.
+Arguments wt_equality_eq {cf c Σ Γ T U}.
 
-Definition wt_cumul {cf} := wt_equality true.
-Definition wt_conv {cf} := wt_equality false.
+Definition wt_cumul {cf} := wt_equality Cumul.
+Definition wt_conv {cf} := wt_equality Conv.
 
 Notation " Σ ;;; Γ |- t <= u ✓" := (wt_cumul Σ Γ t u) (at level 50, Γ, t, u at next level).
 Notation " Σ ;;; Γ |- t = u ✓" := (wt_conv Σ Γ t u) (at level 50, Γ, t, u at next level).
@@ -1316,16 +1316,16 @@ Qed.
 Reserved Notation " Σ ;;; Γ |-[ P ] t <=[ le ] u" (at level 50, Γ, t, u at next level,
   format "Σ  ;;;  Γ  |-[ P ]  t  <=[ le ]  u").
 
-Inductive cumulP {cf} (le : bool) (Σ : global_env_ext) (P : nat -> bool) (Γ : context) : term -> term -> Type :=
-| wt_cumul_refl t u : compare_term le Σ.1 (global_ext_constraints Σ) t u -> Σ ;;; Γ |-[P] t <=[le] u
-| wt_cumul_red_l t u v : red1P P Σ Γ t v -> Σ ;;; Γ |-[P] v <=[le] u -> Σ ;;; Γ |-[P] t <=[le] u
-| wt_cumul_red_r t u v : Σ ;;; Γ |-[P] t <=[le] v -> red1P P Σ Γ u v -> Σ ;;; Γ |-[P] t <=[le] u
+Inductive cumulP {cf} (pb : conv_pb) (Σ : global_env_ext) (P : nat -> bool) (Γ : context) : term -> term -> Type :=
+| wt_cumul_refl t u : compare_term pb Σ.1 (global_ext_constraints Σ) t u -> Σ ;;; Γ |-[P] t <=[pb] u
+| wt_cumul_red_l t u v : red1P P Σ Γ t v -> Σ ;;; Γ |-[P] v <=[pb] u -> Σ ;;; Γ |-[P] t <=[pb] u
+| wt_cumul_red_r t u v : Σ ;;; Γ |-[P] t <=[pb] v -> red1P P Σ Γ u v -> Σ ;;; Γ |-[P] t <=[pb] u
 where " Σ ;;; Γ |-[ P ] t <=[ le ] u " := (cumulP le Σ P Γ t u) : type_scope.
 
-Notation " Σ ;;; Γ |-[ P ] t <= u " := (cumulP true Σ P Γ t u) (at level 50, Γ, t, u at next level,
+Notation " Σ ;;; Γ |-[ P ] t <= u " := (cumulP Cumul Σ P Γ t u) (at level 50, Γ, t, u at next level,
     format "Σ  ;;;  Γ  |-[ P ]  t  <=  u") : type_scope.
 
-Notation " Σ ;;; Γ |-[ P ] t = u " := (cumulP false Σ P Γ t u) (at level 50, Γ, t, u at next level,
+Notation " Σ ;;; Γ |-[ P ] t = u " := (cumulP Conv Σ P Γ t u) (at level 50, Γ, t, u at next level,
   format "Σ  ;;;  Γ  |-[ P ]  t  =  u") : type_scope.
 
 Lemma isType_wf_local {cf:checker_flags} {Σ Γ T} : isType Σ Γ T -> wf_local Σ Γ.
@@ -1861,18 +1861,19 @@ Proof.
   + eapply (isType_substitution Hs), wteq.
   + eapply (isType_substitution Hs), wteq.
   + move/wt_equality_equalityP: wteq; elim.
-    - intros t u. destruct le; simpl; constructor; [now apply subst_leq_term|now apply subst_eq_term].
+    - intros t u cmp. 
+      constructor. now eapply subst_compare_term.
     - move=> t u v red cum.
       destruct le.
-      * eapply red_cumul_cumul.
-        eapply substitution_let_red; tea; eauto with wf; apply red.
       * eapply red_conv_conv.
+        eapply substitution_let_red; tea; eauto with wf; apply red.
+      * eapply red_cumul_cumul.
         eapply substitution_let_red; tea; eauto with wf; apply red.
     - move=> t u v red cum red'.
       destruct le.
-      * eapply red_cumul_cumul_inv; tea.
-        eapply substitution_let_red; tea; apply red'.
       * eapply red_conv_conv_inv; tea.
+        eapply substitution_let_red; tea; apply red'.
+      * eapply red_cumul_cumul_inv; tea.
         eapply substitution_let_red; tea; apply red'.
 Qed.
 

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -322,9 +322,9 @@ Section Validity.
       move: (typing_wf_universe wf Hu') => wfu'.
       eapply (substitution0 (n := na) (T := tSort u')); eauto.
       apply inversion_Prod in Hu' as [na' [s1 [s2 Hs]]]; tas. intuition.
-      eapply (weakening_equality (le:=true) (Γ' := []) (Γ'' := [vass na A])) in b0; pcuic.
+      eapply (weakening_equality (pb:=Cumul) (Γ' := []) (Γ'' := [vass na A])) in b0; pcuic.
       simpl in b0.
-      eapply (type_equality (le:=true)); eauto. pcuic.
+      eapply (type_equality (pb:=Cumul)); eauto. pcuic.
       etransitivity; tea.
       eapply into_equality => //.
       all:eauto with fvs.

--- a/pcuic/theories/PCUICWtCumulativity.v
+++ b/pcuic/theories/PCUICWtCumulativity.v
@@ -1,0 +1,43 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import ssreflect ssrbool.
+From MetaCoq.Template Require Import config utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICLiftSubst PCUICTyping PCUICCumulativity
+     PCUICReduction PCUICWeakeningConv PCUICWeakeningTyp PCUICEquality PCUICUnivSubstitutionConv
+     PCUICSigmaCalculus PCUICContextReduction
+     PCUICParallelReduction PCUICParallelReductionConfluence PCUICClosedConv PCUICClosedTyp
+     PCUICRedTypeIrrelevance PCUICOnFreeVars PCUICConfluence PCUICSubstitution
+     PCUICWellScopedCumulativity PCUICArities.
+
+Require Import CRelationClasses CMorphisms.
+Require Import Equations.Prop.DepElim.
+Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
+From Equations Require Import Equations.
+
+(* High-level lemmas about well-typed equality *)
+
+Notation " Σ ;;; Γ ⊢ t ≤[ le ] u ✓" := (wt_equality le Σ Γ t u) (at level 50, Γ, t, u at next level,
+  format "Σ  ;;;  Γ  ⊢  t  ≤[ le ]  u  ✓").
+
+Coercion wt_equality_equality : wt_equality >-> equality.
+
+Section WtEquality.
+  Context {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ}.
+  
+  Lemma type_wt_equality {le Γ t} T {U} :
+    Σ ;;; Γ |- t : T ->
+    Σ ;;; Γ ⊢ T ≤[le] U ✓ ->
+    Σ ;;; Γ |- t : U.
+  Proof.
+    intros.
+    eapply type_equality; tea. apply X0. exact X0. apply X0.π2.
+    destruct le.
+    - now eapply (cumulAlgo_cumulSpec Σ (pb:=Cumul)).
+    - eapply equality_eq_le in X1.
+      now eapply cumulAlgo_cumulSpec in X1.
+  Qed.
+
+  Lemma wt_equality_subst {le Γ Δ Γ' s t u} :
+    wt_equality le Σ (Γ ,,, Δ ,,, Γ') t u ->
+    wt_equality le Σ (Γ ,,, subst_context s 0 Γ') (subst s #|Γ'| t) (subst s #|Γ'| u).
+  Proof.
+    intros [].

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -1732,40 +1732,24 @@ Proof.
     destruct a as [? []]; reflexivity.
 Qed.
 
-Lemma trans_conv {cf} (Σ : Ast.Env.global_env_ext) Γ T U :
+Lemma trans_cumul_gen {cf} (Σ : Ast.Env.global_env_ext) pb Γ T U :
   Typing.wf Σ.1 ->
   let Σ' := trans_global Σ in
   wf Σ' ->
   All (WfAst.wf_decl Σ.1) Γ ->
-  WfAst.wf Σ.1 T -> WfAst.wf Σ.1 U -> ST.conv Σ Γ T U ->
-  trans_global Σ ;;; trans_local Σ' Γ |- trans Σ' T = trans Σ' U.
+  WfAst.wf Σ.1 T -> WfAst.wf Σ.1 U -> ST.cumul_gen Σ Γ pb T U ->
+  trans_global Σ ;;; trans_local Σ' Γ |- trans Σ' T <=[pb] trans Σ' U.
 Proof.
   intros wfΣ Σ' wfΣ'.
   induction 4.
   - constructor. 
-    eapply trans_eq_term in e; eauto.
-    unfold leq_term_ext. 
-    now rewrite global_ext_constraints_trans.
-  - eapply cumul_red_l; tea. eapply trans_red1; tea. apply IHX2.
-    eapply wf_red1 in r; tea. now eapply typing_wf_sigma in wfΣ. auto.
-  - eapply cumul_red_r; tea. 2:eapply trans_red1; tea.
-    eapply IHX2. auto. eapply wf_red1 in r; tea. now eapply typing_wf_sigma; auto.
-Qed.
-
-Lemma trans_cumul {cf} (Σ : Ast.Env.global_env_ext) Γ T U :
-  Typing.wf Σ.1 ->
-  let Σ' := trans_global Σ in
-  wf Σ' ->
-  All (WfAst.wf_decl Σ.1) Γ ->
-  WfAst.wf Σ.1 T -> WfAst.wf Σ.1 U -> ST.cumul Σ Γ T U ->
-  trans_global Σ ;;; trans_local Σ' Γ |- trans Σ' T <= trans Σ' U.
-Proof.
-  intros wfΣ Σ' wfΣ'.
-  induction 4.
-  - constructor. 
-    eapply trans_leq_term in l; eauto.
-    unfold leq_term_ext.
-    now rewrite global_ext_constraints_trans.
+    destruct pb.
+    * eapply trans_eq_term in c; eauto.
+      unfold leq_term_ext. 
+      now rewrite global_ext_constraints_trans.
+    * eapply trans_leq_term in c; eauto.
+      unfold leq_term_ext. 
+      now rewrite global_ext_constraints_trans.
   - eapply cumul_red_l; tea. eapply trans_red1; tea. apply IHX2.
     eapply wf_red1 in r; tea. now eapply typing_wf_sigma in wfΣ. auto.
   - eapply cumul_red_r; tea. 2:eapply trans_red1; tea.
@@ -2135,39 +2119,39 @@ Qed.
 
 From MetaCoq.PCUIC Require Import PCUICOnFreeVars.
 
-Lemma trans_cumulSpec {cf} {Σ : Ast.Env.global_env_ext} {wfΣ : Typing.wf Σ.1} {Γ T T'} :
+Lemma trans_cumulSpec {cf} {Σ : Ast.Env.global_env_ext} {wfΣ : Typing.wf Σ.1} {pb Γ T T'} :
   let Σ' := trans_global Σ in
   wf Σ' ->
   All (WfAst.wf_decl Σ.1) Γ ->
   WfAst.wf Σ.1 T ->
   WfAst.wf Σ.1 T' ->
-  ST.cumul Σ Γ T T' ->
+  ST.cumul_gen Σ Γ pb T T' ->
   is_closed_context (trans_local Σ' Γ) ->
   is_open_term (trans_local Σ' Γ) (trans Σ' T) ->
   is_open_term (trans_local Σ' Γ) (trans Σ' T') ->
-  Σ';;; trans_local Σ' Γ |- trans Σ' T <=s trans Σ' T'.
+  Σ';;; trans_local Σ' Γ ⊢ trans Σ' T ≤s[pb] trans Σ' T'.
 Proof.
   intros Σ' wfΣ' wfΓ wfT wfT' cum clΓ clT clT'.
-  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (le:=true)).
+  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (pb:=pb)).
   eapply PCUICWellScopedCumulativity.into_equality; eauto with fvs.
-  eapply trans_cumul; tea.
+  eapply trans_cumul_gen; tea.
 Qed.
 
-Lemma trans_cumulSpec_typed {cf} {Σ : Ast.Env.global_env_ext} {wfΣ : Typing.wf Σ.1} {Γ T T'} :
+Lemma trans_cumulSpec_typed {cf} {Σ : Ast.Env.global_env_ext} {wfΣ : Typing.wf Σ.1} {pb Γ T T'} :
   let Σ' := trans_global Σ in
   wf Σ' ->
   All (WfAst.wf_decl Σ.1) Γ ->
   WfAst.wf Σ.1 T ->
   WfAst.wf Σ.1 T' ->
-  ST.cumul Σ Γ T T' ->
+  ST.cumul_gen Σ Γ pb T T' ->
   isType Σ' (trans_local Σ' Γ) (trans Σ' T) ->
   isType Σ' (trans_local Σ' Γ) (trans Σ' T') ->
-  Σ';;; trans_local Σ' Γ |- trans Σ' T <=s trans Σ' T'.
+  Σ';;; trans_local Σ' Γ ⊢ trans Σ' T ≤s[pb] trans Σ' T'.
 Proof.
   intros Σ' wfΣ' wfΓ wfT wfT' cum ist ist'.
-  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (le:=true)).
+  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (pb:=pb)).
   eapply PCUICWellScopedCumulativity.into_equality; eauto with fvs.
-  eapply trans_cumul; tea.
+  eapply trans_cumul_gen; tea.
   eapply isType_wf_local in ist; fvs.
 Qed.
 
@@ -2600,16 +2584,16 @@ Proof.
   move/andP: H0 => [] cl0' cl1'. len in cl1. len in cl1'.
   destruct p; constructor; cbn; auto; depelim X0; depelim X1; destruct w as []; destruct w0 as [].
   
-  eapply trans_cumul in c; tea.
-  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (le:=true)).
+  eapply trans_cumul_gen in eqt; tea.
+  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (pb:=Cumul)).
   eapply PCUICWellScopedCumulativity.into_equality => //.
   now eapply closed_ctx_on_free_vars in cl0.
   1-2:cbn in cl1, cl1'.
   1-2:rewrite closedn_on_free_vars //; len.
   now rewrite (All2_fold_length X).
 
-  eapply trans_conv in c; tea.
-  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (le:=false)).
+  eapply trans_cumul_gen in eqb; tea.
+  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (pb:=Conv)).
   eapply PCUICWellScopedCumulativity.into_equality => //.
   now eapply closed_ctx_on_free_vars in cl0.
   1-2:move/andP: cl1 => [] /= clb cbt.
@@ -2617,8 +2601,8 @@ Proof.
   1-2:rewrite closedn_on_free_vars //; len.
   now rewrite (All2_fold_length X).
 
-  eapply trans_cumul in c0; tea.
-  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (le:=true)).
+  eapply trans_cumul_gen in eqt; tea.
+  eapply (PCUICConversion.cumulAlgo_cumulSpec _ (pb:=Cumul)).
   eapply PCUICWellScopedCumulativity.into_equality => //.
   now eapply closed_ctx_on_free_vars in cl0.
   1-2:move/andP: cl1 => [] /= clb cbt.
@@ -2749,11 +2733,11 @@ Proof.
     eapply All2_map. eapply All2_map_inv in a.
     eapply All2_refl_inv in a. eapply All_All2_refl.
     eapply All_map. solve_all.
-    eapply trans_conv in b0; tea.
+    eapply trans_cumul_gen in b0; tea.
     { move:b0; rewrite !trans_local_subst_instance !trans_local_app trans_arities_context.
       rewrite !trans_smash_context !trans_subst_instance !trans_expand_lets !trans_local_app //.
       intros h. simpl in h.
-      eapply (PCUICConversion.cumulAlgo_cumulSpec _ (le:=false)).
+      eapply (PCUICConversion.cumulAlgo_cumulSpec _ (pb:=Conv)).
       eapply PCUICWellScopedCumulativity.into_equality; tea.
       { move: clctx. 
         rewrite smash_context_app_expand.

--- a/pcuic/theories/Typing/PCUICContextConversionTyp.v
+++ b/pcuic/theories/Typing/PCUICContextConversionTyp.v
@@ -30,7 +30,7 @@ Lemma weakening_cumulSpec0 {cf:checker_flags} {Σ : global_env_ext} {wfΣ : wf �
   Σ ;;; Γ ,,, Γ'' |- lift0 n M <=s lift0 n N.
 Proof.
   intros e H. 
-  eapply (@cumulAlgo_cumulSpec _ _ true). 
+  eapply (@cumulAlgo_cumulSpec _ _ Cumul). 
   eapply into_equality; try  apply lift0_open; eauto.
   - cbn. eapply weakening_cumul0; eauto. apply cumulSpec_cumulAlgo in H; eauto. exact (equality_forget H).   
   - cbn. rewrite on_free_vars_ctx_app; solve_all; intuition.    
@@ -120,11 +120,11 @@ Proof.
   now apply into_equality.
 Qed.
 
-Lemma wt_cum_context_equality {cf:checker_flags} {Σ:global_env_ext} {wfΣ : wf Σ} {Γ Δ : context} le :
+Lemma wt_cum_context_equality {cf:checker_flags} {Σ:global_env_ext} {wfΣ : wf Σ} {Γ Δ : context} pb :
   wf_local Σ Γ ->
   wf_local Σ Δ ->
-  (if le then cumul_context Σ Γ Δ else conv_context Σ Γ Δ) ->
-  Σ ⊢ Γ ≤[le] Δ. 
+  cumul_pb_context pb Σ Γ Δ ->
+  Σ ⊢ Γ ≤[pb] Δ. 
 Proof.
   move/wf_local_closed_context => wfΓ.
   move/wf_local_closed_context => wfΔ.
@@ -149,10 +149,10 @@ Proof.
   intros e.
   eapply All2_fold_impl. 1: tea. cbn; intros.
   destruct X.
-  - econstructor 1; eauto. eapply (@cumulAlgo_cumulSpec _ _ true); eauto.
+  - econstructor 1; eauto. eapply (@cumulAlgo_cumulSpec _ _ Cumul); eauto.
   - econstructor 2; eauto.
-    + eapply (@cumulAlgo_cumulSpec _ _ false); eauto.
-    + eapply (@cumulAlgo_cumulSpec _ _ true); eauto.
+    + eapply (@cumulAlgo_cumulSpec _ _ Conv); eauto.
+    + eapply (@cumulAlgo_cumulSpec _ _ Cumul); eauto.
 Defined.
  
 Lemma context_cumulativity_prop {cf:checker_flags} :
@@ -191,14 +191,14 @@ Proof.
         destruct (split_closed_context (S n) (wf_local_closed_context X1)) as [Δ [Δ' [eqΔ eqΔ' -> hn]]].
         eapply nth_error_Some_length in Hnth. lia.
         rewrite -eqΔ in Hty, Hrel.
-        rewrite -eqΔ in c0, c.
-        assert (is_open_term Δ T).
+        rewrite -eqΔ in eqb, eqt.
+        assert (is_open_term Δ t).
         { eapply nth_error_closed_context in Hnth. 2:eauto with fvs.
           rewrite -eqΔ in Hnth. now move/andP: Hnth => []. }
         eapply PCUICClosedTyp.subject_closed in Hty.
         eapply (@closedn_on_free_vars xpred0) in Hty.
-        eapply (weakening_cumulSpec0 (Γ := Δ) (Γ'' := Δ') (M := exist T H) (N := exist ty Hty)); cbn. lia.
-        unshelve eapply (@cumulAlgo_cumulSpec _ _ true). apply into_equality; eauto.
+        eapply (weakening_cumulSpec0 (Γ := Δ) (Γ'' := Δ') (M := exist t H) (N := exist ty Hty)); cbn. lia.
+        unshelve eapply (@cumulAlgo_cumulSpec _ _ Cumul). apply into_equality; eauto.
         intuition. 
     + cbn in X. destruct X as [s ondecl].
       specialize (ondecl _ Hrel).
@@ -215,8 +215,8 @@ Proof.
       * destruct (split_closed_context (S n) (wf_local_closed_context X1)) as [Δ [Δ' [eqΔ eqΔ' -> hn]]].
         eapply nth_error_Some_length in Hnth. lia.
         rewrite -eqΔ in ondecl, Hrel.
-        rewrite -eqΔ in c.
-        assert (is_open_term Δ T).
+        rewrite -eqΔ in eqt.
+        assert (is_open_term Δ t).
         { rewrite nth_error_app_lt in Hnth. rewrite -hn. lia.
           destruct Δ' as [Δ' hΔ']. cbn in *.
           move: hΔ'.
@@ -227,8 +227,8 @@ Proof.
           now rewrite hn addnP_shiftnP. }
         eapply PCUICClosedTyp.subject_closed in ondecl.
         eapply (@closedn_on_free_vars xpred0) in ondecl.
-        eapply (weakening_cumulSpec0 (Γ := Δ) (Γ'' := Δ') (M := exist T H) (N := exist ty ondecl)); cbn. lia.
-        unshelve eapply (@cumulAlgo_cumulSpec _ _ true). apply into_equality; eauto.
+        eapply (weakening_cumulSpec0 (Γ := Δ) (Γ'' := Δ') (M := exist t H) (N := exist ty ondecl)); cbn. lia.
+        unshelve eapply (@cumulAlgo_cumulSpec _ _ Cumul). apply into_equality; eauto.
         intuition. 
   - constructor; pcuic.
     eapply forall_Γ'0. repeat (constructor; pcuic).
@@ -295,11 +295,11 @@ Proof.
     pose proof (subject_closed (forall_Γ'0 _ X5 X6)). eapply (@closedn_on_free_vars xpred0) in H1. 
     pose proof (type_closed typet). eapply (@closedn_on_free_vars xpred0) in H2. 
     pose proof (subject_closed typeB). eapply (@closedn_on_free_vars xpred0) in H3. 
-    unshelve eapply (@cumulAlgo_cumulSpec  _ _ true); eauto.
+    unshelve eapply (@cumulAlgo_cumulSpec  _ _ Cumul); eauto.
     apply into_equality; eauto.
     * unshelve eapply (cumulSpec_cumulAlgo _ _ (exist Γ _) (exist A _) (exist B _)) in X4; eauto. 
       apply equality_forget in X4. eapply wt_cum_equality in X4; tea.
-      apply (wt_cum_context_equality true) in X5; tea.
+      apply (wt_cum_context_equality Cumul) in X5; tea.
       eapply (equality_equality_ctx X5) in X4.
       now eapply equality_forget in X4.
     * eapply wf_local_closed_context; eauto.  
@@ -319,17 +319,15 @@ Proof.
 Qed.
 #[global] Hint Resolve closed_context_conv_conv : pcuic.
 
-Lemma closed_context_cumulativity {cf:checker_flags} {Σ} {wfΣ : wf Σ.1} Γ {le t T Γ'} :
+Lemma closed_context_cumulativity {cf:checker_flags} {Σ} {wfΣ : wf Σ.1} Γ {pb t T Γ'} :
   Σ ;;; Γ |- t : T ->
   wf_local Σ Γ' ->
-  Σ ⊢ Γ' ≤[le] Γ ->
+  Σ ⊢ Γ' ≤[pb] Γ ->
   Σ ;;; Γ' |- t : T.
 Proof.
   intros h hΓ' e.
   pose proof (context_equality_forget e).
-  destruct le.
-  eapply context_cumulativity_prop; eauto.
-  eapply context_cumulativity_prop; eauto.
+  destruct pb; eapply context_cumulativity_prop; eauto.
   eapply conv_cumul_context in e; tea.
   eapply (context_equality_forget e).
 Qed.
@@ -350,7 +348,7 @@ Lemma wf_conv_context_closed {cf:checker_flags} {Σ} {wfΣ : wf Σ.1} {Γ Γ'} :
   conv_context Σ Γ Γ' -> 
   wf_local Σ Γ ->
   wf_local Σ Γ' ->
-  context_equality false Σ Γ Γ'.
+  Σ ⊢ Γ = Γ'.
 Proof.
   move=> a wf wf'.
   eapply into_context_equality; eauto with fvs.
@@ -360,7 +358,7 @@ Lemma wf_cumul_context_closed {cf:checker_flags} {Σ} {wfΣ : wf Σ.1} {Γ Γ'} 
   cumul_context Σ Γ Γ' -> 
   wf_local Σ Γ ->
   wf_local Σ Γ' ->
-  context_equality true Σ Γ Γ'.
+  Σ ⊢ Γ ≤ Γ'.
 Proof.
   move=> a wf wf'.
   eapply into_context_equality; eauto with fvs.

--- a/pcuic/theories/Typing/PCUICNamelessTyp.v
+++ b/pcuic/theories/Typing/PCUICNamelessTyp.v
@@ -115,9 +115,9 @@ Lemma nl_cumulSpec {cf:checker_flags} :
   Σ ;;; Γ |- A <=s B ->
   nlg Σ ;;; nlctx Γ |- nl A <=s nl B.
 Proof.
-  intros. eapply (cumulAlgo_cumulSpec (nlg Σ) (le:=true)). 
+  intros. eapply (cumulAlgo_cumulSpec (nlg Σ) (pb:=Cumul)). 
   eapply into_equality.
-  - eapply nl_cumul. eapply (equality_forget (le:=true)). 
+  - eapply nl_cumul. eapply (equality_forget (pb:=Cumul)). 
   unshelve eapply (cumulSpec_cumulAlgo _ _ (exist _ _ ) (exist _ _) (exist _ _)); eauto; cbn. 
   - eapply closed_ctx_on_free_vars. apply closed_nlctx. 
     rewrite is_closed_ctx_closed; eauto.

--- a/pcuic/theories/Typing/PCUICRenameTyp.v
+++ b/pcuic/theories/Typing/PCUICRenameTyp.v
@@ -151,42 +151,32 @@ Proof.
        now rewrite /to_extended_list /to_extended_list_k reln_fold.
 Qed.
 
-Lemma convSpec_renameP P Σ Γ Δ f A B : let sP := shiftnP #|Γ| P in
+Lemma cumulSpec_renameP pb P Σ Γ Δ f A B : let sP := shiftnP #|Γ| P in
     wf Σ.1 ->
     urenaming sP Δ Γ f ->
     is_closed_context Γ ->
     is_open_term Γ A ->
     is_open_term Γ B ->
     is_closed_context Δ ->
-    Σ ;;; Γ |- A =s B ->
-    Σ ;;; Δ |- rename f A =s rename f B.
+    Σ ;;; Γ ⊢ A ≤s[pb] B ->
+    Σ ;;; Δ ⊢ rename f A ≤s[pb] rename f B.
 Proof. 
   intros sP wfΣ Hren HfreeA HfreeB HΓ HΔ e. 
-  revert Γ A B e sP Δ f wfΣ Hren HfreeA HfreeB HΓ HΔ e. 
-  eapply (convSpec0_ind_all Σ.1 (eq_universe (global_ext_constraints Σ)) 
-  (fun Γ A B => forall Δ f, let sP := shiftnP #|Γ| P in
-  wf Σ.1 ->
-  urenaming sP Δ Γ f ->
-  is_closed_context Γ ->
-  is_open_term Γ A ->
-  is_open_term Γ B ->
-  is_closed_context Δ ->
-  Σ ;;; Γ |- A =s B ->
-  Σ ;;; Δ |- rename f A =s rename f B)); intros; cbn.
-  all: repeat inv_on_free_vars.
+  revert pb Γ A B e sP Δ f wfΣ Hren HfreeA HfreeB HΓ HΔ e.
+  apply: (cumulSpec0_ind_all Σ); intros; cbn.
   - rewrite rename_subst10. solve [econstructor].
   - rewrite rename_subst10. solve [econstructor].
-  - rename X0 into hf. unfold urenaming in hf.
+  - rename Hren into hf. unfold urenaming in hf.
     destruct (nth_error Γ i) eqn:hnth; noconf H.
-    assert (hav : sP i = true).
-    { clear -a; unfold sP, shiftnP in *. intuition. }
-    clear a. 
+    assert (hav : sP i).
+    { unfold sP, shiftnP in *. cbn in *. rewrite orb_false_r in HfreeB. intuition. }
+    clear HfreeB. 
     specialize hf with (1 := hav) (2 := hnth).
-    destruct hf as [decl' [e' [? [hr hbo]]]].
+    destruct hf as [decl' [e' [eqann [hr hbo]]]].
     rewrite H /= in hbo.
     rewrite lift0_rename.
     destruct (decl_body decl') eqn:hdecl => //. noconf hbo.
-    sigma in H1. sigma. rewrite H1.
+    sigma in H0. sigma. rewrite H0.
     relativize (t.[_]).
     2:{ setoid_rewrite rshiftk_S. rewrite -rename_inst.
         now rewrite -(lift0_rename (S (f i)) _). }
@@ -195,7 +185,7 @@ Proof.
      rewrite rename_iota_red //.
     * rewrite skipn_length; lia.
     * change (bcontext br) with (bcontext (rename_branch f br)).
-     rename p4 into hbrs. 
+     move/and5P: HfreeB => [_ _ _ _ hbrs].
      eapply nth_error_forallb in hbrs; tea. simpl in hbrs.
      move/andP: hbrs => [] clbctx clbod.
      rewrite closedn_ctx_on_free_vars.
@@ -224,313 +214,36 @@ Proof.
    - eapply cumul_Sym; intuition; eauto.
    - eapply cumul_Refl; intuition; eauto.
    - eapply cumul_Evar. cbn in *. 
+     apply forallb_All in HfreeB, HΓ. 
      eapply All2_All_mix_left in X; tea.
      eapply All2_All_mix_right in X; tea.
      eapply All2_map. eapply All2_impl. 1:tea. cbn; intros.
-     eapply X3.1.2; intuition.
-   - eapply cumul_App; try apply X0; try apply X2; eauto.         
-   - eapply cumul_Lambda; try apply X0; try apply X2; eauto;
-     try rewrite shiftnP_S; eauto. 
-     * eapply urenaming_impl. 1: intro; rewrite shiftnP_S; eauto. apply urenaming_vass; eauto. 
-     * fvs.
-     * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
-       cbn. eapply urename_is_open_term; eauto.  
-   - eapply cumul_Prod; try apply X0; try apply X2; eauto;
-     try rewrite shiftnP_S; eauto.
-     * eapply urenaming_impl. 1: intro; rewrite shiftnP_S; eauto. apply urenaming_vass; eauto. 
-     * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
-     * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
-       cbn. eapply urename_is_open_term; eauto.  
-   - eapply cumul_LetIn; try apply X0; try apply X2; eauto; try apply X4; 
-     try rewrite shiftnP_S; eauto.
-     * eapply urenaming_impl. 1: intro; rewrite shiftnP_S; eauto. apply urenaming_vdef; eauto. 
-     * rewrite on_free_vars_ctx_snoc_def; eauto.
-     * rewrite on_free_vars_ctx_snoc_def; eauto. 
-       all: eapply urename_is_open_term; eauto.
-   - rename p0 into Hp'; rename p1 into Hreturn'; rename p2 into Hcontext'; rename p3 into Hc'; rename p4 into Hbrs'.
-     rename p5 into Hp; rename p6 into Hreturn; rename p7 into Hcontext; rename p8 into Hc; rename p9 into Hbrs.
-     eapply cumul_Case.
-     * unfold cumul_predicate. unfold cumul_predicate in X. destruct X as [Xparam [Xuniv [Xcontext [Xeq Xreturn]]]].
-       repeat split; eauto. 
-       + eapply All2_map. apply forallb_All in Hp, Hp'. eapply (All2_All_mix_left Hp) in Xparam. 
-         eapply (All2_All_mix_right Hp') in Xparam.
-         eapply All2_impl. 1: tea. cbn; intros. destruct X as [[X [X''' X']] X'']. apply X'; eauto.
-       + unfold preturn. cbn. rewrite (All2_fold_length Xcontext). eapply Xreturn; eauto.
-         ++ rewrite app_context_length.
-            eapply urenaming_ext; try apply shiftnP_add; try reflexivity. 
-            rewrite <- (All2_fold_length Xcontext).
-            rewrite <- inst_case_predicate_context_length.
-            rewrite inst_case_predicate_context_rename; eauto. 
-            apply urenaming_context; eauto.
-         ++ unfold inst_case_predicate_context. 
-            apply on_free_vars_ctx_inst_case_context; eauto.
-         ++ unfold inst_case_predicate_context.
-            unfold is_open_term. rewrite app_length.
-            rewrite <- shiftnP_add. 
-            rewrite inst_case_predicate_context_length.   
-            eassumption.
-         ++ unfold inst_case_predicate_context.
-            unfold is_open_term. rewrite app_length.
-            rewrite <- shiftnP_add. 
-            rewrite inst_case_predicate_context_length.   
-            rewrite (All2_fold_length Xcontext). eassumption.
-         ++ unfold inst_case_predicate_context. apply on_free_vars_ctx_inst_case_context; eauto.
-            +++ eapply All_forallb. apply All_map. apply forallb_All in Hp; eapply All_impl. 1: tea.
-                cbn; intros. eapply urename_is_open_term; eauto.
-            +++ unfold pparams. cbn. rewrite map_length. exact Hcontext.
-     * apply X1; eauto. 
-     * rename X2 into Hbrsbrs'.
-       apply forallb_All in Hbrs, Hbrs'. apply (All2_All_mix_left Hbrs) in Hbrsbrs'. clear Hbrs.   
-       apply (All2_All_mix_right Hbrs') in Hbrsbrs'. clear Hbrs'.
-       apply All2_map. eapply All2_impl. 1: tea. cbn; intros x y [[Hx Heqxy ] Hy].
-       destruct Heqxy as [[Hbcontext Hbody] Heqxy]. rewrite (All2_fold_length Hbcontext).
-       split; eauto. 
-       apply andb_and in Hx. destruct Hx as [Hx Hbodyx].
-       apply andb_and in Hy. destruct Hy as [Hy Hbodyy].
-       apply Heqxy; eauto.
-       + rewrite app_context_length.
-       eapply urenaming_ext; try apply shiftnP_add; try reflexivity. 
-       rewrite <- (All2_fold_length Hbcontext).
-       rewrite <- (inst_case_branch_context_length p).
-       rewrite test_context_k_closed_on_free_vars_ctx in Hx. 
-       rewrite inst_case_branch_context_rename; eauto. 
-       apply urenaming_context; eauto.
-       + rewrite test_context_k_closed_on_free_vars_ctx in Hx.
-         unfold inst_case_predicate_context.
-         apply on_free_vars_ctx_inst_case_context; eauto.
-      + unfold inst_case_predicate_context.
-         unfold is_open_term. rewrite app_length.
-        rewrite <- shiftnP_add. 
-        rewrite inst_case_branch_context_length.   
-        eassumption.
-      + unfold inst_case_predicate_context.
-        unfold is_open_term. rewrite app_length.
-        rewrite <- shiftnP_add. 
-        rewrite inst_case_branch_context_length.    
-        rewrite (All2_fold_length Hbcontext). eassumption.
-      + unfold inst_case_predicate_context. apply on_free_vars_ctx_inst_case_context; eauto.
-       ++ eapply All_forallb. apply All_map. apply forallb_All in Hp; eapply All_impl. 1: tea.
-           cbn; intros. eapply urename_is_open_term; eauto.
-       ++ unfold pparams. rewrite test_context_k_closed_on_free_vars_ctx in Hx.
-        cbn. rewrite map_length. eassumption.
-  - eapply cumul_Proj; try apply X0; eauto.
-  - rewrite (All2_length X).
-    eapply cumul_Fix. cbn in H0, H1.         
-    apply (All2_All_mix_left H0) in X. clear H0.   
-    apply (All2_All_mix_right H1) in X. clear H1.
-    apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-    destruct X3 as [[Hx [[[_Htype [Htype Hbody_]] [Hbody Harg]] Hname]] Hy].
-    repeat split; eauto.
-    * eapply Htype; eauto. 
-      + cbn in Hx; eapply andb_and in Hx. intuition.
-      + cbn in Hy; eapply andb_and in Hy. intuition.
-    * eapply Hbody; eauto. 
-      + rewrite app_context_length.
-      eapply urenaming_ext; try apply shiftnP_add; try reflexivity. 
-      rewrite <- (All2_length X).
-      rewrite rename_fix_context.
-      rewrite <- fix_context_length.
-      apply urenaming_context; eauto. 
-      + rewrite on_free_vars_ctx_app. 
-        apply andb_and; split; eauto.
-        apply on_free_vars_fix_context.
-        eapply All2_All_left. 1: tea. cbn; intros.
-        apply X3.1.  
-      + unfold test_def in Hx. apply andb_and in Hx. 
-        destruct Hx as [_ Hx]. 
-        unfold is_open_term. rewrite app_length.
-        rewrite <- shiftnP_add. 
-        rewrite fix_context_length. exact Hx.    
-      + unfold test_def in Hy. apply andb_and in Hy. 
-        destruct Hy as [_ Hy]. 
-        unfold is_open_term. rewrite app_length.
-        rewrite <- shiftnP_add. 
-        rewrite fix_context_length. 
-        rewrite (All2_length X). exact Hy.    
-      + rewrite on_free_vars_ctx_app.   
-        apply andb_and; split; eauto.
-        apply on_free_vars_fix_context.
-        apply All_map. 
-        eapply All2_All_left. 1: tea. cbn ; intros.
-        destruct X3 as [[Hx0 _] _].
-        unfold test_def. unfold test_def in Hx0.
-        apply andb_and in Hx0. destruct Hx0 as [Hx0type Hx0body].
-        apply andb_and. cbn. split. 
-        ++ eapply urename_is_open_term; eauto.
-        ++ rewrite map_length. rewrite <-(All2_length X).
-           rewrite <- fix_context_length.
-           eapply urename_on_free_vars_shift; eauto.
-           rewrite fix_context_length; eauto. 
-  - rewrite (All2_length X).
-    eapply cumul_CoFix. cbn in H0, H1.         
-    apply (All2_All_mix_left H0) in X. clear H0.   
-    apply (All2_All_mix_right H1) in X. clear H1.
-    apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-    destruct X3 as [[Hx [[[_Htype [Htype Hbody_]] [Hbody Harg]] Hname]] Hy].
-    repeat split; eauto.
-    * eapply Htype; eauto. 
-      + cbn in Hx; eapply andb_and in Hx. intuition.
-      + cbn in Hy; eapply andb_and in Hy. intuition.
-    * eapply Hbody; eauto. 
-      + rewrite app_context_length.
-      eapply urenaming_ext; try apply shiftnP_add; try reflexivity. 
-      rewrite <- (All2_length X).
-      rewrite rename_fix_context.
-      rewrite <- fix_context_length.
-      apply urenaming_context; eauto. 
-      + rewrite on_free_vars_ctx_app. 
-        apply andb_and; split; eauto.
-        apply on_free_vars_fix_context.
-        eapply All2_All_left. 1: tea. cbn; intros.
-        apply X3.1.  
-      + unfold test_def in Hx. apply andb_and in Hx. 
-        destruct Hx as [_ Hx]. 
-        unfold is_open_term. rewrite app_length.
-        rewrite <- shiftnP_add. 
-        rewrite fix_context_length. exact Hx.    
-      + unfold test_def in Hy. apply andb_and in Hy. 
-        destruct Hy as [_ Hy]. 
-        unfold is_open_term. rewrite app_length.
-        rewrite <- shiftnP_add. 
-        rewrite fix_context_length. 
-        rewrite (All2_length X). exact Hy.    
-      + rewrite on_free_vars_ctx_app.   
-        apply andb_and; split; eauto.
-        apply on_free_vars_fix_context.
-        apply All_map. 
-        eapply All2_All_left. 1: tea. cbn ; intros.
-        destruct X3 as [[Hx0 _] _].
-        unfold test_def. unfold test_def in Hx0.
-        apply andb_and in Hx0. destruct Hx0 as [Hx0type Hx0body].
-        apply andb_and. cbn. split. 
-        ++ eapply urename_is_open_term; eauto.
-        ++ rewrite map_length. rewrite <-(All2_length X).
-           rewrite <- fix_context_length.
-           eapply urename_on_free_vars_shift; eauto.
-           rewrite fix_context_length; eauto. 
-  - repeat rewrite rename_mkApps. eapply cumul_Ind.
-    * repeat rewrite map_length; eauto.
-    * eapply forallb_All in b, b0.
-      apply (All2_All_mix_left b0) in X. clear b0.
-      apply (All2_All_mix_right b) in X. clear b.
-      apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      destruct X3 as [[Hx [Hxy_ Hxy]] Hy].    
-      eapply Hxy; eauto.
-  - repeat rewrite rename_mkApps. eapply cumul_Construct.
-    * repeat rewrite map_length; eauto.
-    * eapply forallb_All in b, b0.
-      apply (All2_All_mix_left b0) in X. clear b0.
-      apply (All2_All_mix_right b) in X. clear b.
-      apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      destruct X3 as [[Hx [Hxy_ Hxy]] Hy].    
-      eapply Hxy; eauto.   
-  - eapply cumul_Sort; eauto.
-  - eapply cumul_Const; eauto.
-Defined. 
-
-Lemma cumulSpec_renameP P Σ Γ Δ f A B : let sP := shiftnP #|Γ| P in
-    wf Σ.1 ->
-    urenaming sP Δ Γ f ->
-    is_closed_context Γ ->
-    is_open_term Γ A ->
-    is_open_term Γ B ->
-    is_closed_context Δ ->
-    Σ ;;; Γ |- A <=s B ->
-    Σ ;;; Δ |- rename f A <=s rename f B.
-Proof. 
-  intros sP wfΣ Hren HfreeA HfreeB HΓ HΔ e. 
-  revert Γ A B e sP Δ f wfΣ Hren HfreeA HfreeB HΓ HΔ e. 
-  eapply (cumulSpec0_ind_all Σ.1 (eq_universe (global_ext_constraints Σ)) 
-  (fun Rle Γ A B => forall Δ f, let sP := shiftnP #|Γ| P in
-  wf Σ.1 ->
-  urenaming sP Δ Γ f ->
-  is_closed_context Γ ->
-  is_open_term Γ A ->
-  is_open_term Γ B ->
-  is_closed_context Δ ->
-  cumulSpec0 Σ.1 (eq_universe (global_ext_constraints Σ)) Rle Γ A B ->
-  cumulSpec0 Σ.1 (eq_universe (global_ext_constraints Σ)) Rle Δ (rename f A) (rename f B))); intros; cbn.
-  - rewrite rename_subst10. solve [econstructor].
-  - rewrite rename_subst10. solve [econstructor].
-  - rename X0 into hf. unfold urenaming in hf.
-    destruct (nth_error Γ i) eqn:hnth; noconf H.
-    assert (hav : sP i = true).
-    { clear -H1; unfold sP, shiftnP in *. cbn in *. rewrite orb_false_r in H1. intuition. }
-    clear H1. 
-    specialize hf with (1 := hav) (2 := hnth).
-    destruct hf as [decl' [e' [? [hr hbo]]]].
-    rewrite H /= in hbo.
-    rewrite lift0_rename.
-    destruct (decl_body decl') eqn:hdecl => //. noconf hbo.
-    sigma in H1. sigma. rewrite H1.
-    relativize (t.[_]).
-    2:{ setoid_rewrite rshiftk_S. rewrite -rename_inst.
-        now rewrite -(lift0_rename (S (f i)) _). }
-     eapply cumul_rel. now rewrite e' /= hdecl.
-   - rewrite rename_mkApps. simpl.
-     rewrite rename_iota_red //.
-    * rewrite skipn_length; lia.
-    * change (bcontext br) with (bcontext (rename_branch f br)).
-     move/and5P: H2 => [_ _ _ _ hbrs].
-     eapply nth_error_forallb in hbrs; tea. simpl in hbrs.
-     move/andP: hbrs => [] clbctx clbod.
-     rewrite closedn_ctx_on_free_vars.
-     now rewrite test_context_k_closed_on_free_vars_ctx in clbctx.
-   * eapply cumul_iota.
-     + rewrite nth_error_map H /= //.
-     + simpl. now len.
-   - rewrite 2!rename_mkApps. simpl.
-     eapply cumul_fix.
-     + eapply rename_unfold_fix. eassumption.
-     + eapply is_constructor_rename. assumption.
-   - rewrite 2!rename_mkApps. simpl.
-     eapply cumul_cofix_case.
-     eapply rename_unfold_cofix. eassumption.
-   - rewrite 2!rename_mkApps. simpl.
-     eapply cumul_cofix_proj.
-     eapply rename_unfold_cofix. eassumption.
-   - rewrite rename_subst_instance.
-     eapply cumul_delta. 
-     + eassumption.
-     + rewrite rename_closed. 2: assumption.
-       eapply declared_constant_closed_body. all: eauto.
-   - rewrite rename_mkApps. simpl.
-     eapply cumul_proj. rewrite nth_error_map. rewrite H. reflexivity.
-   - eapply cumul_Trans; try apply X0; try apply X2; eauto. eapply urename_is_open_term; eauto. 
-   - eapply cumul_Sym; intuition; eauto.
-   - eapply cumul_Refl; intuition; eauto.
-   - eapply cumul_Evar. cbn in *. 
-     apply forallb_All in H0, H1. 
-     eapply All2_All_mix_left in X; tea.
-     eapply All2_All_mix_right in X; tea.
-     eapply All2_map. eapply All2_impl. 1:tea. cbn; intros.
-     eapply X3.1.2; intuition.
-   - cbn in *. apply andb_and in H0 , H1. destruct H0 , H1.
+     eapply X0.1.2; intuition.
+   - cbn in *. rtoProp.
      eapply cumul_App; try apply X0; try apply X2; eauto.         
-   - cbn in H1, H2. apply andb_and in H1 , H2. destruct H1 , H2.
+   - cbn in HfreeB, HΓ; rtoProp.
      eapply cumul_Lambda; try apply X0; try apply X2; eauto;
      try rewrite shiftnP_S; eauto. 
      * eapply urenaming_impl. 1: intro; rewrite shiftnP_S; eauto. apply urenaming_vass; eauto. 
      * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
      * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
        cbn. eapply urename_is_open_term; eauto.  
-   - cbn in H1, H2. apply andb_and in H1, H2. destruct H1 , H2.
+   - cbn in HfreeB, HΓ. rtoProp.
      eapply cumul_Prod; try apply X0; try apply X2; eauto;
      try rewrite shiftnP_S; eauto.
      * eapply urenaming_impl. 1: intro; rewrite shiftnP_S; eauto. apply urenaming_vass; eauto. 
      * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
      * rewrite on_free_vars_ctx_snoc. apply andb_and; split; eauto.
        cbn. eapply urename_is_open_term; eauto.  
-   - cbn in H1, H2. apply andb_and in H1, H2. destruct H1 , H2. 
-     apply andb_and in H4, H5. destruct H4 , H5.
+   - cbn in HfreeB, HΓ; rtoProp.
      eapply cumul_LetIn; try apply X0; try apply X2; eauto; try apply X4; 
      try rewrite shiftnP_S; eauto.
      * eapply urenaming_impl. 1: intro; rewrite shiftnP_S; eauto. apply urenaming_vdef; eauto. 
      * rewrite on_free_vars_ctx_snoc_def; eauto.
      * rewrite on_free_vars_ctx_snoc_def; eauto. 
        all: eapply urename_is_open_term; eauto.
-   - cbn in H0, H1. 
-     rename H into HΓ; rename H0 into H; rename H1 into H'.  
+   - cbn in HfreeB, HΓ. 
+     rename HΓ into H'; rename HfreeB into H.  
      apply andb_andI in H; apply andb_andI in H'; destruct H as [Hp H]; destruct H' as [Hp' H'].
      apply andb_andI in H; apply andb_andI in H'; destruct H as [Hreturn H]; destruct H' as [Hreturn' H'].
      apply andb_andI in H; apply andb_andI in H'; destruct H as [Hcontext H]; destruct H' as [Hcontext' H'].
@@ -603,14 +316,14 @@ Proof.
            cbn; intros. eapply urename_is_open_term; eauto.
        ++ unfold pparams. rewrite test_context_k_closed_on_free_vars_ctx in Hx.
         cbn. rewrite map_length. eassumption.
-  - cbn in H0, H1. eapply cumul_Proj; try apply X0; eauto.
+  - cbn in *. eapply cumul_Proj; try apply X0; eauto.
   - rewrite (All2_length X).
-    eapply cumul_Fix. cbn in H0, H1.         
-    apply forallb_All in H0, H1. 
-    apply (All2_All_mix_left H0) in X. clear H0.   
-    apply (All2_All_mix_right H1) in X. clear H1.
+    eapply cumul_Fix. cbn in *.
+    apply forallb_All in HfreeB, HΓ. 
+    apply (All2_All_mix_left HfreeB) in X. clear HfreeB.  
+    apply (All2_All_mix_right HΓ) in X. clear HΓ.
     apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-    destruct X3 as [[Hx [[[_Htype [Htype Hbody_]] [Hbody Harg]] Hname]] Hy].
+    destruct X0 as [[Hx [[[_Htype [Htype Hbody_]] [Hbody Harg]] Hname]] Hy].
     repeat split; eauto.
     * eapply Htype; eauto. 
       + cbn in Hx; eapply andb_and in Hx. intuition.
@@ -626,7 +339,7 @@ Proof.
         apply andb_and; split; eauto.
         apply on_free_vars_fix_context.
         eapply All2_All_left. 1: tea. cbn; intros.
-        apply X3.1.  
+        apply X0.1.  
       + unfold test_def in Hx. apply andb_and in Hx. 
         destruct Hx as [_ Hx]. 
         unfold is_open_term. rewrite app_length.
@@ -643,7 +356,7 @@ Proof.
         apply on_free_vars_fix_context.
         apply All_map. 
         eapply All2_All_left. 1: tea. cbn ; intros.
-        destruct X3 as [[Hx0 _] _].
+        destruct X0 as [[Hx0 _] _].
         unfold test_def. unfold test_def in Hx0.
         apply andb_and in Hx0. destruct Hx0 as [Hx0type Hx0body].
         apply andb_and. cbn. split. 
@@ -653,12 +366,12 @@ Proof.
            eapply urename_on_free_vars_shift; eauto.
            rewrite fix_context_length; eauto. 
   - rewrite (All2_length X).
-    eapply cumul_CoFix. cbn in H0, H1.         
-    apply forallb_All in H0, H1. 
-    apply (All2_All_mix_left H0) in X. clear H0.   
-    apply (All2_All_mix_right H1) in X. clear H1.
+    eapply cumul_CoFix. cbn in *.
+    apply forallb_All in HfreeB, HΓ. 
+    apply (All2_All_mix_left HfreeB) in X. clear HfreeB.  
+    apply (All2_All_mix_right HΓ) in X. clear HΓ.
     apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-    destruct X3 as [[Hx [[[_Htype [Htype Hbody_]] [Hbody Harg]] Hname]] Hy].
+    destruct X0 as [[Hx [[[_Htype [Htype Hbody_]] [Hbody Harg]] Hname]] Hy].
     repeat split; eauto.
     * eapply Htype; eauto. 
       + cbn in Hx; eapply andb_and in Hx. intuition.
@@ -674,7 +387,7 @@ Proof.
         apply andb_and; split; eauto.
         apply on_free_vars_fix_context.
         eapply All2_All_left. 1: tea. cbn; intros.
-        apply X3.1.  
+        apply X0.1.  
       + unfold test_def in Hx. apply andb_and in Hx. 
         destruct Hx as [_ Hx]. 
         unfold is_open_term. rewrite app_length.
@@ -691,7 +404,7 @@ Proof.
         apply on_free_vars_fix_context.
         apply All_map. 
         eapply All2_All_left. 1: tea. cbn ; intros.
-        destruct X3 as [[Hx0 _] _].
+        destruct X0 as [[Hx0 _] _].
         unfold test_def. unfold test_def in Hx0.
         apply andb_and in Hx0. destruct Hx0 as [Hx0type Hx0body].
         apply andb_and. cbn. split. 
@@ -707,7 +420,7 @@ Proof.
       apply (All2_All_mix_left b0) in X. clear b0.   
       apply (All2_All_mix_right b) in X. clear b.
       apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      destruct X3 as [[Hx [Hxy_ Hxy]] Hy].    
+      destruct X0 as [[Hx [Hxy_ Hxy]] Hy].    
       eapply Hxy; eauto.
   - repeat rewrite rename_mkApps. eapply cumul_Construct.
     * repeat rewrite map_length; eauto.
@@ -716,11 +429,24 @@ Proof.
       apply (All2_All_mix_left Hargs) in X. clear Hargs.   
       apply (All2_All_mix_right Hargs') in X. clear Hargs'.
       apply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      destruct X3 as [[Hx [Hxy_ Hxy]] Hy].    
+      destruct X0 as [[Hx [Hxy_ Hxy]] Hy].    
       eapply Hxy; eauto.   
   - eapply cumul_Sort; eauto.
   - eapply cumul_Const; eauto.
 Defined. 
+
+Lemma convSpec_renameP P Σ Γ Δ f A B : let sP := shiftnP #|Γ| P in
+    wf Σ.1 ->
+    urenaming sP Δ Γ f ->
+    is_closed_context Γ ->
+    is_open_term Γ A ->
+    is_open_term Γ B ->
+    is_closed_context Δ ->
+    Σ ;;; Γ |- A =s B ->
+    Σ ;;; Δ |- rename f A =s rename f B.
+Proof. 
+  apply cumulSpec_renameP.
+Qed.
 
 (* Lemma cumul_decls_renameP {P Σ Γ Γ' Δ Δ' f} d d' :
     wf Σ.1 ->

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -20,25 +20,35 @@ Local Ltac aa := rdest; eauto with univ_subst.
 Section SubstIdentity.
   Context `{cf:checker_flags}.
 
-Lemma convSpec_subst_instance (Σ : global_env_ext) Γ u A B univs :
-valid_constraints (global_ext_constraints (Σ.1, univs))
-                  (subst_instance_cstrs u Σ) ->
-  Σ ;;; Γ |- A =s B ->
-  (Σ.1,univs) ;;; subst_instance u Γ |- subst_instance u A =s subst_instance u B.
+Lemma compare_universe_subst_instance pb {Σ : global_env_ext} univs u :
+  valid_constraints (global_ext_constraints (Σ.1, univs)) (subst_instance_cstrs u Σ) ->
+  RelationClasses.subrelation (compare_universe pb Σ)
+    (fun x y : Universe.t =>
+    compare_universe pb (global_ext_constraints (Σ.1, univs)) (subst_instance_univ u x)
+      (subst_instance_univ u y)).
 Proof.
-  intros e H. pose proof (He := eq_universe_subst_instance _ _ _ e).
-  revert Γ A B H e. 
-  eapply (convSpec0_ind_all Σ (eq_universe (global_ext_constraints Σ)) 
-            (fun Γ A B => valid_constraints (global_ext_constraints (Σ.1, univs)) (subst_instance_cstrs u Σ) ->
-            (Σ.1 , univs) ;;; Γ@[u] |- A@[u] =s B@[u])); intros; cbn ;
-            try solve [econstructor; intuition; eauto].
+  intros v.
+  destruct pb; cbn.
+  - now apply eq_universe_subst_instance.
+  - now apply leq_universe_subst_instance.
+Qed.
+
+Lemma cumulSpec_subst_instance (Σ : global_env_ext) Γ u A B pb univs :
+  valid_constraints (global_ext_constraints (Σ.1, univs))
+                    (subst_instance_cstrs u Σ) ->
+  Σ ;;; Γ ⊢ A ≤s[pb] B ->
+  (Σ.1,univs) ;;; subst_instance u Γ ⊢ subst_instance u A ≤s[pb] subst_instance u B.
+Proof.
+  intros e H. unfold cumulSpec.
+  revert pb Γ A B H e.
+  apply: cumulSpec0_ind_all; intros; cbn; try solve [econstructor; intuition eauto].
   - rewrite subst_instance_subst. solve [econstructor].
   - rewrite subst_instance_subst. solve [econstructor].
   - rewrite subst_instance_lift. eapply cumul_rel.
     unfold subst_instance.
     unfold option_map in *. destruct (nth_error Γ) eqn:E; inversion H.
     unfold map_context. rewrite nth_error_map E. cbn.
-    rewrite map_decl_body. destruct c. cbn in H2. subst.
+    rewrite map_decl_body. destruct c. cbn in *. subst.
     reflexivity.
   - rewrite subst_instance_mkApps. cbn.
     rewrite iota_red_subst_instance.
@@ -89,9 +99,10 @@ Proof.
   - eapply cumul_Case; try solve [intuition; eauto]. 
     * destruct X as [X [Xuni [Xcont [_ Xret]]]]. repeat split; eauto; cbn. 
       + apply All2_map. eapply All2_impl. 1: tea. cbn; intros. eapply X3.2; eauto.
-      + apply precompose_subst_instance. eapply R_universe_instance_impl; eauto.   
+      + apply precompose_subst_instance. eapply R_universe_instance_impl; eauto.
+        now apply eq_universe_subst_instance.
       + rewrite subst_instance_app inst_case_predicate_context_subst_instance in Xret.
-        eapply Xret. eauto.          
+        eapply Xret; eauto.           
     * eapply All2_map. eapply All2_impl. 1: tea. cbn; intros.
       repeat split; eauto; intuition.
       rewrite subst_instance_app inst_case_branch_context_subst_instance in X1; eauto. 
@@ -101,132 +112,34 @@ Proof.
   - eapply cumul_CoFix. apply All2_map. eapply All2_impl. 1: tea. 
     cbn; intros; intuition. 
     rewrite subst_instance_app fix_context_subst_instance in X0; eauto. 
-  - repeat rewrite subst_instance_mkApps. eapply cumul_Ind.
-    * apply precompose_subst_instance_global. cbn. 
-      rewrite map_length. eapply R_global_instance_impl_same_napp; eauto.
-      all: eapply eq_universe_subst_instance; eauto.
-    * eapply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      eapply X0.2; eauto.
-      - repeat rewrite subst_instance_mkApps. eapply cumul_Construct.
-      * apply precompose_subst_instance_global. cbn. 
-        rewrite map_length. eapply R_global_instance_impl_same_napp; eauto.
-        all: eapply eq_universe_subst_instance; eauto.
-      * eapply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-        eapply X0.2; eauto.
-    - eapply cumul_Const. apply precompose_subst_instance.
-      eapply R_universe_instance_impl; eauto. 
-Defined. 
-
-Lemma cumulSpec_subst_instance (Σ : global_env_ext) Γ u A B univs :
-  valid_constraints (global_ext_constraints (Σ.1, univs))
-                    (subst_instance_cstrs u Σ) ->
-  Σ ;;; Γ |- A <=s B ->
-  (Σ.1,univs) ;;; subst_instance u Γ
-                   |- subst_instance u A <=s subst_instance u B.
-Proof.
-  intros e H. unfold cumulSpec.  
-  set (Rle' := leq_universe (global_ext_constraints (Σ.1,univs))). 
-  set (Re := eq_universe (global_ext_constraints Σ)).
-  pose proof (Hle := leq_universe_subst_instance _ _ _ e).
-  pose proof (Hee := eq_universe_subst_instance _ _ _ e).
-  assert (He : subrelation Re
-          (fun x y : Universe.t => Rle' x@[u] y@[u])).
-  { etransitivity; try apply leq_universe_subst_instance; eauto.
-    apply eq_universe_leq_universe.  }
-  pose proof (He_ := He). pose proof (Hle_ := Hle).  
-  revert Hle_ He_. fold Rle'. generalize Rle'. unfold Rle' in *; clear Rle'; intros Rle' Hle_ He_.
-  revert Γ A B H Rle' Hle_ He_ e. 
-  eapply (cumulSpec0_ind_all Σ (eq_universe (global_ext_constraints Σ)) 
-            (fun Rle Γ A B => forall (Rle' : _ -> _ -> Prop), subrelation Rle
-            (fun x y : Universe.t_ => Rle' x@[u] y@[u]) ->
-            subrelation (eq_universe Σ)
-                        (fun x y : Universe.t_ => Rle' x@[u] y@[u]) ->
-            valid_constraints (global_ext_constraints (Σ.1, univs)) (subst_instance_cstrs u Σ) ->
-               cumulSpec0 Σ (eq_universe (global_ext_constraints (Σ.1,univs))) Rle' Γ@[u] A@[u] B@[u]))
-             with (Rle := leq_universe (global_ext_constraints Σ))  ; intros; cbn ;
-            try solve [econstructor; intuition; eauto].
-  - rewrite subst_instance_subst. solve [econstructor].
-  - rewrite subst_instance_subst. solve [econstructor].
-  - rewrite subst_instance_lift. eapply cumul_rel.
-    unfold subst_instance.
-    unfold option_map in *. destruct (nth_error Γ) eqn:E; inversion H.
-    unfold map_context. rewrite nth_error_map E. cbn.
-    rewrite map_decl_body. destruct c. cbn in H2. subst.
-    reflexivity.
-  - rewrite subst_instance_mkApps. cbn.
-    rewrite iota_red_subst_instance.
-    change (bcontext br) with (bcotext (map_branch (subst_instance u) br)). 
-    eapply cumul_iota; eauto with pcuic.
-    * rewrite nth_error_map H //.
-    * simpl. now len.
-  - rewrite !subst_instance_mkApps. cbn.
-    eapply cumul_fix.
-    + unfold unfold_fix in *. destruct (nth_error mfix idx) eqn:E.
-      * inversion H.
-        rewrite nth_error_map E. cbn.
-        destruct d. cbn in *. cbn in *; try congruence.
-        f_equal. f_equal. 
-        now rewrite subst_instance_subst fix_subst_instance_subst.
-      * inversion H.
-    + unfold is_constructor in *.
-      destruct (nth_error args narg) eqn:E; inversion H0; clear H0.
-      rewrite nth_error_map E. cbn.
-     eapply isConstruct_app_subst_instance.
-  - rewrite !subst_instance_mkApps.
-    unfold unfold_cofix in *. destruct (nth_error mfix idx) eqn:E.
-    + inversion H.
-    eapply cumul_cofix_case.  fold subst_instance_constr.
-    unfold unfold_cofix.
-    rewrite nth_error_map E. cbn.
-    rewrite subst_instance_subst.
-    now rewrite cofix_subst_instance_subst.
-    + cbn.
-    inversion H.
-  - unfold unfold_cofix in *.
-    destruct nth_error eqn:E; inversion H.
-    rewrite !subst_instance_mkApps.
-    eapply cumul_cofix_proj. fold subst_instance.
-    unfold unfold_cofix.
-    rewrite nth_error_map. destruct nth_error; cbn.
-     1: rewrite subst_instance_subst cofix_subst_instance_subst.
-    all: now inversion E.
-  - rewrite subst_instance_two. solve [econstructor; eauto].
-  - rewrite !subst_instance_mkApps.
-    eapply cumul_proj. now rewrite nth_error_map H.
-  - eapply cumul_Trans; intuition.
-    * rewrite on_free_vars_ctx_subst_instance; eauto.
-    * rewrite on_free_vars_subst_instance. unfold is_open_term. 
-      replace #|Γ@[u]| with #|Γ|; eauto. rewrite map_length; eauto.
-  - eapply cumul_Evar. eapply All2_map. 
-    eapply All2_impl. 1: tea. cbn; intros. eapply X2.2; eauto.
-  - eapply cumul_Case; try solve [intuition; eauto]. 
-    * destruct X as [X [Xuni [Xcont [_ Xret]]]]. repeat split; eauto; cbn. 
-      + apply All2_map. eapply All2_impl. 1: tea. cbn; intros. eapply X5.2; eauto.
-      + apply precompose_subst_instance. eapply R_universe_instance_impl; eauto.   
-      + rewrite subst_instance_app inst_case_predicate_context_subst_instance in Xret.
-        eapply Xret; eauto.           
-    * eapply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      repeat split; eauto; intuition.
-      rewrite subst_instance_app inst_case_branch_context_subst_instance in b; eauto. 
-  - eapply cumul_Fix. apply All2_map. eapply All2_impl. 1: tea. 
-    cbn; intros; intuition. 
-    rewrite subst_instance_app fix_context_subst_instance in a0; eauto. 
-  - eapply cumul_CoFix. apply All2_map. eapply All2_impl. 1: tea. 
-    cbn; intros; intuition. 
-    rewrite subst_instance_app fix_context_subst_instance in a0; eauto. 
  - repeat rewrite subst_instance_mkApps. eapply cumul_Ind.
     * apply precompose_subst_instance_global.  
       rewrite map_length. eapply R_global_instance_impl_same_napp; try eapply H; eauto.
+      { now apply eq_universe_subst_instance. }
+      { now apply compare_universe_subst_instance. }
     * eapply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      eapply X2.2; eauto.
+      eapply X0.2; eauto.
  - repeat rewrite subst_instance_mkApps. eapply cumul_Construct.
     * apply precompose_subst_instance_global. cbn. 
       rewrite map_length. eapply R_global_instance_impl_same_napp; try eapply H; eauto.
+      { now apply eq_universe_subst_instance. }
+      { now apply compare_universe_subst_instance. }
     * eapply All2_map. eapply All2_impl. 1: tea. cbn; intros.
-      eapply X2.2; eauto.
+      eapply X0.2; eauto.
+  - eapply cumul_Sort. now apply compare_universe_subst_instance.
   - eapply cumul_Const. apply precompose_subst_instance.
-    eapply R_universe_instance_impl; eauto. 
+    eapply R_universe_instance_impl; eauto.
+    now apply compare_universe_subst_instance. 
 Defined. 
+
+Lemma convSpec_subst_instance (Σ : global_env_ext) Γ u A B univs :
+valid_constraints (global_ext_constraints (Σ.1, univs))
+                  (subst_instance_cstrs u Σ) ->
+  Σ ;;; Γ |- A =s B ->
+  (Σ.1,univs) ;;; subst_instance u Γ |- subst_instance u A =s subst_instance u B.
+Proof.
+  apply cumulSpec_subst_instance.
+Qed.
 
 Lemma conv_decls_subst_instance (Σ : global_env_ext) {Γ Γ'} u univs d d' :
   valid_constraints (global_ext_constraints (Σ.1, univs))

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -34,7 +34,7 @@ Lemma weakening_env_convSpec `{CF:checker_flags} Σ Σ' φ Γ M N :
 Proof. 
   intros HΣ' Hextends Ind. 
   revert Γ M N Ind Σ' HΣ' Hextends. 
-  eapply (convSpec0_ind_all Σ (eq_universe (global_ext_constraints (Σ,φ))) 
+  eapply (convSpec0_ind_all (Σ,φ )
             (fun Γ M N => forall Σ' : global_env, wf Σ' -> extends Σ Σ' -> (Σ', φ);;; Γ |- M =s N)); intros; try solve [econstructor; eauto with extends; intuition]. 
   - eapply cumul_Evar. eapply All2_impl. 1: tea. cbn; intros. apply X2.2; eauto.    
   - eapply cumul_Case; intuition.
@@ -56,59 +56,57 @@ Proof.
 
 Ltac subrel := apply subrelations_extends; eauto.
 
-Lemma weakening_env_cumulSpec `{CF:checker_flags} Σ Σ' φ Γ M N :
+Lemma subrelations_compare_extends `{CF:checker_flags} Σ Σ' pb φ :
+  extends Σ Σ' ->
+  RelationClasses.subrelation (compare_universe pb (global_ext_constraints (Σ,φ))) 
+    (compare_universe pb (global_ext_constraints (Σ',φ))).
+Proof. 
+  intros [Σ'' ->] x y e.
+  destruct pb; cbn in *. 
+  - eapply eq_universe_subset; eauto. eapply global_ext_constraints_app.
+  - eapply leq_universe_subset; eauto. eapply global_ext_constraints_app.
+Qed.
+
+Lemma subrelations_eq_compare_extends `{CF:checker_flags} Σ Σ' pb φ :
+  extends Σ Σ' ->
+  RelationClasses.subrelation (eq_universe (global_ext_constraints (Σ,φ))) 
+    (compare_universe pb (global_ext_constraints (Σ',φ))).
+Proof. 
+  intros [Σ'' ->] x y e.
+  destruct pb; cbn in *. 
+  - eapply eq_universe_subset; eauto. eapply global_ext_constraints_app.
+  - eapply leq_universe_subset; eauto. 2:eapply eq_universe_leq_universe; tea.
+    eapply global_ext_constraints_app.
+Qed.
+
+Lemma weakening_env_cumulSpec `{CF:checker_flags} Σ Σ' φ Γ pb M N :
   wf Σ' ->
   extends Σ Σ' ->
-  cumulSpec (Σ, φ) Γ M N ->
-  cumulSpec (Σ', φ) Γ M N.
+  cumulSpec0 (Σ, φ) Γ pb M N ->
+  cumulSpec0 (Σ', φ) Γ pb M N.
+Proof.
   intros HΣ' Hextends Ind.
-  unfold cumulSpec. 
-  pose proof (subrelations_leq__extends _ _  φ Hextends). revert H.
-  assert (RelationClasses.subrelation 
-          (eq_universe (global_ext_constraints (Σ,φ)))
-          (leq_universe (global_ext_constraints (Σ',φ)))). 
-  { etransitivity; try apply subrelations_leq__extends; eauto. 
-    apply eq_universe_leq_universe.  } revert H.
-  generalize (leq_universe (global_ext_constraints (Σ',φ))); intros Rle Hlee Hle . 
-  revert Γ M N Ind Σ' Rle Hle Hlee HΣ' Hextends. 
-  eapply (cumulSpec0_ind_all Σ (eq_universe (global_ext_constraints (Σ,φ))) 
-            (fun Rle Γ M N => forall (Σ' : global_env) Rle', RelationClasses.subrelation Rle Rle' -> RelationClasses.subrelation (eq_universe (global_ext_constraints (Σ,φ))) Rle' -> wf Σ' -> extends Σ Σ' -> cumulSpec0 Σ' (eq_universe (global_ext_constraints (Σ',φ))) Rle' Γ M N)) 
-            with (Rle := leq_universe (global_ext_constraints (Σ,φ))); 
-              intros; try solve [econstructor; eauto with extends; intuition]. 
-  - eapply cumul_Sym. apply X0; eauto. all : apply subrelations_extends; eauto. 
-  - eapply cumul_Evar. eapply All2_impl. 1: tea. cbn; intros. apply X2.2; eauto; subrel.
-  - eapply cumul_App; intuition. eapply X2; eauto; subrel.
-  - eapply cumul_Lambda; intuition. eapply X0; eauto; subrel.
-  - eapply cumul_Prod; intuition. eapply X0; eauto; subrel.
-  - eapply cumul_LetIn; intuition. 
-    + eapply X0; eauto; subrel.
-    + eapply X2; eauto; subrel.
-  - eapply cumul_Case; intuition.
-    * destruct X. repeat split; intuition. 
-      + eapply All2_impl. 1: tea. cbn; intros. apply X.2; eauto; subrel.
+  revert pb Γ M N Ind Σ' HΣ' Hextends.
+  apply: (cumulSpec0_ind_all (Σ,φ)).
+  all:intros; try solve [econstructor; eauto with extends; intuition auto].
+  - eapply cumul_Evar. solve_all.
+  - eapply cumul_Case; intuition auto.
+    * destruct X. repeat split; intuition auto.
+      + solve_all.
       + eapply R_universe_instance_impl'; eauto; subrel.
-      + eapply b; eauto; subrel.
-    * eapply X1; eauto; subrel.      
-    * eapply All2_impl. 1: tea. cbn; intros. intuition.
-      eapply b; eauto; subrel.
-  - eapply cumul_Proj. eapply X0; eauto; subrel.
-  - eapply cumul_Fix. eapply All2_impl. 1: tea. cbn; intros. intuition.
-    + eapply a1; eauto;subrel.
-    + eapply a0; eauto;subrel.
-  - eapply cumul_CoFix. eapply All2_impl. 1: tea. cbn; intros. intuition.
-    + eapply a1; eauto; subrel.
-    + eapply a0; eauto; subrel.
-  - eapply cumul_Ind.
-    * eapply @R_global_instance_weaken_env with (Re := eq_universe (global_ext_constraints (Σ, φ))) (Rle := Rle); eauto. 
-      subrel.
-    * eapply All2_impl. 1: tea. cbn; intros. intuition.  
-      apply b; eauto; subrel. 
-  - eapply cumul_Construct.
-    * eapply @R_global_instance_weaken_env with (Re := eq_universe (global_ext_constraints (Σ, φ))) (Rle := Rle); eauto. 
-      subrel.
-    * eapply All2_impl. 1: tea. cbn; intros. intuition. 
-      apply b; eauto; subrel. 
-  - eapply cumul_Const; eauto. eapply R_universe_instance_impl'; eauto; subrel.  
+    * solve_all.
+  - eapply cumul_Fix; solve_all.
+  - eapply cumul_CoFix; solve_all.
+  - eapply cumul_Ind; eauto. 2:solve_all.
+    eapply @R_global_instance_weaken_env. 1,2,6:eauto. all:try subrel.
+    * now apply subrelations_compare_extends.
+    * now apply subrelations_eq_compare_extends.
+  - eapply cumul_Construct; eauto. 2:solve_all.
+    eapply @R_global_instance_weaken_env. 1,2,6:eauto. all:try subrel.
+    * now apply subrelations_compare_extends.
+    * now apply subrelations_eq_compare_extends.
+  - eapply cumul_Sort. eapply subrelations_compare_extends; tea.
+  - eapply cumul_Const. eapply R_universe_instance_impl'; eauto; subrel.
 Defined.
 
 Lemma weakening_env_conv_decls {cf} {Σ φ Σ' Γ Γ'} :

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -529,52 +529,46 @@ Section CheckEnv.
     typing_result (∥ context_equality_rel le Σ Γ Δ Δ' ∥) :=
     check_equality_ctx (wf_env_ext_wf Σ) Σ (wf_env_ext_graph_wf Σ) le Γ Δ Δ' wfΔ wfΔ'.
   
-  Program Definition check_eq_term le (Σ : wf_env_ext) t u : typing_result (∥ compare_term le Σ Σ t u ∥) :=
-    check <- check_eq_true (if le then leqb_term Σ Σ t u else eqb_term Σ Σ t u) (Msg "Terms are not equal") ;;
+  Program Definition check_eq_term pb (Σ : wf_env_ext) t u : typing_result (∥ compare_term pb Σ Σ t u ∥) :=
+    check <- check_eq_true (eqb_termp Σ Σ pb t u) (Msg "Terms are not equal") ;;
     ret _.
     Next Obligation.
       destruct Σ as [Σ wfΣ G wfG]; simpl in *. sq.
-      destruct le; simpl.
-      - eapply leqb_term_spec in check; sq; auto.
-        eapply wfΣ.
-      - eapply eqb_term_spec in check; sq; auto.
-        apply wfΣ.
+      apply eqb_termp_napp_spec in check; sq; auto. eapply wfΣ.
     Qed.
 
-  Program Definition check_eq_decl le (Σ : wf_env_ext) d d' : typing_result (∥ eq_decl le Σ Σ d d' ∥) := 
+  Program Definition check_eq_decl pb (Σ : wf_env_ext) d d' : typing_result (∥ compare_decl pb Σ Σ d d' ∥) := 
     match d, d' return typing_result _ with
     | {| decl_name := na; decl_body := Some b; decl_type := ty |},
       {| decl_name := na'; decl_body := Some b'; decl_type := ty' |} => 
       eqna <- check_eq_true (eqb_binder_annot na na') (Msg "Binder annotations do not match") ;;
-      eqb <- check_eq_term false Σ b b' ;;
-      leqty <- check_eq_term le Σ ty ty' ;;
+      eqb <- check_eq_term Conv Σ b b' ;;
+      leqty <- check_eq_term pb Σ ty ty' ;;
       ret (let 'sq eqb := eqb in 
             let 'sq leqty := leqty in
             sq _)
     | {| decl_name := na; decl_body := None; decl_type := ty |},
       {| decl_name := na'; decl_body := None; decl_type := ty' |} => 
       eqna <- check_eq_true (eqb_binder_annot na na') (Msg "Binder annotations do not match") ;;
-      cumt <- check_eq_term le Σ ty ty' ;;
+      cumt <- check_eq_term pb Σ ty ty' ;;
       ret (let 'sq cumt := cumt in sq _)  
     | _, _ => raise (Msg "While checking syntactic cumulativity of contexts: declarations do not match")
     end.
     Next Obligation.
       eapply eqb_binder_annot_spec in eqna.
-      constructor; auto. red in leqty.
-      destruct le; auto.
+      constructor; auto.
     Qed.
     Next Obligation.
       eapply eqb_binder_annot_spec in eqna.
-      constructor; auto. red in cumt.
-      destruct le; auto.
+      constructor; auto. 
     Qed.
     
-  Program Fixpoint check_leq_context (le : bool) (Σ : wf_env_ext) Γ Δ : typing_result (∥ eq_context le Σ Σ Γ Δ ∥) :=
+  Program Fixpoint check_compare_context (pb : conv_pb) (Σ : wf_env_ext) Γ Δ : typing_result (∥ PCUICEquality.compare_context pb Σ Σ Γ Δ ∥) :=
     match Γ, Δ with
     | [], [] => ret (sq (All2_fold_nil _))
     | decl :: Γ, decl' :: Δ => 
-      cctx <- check_leq_context le Σ Γ Δ ;;
-      cdecl <- check_eq_decl le Σ decl decl' ;;
+      cctx <- check_compare_context pb Σ Γ Δ ;;
+      cdecl <- check_eq_decl pb Σ decl decl' ;;
       ret _
     | _, _ => raise (Msg "While checking equality of contexts: contexts do not have the same length")
     end.
@@ -590,12 +584,12 @@ Section CheckEnv.
       intuition congruence.
     Qed.
 
-  Program Fixpoint check_leq_terms (le : bool) (Σ : wf_env_ext) l l' : typing_result (∥ All2 (compare_term le Σ Σ) l l' ∥) :=
+  Program Fixpoint check_leq_terms (pb : conv_pb) (Σ : wf_env_ext) l l' : typing_result (∥ All2 (compare_term pb Σ Σ) l l' ∥) :=
     match l, l' with
     | [], [] => ret (sq All2_nil)
     | t :: l, t' :: l' => 
-      cctx <- check_leq_terms le Σ l l' ;;
-      cdecl <- check_eq_term le Σ t t' ;;
+      cctx <- check_leq_terms pb Σ l l' ;;
+      cdecl <- check_eq_term pb Σ t t' ;;
       ret _
     | _, _ => raise (Msg "While checking equality of term lists: lists do not have the same length")
     end.
@@ -949,7 +943,7 @@ Section CheckEnv.
     etransitivity.
     symmetry.
     epose proof (red_expand_let (isType_wf_local isty)).
-    epose proof (weakening_equality (le:=false) (Γ := Γ ,, decl) (Γ' := []) (Γ'' := Δ)).
+    epose proof (weakening_equality (pb:=Conv) (Γ := Γ ,, decl) (Γ' := []) (Γ'' := Δ)).
     simpl in X0.
     eapply X0.
     symmetry. eapply red_conv. apply X. fvs. eapply isType_wf_local, wf_local_closed_context in isty'. fvs.
@@ -1367,7 +1361,7 @@ Section CheckEnv.
   Qed.
 
   Lemma eq_decl_eq_decl_upto (Σ : global_env_ext) x y : 
-    eq_decl true Σ Σ x y ->
+    compare_decl Cumul Σ Σ x y ->
     eq_decl_upto_gen Σ (eq_universe Σ) (leq_universe Σ) x y.
   Proof.
     intros []; constructor; intuition auto. cbn. constructor.
@@ -1410,7 +1404,7 @@ Section CheckEnv.
     reflexivity. tc. tc.
   Qed.
   Lemma leq_context_cumul_context (Σ : global_env_ext) Γ Δ Δ' : 
-    eq_context true Σ Σ Δ Δ' ->
+    PCUICEquality.compare_context Cumul Σ Σ Δ Δ' ->
     PCUICConversionSpec.cumul_ctx_rel Σ Γ Δ Δ'.
   Proof.
     intros eqc.
@@ -1556,11 +1550,11 @@ Section CheckEnv.
            TODO: do as in Coq's kernel and implement a routine that takes whnfs of both sides and compare
            syntactically the heads. *)
         check_args <- wrap_error wfext.(@wf_env_ext_env cf) (string_of_kername id)
-          (check_leq_context true wfext 
+          (check_compare_context Cumul wfext
             (subst_instance u (expand_lets_ctx (ind_params mdecl) (smash_context [] (cstr_args cs))))
             (subst_instance u' (expand_lets_ctx (ind_params mdecl) (smash_context [] (cstr_args cs))))) ;;
         check_indices <- wrap_error wfext.(@wf_env_ext_env cf) (string_of_kername id)
-          (check_leq_terms false wfext
+          (check_leq_terms Conv wfext
             (map (subst_instance u ∘ expand_lets (ind_params mdecl ,,, cs.(cstr_args))) (cstr_indices cs))
             (map (subst_instance u' ∘ expand_lets (ind_params mdecl ,,, cs.(cstr_args))) (cstr_indices cs))) ;;
         ret _
@@ -1864,7 +1858,7 @@ Section CheckEnv.
       | Some ((univs0, u), u') => 
         '(exist wfext eq) <- make_wf_env_ext Σ id univs0 ;;
         checkctx <- wrap_error wfext.(@wf_env_ext_env cf) (string_of_kername id)
-          (check_leq_context true wfext
+          (check_compare_context Cumul wfext
             (subst_instance u (expand_lets_ctx (ind_params mdecl) (smash_context [] indices)))
             (subst_instance u' (expand_lets_ctx (ind_params mdecl) (smash_context [] indices)))) ;;
         ret _

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -199,21 +199,21 @@ Section Conversion.
     intros Γ t p w q s ht.
     rewrite R_aux_equation_1.
     unshelve eapply dlexmod_Acc.
-    - intros x y [e]. constructor. eapply eq_term_sym. assumption.
-    - intros x y z [e1] [e2]. constructor. eapply eq_term_trans. all: eauto.
+    - intros x y [e]. constructor. symmetry. assumption.
+    - intros x y z [e1] [e2]. constructor. etransitivity. all: eauto.
     - intro u. eapply Subterm.wf_lexprod.
       + intro. eapply posR_Acc.
       + intros [w' q'].
         unshelve eapply dlexmod_Acc.
-        * intros x y [e]. constructor. eapply eq_term_sym. assumption.
-        * intros x y z [e1] [e2]. constructor. eapply eq_term_trans. all: eauto.
+        * intros x y [e]. constructor. symmetry. assumption.
+        * intros x y z [e1] [e2]. constructor. etransitivity. all: eauto.
         * intros [t' h']. eapply Subterm.wf_lexprod.
           -- intro. eapply posR_Acc.
           -- intro. eapply stateR_Acc.
         * intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]].
           eexists _,_. intuition eauto using sq.
-          constructor. eapply eq_term_trans. all: eauto.
-        * intros x. exists (sq (eq_term_refl _ _ _)). intros [[q'' h] ?].
+          constructor. etransitivity. all: eauto.
+        * intros x. exists (sq (compare_term_refl _ _ _)). intros [[q'' h] ?].
           unfold R_aux_obligations_obligation_2.
           simpl. f_equal. f_equal.
           eapply uip.
@@ -237,8 +237,8 @@ Section Conversion.
         * eapply wcored_wf.
     - intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]].
       eexists _,_. intuition eauto using sq.
-      constructor. eapply eq_term_trans. all: eauto.
-    - intros x. exists (sq (eq_term_refl _ _ _)). intros [[q' h] [? [? ?]]].
+      constructor. etransitivity. all: eauto.
+    - intros x. exists (sq (compare_term_refl _ _ _)). intros [[q' h] [? [? ?]]].
       unfold R_aux_obligations_obligation_1.
       simpl. f_equal. f_equal.
       eapply uip.
@@ -1285,13 +1285,13 @@ Section Conversion.
   
   Arguments LevelSet.mem : simpl never.
 
-  Notation conv_pb_relb := (conv_pb_relb G).
+  Notation compare_universeb := (compare_universeb G).
 
-  Lemma conv_pb_relb_complete leq u u' :
+  Lemma compare_universeb_complete leq u u' :
     wf_universe Σ u ->
     wf_universe Σ u' ->
-    conv_pb_rel leq (global_ext_constraints Σ) u u' ->
-    conv_pb_relb leq u u'.
+    compare_universe leq (global_ext_constraints Σ) u u' ->
+    compare_universeb leq u u'.
   Proof.
     intros all1 all2 conv.
     destruct heΣ.
@@ -1308,14 +1308,14 @@ Section Conversion.
     UnivExpr.get_level (UnivExpr.make l) = l.
   Proof. now destruct l. Qed.
   
-  Lemma conv_pb_relb_make_complete leq x y :
+  Lemma compare_universeb_make_complete leq x y :
     wf_universe_level Σ x ->
     wf_universe_level Σ y ->
-    conv_pb_rel leq (global_ext_constraints Σ) (Universe.make x) (Universe.make y) ->
-    conv_pb_relb leq (Universe.make x) (Universe.make y).
+    compare_universe leq (global_ext_constraints Σ) (Universe.make x) (Universe.make y) ->
+    compare_universeb leq (Universe.make x) (Universe.make y).
   Proof.
     intros wfx wfy r.
-    apply conv_pb_relb_complete; auto.
+    apply compare_universeb_complete; auto.
     - intros ? ->%UnivExprSet.singleton_spec; auto.
     - intros ? ->%UnivExprSet.singleton_spec; auto.
   Qed.
@@ -1336,27 +1336,27 @@ Section Conversion.
       cbn in *.
       apply Bool.andb_true_iff.
       split.
-      + apply (conv_pb_relb_make_complete Conv); auto.
+      + apply (compare_universeb_make_complete Conv); auto.
       + now apply IHu.
   Qed.
 
   Lemma compare_universe_variance_complete leq v u u' :
     wf_universe_level Σ u ->
     wf_universe_level Σ u' ->
-    R_universe_variance (eq_universe Σ) (conv_pb_rel leq Σ) v u u' ->
-    compare_universe_variance (check_eqb_universe G) (conv_pb_relb leq) v u u'.
+    R_universe_variance (eq_universe Σ) (compare_universe leq Σ) v u u' ->
+    compare_universe_variance (check_eqb_universe G) (compare_universeb leq) v u u'.
   Proof.
     intros memu memu' r.
     destruct v; cbn in *; auto.
-    - apply conv_pb_relb_make_complete; auto.
-    - apply (conv_pb_relb_make_complete Conv); auto.
+    - apply compare_universeb_make_complete; auto.
+    - apply (compare_universeb_make_complete Conv); auto.
   Qed.
 
   Lemma compare_universe_instance_variance_complete leq v u u' :
     wf_universe_instance Σ u ->
     wf_universe_instance Σ u' ->
-    R_universe_instance_variance (eq_universe Σ) (conv_pb_rel leq Σ) v u u' ->
-    compare_universe_instance_variance (check_eqb_universe G) (conv_pb_relb leq) v u u'.
+    R_universe_instance_variance (eq_universe Σ) (compare_universe leq Σ) v u u' ->
+    compare_universe_instance_variance (check_eqb_universe G) (compare_universeb leq) v u u'.
   Proof.
     intros memu memu' r.
     induction u in v, u', memu, memu', r |- *.
@@ -1376,8 +1376,8 @@ Section Conversion.
   Lemma compare_global_instance_complete u v leq gr napp :
     wf_universe_instance Σ u ->
     wf_universe_instance Σ v ->
-    R_global_instance Σ (eq_universe Σ) (conv_pb_rel leq Σ) gr napp u v ->
-    compare_global_instance Σ (check_eqb_universe G) (conv_pb_relb leq) gr napp u v.
+    R_global_instance Σ (eq_universe Σ) (compare_universe leq Σ) gr napp u v ->
+    compare_global_instance Σ (check_eqb_universe G) (compare_universeb leq) gr napp u v.
   Proof.
     intros consu consv r.
     unfold compare_global_instance, R_global_instance, R_opt_variance in *.
@@ -1588,12 +1588,12 @@ Section Conversion.
                forall (leq : conv_pb) (Δh : context_hole) (t : term) (Δh' : context_hole) (t' : term),
                  Δ = fill_context_hole Δh t ->
                  Δ' = fill_context_hole Δh' t' ->
-                 ∥ context_equality_rel false Σ Γ (context_hole_context Δh) (context_hole_context Δh')∥ ->
+                 ∥ context_equality_rel Conv Σ Γ (context_hole_context Δh) (context_hole_context Δh')∥ ->
                  ConversionResult (conv_cum leq Σ (Γ,,, context_hole_context Δh) t t'))
             (Δpre Δ'pre Δpost Δ'post : context)
             (eq : Δ = Δpre ,,, Δpost)
             (eq' : Δ' = Δ'pre ,,, Δ'post) :
-    ConversionResult (∥context_equality_rel false Σ Γ Δpre Δ'pre∥) by struct Δpre := {
+    ConversionResult (∥context_equality_rel Conv Σ Γ Δpre Δ'pre∥) by struct Δpre := {
 
     isconv_context_aux Γ Γ' Δ Δ' cc check [] [] Δpost Δ'post eq eq' => yes;
 
@@ -1732,9 +1732,9 @@ Section Conversion.
                forall (leq : conv_pb) (Δh : context_hole) (t : term) (Δh' : context_hole) (t' : term),
                  Δ = fill_context_hole Δh t ->
                  Δ' = fill_context_hole Δh' t' ->
-                 ∥context_equality_rel false Σ Γ (context_hole_context Δh) (context_hole_context Δh')∥ ->
+                 ∥context_equality_rel Conv Σ Γ (context_hole_context Δh) (context_hole_context Δh')∥ ->
                  ConversionResult (conv_cum leq Σ (Γ,,, context_hole_context Δh) t t'))
-    : ConversionResult (∥context_equality_rel false Σ Γ Δ Δ'∥) :=
+    : ConversionResult (∥context_equality_rel Conv Σ Γ Δ Δ'∥) :=
     isconv_context_aux Γ Γ' Δ Δ' cc check Δ Δ' [] [] eq_refl eq_refl.
 
   Lemma case_conv_brs_inv {Γ ci br br' p c brs1 brs2 π}
@@ -2320,7 +2320,7 @@ Section Conversion.
           forall Ξ,
             is_closed_context (Γ ,,, Ξ) ->
             #|Ξ| = i ->
-            equality_open_decls false Σ (Γ ,,, Ξ) d d'
+            equality_open_decls Conv Σ (Γ ,,, Ξ) d d'
         ) 0 l l'
       )
     end.
@@ -2659,7 +2659,7 @@ Section Conversion.
   Qed.
   
   Lemma conv_cum_red_conv_inv leq Γ Γ' t1 t2 t1' t2' :
-    context_equality false Σ Γ Γ' ->
+    context_equality Conv Σ Γ Γ' ->
     red Σ Γ t1 t1' ->
     red Σ Γ' t2 t2' ->
     sq_equality leq Σ Γ t1 t2 ->
@@ -5159,9 +5159,6 @@ Section Conversion.
       rewrite on_free_vars_mkApps in h2. now apply andb_true_iff in h2 as [].
   Qed.
 
-  Lemma leq_rel_conv_pb_dir leq : leq_rel (conv_pb_dir leq) = conv_pb_rel leq.
-  Proof. destruct leq; reflexivity. Qed.
-
   Next Obligation.
     unfold eqb_termp_napp in noteq.
     destruct ir1 as (notapp1&[whδ1]), ir2 as (notapp2&[whδ2]).
@@ -5197,7 +5194,6 @@ Section Conversion.
          apply inversion_Ind in typ2 as (?&?&?&?&?&?); auto.
          apply consistent_instance_ext_wf in c0.
          apply consistent_instance_ext_wf in c.
-         rewrite leq_rel_conv_pb_dir in H3.
          apply compare_global_instance_complete in H3; auto.
          rewrite PCUICParallelReductionConfluence.eqb_refl in noteq.
          apply All2_length in rargs1.
@@ -5218,7 +5214,6 @@ Section Conversion.
          apply inversion_Construct in typ2 as (?&?&?&?&?&?&?); auto.
          apply consistent_instance_ext_wf in c0.
          apply consistent_instance_ext_wf in c.
-         rewrite leq_rel_conv_pb_dir in H4.
          apply compare_global_instance_complete in H4; auto.
          rewrite !PCUICParallelReductionConfluence.eqb_refl in noteq.
          apply All2_length in rargs1.
@@ -5248,8 +5243,7 @@ Section Conversion.
       simpl in h2.
       apply inversion_Sort in h2 as (_&h2&_); auto.
       apply inversion_Sort in h1 as (_&h1&_); auto.
-      rewrite leq_rel_conv_pb_dir in H0.      
-      eapply conv_pb_relb_complete in H0; eauto.
+      eapply compare_universeb_complete in H0; eauto.
       congruence.
   Qed.
   

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -107,7 +107,7 @@ Lemma inductive_cumulative_indices_smash {cf : checker_flags} {Σ : global_env_e
   let indctx' := idecl.(ind_indices)@[u'] in
   let pindctx := subst_context_let_expand (List.rev pars) (ind_params mdecl)@[u] (smash_context [] indctx) in
   let pindctx' := subst_context_let_expand (List.rev pars') (ind_params mdecl)@[u'] (smash_context [] indctx') in
-  context_equality_rel true Σ Γ pindctx pindctx'.
+  context_equality_rel Cumul Σ Γ pindctx pindctx'.
 Proof.
   intros ind mdecl idecl u u' napp isdecl up cu cu' hR Γ pars pars' sppars sppars' eq.
   unshelve epose proof (spine_subst_smash_inv _ sppars) as [parsubst sppars2].

--- a/template-coq/theories/TermEquality.v
+++ b/template-coq/theories/TermEquality.v
@@ -263,17 +263,15 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 
-(* ** Syntactic conversion up-to universes *)
+(* ** Syntactic conversion/cumulativity up-to universes *)
 
-Definition eq_term `{checker_flags} Σ φ :=
-  eq_term_upto_univ Σ (eq_universe φ) (eq_universe φ).
+Definition compare_term `{checker_flags} (pb : conv_pb) Σ φ :=
+  eq_term_upto_univ Σ (eq_universe φ) (compare_universe pb φ).
 
-(* ** Syntactic cumulativity up-to universes *)
+Notation eq_term := (compare_term Conv).
+Notation leq_term := (compare_term Cumul).
 
-Definition leq_term `{checker_flags} Σ φ :=
-  eq_term_upto_univ Σ (eq_universe φ) (leq_universe φ).
-
-  Lemma R_global_instance_refl Σ Re Rle gr napp u : 
+Lemma R_global_instance_refl Σ Re Rle gr napp u : 
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
   R_global_instance Σ Re Rle gr napp u u.

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -6,6 +6,7 @@ Require Import ssreflect.
 Local Open Scope nat_scope.
 Local Open Scope string_scope2.
 
+Implicit Types (cf : checker_flags).
 
 Ltac absurd :=
   match goal with
@@ -1620,9 +1621,8 @@ Section Univ.
     intros [l r]. now eapply leq_universe_antisym.
   Defined.
 
-
-  Definition eq_universe_leq_universe' {cf} φ u u'
-    := @eq_universe_leq_universe cf φ u u'.
+  Definition eq_universe_leq_universe' φ u u'
+    := @eq_universe_leq_universe φ u u'.
   Definition leq_universe_refl' φ u
     := @leq_universe_refl φ u.
 
@@ -2203,3 +2203,32 @@ Section no_prop_leq_type.
   Qed.
 
 End no_prop_leq_type.
+
+Definition compare_universe {cf:checker_flags} (pb : conv_pb) :=
+  match pb with
+  | Conv => eq_universe
+  | Cumul => leq_universe
+  end.
+  
+#[global] Instance compare_universe_subrel {cf} pb Σ : RelationClasses.subrelation (eq_universe Σ) (compare_universe pb Σ).
+Proof.
+  destruct pb; tc.
+Qed.
+
+#[global]
+Instance compare_universe_refl {cf} pb Σ : RelationClasses.Reflexive (compare_universe pb Σ).
+Proof.
+  destruct pb; tc.
+Qed.
+
+#[global]
+Instance compare_universe_trans {cf} pb Σ : RelationClasses.Transitive (compare_universe pb Σ).
+Proof.
+  destruct pb; tc.
+Qed.
+
+#[global]
+Instance compare_universe_preorder {cf} pb Σ : RelationClasses.PreOrder (compare_universe pb Σ).
+Proof.
+  destruct pb; tc.
+Qed.


### PR DESCRIPTION
Also factorize `conv_decls/cumul_decls/conv_context/cumul_context` based on this: there is only one generic `All_decls_alpha_pb` to compare two declarations, which can be customized depending on the test we want on types/let-bodies.