### PR TITLE
Efficient universe structures

### DIFF
--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -6,10 +6,6 @@
 # src/classes0.ml
 
 # From Coq's stdlib
-# src/mSetWeakList.mli
-# src/mSetWeakList.ml
-# src/eqdepFacts.mli
-# src/eqdepFacts.ml
 src/orderedTypeAlt.mli
 src/orderedTypeAlt.ml
 

--- a/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
+++ b/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
@@ -372,7 +372,7 @@ Proof.
                         /\ In c' (CS.elements ctrs)).
     1: intuition.
     apply iff_ex; intro. apply and_iff_compat_l. symmetry.
-    etransitivity. 1: eapply CS.elements_spec1.
+    etransitivity. 1: symmetry; apply CS.elements_spec1.
     etransitivity. 1: eapply SetoidList.InA_alt.
     split; intro; eauto.
     now destruct H as [? [[] ?]].

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -4332,18 +4332,6 @@ Proof. reflexivity. Qed.
 
 Notation levels_of_list := LevelSetProp.of_list.
 
-Lemma levels_of_list_app l l' : 
-  levels_of_list (l ++ l') = 
-  LevelSet.union (levels_of_list l) 
-    (levels_of_list l').
-Proof.
-  rewrite /LevelSetProp.of_list fold_right_app.
-  induction l; cbn.
-  now rewrite LevelSet_union_empty.
-  apply LevelSet.eq_leibniz. red.
-  rewrite IHl. rewrite LevelSetProp.union_add //.
-Qed.
-
 From Coq Require Import MSetDecide.
 
 Module ConstraintSetDecide := WDecide (ConstraintSet).
@@ -4355,31 +4343,6 @@ Definition aulevels inst cstrs :
 Proof.
   cbn.
   now rewrite mapi_unfold.
-Qed.
-
-#[global] Instance unfold_proper {A} : Proper (eq ==> `=1` ==> eq) (@unfold A).
-Proof.
-  intros x y -> f g eqfg.
-  induction y; cbn; auto. f_equal; auto. f_equal. apply eqfg.
-Qed.
-
-(* sLemma unfold_add {A} n k (f : nat -> A) : skipn k (unfold (k + n) f) = unfold k (fun x => f (x + n)). *)
-
-Lemma unfold_add {A} n k (f : nat -> A) : unfold (n + k) f = unfold k f ++ unfold n (fun x => f (x + k)).
-Proof.
-  induction n in k |- *.
-  cbn. now rewrite app_nil_r.
-  cbn. rewrite IHn. now rewrite app_assoc.
-Qed.
-
-
-Definition unfold_levels_app n k : 
-  LevelSetProp.of_list (unfold (n + k) Level.Var) = 
-  LevelSet.union (LevelSetProp.of_list (unfold k Level.Var))
-    (LevelSetProp.of_list (unfold n (fun i => Level.Var (k + i)))).
-Proof.
-  rewrite unfold_add levels_of_list_app //.
-  now setoid_rewrite Nat.add_comm at 1.
 Qed.
 
 Lemma levels_of_list_spec l ls : 

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -1995,7 +1995,7 @@ Proof.
                         /\ In c' (CS.elements ctrs)).
     1: intuition.
     apply iff_ex; intro. apply and_iff_compat_l. symmetry.
-    etransitivity. 1: eapply CS.elements_spec1.
+    etransitivity. 1: symmetry; eapply CS.elements_spec1.
     etransitivity. 1: eapply SetoidList.InA_alt.
     split; intro; eauto.
     now destruct H as [? [[] ?]].

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -700,6 +700,7 @@ Section Wcbv.
   Proof.
     destruct d, d'.
     destruct d, d0.
+
     assert (d0 = d) as -> by now apply uip.
     assert (e1 = e2) as -> by now apply uip.
     assert (e = e0) as -> by now apply uip.

--- a/safechecker/Makefile.plugin.local
+++ b/safechecker/Makefile.plugin.local
@@ -1,4 +1,5 @@
 CAMLFLAGS+=-open Metacoq_template_plugin
+CAMLFLAGS+=-w -8 # Non-exhaustive matches due to translation of comparison to int
 CAMLFLAGS+=-w -33 # Unused opens
 CAMLFLAGS+=-w -32 # Unused values
 CAMLFLAGS+=-w -34 # Unused types

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -6,8 +6,6 @@
 # src/classes0.ml
 
 # From Coq's stdlib
-src/mSetWeakList.mli
-src/mSetWeakList.ml
 src/eqdepFacts.mli
 src/eqdepFacts.ml
 

--- a/safechecker/src/metacoq_safechecker_plugin.mlpack
+++ b/safechecker/src/metacoq_safechecker_plugin.mlpack
@@ -1,4 +1,4 @@
-MSetWeakList
+MSetAVL
 EqdepFacts
 Utils
 

--- a/safechecker/src/metacoq_safechecker_plugin.mlpack
+++ b/safechecker/src/metacoq_safechecker_plugin.mlpack
@@ -1,4 +1,3 @@
-MSetAVL
 EqdepFacts
 Utils
 

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -26,6 +26,26 @@ Local Set Keyed Unification.
 Set Equations Transparent.
 
 Import MCMonadNotation.
+Require Import Morphisms.
+
+Instance proper_add_level_edges levels : Morphisms.Proper (wGraph.EdgeSet.Equal ==> wGraph.EdgeSet.Equal)%signature (add_level_edges levels).
+Proof.
+  intros e e' he.
+  rewrite /add_level_edges.
+  rewrite !VSet.fold_spec.
+  induction (VSet.elements levels) in e, e', he |- *; cbn; auto.
+  apply IHl. destruct variable_of_level => //.
+  now rewrite he.
+Qed.
+
+Instance proper_add_uctx cstrs : Morphisms.Proper (Equal_graph ==> Equal_graph)%signature (add_uctx cstrs).
+Proof.
+  intros g g' eq. rewrite /add_uctx; cbn.
+  split. cbn. now rewrite (proj1 eq).
+  cbn. split => //.
+  rewrite /add_level_edges. now rewrite (proj1 (proj2 eq)).
+  apply eq.
+Qed.
 
 (** It otherwise tries [auto with *], very bad idea. *)
 Ltac Coq.Program.Tactics.program_solve_wf ::= 
@@ -248,10 +268,7 @@ Section CheckEnv.
 
   Section UniverseChecks.
   Obligation Tactic := idtac.
-
-  Instance proper_is_true : Proper (eq ==> eq) is_true.
-  Proof. now intros x y ->. Qed.
-
+ 
   Program Definition check_udecl id (Σ : global_env) (HΣ : ∥ wf Σ ∥) G
           (HG : is_graph_of_uctx G (global_uctx Σ)) (udecl : universes_decl)
     : EnvCheck (∑ uctx', gc_of_uctx (uctx_of_udecl udecl) = Some uctx' /\
@@ -330,14 +347,11 @@ Section CheckEnv.
       rewrite {}HΣctrs {}Hctrs in H. simpl in H.
       destruct gc_of_constraints. simpl in H.
       inversion Huctx; subst; clear Huctx.
-      clear -H H2 cf. setoid_rewrite add_uctx_make_graph in H2.
+      clear -H H2 cf HG. rewrite -HG add_uctx_make_graph in H2.
       red; rewrite -H2. apply is_acyclic_proper.
-      + assert(Equal_graph (make_graph (global_ext_levels (Σ, udecl), t)) 
-          (make_graph (global_ext_levels (Σ, udecl), (GoodConstraintSet.union ctrs Σctrs)))).
-        red. split. cbn. reflexivity. split.
+      + red. split. cbn. reflexivity. split.
         unfold make_graph. simpl.
         now rewrite H. simpl. reflexivity.
-        apply H0.
       + now simpl in H. 
     Qed.
 
@@ -351,22 +365,20 @@ Section CheckEnv.
     intros. simpl.
     destruct uctx as [uctx' [gcof onu]].
     subst G'.
-    simpl. split.
+    simpl. split; [|sq; pcuic].
     red in wfG |- *.
     unfold global_ext_uctx, gc_of_uctx. simpl.
     unfold gc_of_uctx in gcof. simpl in gcof.
     unfold gc_of_uctx in wfG. unfold global_ext_constraints. simpl in wfG |- *.
     pose proof (gc_of_constraints_union (constraints_of_udecl ext) (global_constraints Σ)).
     destruct (gc_of_constraints (global_constraints Σ)); simpl in *; auto.
-    destruct (gc_of_constraints (constraints_of_udecl ext)); simpl in *; auto.
-    noconf gcof.
+    destruct (gc_of_constraints (constraints_of_udecl ext)); simpl in *; auto; noconf gcof.
     simpl in H.
     destruct gc_of_constraints; simpl in *; auto.
-    symmetry. subst G.
-    rewrite add_uctx_make_graph.
-    apply graph_eq; simpl; auto.
-    reflexivity. now rewrite H. discriminate.
-    sq. pcuic.
+    symmetry. rewrite -wfG add_uctx_make_graph. simpl.
+    unfold make_graph. simpl. split; simpl. reflexivity.
+    split; try reflexivity.
+    now rewrite H.
   Qed.
 
   Program Definition make_wf_env_ext (Σ : wf_env) id (ext : universes_decl) : 
@@ -2054,6 +2066,60 @@ Section CheckEnv.
 
   Obligation Tactic := Program.Tactics.program_simpl.
 
+  Definition cs_equal (x y : ContextSet.t) : Prop :=
+    LevelSet.Equal x.1 y.1 /\ ConstraintSet.Equal x.2 y.2.
+
+  Definition gcs_equal x y : Prop :=
+    LevelSet.Equal x.1 y.1 /\ GoodConstraintSet.Equal x.2 y.2.
+  
+  Require Import Relation_Definitions.
+
+  Definition R_opt {A} (R : relation A) : relation (option A) :=
+    fun x y => match x, y with
+      | Some x, Some y => R x y
+      | None, None => True
+      | _, _ => False
+    end.
+
+  Instance gc_of_constraints_proper : Proper (ConstraintSet.Equal ==> R_opt GoodConstraintSet.Equal) gc_of_constraints.
+  Proof.
+    intros c c' eqc; cbn.
+    destruct (gc_of_constraintsP c);
+    destruct (gc_of_constraintsP c'); cbn.
+    - intros cs; rewrite i i0. firstorder eauto.
+    - destruct e0 as [cs [incs gcn]].
+      apply eqc in incs. destruct (e cs incs) as [? []]. congruence.
+    - destruct e as [cs [incs gcn]].
+      apply eqc in incs. destruct (e0 cs incs) as [? []]. congruence.
+    - exact I.
+  Qed.
+
+  Instance proper_add_level_edges' : Morphisms.Proper (LevelSet.Equal ==> wGraph.EdgeSet.Equal ==> wGraph.EdgeSet.Equal)%signature add_level_edges.
+  Proof.
+    intros l l' hl e e' <-.
+    intros x; rewrite !add_level_edges_spec. firstorder eauto.
+  Qed.
+  
+  Instance make_graph_proper : Proper (gcs_equal ==> Equal_graph) make_graph.
+  Proof.
+    intros [v c] [v' c'] [eqv eqc]; cbn.
+    unfold make_graph; cbn in *.
+    split; cbn; auto.
+    split; cbn; try reflexivity.
+    now rewrite eqc eqv.
+  Qed.
+  Require Import SetoidTactics.
+
+  Instance is_graph_of_uctx_proper G : Proper (cs_equal ==> iff) (is_graph_of_uctx G).
+  Proof.
+    intros [l c] [l' c'] [eql eqc]; cbn.
+    unfold is_graph_of_uctx; cbn. cbn in *.
+    pose proof (gc_of_constraints_proper _ _ eqc).
+    destruct (gc_of_constraints c); cbn in *; destruct (gc_of_constraints c'); cbn.
+    now setoid_replace (l, t) with (l', t0) using relation gcs_equal. elim H. elim H.
+    intuition.
+  Qed.
+
   Program Fixpoint check_wf_env (Σ : global_env)
     : EnvCheck (∑ G, (is_graph_of_uctx G (global_uctx Σ) /\ ∥ wf Σ ∥)) :=
     match Σ with
@@ -2072,7 +2138,7 @@ Section CheckEnv.
         end
     end.
   Next Obligation.
-    repeat constructor.
+    constructor. red. cbn. reflexivity. repeat constructor.
   Qed.
   Next Obligation.
     sq. split; eauto.
@@ -2093,11 +2159,10 @@ Section CheckEnv.
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
     intros Σctrs HΣctrs; rewrite HΣctrs in H0, i; simpl in *.
     destruct (gc_of_constraints (ConstraintSet.union _ _)).
-    simpl in H0. 
-    subst G. unfold global_ext_levels; simpl.
-    symmetry. rewrite add_uctx_make_graph.
-    apply graph_eq. simpl. reflexivity.
-    simpl. now rewrite H0. simpl. reflexivity.
+    simpl in H0. unfold global_ext_levels; simpl.
+    symmetry. rewrite -i add_uctx_make_graph.
+    simpl. split; simpl. reflexivity. split. 
+    now rewrite H0. reflexivity.
     now simpl in H0.
   Qed.
   Next Obligation.
@@ -2123,14 +2188,13 @@ Section CheckEnv.
       [|intro HH; rewrite HH in i; cbn in i; contradiction i].
     intros Σctrs HΣctrs; rewrite HΣctrs in H1, i; simpl in *.
     destruct (gc_of_constraints (ConstraintSet.union _ _)).
-    simpl in H1.
-    subst G. unfold global_ext_levels; simpl.
+    simpl in H1. unfold global_ext_levels; simpl.
     assert (eq: monomorphic_levels_decl g
                 = levels_of_udecl (universes_decl_of_decl g)). {
       destruct g. destruct c, cst_universes0; try discriminate; reflexivity.
       destruct m, ind_universes0; try discriminate; reflexivity. }
-    rewrite eq. simpl. rewrite add_uctx_make_graph.
-    apply graph_eq; try reflexivity.
+    rewrite eq. simpl. rewrite -i add_uctx_make_graph.
+    split; try reflexivity.
     simpl. now rewrite H1.
     now simpl in H1.
   Qed.
@@ -2145,7 +2209,11 @@ Section CheckEnv.
       destruct g. destruct c, cst_universes0; try discriminate; reflexivity.
       destruct m, ind_universes0; try discriminate; reflexivity. }
     rewrite eq1; clear eq1.
-    now rewrite LevelSet_union_empty CS_union_empty.
+    setoid_replace (LevelSet.union LevelSet.empty (global_levels Σ),
+    ConstraintSet.union ConstraintSet.empty (global_constraints Σ)) with
+      (global_levels Σ, global_constraints Σ) using relation cs_equal.
+      apply i.
+    split; cbn; auto using LevelSet_union_empty, CS_union_empty.
   Qed.
 
   Obligation Tactic := idtac.
@@ -2173,10 +2241,8 @@ Section CheckEnv.
     destruct (gc_of_constraints (global_constraints Σ)) eqn:HΣcstrs; auto.
     simpl. unfold global_ext_levels; simpl.
     destruct (gc_of_constraints (ConstraintSet.union _ _)); simpl in H => //.
-    simpl.
-    subst G. symmetry. rewrite add_uctx_make_graph.
-    apply graph_eq; try reflexivity.
-    now simpl; rewrite H.
+    simpl. rewrite -i add_uctx_make_graph.
+    apply make_graph_proper. split; auto. reflexivity.
     sq; split; auto.
   Qed.
 
@@ -2243,9 +2309,9 @@ Section CheckEnv.
     simpl. unfold global_ext_levels; simpl.
     destruct (gc_of_constraints (ConstraintSet.union _ _)); simpl in H => //.
     simpl. simpl in i.
-    subst x. symmetry. rewrite add_uctx_make_graph.
-    apply graph_eq; try reflexivity.
-    now simpl; rewrite H. simpl in H.
+    rewrite -i add_uctx_make_graph. apply make_graph_proper.
+    split; auto; try reflexivity.
+    simpl in H.
     destruct (gc_of_constraints (ConstraintSet.union _ _)); simpl in H => //.
   Qed.
   Next Obligation.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -249,6 +249,9 @@ Section CheckEnv.
   Section UniverseChecks.
   Obligation Tactic := idtac.
 
+  Instance proper_is_true : Proper (eq ==> eq) is_true.
+  Proof. now intros x y ->. Qed.
+
   Program Definition check_udecl id (Σ : global_env) (HΣ : ∥ wf Σ ∥) G
           (HG : is_graph_of_uctx G (global_uctx Σ)) (udecl : universes_decl)
     : EnvCheck (∑ uctx', gc_of_uctx (uctx_of_udecl udecl) = Some uctx' /\
@@ -327,15 +330,14 @@ Section CheckEnv.
       rewrite {}HΣctrs {}Hctrs in H. simpl in H.
       destruct gc_of_constraints. simpl in H.
       inversion Huctx; subst; clear Huctx.
-      clear -H H2 cf. rewrite add_uctx_make_graph in H2.
-      refine (eq_rect _ (fun G => wGraph.is_acyclic G = true) H2 _ _).
-      apply graph_eq; try reflexivity.
-      + assert(make_graph (global_ext_levels (Σ, udecl), t) = 
-        make_graph (global_ext_levels (Σ, udecl), (GoodConstraintSet.union ctrs Σctrs))).
-        apply graph_eq. simpl; reflexivity.
+      clear -H H2 cf. setoid_rewrite add_uctx_make_graph in H2.
+      red; rewrite -H2. apply is_acyclic_proper.
+      + assert(Equal_graph (make_graph (global_ext_levels (Σ, udecl), t)) 
+          (make_graph (global_ext_levels (Σ, udecl), (GoodConstraintSet.union ctrs Σctrs)))).
+        red. split. cbn. reflexivity. split.
         unfold make_graph. simpl.
         now rewrite H. simpl. reflexivity.
-        rewrite H0. reflexivity.
+        apply H0.
       + now simpl in H. 
     Qed.
 

--- a/safechecker/theories/PCUICWfEnv.v
+++ b/safechecker/theories/PCUICWfEnv.v
@@ -1,6 +1,6 @@
 
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import ProofIrrelevance.
+From Coq Require Import ssreflect.
 From MetaCoq.Template Require Import config utils uGraph.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICReflect PCUICTyping PCUICGlobalEnv.
@@ -55,8 +55,9 @@ Section GraphSpec.
       rewrite -> XX in *; simpl in *; [|contradiction].
     unfold gc_of_uctx in XX; simpl in XX.
     destruct (gc_of_constraints Σ); [|discriminate].
-    inversion XX; subst. generalize (global_ext_levels Σ); intros lvs; cbn.
-    reflexivity.
+    inversion XX; subst.
+    unfold is_true. rewrite !LevelSet.mem_spec. 
+    symmetry. apply HG. 
   Qed.
 
 End GraphSpec.

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -68,7 +68,8 @@ gen-src/primInt63.ml
 gen-src/primInt63.mli
 gen-src/uint0.ml
 gen-src/uint0.mli
-
+gen-src/int0.ml
+gen-src/int0.mli
 gen-src/sumbool.mli
 gen-src/sumbool.ml
 gen-src/zeven.mli
@@ -127,6 +128,8 @@ gen-src/mSetInterface.ml
 gen-src/mSetInterface.mli
 gen-src/mSetList.ml
 gen-src/mSetList.mli
+gen-src/mSetAVL.ml
+gen-src/mSetAVL.mli
 gen-src/mSetProperties.ml
 gen-src/mSetProperties.mli
 gen-src/nat0.ml

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -23,10 +23,12 @@ OrdersTac
 OrdersFacts
 OrdersLists
 OrderedType0
+Int0
 MSetInterface
 MSetFacts
 MSetDecide
 MSetList
+MSetAVL
 MSetProperties
 BinNums
 EqDec

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -192,7 +192,7 @@ struct
         CErrors.user_err ~hdr:"unquote_level" (str "It is not possible to unquote a fresh level in Strict Unquote Universe Mode.")
       else
         let evm, l = Evd.new_univ_level_variable (Evd.UnivFlexible false) evm in
-        Feedback.msg_info (str"Fresh level " ++ Univ.Level.pr l ++ str" was added to the context.");
+        debug (fun () -> str"Fresh level " ++ Univ.Level.pr l ++ str" was added to the context.");
         evm, l
     else if constr_equall h lzero then
       match args with
@@ -227,7 +227,7 @@ struct
         CErrors.user_err ~hdr:"unquote_universe" (str "It is not possible to unquote a fresh universe in Strict Unquote Universe Mode.")
       else
         let evm, u = Evd.new_univ_variable (Evd.UnivFlexible false) evm in
-        Feedback.msg_info (str"Fresh universe " ++ Univ.Universe.pr u ++ str" was added to the context.");
+        debug (fun () -> str"Fresh universe " ++ Univ.Universe.pr u ++ str" was added to the context.");
         evm, u
     else if constr_equall h lSProp then
       match args with

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -175,7 +175,6 @@ struct
   (* let tto_kernel_repr = ast "universe.to_kernel_repr" *)
   let tof_levels = ast "universe.of_levels"
   let tLevelSet_of_list = ast "universe.of_list"
-
   let noprop_tSet = ast "noproplevel.lzero"
   let noprop_tLevel = ast "noproplevel.Level"
   let noprop_tLevelVar = ast "noproplevel.Var"
@@ -196,7 +195,9 @@ struct
   let tConstraintSet = ast "ConstraintSet.t_"
   let tConstraintSetempty = ast "ConstraintSet.empty"
   let tConstraintSetadd = ast "ConstraintSet.add"
+  let tConstraintSet_elements = ast "ConstraintSet.elements"
   let tLevelSet = ast "LevelSet.t"
+  let tLevelSet_elements = ast "LevelSet.elements"
   let tmake_univ_constraint = ast "make_univ_constraint"
   let tinit_graph = ast "graph.init"
   (* FIXME this doesn't exist! *)

--- a/template-coq/src/g_template_coq.mlg
+++ b/template-coq/src/g_template_coq.mlg
@@ -22,13 +22,6 @@ open Stdarg
 open Tacarg
 open Genredexpr
 
-let _ = Goptions.declare_bool_option {
-  Goptions.optdepr = false;
-  Goptions.optkey = ["Template";"Cast";"Propositions"];
-  Goptions.optread = (fun () -> !Quoter.cast_prop);
-  Goptions.optwrite = (fun a -> Quoter.cast_prop:=a);
-}
-
 (* If strict unquote universe mode is on then fail when unquoting a non *)
 (* declared universe / an empty list of level expressions. *)
 (* Otherwise, add it / a fresh level the global environnment. *)

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -137,6 +137,7 @@ Register MetaCoq.Template.Universes.Polymorphic_ctx as metacoq.ast.Polymorphic_c
 Register MetaCoq.Template.Universes.ConstraintSet.t_ as metacoq.ast.ConstraintSet.t_.
 Register MetaCoq.Template.Universes.ConstraintSet.empty as metacoq.ast.ConstraintSet.empty.
 Register MetaCoq.Template.Universes.ConstraintSet.add as metacoq.ast.ConstraintSet.add.
+Register MetaCoq.Template.Universes.ConstraintSet.elements as metacoq.ast.ConstraintSet.elements.
 
 Register MetaCoq.Template.Universes.UContext.t as metacoq.ast.UContext.t.
 Register MetaCoq.Template.Universes.UContext.make as metacoq.ast.UContext.make.
@@ -144,6 +145,7 @@ Register MetaCoq.Template.Universes.AUContext.t as metacoq.ast.AUContext.t.
 Register MetaCoq.Template.Universes.AUContext.make as metacoq.ast.AUContext.make.
 
 Register MetaCoq.Template.Universes.LevelSet.t_ as metacoq.ast.LevelSet.t.
+Register MetaCoq.Template.Universes.LevelSet.elements as metacoq.ast.LevelSet.elements.
 Register MetaCoq.Template.Universes.UnivConstraint.make as metacoq.ast.make_univ_constraint.
 
 Register MetaCoq.Template.common.uGraph.init_graph as metacoq.ast.graph.init.

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -435,7 +435,7 @@ Proof.
   destruct (Z.eqb_spec z z0); constructor. now subst.
   cong.
 Defined.
-
+(* 
 Definition eqb_ConstraintSet x y :=
   eqb (ConstraintSet.this x) (ConstraintSet.this y).
 
@@ -449,7 +449,7 @@ Proof.
   - f_equal; apply uip.
   - congruence.
 Defined.
-
+ *)
 Definition eqb_LevelSet x y :=
   eqb (LevelSet.this x) (LevelSet.this y).
 
@@ -463,13 +463,13 @@ Proof.
   - f_equal; apply uip.
   - congruence.
 Defined.
-
+(* 
 Definition eqb_universes_decl x y :=
   match x, y with
   | Monomorphic_ctx cx, Monomorphic_ctx cy => eqb cx cy
   | Polymorphic_ctx cx, Polymorphic_ctx cy => eqb cx cy
   | _, _ => false
-  end.
+  end. *)
 
 Ltac finish_reflect :=
   (repeat
@@ -477,13 +477,13 @@ Ltac finish_reflect :=
     | |- context[eqb ?a ?b] => destruct (eqb_spec a b); [subst|constructor; congruence]
     end);
   constructor; trivial; congruence.
-
+(* 
 #[global] Instance reflect_universes_decl : ReflectEq universes_decl.
 Proof.
   refine {| eqb := eqb_universes_decl |}.
   unfold eqb_universes_decl.
   intros [] []; finish_reflect.
-Defined.
+Defined. *)
 
 Definition eqb_allowed_eliminations x y :=
   match x, y with

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -435,41 +435,189 @@ Proof.
   destruct (Z.eqb_spec z z0); constructor. now subst.
   cong.
 Defined.
-(* 
-Definition eqb_ConstraintSet x y :=
-  eqb (ConstraintSet.this x) (ConstraintSet.this y).
 
-#[global] Instance reflect_ConstraintSet : ReflectEq ConstraintSet.t.
+#[global] Instance Z_as_int : ReflectEq Int.Z_as_Int.t.
 Proof.
-  refine {| eqb := eqb_ConstraintSet |}.
-  intros [thisx okx] [thisy oky].
-  unfold eqb_ConstraintSet.
-  cbn -[eqb].
-  destruct (eqb_spec thisx thisy); subst; constructor.
-  - f_equal; apply uip.
-  - congruence.
+  refine {| eqb := Z.eqb |}.
+  apply Z.eqb_spec.
 Defined.
- *)
-Definition eqb_LevelSet x y :=
-  eqb (LevelSet.this x) (LevelSet.this y).
 
-#[global] Instance reflect_LevelSet : ReflectEq LevelSet.t.
+
+Scheme level_lt_ind_dep := Induction for Level.lt_ Sort Prop.
+Scheme constraint_type_lt_ind_dep := Induction for ConstraintType.lt_ Sort Prop.
+Scheme constraint_lt_ind_dep := Induction for UnivConstraint.lt_ Sort Prop.
+Derive Signature for UnivConstraint.lt_.
+Derive Signature for le.
+Set Equations With UIP.
+
+Derive NoConfusion EqDec for comparison.
+
+Lemma string_compare_irrel {s s'} {c} (H H' : string_compare s s' = c) : H = H'.
 Proof.
-  refine {| eqb := eqb_LevelSet |}.
-  intros [thisx okx] [thisy oky].
-  unfold eqb_LevelSet.
-  cbn -[eqb].
-  destruct (eqb_spec thisx thisy); subst; constructor.
-  - f_equal; apply uip.
-  - congruence.
-Defined.
-(* 
+  apply uip.
+Qed.  
+
+Scheme le_ind_prop := Induction for le Sort Prop.
+
+Lemma nat_le_irrel {x y : nat} (l l' : x <= y) : l = l'.
+Proof.
+  induction l using le_ind_prop; depelim l'.
+  - reflexivity.
+  - lia.
+  - lia.
+  - f_equal. apply IHl.
+Qed.
+
+Lemma lt_level_irrel {x y : Level.t} (l l' : Level.lt_ x y) : l = l'.
+Proof.
+  induction l using level_lt_ind_dep; depelim l'; auto.
+  - now replace s0 with s2 by apply uip.
+  - f_equal. apply nat_le_irrel.
+Qed.
+
+Lemma constraint_type_lt_level_irrel {x y} (l l' : ConstraintType.lt_ x y) : l = l'.
+Proof.
+  induction l using constraint_type_lt_ind_dep; depelim l'; auto.
+  f_equal. apply uip.
+Qed.
+
+Require Import RelationClasses.
+Existing Instance ConstraintType.lt_strorder.
+    
+Lemma constraint_lt_irrel (x y : UnivConstraint.t) (l l' : UnivConstraint.lt_ x y) : l = l'.
+Proof.
+  revert l'. induction l using constraint_lt_ind_dep.
+  - intros l'. depelim l'.
+    now rewrite (lt_level_irrel l l4).
+    now elim (irreflexivity (R:=ConstraintType.lt) l4).
+    now elim (irreflexivity l4).
+  - intros l'; depelim l'.
+    now elim (irreflexivity (R:=ConstraintType.lt) l).
+    now rewrite (constraint_type_lt_level_irrel l l4).
+    now elim (irreflexivity l4).
+  - intros l'; depelim l'.
+    now elim (irreflexivity l).
+    now elim (irreflexivity l).
+    now rewrite (lt_level_irrel l l4).
+Qed.
+
+Module LevelSetsUIP.
+  Import LevelSet.Raw.
+  
+  Fixpoint levels_tree_eqb (x y : LevelSet.Raw.t) := 
+  match x, y with
+  | LevelSet.Raw.Leaf, LevelSet.Raw.Leaf => true
+  | LevelSet.Raw.Node h l o r, LevelSet.Raw.Node h' l' o' r' => 
+    eqb h h' && levels_tree_eqb l l' && eqb o o' && levels_tree_eqb r r'
+  | _, _ => false
+  end.
+  
+  Scheme levels_tree_rect := Induction for LevelSet.Raw.tree Sort Type.
+
+  #[global] Instance levels_tree_reflect : ReflectEq LevelSet.Raw.t.
+  Proof.
+    refine {| eqb := levels_tree_eqb |}.
+    induction x using levels_tree_rect; destruct y; try constructor; auto; try congruence.
+    cbn [levels_tree_eqb].
+    destruct (eqb_spec t0 t2); try constructor; auto; try congruence.
+    destruct (IHx1 y1); try constructor; auto; try congruence.
+    destruct (eqb_spec t1 t3); try constructor; auto; try congruence.
+    destruct (IHx2 y2); try constructor; auto; try congruence.
+  Qed.
+  
+  Derive NoConfusion for LevelSet.Raw.tree.
+  Derive Signature for LevelSet.Raw.bst.
+  
+  Definition eqb_LevelSet x y :=
+    eqb (LevelSet.this x) (LevelSet.this y).
+  
+  Lemma ok_irrel (x : t) (o o' : Ok x) : o = o'.
+  Proof.
+    unfold Ok in *.
+    induction o.
+    - now depelim o'.
+    - depelim o'. f_equal; auto.
+      clear -l0 l2. red in l0, l2.
+      extensionality y. extensionality inl.
+      apply lt_level_irrel.
+      extensionality y. extensionality inl.
+      apply lt_level_irrel.
+  Qed.
+
+  #[global] Instance reflect_LevelSet : ReflectEq LevelSet.t.
+  Proof.
+    refine {| eqb := eqb_LevelSet |}.
+    intros [thisx okx] [thisy oky].
+    unfold eqb_LevelSet.
+    cbn -[eqb].
+    destruct (eqb_spec thisx thisy); subst; constructor.
+    - f_equal. apply ok_irrel.
+    - congruence.
+  Defined.
+End LevelSetsUIP.
+
+Module ConstraintSetsUIP.
+  Import ConstraintSet.Raw.
+
+  Fixpoint cs_tree_eqb (x y : t) := 
+    match x, y with
+    | ConstraintSet.Raw.Leaf, ConstraintSet.Raw.Leaf => true
+    | ConstraintSet.Raw.Node h l o r, ConstraintSet.Raw.Node h' l' o' r' => 
+      eqb h h' && cs_tree_eqb l l' && eqb o o' && cs_tree_eqb r r'
+    | _, _ => false
+    end.
+
+  Scheme cs_tree_rect := Induction for ConstraintSet.Raw.tree Sort Type.
+
+  #[global] Instance cs_tree_reflect : ReflectEq ConstraintSet.Raw.t.
+  Proof.
+    refine {| eqb := cs_tree_eqb |}.
+    induction x using cs_tree_rect; destruct y; try constructor; auto; try congruence.
+    cbn [cs_tree_eqb].
+    destruct (eqb_spec t0 t1); try constructor; auto; try congruence.
+    destruct (IHx1 y1); try constructor; auto; try congruence.
+    destruct (eqb_spec p p0); try constructor; auto; try congruence.
+    destruct (IHx2 y2); try constructor; auto; try congruence.
+  Qed.
+
+  Definition eqb_ConstraintSet x y :=
+    eqb (ConstraintSet.this x) (ConstraintSet.this y).
+
+  Derive NoConfusion for ConstraintSet.Raw.tree.
+  Derive Signature for ConstraintSet.Raw.bst.
+
+  Lemma ok_irrel (x : t) (o o' : Ok x) : o = o'.
+  Proof.
+    unfold Ok in *.
+    induction o.
+    - now depelim o'.
+    - depelim o'. f_equal; auto.
+      clear -l0 l2. red in l0, l2.
+      extensionality y. extensionality inl.
+      apply constraint_lt_irrel.
+      extensionality y. extensionality inl.
+      apply constraint_lt_irrel.
+  Qed.
+
+  #[global] Instance reflect_ConstraintSet : ReflectEq ConstraintSet.t.
+  Proof.
+    refine {| eqb := eqb_ConstraintSet |}.
+    intros [thisx okx] [thisy oky].
+    unfold eqb_ConstraintSet. cbn.
+    cbn -[eqb].
+    destruct (eqb_spec thisx thisy); subst; constructor.
+    - f_equal. apply ok_irrel.
+    - congruence.
+  Defined.
+
+End ConstraintSetsUIP.
+ 
 Definition eqb_universes_decl x y :=
   match x, y with
   | Monomorphic_ctx cx, Monomorphic_ctx cy => eqb cx cy
   | Polymorphic_ctx cx, Polymorphic_ctx cy => eqb cx cy
   | _, _ => false
-  end. *)
+  end.
 
 Ltac finish_reflect :=
   (repeat
@@ -477,13 +625,13 @@ Ltac finish_reflect :=
     | |- context[eqb ?a ?b] => destruct (eqb_spec a b); [subst|constructor; congruence]
     end);
   constructor; trivial; congruence.
-(* 
+ 
 #[global] Instance reflect_universes_decl : ReflectEq universes_decl.
 Proof.
   refine {| eqb := eqb_universes_decl |}.
   unfold eqb_universes_decl.
   intros [] []; finish_reflect.
-Defined. *)
+Defined.
 
 Definition eqb_allowed_eliminations x y :=
   match x, y with

--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -163,7 +163,7 @@ Defined.
 
 #[global] Instance eqb_ctx : ReflectEq context := _.
 
-Definition eqb_constant_body (x y : constant_body) :=
+(* Definition eqb_constant_body (x y : constant_body) :=
   let (tyx, bodyx, univx) := x in
   let (tyy, bodyy, univy) := y in
   eqb tyx tyy && eqb bodyx bodyy && eqb univx univy.
@@ -230,4 +230,4 @@ Proof.
   refine {| eqb := eqb_global_decl |}.
   unfold eqb_global_decl.
   intros [] []; finish_reflect.
-Defined.
+Defined. *)

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -157,7 +157,7 @@ Module Level.
 
 End Level.
 
-Module LevelSet := MSetList.MakeWithLeibniz Level.
+Module LevelSet := MSetAVL.Make Level.
 Module LevelSetFact := WFactsOn Level LevelSet.
 Module LevelSetProp := WPropertiesOn Level LevelSet.
 Module LevelSetDecide := WDecide (LevelSet).
@@ -195,10 +195,8 @@ Proof.
     * rewrite LevelSet.add_spec. intuition auto.
 Qed.
 
-Lemma LevelSet_union_empty s : LevelSet.union LevelSet.empty s = s.
+Lemma LevelSet_union_empty s : LevelSet.Equal (LevelSet.union LevelSet.empty s) s.
 Proof.
-  apply LevelSet.eq_leibniz.
-  change LevelSet.eq with LevelSet.Equal.
   intros x; rewrite LevelSet.union_spec. lsets.
 Qed.
 

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -1,4 +1,4 @@
-From Coq Require Import MSetList MSetFacts MSetProperties MSetDecide.
+From Coq Require Import MSetList MSetAVL MSetFacts MSetProperties MSetDecide.
 From MetaCoq.Template Require Import utils BasicAst config.
 From Equations Require Import Equations.
 Require Import ssreflect.
@@ -1173,15 +1173,13 @@ Module UnivConstraint.
   Definition eq_leibniz (x y : t) : eq x y -> x = y := id.
 End UnivConstraint.
 
-Module ConstraintSet := MSetList.MakeWithLeibniz UnivConstraint.
+Module ConstraintSet := MSetAVL.Make UnivConstraint.
 Module ConstraintSetFact := WFactsOn UnivConstraint ConstraintSet.
 Module ConstraintSetProp := WPropertiesOn UnivConstraint ConstraintSet.
 Module CS := ConstraintSet.
 
-Lemma CS_union_empty s : ConstraintSet.union ConstraintSet.empty s = s.
+Lemma CS_union_empty s : ConstraintSet.Equal (ConstraintSet.union ConstraintSet.empty s) s.
 Proof.
-  apply ConstraintSet.eq_leibniz.
-  change ConstraintSet.eq with ConstraintSet.Equal.
   intros x; rewrite ConstraintSet.union_spec. lsets.
 Qed.
 
@@ -1206,17 +1204,6 @@ Proof.
   intros s s' eqs.
   unfold CS.For_all. split; intros IH x inxs; apply (IH x);
   now apply eqs.
-Qed.
-
-(* Being built up from sorted lists without duplicates, constraint sets have 
-  decidable equality. This is however not used in the development. *)
-Set Equations With UIP.
-Remark ConstraintSet_EqDec : EqDec ConstraintSet.t.
-Proof.
-  intros p p'.
-  destruct (ConstraintSet.eq_dec p p').
-  - now left; eapply ConstraintSet.eq_leibniz in e.
-  - right. intros ->. apply n. reflexivity.
 Qed.
 
 (** {6 Universe instances} *)

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -95,6 +95,7 @@ Module Level.
   | ltLevelLevel s s' : string_lt s s' -> lt_ (Level s) (Level s')
   | ltLevelVar s n : lt_ (Level s) (Var n)
   | ltVarVar n n' : Nat.lt n n' -> lt_ (Var n) (Var n').
+  Derive Signature for lt_.
 
   Definition lt := lt_.
 
@@ -1078,6 +1079,7 @@ Module ConstraintType.
   Inductive lt_ : t -> t -> Prop :=
   | LeLe n m : (n < m)%Z -> lt_ (Le n) (Le m)
   | LeEq n : lt_ (Le n) Eq.
+  Derive Signature for lt_.
   Definition lt := lt_.
 
   Lemma lt_strorder : StrictOrder lt.

--- a/template-coq/theories/utils/MCCompare.v
+++ b/template-coq/theories/utils/MCCompare.v
@@ -182,7 +182,7 @@ Proof.
   - apply GT. red. now apply string_compare_lt.
 Qed.
 
-Lemma transitive_string_lt : Transitive string_lt.
+#[local] Instance transitive_string_lt : Transitive string_lt.
 Proof.
   red. unfold string_lt.
   intro s; induction s.
@@ -200,7 +200,6 @@ Proof.
       intro Hy1. eapply transitive_ascii_lt in Ha.
       specialize (Ha Hy1). now rewrite Ha.
 Qed.
-
 
 Lemma CompareSpec_Proper : Proper (iff ==> iff ==> iff ==> Logic.eq ==> iff) CompareSpec.
   intros A A' HA B B' HB C C' HC c c' [].
@@ -222,6 +221,25 @@ Proof.
       all: reflexivity.
     + reflexivity.
     + apply ascii_compare_Lt in H; now rewrite H.
+Qed.
+
+Lemma string_compare_Opp (x y : string) : string_compare x y = CompOpp (string_compare y x).
+Proof.
+  destruct (CompareSpec_string x y). subst.
+  rewrite (proj2 (string_compare_eq _ _)); auto.
+  rewrite (proj1 (string_compare_lt _ _)); auto.
+  rewrite (proj2 (string_compare_lt _ _)); auto.
+  red in H.
+  now apply string_compare_lt.
+Qed.
+
+Lemma string_compare_trans (x y z : string) c : string_compare x y = c -> string_compare y z = c -> string_compare x z = c.
+Proof.
+  destruct (CompareSpec_string x y); subst; intros <-;
+  destruct (CompareSpec_string y z); subst; try congruence.
+  eapply transitivity in H0. 2:eassumption. now red in H0.
+  eapply transitivity in H. 2:eassumption. red in H.
+  now apply string_compare_lt in H.
 Qed.
 
 Definition ascii_lt_irreflexive : Irreflexive ascii_lt.

--- a/template-coq/theories/utils/wGraph.v
+++ b/template-coq/theories/utils/wGraph.v
@@ -1,5 +1,5 @@
 Require Import ZArith Zcompare Lia ssrbool.
-Require Import MSets.MSetList MSetFacts MSetProperties.
+Require Import MSetAVL MSetFacts MSetProperties.
 From MetaCoq.Template Require Import MCUtils.
 Require Import ssreflect.
 From Equations Require Import Equations.
@@ -269,12 +269,7 @@ Import Nbar.
 
 Require Import MSetDecide MSetInterface.
 
-Module Type UsualOrderedTypeWithLeibniz.
-  Include UsualOrderedType.
-  Parameter eq_leibniz : forall x y, eq x y -> x = y.
-End UsualOrderedTypeWithLeibniz.
-
-Module WeightedGraph (V : UsualOrderedTypeWithLeibniz) (VSet : MSetList.SWithLeibniz with Module E := V).
+Module WeightedGraph (V : UsualOrderedType) (VSet : MSetInterface.S with Module E := V).
   Module VSetFact := WFactsOn V VSet.
   Module VSetProp := WPropertiesOn V VSet.
   Module VSetDecide := WDecide (VSet).
@@ -339,7 +334,7 @@ Module WeightedGraph (V : UsualOrderedTypeWithLeibniz) (VSet : MSetList.SWithLei
     Definition eq_leibniz : forall x y, eq x y -> x = y := fun x y eq => eq.
     
   End Edge.
-  Module EdgeSet:= MSets.MSetList.MakeWithLeibniz Edge.
+  Module EdgeSet:= MSetAVL.Make Edge.
   Module EdgeSetFact := WFactsOn Edge EdgeSet.
   Module EdgeSetProp := WPropertiesOn Edge EdgeSet.
   Module EdgeSetDecide := WDecide (EdgeSet).

--- a/template-coq/theories/utils/wGraph.v
+++ b/template-coq/theories/utils/wGraph.v
@@ -338,6 +338,7 @@ Module WeightedGraph (V : UsualOrderedType) (VSet : MSetInterface.S with Module 
   Module EdgeSetFact := WFactsOn Edge EdgeSet.
   Module EdgeSetProp := WPropertiesOn Edge EdgeSet.
   Module EdgeSetDecide := WDecide (EdgeSet).
+  Ltac esets := EdgeSetDecide.fsetdec.
 
   Definition t := (VSet.t * EdgeSet.t * V.t)%type.
 

--- a/test-suite/extractable.v
+++ b/test-suite/extractable.v
@@ -6,6 +6,7 @@ From MetaCoq.Template.TemplateMonad Require Import
      Common Extractable.
 
 Local Open Scope string_scope.
+Import MCMonadNotation.
 
 Notation "<% x %>" := (ltac:(let p y := exact y in quote_term x p))
    (only parsing).
@@ -48,13 +49,6 @@ MetaCoq Run
     (tmBind (tmQuoteInductive (MPfile ["Datatypes"; "Init"; "Coq"], "nat"))
             (fun mi => tmMsg (string_of_nat (length mi.(ind_bodies))))).
 
-Definition empty_constraints : ConstraintSet.t_.
-  econstructor.
-  Unshelve.
-  2:{ exact nil. }
-  constructor.
-Defined.
-
 Definition nAnon := {| binder_name := nAnon; binder_relevance := Relevant |}.
 
 
@@ -69,7 +63,7 @@ MetaCoq Run
                        ; mind_entry_lc := tProd nAnon <% bool %> (tRel 1) ::
                                           tProd nAnon <% string %> (tRel 1) :: nil
                        |} :: nil
-                  ; mind_entry_universes := Monomorphic_entry (LevelSet.empty, empty_constraints)
+                  ; mind_entry_universes := Monomorphic_entry ContextSet.empty
                   ; mind_entry_template := false
                   ; mind_entry_variance := None
                   ; mind_entry_private := None |}).

--- a/test-suite/safechecker_test.v
+++ b/test-suite/safechecker_test.v
@@ -1,36 +1,22 @@
 From MetaCoq.Template Require Import Loader.
 From MetaCoq.SafeChecker Require Import Loader.
+Require Import MetaCoq.SafeChecker.SafeTemplateChecker.
 
 Local Open Scope string_scope.
-MetaCoq SafeCheck nat.
 
+MetaCoq SafeCheck nat.
 (*
 Environment is well-formed and Ind(Coq.Init.Datatypes.nat,0,[]) has type: Sort([Set])
 *)
 
-MetaCoq SafeCheck 3.
 MetaCoq SafeCheck (3 + 1).
 
-MetaCoq Quote Definition foo := (3 + 1).
-
-MetaCoq SafeCheck plus.
-MetaCoq CoqCheck Nat.add.
-
-Require Import MetaCoq.SafeChecker.SafeTemplateChecker.
-
-
 Definition bool_list := List.map negb (cons true (cons false nil)).
-Set Printing Universes.
-(* Universe issues: undeclared universes from sections *)
-(* MetaCoq Quote Recursively Definition boolq := bool_list. *)
 MetaCoq SafeCheck bool_list.
 MetaCoq CoqCheck bool_list.
 
-(* Even with universe checking disabled, we get:
-Error: Type error: Msgundeclared level, while checking MetaCoq.Template.Universes.LevelSet.Raw.elt
-*)
 (* Time MetaCoq SafeCheck @infer_and_print_template_program. *)
-(*
+(* Uses template polymorphism:
 Error:
 Type error: Terms are not <= for cumulativity: Sort([Coq.Init.Datatypes.23,Coq.Init.Datatypes.24]) Sort([Set]) after reduction: Sort([Coq.Init.Datatypes.23,Coq.Init.Datatypes.24]) Sort([Set]), while checking MetaCoq.Template.Universes.Universe.Expr.t
 *)
@@ -43,20 +29,6 @@ Definition bignat : nat := Nat.of_num_uint 10000%uint.
 MetaCoq SafeCheck bignat.
 MetaCoq CoqCheck bignat.
 
-(*Require Import String.
-From MetaCoq.Template Require Import Loader Core TemplateMonad monad_utils Pretty.
-Import MonadNotation.
-Open Scope monad_scope.
-Require Import String.
-Open Scope string_scope.
-Definition topkn s : BasicAst.kername := 
-  (Datatypes.pair (BasicAst.MPfile ("safechecker_test" :: nil)%list) (s))%string.
-
-MetaCoq Quote Recursively Definition prodq := prod_rect.
-
-MetaCoq Run
-  (tmEval cbv (print_program false 2 prodq) >>= tmPrint).
-*)
 Set Universe Polymorphism.
 
 (* Basic notations *)
@@ -557,10 +529,6 @@ Definition isequiv_adjointify {A B : Type} (f : A -> B) (g : B -> A)
   := BuildIsEquiv A B f g (issect' f g issect isretr) isretr
                   (is_adjoint' f g issect isretr).
 
-
-(* MetaCoq Run (tmEval (unfold concatkn)
-  (@safechecker_test.concat) >>=  tmQuote >>= tmPrint). *)
-  (* fun t => tmEval cbv (print_program false 1 t) >>= tmPrint). *)
 
 MetaCoq SafeCheck @issect'.
 


### PR DESCRIPTION
Instead of relying on the highly inefficient weak lists (lists without duplicates, unsorted) to represent sets of levels and constraints everywhere, we introduce a minor quotient to use AVLs instead, greatly improving the representation and performance of the ML code dealing with universes. It only requires a few Proper instances to make it work, so we were not relying too much on the fact that Leibniz equality could be used to compare those, thankfully.