### PR TITLE
Backport change of global universes from master

### DIFF
--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -1,7 +1,6 @@
 -I src
 -Q src MetaCoq.Erasure
 -R theories MetaCoq.Erasure
-
 # src/classes0.mli
 # src/classes0.ml
 

--- a/erasure/theories/ECSubst.v
+++ b/erasure/theories/ECSubst.v
@@ -51,7 +51,7 @@ Proof.
     simpl; try f_equal; eauto; solve_all.
   - destruct (PeanoNat.Nat.compare_spec k n).
     + subst k.
-      rewrite PeanoNat.Nat.leb_refl minus_diag /=.
+      rewrite PeanoNat.Nat.leb_refl Nat.sub_diag /=.
       now rewrite lift_closed.
     + destruct (leb_spec_Set k n); try lia.
       destruct (nth_error_spec [t] (n - k) ).

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -822,20 +822,19 @@ Qed.
 
 Lemma erases_global_closed_env {Σ : global_env} Σ' : wf Σ -> erases_global Σ Σ' -> closed_env Σ'.
 Proof.
-  intros wf er. move: wf.
-  induction er. intros wf.
+  destruct Σ as [univs Σ]; cbn in *.
+  intros [onu wf] er; cbn in *.
+  move: wf. red in er; cbn in er.
+  induction er; intros wf.
   - constructor.
   - cbn. destruct cb' as [[]].
-    cbn in *. intros wf. red in wf; depelim wf.
-    red in o0.
-    rewrite [forallb _ _](IHer wf).
+    cbn in *. depelim wf. 
+    rewrite [forallb _ _](IHer wf) andb_true_r.
     red in H. destruct cb as [ty []]; cbn in *.
-    unshelve eapply PCUICClosedTyp.subject_closed in o0. eapply wf.
-    eapply erases_closed in H; tea. rewrite H //.
-    destruct H.
-    cbn. intros. red in wf. depelim wf.
-    apply IHer, wf.
-  - intros wf. red in wf. depelim wf.
+    unshelve eapply PCUICClosedTyp.subject_closed in o0. cbn. split; auto.
+    eapply erases_closed in H; tea. elim H.
+    cbn. apply IHer. now depelim wf.
+  - depelim wf.
     cbn. apply IHer, wf.
 Qed.
 

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -26,7 +26,7 @@ Program Definition erase_template_program (p : Ast.Env.program)
   (wt : ∥ ∑ T, Typing.typing (Ast.Env.empty_ext p.1) [] p.2 T ∥)
   : (EAst.global_context * EAst.term) :=
   let Σ0 := (trans_global (Ast.Env.empty_ext p.1)).1 in
-  let Σ := (PCUICExpandLets.trans_global_decls Σ0) in
+  let Σ := (PCUICExpandLets.trans_global_env Σ0) in
   let wfΣ := map_squash (PCUICExpandLetsCorrectness.trans_wf_ext ∘
     (template_to_pcuic_env_ext (Ast.Env.empty_ext p.1))) wfΣ in
   let t := ErasureFunction.erase (build_wf_env_ext (empty_ext Σ) wfΣ) nil (PCUICExpandLets.trans (trans Σ0 p.2)) _ in
@@ -37,9 +37,9 @@ Next Obligation.
   sq. destruct wt as [T Ht].
   cbn.
   set (Σ' := empty_ext _).
-  exists (PCUICExpandLets.trans (trans (trans_global_decls p.1) T)).
+  exists (PCUICExpandLets.trans (trans (trans_global_env p.1) T)).
   change Σ' with (PCUICExpandLets.trans_global (trans_global (Ast.Env.empty_ext p.1))).
-  change (@nil (@BasicAst.context_decl term)) with (PCUICExpandLets.trans_local (trans_local (trans_global_decls p.1) [])).
+  change (@nil (@BasicAst.context_decl term)) with (PCUICExpandLets.trans_local (trans_local (trans_global_env p.1) [])).
   eapply (PCUICExpandLetsCorrectness.expand_lets_sound (cf := extraction_checker_flags)).
   apply (template_to_pcuic_typing (Ast.Env.empty_ext p.1));simpl. apply wfΣ0.
   apply Ht. Unshelve. now eapply template_to_pcuic_env.
@@ -72,7 +72,7 @@ Proof.
   set (t' := erase (build_wf_env_ext (empty_ext (PCUICExpandLets.trans_global (trans_global Σ)))
     wftΣ) [] (PCUICExpandLets.trans (trans (trans_global Σ) p.2)) wtp).
   set (deps := (term_global_deps _)).
-  change (empty_ext (PCUICExpandLets.trans_global_decls (trans_global_decls p.1))) with
+  change (empty_ext (PCUICExpandLets.trans_global_env (trans_global_env p.1))) with
     (PCUICExpandLets.trans_global (trans_global Σ)) in *.
   specialize (H (erase_global deps (PCUICExpandLets.trans_global (trans_global Σ)) (sq_wf_ext wftΣ))).
   specialize (H _ deps wtp eq_refl).
@@ -93,7 +93,7 @@ Proof.
   destruct H as [v' [Hv He]].
   sq.
   eapply EOptimizePropDiscr.optimize_correct in He.
-  change (empty_ext (trans_global_decls p.1)) with (trans_global Σ).
+  change (empty_ext (trans_global_env p.1)) with (trans_global Σ).
   set (eΣ := erase_global _ _ _) in *. eexists; exists v'. split => //.
   constructor. exact He. eapply erase_global_closed.
   eapply (erases_closed _ []).

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -1,24 +1,16 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlFloats ExtrOCamlInt63.
+From Coq Require Import Ascii FSets ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlFloats ExtrOCamlInt63.
 From MetaCoq.Template Require Import utils.
 
 (** * Extraction setup for the erasure phase of template-coq.
 
     Any extracted code planning to link with the plugin
     should use these same directives for consistency.
-
-    ExtrOCamlInt63 extracts comparison to int (-1, 0, 1), so one might need to adapt code accordingly.
 *)
 
 Extract Constant ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
-
-(* Ignore [Decimal.int] before the extraction issue is solved:
-   https://github.com/coq/coq/issues/7017. *)
-Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-
+ 
 Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int
            UnivSubst Typing Checker Retyping OrderedType Logic Common ws_cumul_pb Classes Numeral
            Uint63.

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -8,11 +8,7 @@ From MetaCoq.PCUIC Require Import PCUICTyping PCUICAst PCUICAstUtils
 From MetaCoq.SafeChecker Require Import PCUICErrors.
 From Coq Require Import Program ssreflect.
 
-
 Local Existing Instance extraction_checker_flags.
-
-Module PA := PCUICAst.
-Module P := PCUICWcbvEval.
 
 Ltac inv H := inversion H; subst; clear H.
 
@@ -118,7 +114,7 @@ Proof.
   intros m. revert n. induction m; cbn; intros.
   - destruct n; inv H.
   - destruct n.
-    + cbn. now rewrite <- minus_n_O.
+    + cbn. now rewrite Nat.sub_0_r.
     + cbn. rewrite IHm. lia. reflexivity.
 Qed.
 
@@ -130,7 +126,7 @@ Proof.
   intros m. revert n. induction m; cbn; intros.
   - destruct n; inv H.
   - destruct n.
-    + cbn. now rewrite <- minus_n_O.
+    + cbn. now rewrite Nat.sub_0_r.
     + cbn. rewrite IHm. lia. reflexivity.
 Qed.
 
@@ -146,14 +142,14 @@ Proof.
   induction mfix0 using rev_ind.
   - econstructor.
   - rewrite mapi_app. cbn in *. rewrite rev_app_distr. cbn in *.
-    rewrite app_length. cbn. rewrite plus_comm. cbn. econstructor.
+    rewrite app_length. cbn. rewrite Nat.add_comm /=; econstructor.
     + eapply IHmfix0. destruct H as [L]. exists (x :: L). subst. now rewrite <- app_assoc.
     + rewrite <- plus_n_O.
       rewrite PCUICLiftSubst.simpl_subst_k. clear. induction l; cbn; try congruence.
       eapply inversion_Fix in X as (? & ? & ? & ? & ? & ? & ?) ; auto.
       econstructor; eauto. destruct H. subst.
-      rewrite <- app_assoc. rewrite nth_error_app_ge. lia.
-      rewrite minus_diag. cbn. reflexivity.
+      rewrite <- app_assoc, nth_error_app_ge; try lia.
+      now rewrite Nat.sub_diag.
 Qed.
 
 Lemma cofix_subst_nth mfix n :
@@ -164,8 +160,8 @@ Proof.
   intros m. revert n. induction m; cbn; intros.
   - destruct n; inv H.
   - destruct n.
-    + cbn. now rewrite <- minus_n_O.
-    + cbn. rewrite IHm. lia. reflexivity.
+    + cbn. now rewrite Nat.sub_0_r.
+    + cbn. rewrite IHm; lia_f_equal.
 Qed.
 
 Lemma ecofix_subst_nth mfix n :
@@ -176,7 +172,7 @@ Proof.
   intros m. revert n. induction m; cbn; intros.
   - destruct n; inv H.
   - destruct n.
-    + cbn. now rewrite <- minus_n_O.
+    + cbn. now rewrite Nat.sub_0_r.
     + cbn. rewrite IHm. lia. reflexivity.
 Qed.
 
@@ -192,14 +188,14 @@ Proof.
   induction mfix0 using rev_ind.
   - econstructor.
   - rewrite mapi_app. cbn in *. rewrite rev_app_distr. cbn in *.
-    rewrite app_length. cbn. rewrite plus_comm. cbn. econstructor.
+    rewrite app_length /= Nat.add_comm /=. econstructor.
     + eapply IHmfix0. destruct H as [L]. exists (x :: L). subst. now rewrite <- app_assoc.
     + rewrite <- plus_n_O.
       rewrite PCUICLiftSubst.simpl_subst_k. clear. induction l; cbn; try congruence.
       eapply inversion_CoFix in X as (? & ? & ? & ? & ? & ? & ?) ; auto.
       econstructor; eauto. destruct H. subst.
       rewrite <- app_assoc. rewrite nth_error_app_ge. lia.
-      rewrite minus_diag. cbn. reflexivity.
+      now rewrite Nat.sub_diag.
 Qed.
 
 (** ** Prelim on typing *)

--- a/examples/add_constructor.v
+++ b/examples/add_constructor.v
@@ -126,6 +126,6 @@ MetaCoq Run (add_constructor <%@odd%> "foo''"
                     <%(fun (even' odd':nat -> Prop) => odd' 0)%>).
 Definition test4 := foo''.
 Module A.
-MetaCoq Run (add_constructor <%even%> "foo'"
+MetaCoq Run (add_constructor <%@even%> "foo'"
                     <%(fun (even' odd':nat -> Prop) => even' 0)%>).
 End A.

--- a/examples/demo.v
+++ b/examples/demo.v
@@ -168,7 +168,7 @@ Definition mut_list_i : mutual_inductive_entry :=
 
 
 MetaCoq Unquote Inductive mut_list_i.
-
+(* Print demoList. *)
 (** Records *)
 
 Definition one_pt_i : one_inductive_entry :=
@@ -187,7 +187,7 @@ Definition mut_pt_i : mutual_inductive_entry :=
   mind_entry_params := [{| decl_name := bnamed "A"; decl_body := None;
                          decl_type := (tSort Universe.type0) |}];
   mind_entry_inds := [one_pt_i];
-  mind_entry_universes := Monomorphic_entry (LevelSet.empty, ConstraintSet.empty);
+  mind_entry_universes := Monomorphic_entry ContextSet.empty;
   mind_entry_template := false;
   mind_entry_variance := None;
   mind_entry_private := None;

--- a/examples/metacoq_tour.v
+++ b/examples/metacoq_tour.v
@@ -87,7 +87,8 @@ Proof.
 Qed.
 
 (** The extracted typechecker also runs in OCaml *)
-MetaCoq SafeCheck (fun x : nat => x + 1).
+(* FIXME: checker unusable in OCaml due to representation of universes *)
+(* MetaCoq SafeCheck (fun x : nat => x + 1). *)
 
 (** Erasure *)
 From MetaCoq.Erasure Require Import Erasure Loader.

--- a/examples/metacoq_tour_prelude.v
+++ b/examples/metacoq_tour_prelude.v
@@ -23,7 +23,7 @@ Definition univ := Level.Level "s".
 (* TODO move to SafeChecker *)
 
 Definition gctx : global_env_ext := 
-  ([], Monomorphic_ctx (LevelSet.singleton univ, ConstraintSet.empty)).
+  ({| universes := (LevelSet.singleton univ, ConstraintSet.empty); declarations := [] |}, Monomorphic_ctx).
 
 (** We use the environment checker to produce the proof that gctx, which is a singleton with only 
     universe "s" declared  is well-formed. *)

--- a/examples/tauto.v
+++ b/examples/tauto.v
@@ -805,8 +805,8 @@ Proof.
      }
     assert (predicate_size tsize (map_predicate id (subst [tRel 0] k) (subst [tRel 0] (#|pcontext t| + k)) t) <=
       predicate_size tsize t).
-    { apply plus_le_compat; simpl; auto. 2:apply X. destruct X.
-      induction a; simpl; auto. apply le_n_S, plus_le_compat; simpl; auto. }
+    { apply Nat.add_le_mono; simpl; auto. 2:apply X. destruct X.
+      induction a; simpl; auto. apply le_n_S, Nat.add_le_mono; simpl; auto. }
   lia.
   - eapply le_n_S.
     generalize (#|m| + k). intro p.
@@ -1024,13 +1024,13 @@ Section Plugin.
   Inductive NotSolvable (s: string) : Prop := notSolvable: NotSolvable s.
 
   Definition inhabit_formula gamma Mphi Gamma :
-    match reify (empty_ext []) gamma Mphi with
+    match reify (empty_ext empty_global_env) gamma Mphi with
       Some phi => 
       match tauto_proc (size phi) {| hyps := []; concl := phi |} with 
         Valid => sem (concl {| hyps := []; concl := phi |}) (can_val_Prop Gamma)
       | _ => NotSolvable "not a valid formula" end 
     | None => NotSolvable "not a formaula" end.
-    destruct (reify (empty_ext []) gamma Mphi); try exact (notSolvable _).
+    destruct (reify (empty_ext _) gamma Mphi); try exact (notSolvable _).
     destruct (tauto_proc (size f) {| hyps := []; concl := f |}) eqn : e; try exact (notSolvable _).
     exact (tauto_sound (size f) (mkS [] f) e (can_val_Prop Gamma) (trivial_hyp [] _)).
   Defined.

--- a/examples/typing_correctness.v
+++ b/examples/typing_correctness.v
@@ -23,7 +23,7 @@ Definition univ := Level.Level "s".
 (* TODO move to SafeChecker *)
 
 Definition gctx : global_env_ext := 
-  ([], Monomorphic_ctx (LevelSet.singleton univ, ConstraintSet.empty)).
+  ({| universes := (LevelSet.singleton univ, ConstraintSet.empty); declarations := [] |}, Monomorphic_ctx).
 
 (** We use the environment checker to produce the proof that gctx, which is a singleton with only 
     universe "s" declared  is well-formed. *)

--- a/pcuic/theories/Bidirectional/BDStrengthening.v
+++ b/pcuic/theories/Bidirectional/BDStrengthening.v
@@ -24,9 +24,7 @@ Proof.
   intros k.
   rewrite !/shiftnP /shiftn.
   destruct (Nat.ltb_spec k i) => /=.
-  all: case_inequalities => //=.
-  1-2: lia.
-  by rewrite minus_plus.
+  all: case_inequalities => //=; lia_f_equal.
 Qed.
 
 Lemma on_free_vars_rename P f t :
@@ -943,8 +941,7 @@ Proof.
       apply rename_proper ; auto.
       intros x.
       rewrite !rshiftk_S lift_renaming_spec -(shiftn_rshiftk _ _ _) !shiftn_add -lift_renaming_spec.
-      rewrite Nat.add_0_r le_plus_minus_r.
-      1: lia.
+      rewrite Nat.add_0_r Nat.add_comm Nat.sub_add; try lia.
       rewrite (lift_unlift _ _ _) /ren_id /unlift_renaming.
       by move: (iΓ'') => /Nat.ltb_spec0 ->.
     + cbn ; destruct (decl_body decl'') ; rewrite //=.
@@ -955,8 +952,8 @@ Proof.
       change (S (i + _)) with
         (rshiftk (S i) (shiftn (#|Γ''| - S i) (lift_renaming #|Γ'| 0) x)).
       rewrite shiftn_lift_renaming lift_renaming_spec -(shiftn_rshiftk _ _ _) shiftn_add.
-      rewrite -lift_renaming_spec Nat.add_0_r le_plus_minus_r.
-      1: lia.
+      rewrite -lift_renaming_spec Nat.add_0_r.
+      rewrite Nat.add_comm Nat.sub_add //.
       rewrite (lift_unlift _ _ _) /ren_id /unlift_renaming.
       by move: (iΓ'') => /Nat.ltb_spec0 ->.
   - rewrite -app_context_assoc /= in nthi.

--- a/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
+++ b/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
@@ -12,16 +12,16 @@ Set Default Goal Selector "!".
 Implicit Types (cf : checker_flags).
 
 Lemma global_ext_constraints_app Σ Σ' φ
-  : ConstraintSet.Subset (global_ext_constraints (Σ, φ))
-                         (global_ext_constraints (Σ' ++ Σ, φ)).
+  : ConstraintSet.Subset (universes Σ).2 (universes Σ').2 ->
+    ConstraintSet.Subset (global_ext_constraints (Σ, φ))
+                         (global_ext_constraints (Σ', φ)).
 Proof.
   unfold global_ext_constraints; simpl.
-  intros ctr Hc. apply ConstraintSet.union_spec in Hc.
+  intros sub ctr Hc. apply ConstraintSet.union_spec in Hc.
   apply ConstraintSet.union_spec.
   destruct Hc as [Hc|Hc]; [now left|right]. clear φ.
-  induction Σ' in ctr, Hc |- *.
-  - now rewrite app_nil_l.
-  - simpl. apply ConstraintSet.union_spec. right; eauto.
+  unfold global_constraints in Hc.
+  apply (sub _ Hc).
 Qed.
 
 Lemma satisfies_subset φ φ' val :
@@ -69,8 +69,9 @@ Generalizable Variables Σ Γ t T.
 
 Definition weaken_env_prop_full {cf:checker_flags}
   (P : global_env_ext -> context -> term -> term -> Type) :=
-  forall (Σ : global_env_ext) (Σ' : global_env), wf Σ' -> extends Σ.1 Σ' ->
-                                      forall Γ t T, P Σ Γ t T -> P (Σ', Σ.2) Γ t T.
+  forall (Σ : global_env_ext) (Σ' : global_env), 
+    wf Σ -> wf Σ' -> extends Σ.1 Σ' ->
+    forall Γ t T, P Σ Γ t T -> P (Σ', Σ.2) Γ t T.
 
 Lemma weakening_env_global_ext_levels Σ Σ' φ (H : extends Σ Σ') l
   : LevelSet.In l (global_ext_levels (Σ, φ))
@@ -80,10 +81,9 @@ Proof.
   intros Hl. apply LevelSet.union_spec in Hl.
   apply LevelSet.union_spec.
   destruct Hl as [Hl|Hl]; [now left|right]. clear φ.
-  destruct H as [Σ'' eq]; subst.
-  induction Σ'' in l, Hl |- *.
-  - now rewrite app_nil_l.
-  - simpl. apply LevelSet.union_spec. right; eauto.
+  destruct H as [[lsub csub] [Σ'' eq]]; subst.
+  apply LevelSet.union_spec in Hl.
+  apply LevelSet.union_spec; intuition auto.
 Qed.
 
 Lemma weakening_env_global_ext_levels' Σ Σ' φ (H : extends Σ Σ') l
@@ -94,13 +94,12 @@ Proof.
   now eapply LevelSet.mem_spec, weakening_env_global_ext_levels.
 Qed.
 
-
 Lemma weakening_env_global_ext_constraints Σ Σ' φ (H : extends Σ Σ')
   : ConstraintSet.Subset (global_ext_constraints (Σ, φ))
                          (global_ext_constraints (Σ', φ)).
 Proof.
-  destruct H as [Σ'' eq]. subst.
-  apply global_ext_constraints_app.
+  destruct H as [sub [Σ'' eq]]. subst.
+  apply global_ext_constraints_app, sub.
 Qed.
 
 Lemma eq_term_subset {cf:checker_flags} Σ φ φ' t t'
@@ -142,8 +141,8 @@ Ltac my_rename_hyp h th :=
 
 Ltac rename_hyp h ht ::= my_rename_hyp h ht.
 
-Lemma lookup_env_Some_fresh `{checker_flags} Σ c decl :
-  lookup_env Σ c = Some decl -> ~ (fresh_global c Σ).
+Lemma lookup_global_Some_fresh `{checker_flags} Σ c decl :
+  lookup_global Σ c = Some decl -> ~ (fresh_global c Σ).
 Proof.
   induction Σ; cbn. 1: congruence.
   unfold eq_kername; destruct kername_eq_dec; subst.
@@ -153,21 +152,27 @@ Proof.
     now inv H2.
 Qed.
 
+Lemma lookup_env_Some_fresh `{checker_flags} Σ c decl :
+  lookup_env Σ c = Some decl -> ~ (fresh_global c Σ.(declarations)).
+Proof.
+  apply lookup_global_Some_fresh.
+Qed.
+
 Lemma extends_lookup `{checker_flags} Σ Σ' c decl :
   wf Σ' ->
   extends Σ Σ' ->
   lookup_env Σ c = Some decl ->
   lookup_env Σ' c = Some decl.
 Proof.
-  intros wfΣ' [Σ'' ->]. simpl.
-  induction Σ'' in wfΣ', c, decl |- *.
+  destruct Σ as [univs Σ], Σ' as [univs' Σ']; cbn.
+  intros [hu hΣ].
+  rewrite /lookup_env; intros [sub [Σ'' eq]]; cbn in *. subst Σ'.
+  induction Σ'' in hΣ, c, decl |- *.
   - simpl. auto.
-  - specialize (IHΣ'' c decl). forward IHΣ''.
-    + inv wfΣ'. simpl in X0. apply X.
-    + intros HΣ. specialize (IHΣ'' HΣ).
-      inv wfΣ'. simpl in *.
-      unfold eq_kername; destruct kername_eq_dec; subst; auto.
-      apply lookup_env_Some_fresh in IHΣ''; contradiction.
+  - intros hl. depelim hΣ. specialize (IHΣ'' c decl hΣ hl).
+    simpl in *.
+    unfold eq_kername; destruct kername_eq_dec; subst; auto.
+    apply lookup_global_Some_fresh in IHΣ''; contradiction.
 Qed.
 #[global]
 Hint Resolve extends_lookup : extends.
@@ -323,21 +328,53 @@ Proof.
     try solve [econstructor; eauto with extends; solve_all].
 Qed.
 
+Existing Class extends.
+
+#[global] Instance subrel_extends_eq {cf} (Σ Σ' : global_env) (ϕ : universes_decl) : 
+  extends Σ Σ' ->
+  RelationClasses.subrelation (eq_universe (global_ext_constraints (Σ, ϕ))) 
+    (eq_universe (global_ext_constraints (Σ', ϕ))).
+Proof.
+  intros ext u u'.
+  apply eq_universe_subset.
+  apply global_ext_constraints_app, ext.
+Qed.
+
+#[global] Instance subrel_extends_le {cf} (Σ Σ' : global_env) (ϕ : universes_decl) : 
+  extends Σ Σ' ->
+  RelationClasses.subrelation (leq_universe (global_ext_constraints (Σ, ϕ))) 
+    (leq_universe (global_ext_constraints (Σ', ϕ))).
+Proof.
+  intros ext u u'.
+  apply leq_universe_subset.
+  apply global_ext_constraints_app, ext.
+Qed.
+
+#[global] Instance subrel_extends_eq_le {cf} (Σ Σ' : global_env) (ϕ : universes_decl) : 
+  extends Σ Σ' ->
+  RelationClasses.subrelation (eq_universe (global_ext_constraints (Σ, ϕ))) 
+    (leq_universe (global_ext_constraints (Σ', ϕ))).
+Proof.
+  intros ext u u'. intros eq.
+  eapply eq_universe_leq_universe.
+  eapply eq_universe_subset; tea.
+  apply global_ext_constraints_app, ext.
+Qed.
+
 Lemma weakening_env_conv `{CF:checker_flags} Σ Σ' φ Γ M N :
   wf Σ' ->
   extends Σ Σ' ->
   convAlgo (Σ, φ) Γ M N ->
   convAlgo (Σ', φ) Γ M N.
 Proof.
-  intros wfΣ [Σ'' ->].
+  intros wfΣ ext.
   induction 1; simpl.
   - econstructor. eapply eq_term_subset.
-    + eapply global_ext_constraints_app.
+    + now eapply global_ext_constraints_app.
     + simpl in *. eapply eq_term_upto_univ_weaken_env in c; simpl; eauto.
-      1:exists Σ''; eauto.
       all:typeclasses eauto.
-  - econstructor 2; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
-  - econstructor 3; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
+  - econstructor 2; eauto. eapply weakening_env_red1; eauto.
+  - econstructor 3; eauto. eapply weakening_env_red1; eauto.
 Qed.
 
 Lemma weakening_env_cumul `{CF:checker_flags} Σ Σ' φ Γ M N :
@@ -346,15 +383,14 @@ Lemma weakening_env_cumul `{CF:checker_flags} Σ Σ' φ Γ M N :
   cumulAlgo (Σ, φ) Γ M N ->
   cumulAlgo (Σ', φ) Γ M N.
 Proof.
-  intros wfΣ [Σ'' ->].
+  intros wfΣ ext.
   induction 1; simpl.
   - econstructor. eapply leq_term_subset.
-    + eapply global_ext_constraints_app.
+    + now eapply global_ext_constraints_app.
     + simpl in *. eapply eq_term_upto_univ_weaken_env in c; simpl; eauto.
-      1:exists Σ''; eauto.
       all:typeclasses eauto.
-  - econstructor 2; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
-  - econstructor 3; eauto. eapply weakening_env_red1; eauto. exists Σ''; eauto.
+  - econstructor 2; eauto. eapply weakening_env_red1; eauto.
+  - econstructor 3; eauto. eapply weakening_env_red1; eauto.
 Qed.
 
 Lemma weakening_env_is_allowed_elimination `{CF:checker_flags} Σ Σ' φ u allowed :
@@ -362,13 +398,13 @@ Lemma weakening_env_is_allowed_elimination `{CF:checker_flags} Σ Σ' φ u allow
   is_allowed_elimination (global_ext_constraints (Σ, φ)) u allowed ->
   is_allowed_elimination (global_ext_constraints (Σ', φ)) u allowed.
 Proof.
-  intros wfΣ [Σ'' ->] al.
+  intros wfΣ ext al.
   unfold is_allowed_elimination in *.
   destruct check_univs; auto.
   intros val sat.
   unshelve epose proof (al val _) as al.
   { eapply satisfies_subset; eauto.
-    apply global_ext_constraints_app. }
+    apply global_ext_constraints_app, ext. }
   destruct allowed; auto; cbn in *; destruct ?; auto.
 Qed.
 
@@ -436,10 +472,7 @@ Qed.
 Lemma global_levels_Set Σ :
   LevelSet.In Level.lzero (global_levels Σ).
 Proof.
-  unfold global_levels.
-  induction Σ; simpl; auto.
-  - now apply LevelSet.singleton_spec.
-  - apply LevelSet.union_spec. right; auto.
+  unfold global_levels. lsets.
 Qed.
 
 Lemma global_levels_set Σ :
@@ -451,86 +484,87 @@ Proof.
   apply global_levels_Set.
 Qed.
 
-Lemma global_levels_ext {Σ Σ'} :
-  LevelSet.Equal (global_levels (Σ ++ Σ')) (LevelSet.union (global_levels Σ) (global_levels Σ')).
+Lemma global_levels_sub {univs univs'} : univs ⊂_cs univs' ->
+  LevelSet.Subset (global_levels univs) (global_levels univs').
 Proof.
-  unfold global_levels at 1.
-  induction Σ; simpl.
-  - rewrite global_levels_set. reflexivity.
-  - rewrite IHΣ. lsets.
+  unfold global_levels => sub.
+  intros x hin % LevelSet.union_spec. 
+  apply LevelSet.union_spec. 
+  intuition auto. left. now apply sub.
 Qed.
 
 Lemma extends_wf_universe {cf:checker_flags} {Σ : global_env_ext} Σ' u : extends Σ Σ' -> wf Σ' ->
   wf_universe Σ u -> wf_universe (Σ', Σ.2) u.
 Proof.
   destruct Σ as [Σ univ]; cbn.
-  intros [Σ'' eq] wf.
+  intros [sub [Σ'' eq]] wf.
   destruct u; simpl; auto.
   intros Hl.
   intros l inl; specialize (Hl l inl).
-  cbn. rewrite eq /=.
+  cbn.
   unfold global_ext_levels.
   eapply LevelSet.union_spec; simpl.
   apply LevelSet.union_spec in Hl as [Hl|Hl]; cbn in Hl.
   - simpl. simpl in Hl. now left.
-  - right. rewrite global_levels_ext.
-    eapply LevelSet.union_spec. right.
-    apply Hl.
+  - right. eapply global_levels_sub; tea.
 Qed.
 
 #[global]
 Hint Resolve extends_wf_fixpoint extends_wf_cofixpoint : extends.
 
-
-
-Lemma wf_extends `{checker_flags} {Σ Σ'} : wf Σ' -> extends Σ Σ' -> wf Σ.
+(* Lemma wf_extends `{checker_flags} {Σ Σ'} : wf Σ' -> extends Σ Σ' -> wf Σ.
 Proof.
-  intros HΣ' [Σ'' ->]. simpl in *.
+  intros HΣ' [univs [Σ'' eq]]. simpl in *.
+  split => //.
+  - red.
   induction Σ''; auto.
   inv HΣ'. auto.
-Qed.
+Qed. *)
 
-
-
-Definition on_udecl_prop `{checker_flags} Σ (udecl : universes_decl)
+Definition on_udecl_prop `{checker_flags} (Σ : global_env) (udecl : universes_decl)
   := let levels := levels_of_udecl udecl in
-     let global_levels := global_levels Σ in
+     let global_levels := global_levels Σ.(universes) in
      let all_levels := LevelSet.union levels global_levels in
-     ConstraintSet.For_all (fun '(l1,_,l2) => LevelSet.In l1 all_levels
-                                             /\ LevelSet.In l2 all_levels)
-                             (constraints_of_udecl udecl)
-     /\ match udecl with
+     ConstraintSet.For_all (declared_cstr_levels all_levels) (constraints_of_udecl udecl).
+     (* /\ match udecl with
        | Monomorphic_ctx ctx => LevelSet.for_all (negb ∘ Level.is_var) ctx.1
                                /\ LevelSet.Subset ctx.1 global_levels
                                /\ ConstraintSet.Subset ctx.2 (global_constraints Σ)
-                               /\ satisfiable_udecl Σ udecl
+                               /\ satisfiable_udecl Σ.(universes) udecl
        | _ => True
-       end.
+       end. *)
 
+Lemma in_global_levels l u : 
+  LevelSet.In l (ContextSet.levels u) ->
+  LevelSet.In l (global_levels u).
+Proof.
+  intros hin; now apply LevelSet.union_spec.
+Qed.
 
 Lemma weaken_lookup_on_global_env' `{checker_flags} Σ c decl :
   wf Σ ->
   lookup_env Σ c = Some decl ->
   on_udecl_prop Σ (universes_decl_of_decl decl).
 Proof.
-  intros wfΣ HH.
+  intros [onu wfΣ] HH.
+  destruct Σ as [univs Σ]; cbn in *.
   induction wfΣ; simpl. 1: discriminate.
   cbn in HH. subst udecl.
   unfold eq_kername in HH; destruct kername_eq_dec; subst.
   - apply some_inj in HH; destruct HH. subst.
     clear -o. unfold on_udecl, on_udecl_prop in *.
     destruct o as [H1 [H2 [H3 H4]]]. repeat split.
-    + clear -H2. intros [[? ?] ?] Hc. specialize (H2 _ Hc).
-      destruct H2 as [H H']. simpl. split.
-      * apply LevelSet.union_spec in H. apply LevelSet.union_spec.
-        destruct H; [now left|right]. apply LevelSet.union_spec; now right.
-      * apply LevelSet.union_spec in H'. apply LevelSet.union_spec.
-        destruct H'; [now left|right]. apply LevelSet.union_spec; now right.
-    + revert H3. case_eq (universes_decl_of_decl d); trivial.
+    clear -H2. intros [[? ?] ?] Hc. specialize (H2 _ Hc).
+    destruct H2 as [H H']. simpl. split.
+    * apply LevelSet.union_spec in H. apply LevelSet.union_spec.
+      destruct H; [now left|right]; auto.
+    * apply LevelSet.union_spec in H'. apply LevelSet.union_spec.
+      destruct H'; [now left|right]; auto.
+    (*+ revert H3. case_eq (universes_decl_of_decl d); trivial.
       intros ctx eq Hctx. repeat split.
       * auto.
       * intros l Hl. simpl. replace (monomorphic_levels_decl d) with ctx.1.
-        -- apply LevelSet.union_spec; now left.
+        -- apply in_global_levels. apply LevelSet.union_spec; now left.
         -- clear -eq. destruct d as [c|c]; cbn in *.
            all: destruct c; cbn in *; now rewrite eq.
       * simpl. replace (monomorphic_constraints_decl d) with ctx.2.
@@ -545,18 +579,18 @@ Proof.
       -- apply ConstraintSet.union_spec; left. simpl.
          destruct d as [[? ? []]|[? ? ? ? []]]; simpl in *; tas;
            now apply ConstraintSet.empty_spec in Hc.
-      -- apply ConstraintSet.union_spec; now right.
+      -- apply ConstraintSet.union_spec; now right.*)
   - specialize (IHwfΣ HH). revert IHwfΣ o; clear.
     generalize (universes_decl_of_decl decl); intros d' HH Hd.
     unfold on_udecl_prop in *.
-    destruct HH as [H1 H2]. split.
-    + clear -H1. intros [[? ?] ?] Hc. specialize (H1 _ Hc).
-      destruct H1 as [H H']. simpl. split.
-      * apply LevelSet.union_spec in H. apply LevelSet.union_spec.
-        destruct H; [now left|right]. apply LevelSet.union_spec; now right.
-      * apply LevelSet.union_spec in H'. apply LevelSet.union_spec.
-        destruct H'; [now left|right]. apply LevelSet.union_spec; now right.
-    + destruct d'; trivial. repeat split.
+    intros [[? ?] ?] Hc. specialize (HH _ Hc).
+    destruct HH as [H' H'']. simpl. split.
+    * apply LevelSet.union_spec in H'. apply LevelSet.union_spec.
+      destruct H'; [now left|right]; auto.
+    * apply LevelSet.union_spec in H''. apply LevelSet.union_spec.
+      destruct H''; [now left|right]; auto.
+      
+    (*+ destruct d'; trivial. repeat split.
       * destruct H2; auto.
       * intros l Hl. apply H2 in Hl.
         apply LevelSet.union_spec; now right.
@@ -571,15 +605,57 @@ Proof.
           -- clear -Hc. destruct d as [[? ? []]|[? ? ? ? []]]; cbn in *.
              all: try (apply ConstraintSet.empty_spec in Hc; contradiction).
              all: apply ConstraintSet.union_spec; now left.
-          -- apply ConstraintSet.union_spec; now right.
+          -- apply ConstraintSet.union_spec; now right.*)
 Qed.
 
-Lemma on_udecl_on_udecl_prop {cf:checker_flags} Σ ctx :
-  on_udecl Σ (Polymorphic_ctx ctx) -> on_udecl_prop Σ (Polymorphic_ctx ctx).
+Lemma declared_cstr_levels_sub l l' c : 
+  LevelSet.Subset l l' ->
+  declared_cstr_levels l c -> declared_cstr_levels l' c.
 Proof.
-  intros [? [? [_ ?]]]. red. split; auto.
+  intros sub; unfold declared_cstr_levels.
+  destruct c as [[l1 eq] l2]. intuition auto.
+Qed.
+
+Lemma on_udecl_on_udecl_prop {cf:checker_flags} (Σ : global_env) ctx :
+  on_udecl Σ.(universes) (Polymorphic_ctx ctx) -> on_udecl_prop Σ (Polymorphic_ctx ctx).
+Proof.
+  intros [? [? ?]]. red.
+  intros x hin. specialize (H0 x hin).
+  eapply declared_cstr_levels_sub; tea.
+  intros x' hin'.
+  eapply LevelSet.union_spec. apply LevelSet.union_spec in hin'.
+  intuition auto.
+Qed.
+
+Definition extends_decls (Σ Σ' : global_env) := 
+  Σ.(universes) = Σ'.(universes) ×
+  ∑ Σ'', declarations Σ' = Σ'' ++ Σ.(declarations).
+
+Existing Class extends_decls.
+
+#[global] Instance extends_decls_extends Σ Σ' : extends_decls Σ Σ' -> extends Σ Σ'.
+Proof.
+  intros []. split => //.
+  rewrite e. split; [lsets|csets].
 Qed.
 
 Definition weaken_env_prop `{checker_flags}
            (P : global_env_ext -> context -> term -> option term -> Type) :=
-  forall Σ Σ' φ, wf Σ' -> extends Σ Σ' -> forall Γ t T, P (Σ, φ) Γ t T -> P (Σ', φ) Γ t T.
+  forall Σ Σ' φ, wf Σ -> wf Σ' -> extends Σ Σ' -> forall Γ t T, P (Σ, φ) Γ t T -> P (Σ', φ) Γ t T.
+
+Definition weaken_env_decls_prop `{checker_flags}
+  (P : global_env_ext -> context -> term -> option term -> Type) :=
+  forall Σ Σ' φ, wf Σ' -> extends_decls Σ Σ' -> forall Γ t T, P (Σ, φ) Γ t T -> P (Σ', φ) Γ t T.
+
+Lemma extends_decls_wf {cf} Σ Σ' : 
+  wf Σ' -> extends_decls Σ Σ' -> wf Σ.
+Proof.
+  intros [onu ond] [eq [Σ'' eq']].
+  split => //. 
+  - red. rewrite eq. apply onu.
+  - rewrite eq. rewrite eq' in ond.
+    revert ond; clear.
+    induction Σ''; cbn; auto.
+    intros H; depelim H.
+    apply IHΣ''. apply H.
+Qed. 

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -17,8 +17,8 @@ Implicit Types cf : checker_flags.
 
 Notation "`≡α`" := upto_names.
 Infix "≡α" := upto_names (at level 60).
-Notation "`≡Γ`" := (eq_context_upto [] eq eq).
-Infix "≡Γ" := (eq_context_upto [] eq eq) (at level 20, no associativity).
+Notation "`≡Γ`" := (eq_context_upto empty_global_env eq eq).
+Infix "≡Γ" := (eq_context_upto empty_global_env eq eq) (at level 20, no associativity).
 
 #[global]
 Instance upto_names_terms_refl : CRelationClasses.Reflexive (All2 `≡α`).
@@ -135,7 +135,7 @@ Section Alpha.
   Qed.
 
   Lemma upto_names_destInd Re Rle t u :
-    eq_term_upto_univ [] Re Rle t u ->
+    eq_term_upto_univ empty_global_env Re Rle t u ->
     rel_option (fun '(ind, u) '(ind', u') => (ind = ind') * R_universe_instance Re u u')%type (destInd t) (destInd u).
   Proof.
     induction 1; simpl; constructor; try congruence.
@@ -158,9 +158,9 @@ Section Alpha.
     pose proof (decompose_prod_assum_upto_names' [] [] ty ty' ltac:(constructor) eqty).
     do 2 destruct decompose_prod_assum.
     destruct X0 as [eqctx eqt].
-    apply (eq_context_upto_smash_context [] [] []) in eqctx; try constructor.
+    apply (eq_context_upto_smash_context empty_global_env [] []) in eqctx; try constructor.
     apply eq_context_upto_rev' in eqctx.
-    eapply (eq_context_upto_nth_error [] _ _ _ _ rarg) in eqctx.
+    eapply (eq_context_upto_nth_error empty_global_env _ _ _ _ rarg) in eqctx.
     subst rarg'.
     destruct (nth_error (List.rev (smash_context [] c)) rarg).
     inv eqctx. destruct X0.
@@ -356,7 +356,7 @@ Section Alpha.
 
   Lemma eq_context_gen_upto ctx ctx' :
     eq_context_gen eq eq ctx ctx' ->
-    eq_context_upto [] eq eq ctx ctx'.
+    eq_context_upto empty_global_env eq eq ctx ctx'.
   Proof.
     intros a; eapply All2_fold_impl; tea.
     intros. destruct X; subst; constructor; auto; try reflexivity.
@@ -364,7 +364,7 @@ Section Alpha.
 
   Lemma case_predicate_context_equiv {ind mdecl idecl p p'} :
     eq_predicate upto_names' eq p p' ->
-    eq_context_upto [] eq eq
+    eq_context_upto empty_global_env eq eq
       (case_predicate_context ind mdecl idecl p)
       (case_predicate_context ind mdecl idecl p').
   Proof.
@@ -571,7 +571,7 @@ Section Alpha.
   Lemma typing_alpha_prop :
     env_prop (fun Σ Γ u A =>
       forall Δ v,
-        eq_term_upto_univ [] eq eq u v ->
+        eq_term_upto_univ empty_global_env eq eq u v ->
         Γ ≡Γ Δ ->
         Σ ;;; Δ |- v : A)
     (fun Σ Γ => forall Δ, Γ ≡Γ Δ ->  wf_local Σ Δ).
@@ -1011,7 +1011,7 @@ Section Alpha.
   Local Ltac inv H := inversion H; subst; clear H.
 
   Lemma eq_term_upto_univ_napp_0 n t t' :
-    eq_term_upto_univ_napp [] eq eq n t t' ->
+    eq_term_upto_univ_napp empty_global_env eq eq n t t' ->
     t ≡α t'.
   Proof.
     apply eq_term_upto_univ_empty_impl; typeclasses eauto.

--- a/pcuic/theories/PCUICCSubst.v
+++ b/pcuic/theories/PCUICCSubst.v
@@ -50,7 +50,7 @@ Proof.
     simpl; try f_equal; eauto with pcuic; solve_all.
   - destruct (PeanoNat.Nat.compare_spec k n).
     + subst k.
-      rewrite PeanoNat.Nat.leb_refl minus_diag /=.
+      rewrite PeanoNat.Nat.leb_refl Nat.sub_diag /=.
       now rewrite lift_closed.
     + destruct (leb_spec_Set k n); try lia.
       destruct (nth_error_spec [t] (n - k) ).

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -2379,7 +2379,7 @@ Section AbstractConfluence.
   End Definitions.
 
   Global Instance joinable_proper A :
-    Proper (relation_equivalence ==> relation_equivalence)%signatureT (@joinable A).
+    Proper (relation_equivalence ==> relation_equivalence)%signature (@joinable A).
   Proof.
     reduce_goal. split; unfold joinable; intros.
     destruct X0. exists x1. intuition eauto. setoid_rewrite (X x0 x1) in a. auto.
@@ -2390,7 +2390,7 @@ Section AbstractConfluence.
     exists z; split; auto.
   Qed.
 
-  Global Instance diamond_proper A : Proper (relation_equivalence ==> iffT)%signatureT (@diamond A).
+  Global Instance diamond_proper A : Proper (relation_equivalence ==> iffT)%signature (@diamond A).
   Proof.
     reduce_goal.
     rewrite /diamond.
@@ -2414,7 +2414,7 @@ Section AbstractConfluence.
     induction X0; try apply X in r; try solve [econstructor; eauto].
   Qed.
 
-  Global Instance confluent_proper A : Proper (relation_equivalence ==> iffT)%signatureT (@confluent A).
+  Global Instance confluent_proper A : Proper (relation_equivalence ==> iffT)%signature (@confluent A).
   Proof.
     reduce_goal.
     split; rewrite /confluent; auto.

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -89,6 +89,28 @@ Proof.
   intros []; split; tc.
 Qed.
 
+Lemma clos_rt_OnOne2_local_env_incl R :
+inclusion (OnOne2_local_env (on_one_decl (fun Δ => clos_refl_trans (R Δ))))
+          (clos_refl_trans (OnOne2_local_env (on_one_decl R))).
+Proof.
+  intros x y H.
+  induction H; firstorder; try subst na'.
+  - induction b. repeat constructor. pcuicfo.
+    constructor 2.
+    econstructor 3 with (Γ ,, vass na y); auto.
+  - subst.
+    induction a0. repeat constructor. pcuicfo.
+    constructor 2.
+    econstructor 3 with (Γ ,, vdef na b' y); auto.
+  - subst t'.
+    induction a0. constructor. constructor. red. simpl. pcuicfo.
+    constructor 2.
+    econstructor 3 with (Γ ,, vdef na y t); auto.
+  - clear H. induction IHOnOne2_local_env. constructor. now constructor 3.
+    constructor 2.
+    eapply transitivity. eauto. auto.
+Qed.
+
 Lemma All2_fold_refl {A} {P : list A -> list A -> A -> A -> Type} : 
   (forall Γ, Reflexive (P Γ Γ)) ->
   Reflexive (All2_fold P).
@@ -2357,7 +2379,7 @@ Section AbstractConfluence.
   End Definitions.
 
   Global Instance joinable_proper A :
-    Proper (relation_equivalence ==> relation_equivalence)%signature (@joinable A).
+    Proper (relation_equivalence ==> relation_equivalence)%signatureT (@joinable A).
   Proof.
     reduce_goal. split; unfold joinable; intros.
     destruct X0. exists x1. intuition eauto. setoid_rewrite (X x0 x1) in a. auto.
@@ -2368,7 +2390,7 @@ Section AbstractConfluence.
     exists z; split; auto.
   Qed.
 
-  Global Instance diamond_proper A : Proper (relation_equivalence ==> iffT)%signature (@diamond A).
+  Global Instance diamond_proper A : Proper (relation_equivalence ==> iffT)%signatureT (@diamond A).
   Proof.
     reduce_goal.
     rewrite /diamond.
@@ -2392,7 +2414,7 @@ Section AbstractConfluence.
     induction X0; try apply X in r; try solve [econstructor; eauto].
   Qed.
 
-  Global Instance confluent_proper A : Proper (relation_equivalence ==> iffT)%signature (@confluent A).
+  Global Instance confluent_proper A : Proper (relation_equivalence ==> iffT)%signatureT (@confluent A).
   Proof.
     reduce_goal.
     split; rewrite /confluent; auto.
@@ -2832,28 +2854,6 @@ Section RedConfluence.
     move=> x. eapply All2_fold_refl; intros; apply All_decls_refl; auto.
   Qed.
 
-  Lemma clos_rt_OnOne2_local_env_incl R :
-    inclusion (OnOne2_local_env (on_one_decl (fun Δ => clos_refl_trans (R Δ))))
-              (clos_refl_trans (OnOne2_local_env (on_one_decl R))).
-  Proof.
-    intros x y H.
-    induction H; firstorder; try subst na'.
-    - induction b. repeat constructor. pcuicfo.
-      constructor 2.
-      econstructor 3 with (Γ ,, vass na y); auto.
-    - subst.
-      induction a0. repeat constructor. pcuicfo.
-      constructor 2.
-      econstructor 3 with (Γ ,, vdef na b' y); auto.
-    - subst t'.
-      induction a0. constructor. constructor. red. simpl. pcuicfo.
-      constructor 2.
-      econstructor 3 with (Γ ,, vdef na y t); auto.
-    - clear H. induction IHOnOne2_local_env. constructor. now constructor 3.
-      constructor 2.
-      eapply transitivity. eauto. auto.
-  Qed.
-
   Hint Constructors clos_refl_trans_ctx : pcuic.
   Hint Resolve alpha_eq_reflexive : pcuic.  
   Set Firstorder Solver eauto with pcuic core typeclass_instances.
@@ -2869,7 +2869,7 @@ Section RedConfluence.
   Lemma red_ctx_clos_rt_red1_ctx : inclusion (red_ctx Σ) (clos_refl_trans_ctx (red1_ctx Σ)).
   Proof.
     intros x y H.
-    induction H; try firstorder.
+    induction H; [firstorder|].
     destruct p.
     - transitivity (Γ ,, vass na t').
       eapply clos_rt_OnOne2_local_env_ctx_incl, clos_rt_OnOne2_local_env_incl. constructor.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -1106,7 +1106,7 @@ Instance eq_subrel_eq_univ {cf:checker_flags} Σ : RelationClasses.subrelation e
 Proof. intros x y []. reflexivity. Qed.
 
 Lemma eq_context_upto_empty_conv_context {cf:checker_flags} (Σ : global_env_ext) :
-  subrelation (eq_context_upto [] eq eq) (fun Γ Γ' => conv_context Σ Γ Γ').
+  subrelation (eq_context_upto empty_global_env eq eq) (fun Γ Γ' => conv_context Σ Γ Γ').
 Proof.
   intros Γ Δ h. induction h.
   - constructor.
@@ -1116,16 +1116,16 @@ Proof.
 Qed.
 
 Lemma eq_context_upto_univ_conv_context {cf:checker_flags} {Σ : global_env_ext} Γ Δ :
-    eq_context_upto Σ.1 (eq_universe Σ) (eq_universe Σ) Γ Δ ->
-    conv_context Σ Γ Δ.
+  eq_context_upto Σ.1 (eq_universe Σ) (eq_universe Σ) Γ Δ ->
+  conv_context Σ Γ Δ.
 Proof.
   intros h. eapply eq_context_upto_conv_context; tea.
   reflexivity.
 Qed.
 
 Lemma eq_context_upto_univ_cumul_context {cf:checker_flags} {Σ : global_env_ext} Γ Δ :
-    eq_context_upto Σ.1 (eq_universe Σ) (leq_universe Σ) Γ Δ ->
-    cumul_context Σ Γ Δ.
+  eq_context_upto Σ.1 (eq_universe Σ) (leq_universe Σ) Γ Δ ->
+  cumul_context Σ Γ Δ.
 Proof.
   intros h. eapply eq_context_upto_cumul_context; tea.
   reflexivity. tc. tc.

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -162,11 +162,7 @@ Lemma type_local_ctx_instantiate {cf:checker_flags} Σ ind mdecl Γ Δ u s :
 Proof.
   intros Hctx Hu.
   induction Δ; simpl in *; intuition auto.
-  { destruct Σ as [Σ univs]. eapply (wf_universe_subst_instance (Σ, ind_universes mdecl)); eauto.
-    simpl in *.
-    assert (wg := weaken_lookup_on_global_env'' _ _ _ Hctx Hu).
-    eapply sub_context_set_trans. eauto.
-    eapply global_context_set_sub_ext. }
+  { destruct Σ as [Σ univs]. eapply (wf_universe_subst_instance (Σ, ind_universes mdecl)); eauto. }
   destruct a as [na [b|] ty]; simpl; intuition auto.
   - destruct a0.
     exists (subst_instance_univ u x).

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -42,7 +42,7 @@ Derive Signature for clos_refl_trans_1n.
 Notation ws_cumul_pb_terms Σ Γ := (All2 (ws_cumul_pb Conv Σ Γ)).
 
 #[global]
-Instance ws_cumul_pb_terms_Proper {cf:checker_flags} Σ Γ : CMorphisms.Proper (eq ==> eq ==> arrow)%signature (ws_cumul_pb_terms Σ Γ).
+Instance ws_cumul_pb_terms_Proper {cf:checker_flags} Σ Γ : CMorphisms.Proper (eq ==> eq ==> arrow)%signatureT (ws_cumul_pb_terms Σ Γ).
 Proof. intros x y -> x' y' -> f. exact f. Qed.
 
 #[global]
@@ -3535,7 +3535,7 @@ Proof.
     { unfold app_context.
       intros.
       rewrite nth_error_app2; [lia|].
-      rewrite minus_plus; auto. }
+      rewrite Nat.add_comm Nat.add_sub; auto. }
     eapply red_case.
     + induction IHparams; pcuic.
     + apply IHret; auto.

--- a/pcuic/theories/PCUICConversion.v
+++ b/pcuic/theories/PCUICConversion.v
@@ -42,7 +42,7 @@ Derive Signature for clos_refl_trans_1n.
 Notation ws_cumul_pb_terms Σ Γ := (All2 (ws_cumul_pb Conv Σ Γ)).
 
 #[global]
-Instance ws_cumul_pb_terms_Proper {cf:checker_flags} Σ Γ : CMorphisms.Proper (eq ==> eq ==> arrow)%signatureT (ws_cumul_pb_terms Σ Γ).
+Instance ws_cumul_pb_terms_Proper {cf:checker_flags} Σ Γ : CMorphisms.Proper (eq ==> eq ==> arrow)%signature (ws_cumul_pb_terms Σ Γ).
 Proof. intros x y -> x' y' -> f. exact f. Qed.
 
 #[global]

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -26,7 +26,7 @@ Definition SingletonProp `{cf : checker_flags} (Σ : global_env_ext) (ind : indu
     declared_inductive (fst Σ) ind mdecl idecl ->
     forall Γ args u n (Σ' : global_env_ext),
       wf Σ' ->
-      extends Σ Σ' ->
+      extends_decls Σ Σ' ->
       welltyped Σ' Γ (mkApps (tConstruct ind n u) args) ->
       ∥Is_proof Σ' Γ (mkApps (tConstruct ind n u) args)∥ /\
        #|ind_ctors idecl| <= 1 /\
@@ -37,7 +37,7 @@ Definition Computational `{cf : checker_flags} (Σ : global_env_ext) (ind : indu
     declared_inductive (fst Σ) ind mdecl idecl ->
     forall Γ args u n (Σ' : global_env_ext),
       wf Σ' ->
-      extends Σ Σ' ->
+      extends_decls Σ Σ' ->
       welltyped Σ' Γ (mkApps (tConstruct ind n u) args) ->
       Is_proof Σ' Γ (mkApps (tConstruct ind n u) args) -> False.
 
@@ -46,7 +46,7 @@ Definition Informative `{cf : checker_flags} (Σ : global_env_ext) (ind : induct
     declared_inductive (fst Σ) ind mdecl idecl ->
     forall Γ args u n (Σ' : global_env_ext),
       wf_ext Σ' ->
-      extends Σ Σ' ->
+      extends_decls Σ Σ' ->
       Is_proof Σ' Γ (mkApps (tConstruct ind n u) args) ->
        #|ind_ctors idecl| <= 1 /\
        squash (All (Is_proof Σ' Γ) (skipn (ind_npars mdecl) args)).
@@ -618,7 +618,7 @@ Proof.
   intros ?. intros.
   eapply declared_inductive_inj in H as []; eauto; subst idecl0 mind.
   eapply Is_proof_mkApps_tConstruct in X1; tea.
-  now eapply weakening_env_declared_inductive.
+  now eapply weakening_env_declared_inductive; tc.
 Qed.
 
 Lemma elim_restriction_works `{cf : checker_flags} (Σ : global_env_ext) Γ T (ci : case_info) p c brs mind idecl : 

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -879,9 +879,9 @@ Proof.
   destruct t0; simpl; auto.
 Qed.
 
-Lemma global_variance_empty gr napp : global_variance [] gr napp = None.
+Lemma global_variance_empty gr napp env : env.(declarations) = [] -> global_variance env gr napp = None.
 Proof.
-  destruct gr; auto.
+  destruct env; cbn => ->. destruct gr; auto.
 Qed.
 
 (** Pure syntactic equality, without cumulative inductive types subtyping *)
@@ -891,11 +891,11 @@ Instance R_global_instance_empty_impl Σ Re Re' Rle Rle' gr napp napp' :
   RelationClasses.subrelation Re Re' ->
   RelationClasses.subrelation Rle Rle' ->
   RelationClasses.subrelation Re Rle' ->
-  subrelation (R_global_instance [] Re Rle gr napp) (R_global_instance Σ Re' Rle' gr napp').
+  subrelation (R_global_instance empty_global_env Re Rle gr napp) (R_global_instance Σ Re' Rle' gr napp').
 Proof.
   intros he hle hele t t'.
   rewrite /R_global_instance /R_opt_variance. simpl.
-  rewrite global_variance_empty.
+  rewrite global_variance_empty //.
   destruct global_variance as [v|]; eauto using R_universe_instance_impl'.
   induction t in v, t' |- *; destruct v, t'; simpl; intros H; inv H; auto.
   simpl.
@@ -952,7 +952,7 @@ Instance eq_term_upto_univ_empty_impl Σ Re Re' Rle Rle' napp napp' :
   RelationClasses.subrelation Re Re' ->
   RelationClasses.subrelation Rle Rle' ->
   RelationClasses.subrelation Re Rle' ->
-  subrelation (eq_term_upto_univ_napp [] Re Rle napp) (eq_term_upto_univ_napp Σ Re' Rle' napp').
+  subrelation (eq_term_upto_univ_napp empty_global_env Re Rle napp) (eq_term_upto_univ_napp Σ Re' Rle' napp').
 Proof.
   intros he hle hele t t'.
   induction t in napp, napp', t', Rle, Rle', hle, hele |- * using term_forall_list_ind;
@@ -1249,7 +1249,8 @@ Proof.
   subst. constructor ; auto.
 Qed.
 
-Lemma valid_constraints_empty {cf} i : valid_constraints (empty_ext []) (subst_instance_cstrs i (empty_ext [])).
+Lemma valid_constraints_empty {cf} i : 
+  valid_constraints (empty_ext empty_global_env) (subst_instance_cstrs i (empty_ext empty_global_env)).
 Proof.
   red. destruct check_univs => //.
 Qed.
@@ -1265,12 +1266,12 @@ Qed.
 
 (** ** Syntactic ws_cumul_pb up to printing anotations ** *)
 
-Definition upto_names := eq_term_upto_univ [] eq eq.
+Definition upto_names := eq_term_upto_univ empty_global_env eq eq.
 
 Infix "≡" := upto_names (at level 70).
 
-Infix "≡'" := (eq_term_upto_univ [] eq eq) (at level 70).
-Notation upto_names' := (eq_term_upto_univ [] eq eq).
+Infix "≡'" := (eq_term_upto_univ empty_global_env eq eq) (at level 70).
+Notation upto_names' := (eq_term_upto_univ empty_global_env eq eq).
 
 #[global]
 Instance upto_names_ref : Reflexive upto_names.

--- a/pcuic/theories/PCUICEqualityDec.v
+++ b/pcuic/theories/PCUICEqualityDec.v
@@ -757,7 +757,7 @@ Qed.
 Section EqualityDec.
   Context {cf : checker_flags}.
   Context (Σ : global_env_ext).
-  Context (hΣ : ∥ wf Σ ∥) (Hφ : ∥ on_udecl Σ.1 Σ.2 ∥).
+  Context (hΣ : ∥ wf Σ ∥) (Hφ : ∥ on_udecl Σ.1.(universes) Σ.2 ∥).
   Context (G : universes_graph) (HG : is_graph_of_uctx G (global_ext_uctx Σ)).
 
   Local Definition hΣ' : ∥ wf_ext Σ ∥.

--- a/pcuic/theories/PCUICExpandLets.v
+++ b/pcuic/theories/PCUICExpandLets.v
@@ -96,8 +96,12 @@ Definition trans_global_decl (d : PCUICEnvironment.global_decl) :=
   | PCUICEnvironment.InductiveDecl bd => InductiveDecl (trans_minductive_body bd)
   end.
 
-Definition trans_global_decls (d : PCUICEnvironment.global_env) : global_env :=
+Definition trans_global_decls (d : PCUICEnvironment.global_declarations) : global_declarations :=
   List.map (on_snd trans_global_decl) d.
 
+Definition trans_global_env (d : PCUICEnvironment.global_env) : global_env :=
+  {| universes := d.(PCUICEnvironment.universes);
+     declarations := trans_global_decls d.(PCUICEnvironment.declarations) |}.
+  
 Definition trans_global (Σ : PCUICEnvironment.global_env_ext) : global_env_ext :=
-  (trans_global_decls (fst Σ), snd Σ).
+  (trans_global_env (fst Σ), snd Σ).

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -278,11 +278,9 @@ Section OnConstructor.
     pose proof (on_declared_constructor declc) as [[onmind oib] [cunivs [hnth onc]]].
     pose proof (onc.(on_cargs)). simpl in X.
     split. split. split.
-    2:{ eapply (weaken_lookup_on_global_env'' _ _ (InductiveDecl mdecl)); tea.
+    2:{ eapply (weaken_lookup_on_global_env' _ _ (InductiveDecl mdecl)); tea.
         eapply declc. }
-    red. split; eauto. simpl. 
-    eapply (weaken_lookup_on_global_env' _ _ (InductiveDecl mdecl)); eauto.
-    eapply declc.
+    red. apply wfΣ. 
     eapply sorts_local_ctx_wf_local in X => //. clear X.
     eapply weaken_wf_local => //.
     eapply wf_arities_context; eauto; eapply declc.
@@ -1846,7 +1844,7 @@ Lemma variance_universes_insts {cf} {Σ mdecl l} :
   ∑ v i i',
   [× variance_universes (PCUICEnvironment.ind_universes mdecl) l = Some (v, i, i'),
     match ind_universes mdecl with
-    | Monomorphic_ctx (_, cstrs) => False
+    | Monomorphic_ctx => False
     | Polymorphic_ctx (inst, cstrs) => 
       let cstrs := ConstraintSet.union (ConstraintSet.union cstrs (lift_constraints #|i| cstrs)) (variance_cstrs l i i')
       in v = Polymorphic_ctx (inst ++ inst, cstrs)
@@ -1923,7 +1921,8 @@ Lemma on_udecl_prop_poly_bounded {cf:checker_flags} Σ inst cstrs :
   on_udecl_prop Σ (Polymorphic_ctx (inst, cstrs)) ->
   closedu_cstrs #|inst| cstrs.
 Proof.
-  rewrite /on_udecl_prop. intros wfΣ [nlevs _].
+  rewrite /on_udecl_prop.
+  intros wfΣ nlevs.
   red.
   rewrite /closedu_cstrs.
   intros x incstrs.
@@ -2123,7 +2122,7 @@ Proof.
   2:{ rewrite -satisfies_subst_instance_ctr //.
       rewrite equal_subst_instance_cstrs_mono //.
       red; apply monomorphic_global_constraint; auto. }
-  destruct (ind_universes mdecl) as [[inst cstrs']|[inst cstrs']].
+  destruct (ind_universes mdecl) as [|[inst cstrs']].
   { simpl in vari => //. }
   cbn in cstrs. subst v; cbn.
   rewrite !satisfies_union. len.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -295,7 +295,7 @@ Section OnInductives.
     eapply isType_weaken => //.
     rewrite -(subst_instance_it_mkProd_or_LetIn u _ (tSort _)).
     rewrite -it_mkProd_or_LetIn_app in ar.
-    eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u) in ar.
+    eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u wfΣ) in ar.
     all:pcuic. eapply decli.
   Qed.
 
@@ -309,7 +309,7 @@ Section OnInductives.
     pose proof (oib.(onArity)) as ar.
     destruct ar as [s ar].
     eapply isType_weaken => //.
-    eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u) in ar.
+    eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u wfΣ) in ar.
     all:pcuic. eapply decli.
   Qed.
 
@@ -335,10 +335,6 @@ Section OnInductives.
     destruct Σ. intros cu.
     eapply wf_universe_instantiate; eauto.
     now eapply consistent_instance_ext_wf.
-    eapply sub_context_set_trans.
-    eapply (weaken_lookup_on_global_env'' _ _ (InductiveDecl mdecl)); eauto.
-    eapply decli.
-    eapply global_context_set_sub_ext.
   Qed.
 
   Lemma nth_errror_arities_context decl :

--- a/pcuic/theories/PCUICLoader.v
+++ b/pcuic/theories/PCUICLoader.v
@@ -1,4 +1,4 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import Ast TemplateMonad.
 
-Declare ML Module "template_coq".
+Declare ML Module "coq-metacoq-template.template_coq".

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -510,14 +510,14 @@ Section Rho.
         dbody := rho (Γ ,,, mfixctx) (dbody d) _; rarg := (rarg d) |})).
   Next Obligation.
     eapply (In_list_depth (def_depth_gen depth)) in H.
-    eapply le_lt_trans with (def_depth_gen depth d).
+    eapply Nat.le_lt_trans with (def_depth_gen depth d).
     unfold def_depth_gen. lia.
     unfold mfixpoint_depth in H0.
     lia.
   Qed.
   Next Obligation.
     eapply (In_list_depth (def_depth_gen depth)) in H.
-    eapply le_lt_trans with (def_depth_gen depth d).
+    eapply Nat.le_lt_trans with (def_depth_gen depth d).
     unfold def_depth_gen. lia.
     unfold mfixpoint_depth in H0.
     lia.
@@ -1176,10 +1176,9 @@ Section Rho.
     intros. simpl. rewrite mapi_app. simpl.
     rewrite IHm. cbn.
     rewrite - app_assoc. simpl. rewrite List.rev_length.
-    rewrite Nat.add_0_r. rewrite minus_diag. simpl.
+    rewrite Nat.add_0_r. rewrite Nat.sub_diag Nat.add_0_r. simpl.
     f_equal. apply mapi_ext_size. simpl; intros.
-    rewrite List.rev_length in H.
-    f_equal. f_equal. lia. f_equal. f_equal. f_equal. lia.
+    rewrite List.rev_length in H. lia_f_equal.
   Qed.
 
   Lemma fold_fix_context_rev {Γ m} :

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -384,28 +384,28 @@ Proof.
 Qed.
 
 Lemma eq_term_empty_leq_term {cf:checker_flags} {Σ : global_env_ext} {x y} :
-  eq_term [] Σ x y ->
-  leq_term [] Σ x y.
+  eq_term empty_global_env Σ x y ->
+  leq_term empty_global_env Σ x y.
 Proof.
   eapply eq_term_upto_univ_impl; auto; typeclasses eauto.
 Qed.
 
 Lemma eq_term_empty_eq_term {cf:checker_flags} {Σ : global_env_ext} {x y} :
-  eq_term [] Σ x y ->
+  eq_term empty_global_env Σ x y ->
   eq_term Σ Σ x y.
 Proof.
   eapply eq_term_upto_univ_empty_impl; auto; typeclasses eauto.
 Qed.
 
 Lemma leq_term_empty_leq_term {cf:checker_flags} {Σ : global_env_ext} {x y} :
-  leq_term [] Σ x y ->
+  leq_term empty_global_env Σ x y ->
   leq_term Σ Σ x y.
 Proof.
   eapply eq_term_upto_univ_empty_impl; auto; typeclasses eauto.
 Qed.
 
 Lemma eq_context_empty_eq_context {cf:checker_flags} {Σ : global_env_ext} {x y} :
-  eq_context_upto [] (eq_universe Σ) (eq_universe Σ) x y ->
+  eq_context_upto empty_global_env (eq_universe Σ) (eq_universe Σ) x y ->
   eq_context_upto Σ (eq_universe Σ) (eq_universe Σ) x y.
 Proof.
   intros.
@@ -428,7 +428,7 @@ Proof.
 Qed.
 
 Lemma R_global_instance_empty_universe_instance Re Rle ref napp u u' :
-  R_global_instance [] Re Rle ref napp u u' ->
+  R_global_instance empty_global_env Re Rle ref napp u u' ->
   R_universe_instance Re u u'.
 Proof.
   rewrite /R_global_instance.
@@ -436,7 +436,7 @@ Proof.
 Qed.
 
 Lemma eq_context_upto_inst_case_context {cf : checker_flags} {Σ : global_env_ext} pars pars' puinst puinst' ctx :
-  All2 (eq_term_upto_univ [] (eq_universe Σ) (eq_universe Σ)) pars pars' ->
+  All2 (eq_term_upto_univ empty_global_env (eq_universe Σ) (eq_universe Σ)) pars pars' ->
   R_universe_instance (eq_universe Σ) puinst puinst' ->
   eq_context_upto Σ.1 (eq_universe Σ) (eq_universe Σ) (inst_case_context pars puinst ctx)
     (inst_case_context pars' puinst' ctx).
@@ -454,7 +454,7 @@ Lemma typing_leq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' :
   on_udecl Σ.1 Σ.2 ->
   Σ ;;; Γ |- t : T ->
   Σ ;;; Γ |- t' : T' ->
-  leq_term [] Σ t' t -> 
+  leq_term empty_global_env Σ t' t -> 
   (* No cumulativity of inductive types, as they can relate 
     inductives in different sorts. *)
   Σ ;;; Γ |- t' : T.
@@ -464,7 +464,7 @@ Proof.
   eapply (typing_ind_env 
   (fun Σ Γ t T =>
     forall (onu : on_udecl Σ.1 Σ.2),
-    forall t' T' : term, Σ ;;; Γ |- t' : T' -> leq_term [] Σ t' t -> Σ;;; Γ |- t' : T)
+    forall t' T' : term, Σ ;;; Γ |- t' : T' -> leq_term empty_global_env Σ t' t -> Σ;;; Γ |- t' : T)
   (fun Σ Γ => wf_local Σ Γ)); auto;intros Σ wfΣ Γ wfΓ; intros.
     1-13:match goal with
     [ H : leq_term _ _ _ _ |- _ ] => depelim H
@@ -722,7 +722,7 @@ Lemma typing_eq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' :
   wf_ext Σ ->
   Σ ;;; Γ |- t : T ->
   Σ ;;; Γ |- t' : T' ->
-  eq_term [] Σ t t' ->
+  eq_term empty_global_env Σ t t' ->
   Σ ;;; Γ |- t' : T.
 Proof.
   intros wfΣ ht ht' eq.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -238,9 +238,9 @@ Section Lemmata.
   Defined.
 
   Lemma welltyped_alpha Γ u v :
-      welltyped Σ Γ u ->
-      eq_term_upto_univ [] eq eq u v ->
-      welltyped Σ Γ v.
+    welltyped Σ Γ u ->
+    eq_term_upto_univ empty_global_env eq eq u v ->
+    welltyped Σ Γ v.
   Proof.
     intros [A h] e.
     exists A. eapply typing_alpha ; eauto.

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -1280,7 +1280,7 @@ Lemma nat_recursion_ext {A} (x : A) f g n :
   Nat.recursion x f n = Nat.recursion x g n.
 Proof.
   intros.
-  generalize (le_refl n). 
+  generalize (Nat.le_refl n). 
   induction n at 1 3 4; simpl; auto. 
   intros. simpl. rewrite IHn0; try lia. now rewrite H.
 Qed.

--- a/pcuic/theories/PCUICSpine.v
+++ b/pcuic/theories/PCUICSpine.v
@@ -224,8 +224,7 @@ Proof.
   intros wfext ctxi cu.
   induction ctxi; simpl; constructor; auto.
   * destruct Σ as [Σ univs].
-    eapply (typing_subst_instance'' Σ); eauto. apply wfext.
-    apply wfext.
+    eapply (typing_subst_instance'' Σ); eauto.
   * rewrite (subst_telescope_subst_instance u [i]).
     apply IHctxi.
   * rewrite (subst_telescope_subst_instance u [b]).
@@ -826,14 +825,10 @@ Qed.*)
     induction subsl; simpl; rewrite ?subst_instance_subst; constructor; auto.
     * destruct Σ as [Σ' univs].
       rewrite -subst_instance_subst.
-      eapply (typing_subst_instance'' Σ'); simpl; auto.
-      apply wfext. simpl in wfext. apply t0. 
-      apply wfext. auto.
+      eapply (typing_subst_instance'' Σ'); simpl; eauto.
     * rewrite - !subst_instance_subst. simpl.
       destruct Σ as [Σ' univs].
-      eapply (typing_subst_instance'' Σ'); simpl; auto.
-      apply wfext. simpl in wfext. apply t0. 
-      apply wfext. auto.
+      eapply (typing_subst_instance'' Σ'); simpl; eauto.
   Qed.
 
   Lemma spine_subst_weakening {Γ i s Δ Γ'} : 

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -95,8 +95,12 @@ Definition trans_global_decl (d : PCUICEnvironment.global_decl) :=
   | PCUICEnvironment.InductiveDecl bd => InductiveDecl (trans_minductive_body bd)
   end.
 
-Definition trans_global_decls (d : PCUICEnvironment.global_env) : global_env :=
+Definition trans_global_decls (d : PCUICEnvironment.global_declarations) : global_declarations :=
   List.map (on_snd trans_global_decl) d.
 
+Definition trans_global_env (d : PCUICEnvironment.global_env) : global_env :=
+  {| universes := d.(PCUICEnvironment.universes); 
+     declarations := trans_global_decls d.(PCUICEnvironment.declarations) |}.
+  
 Definition trans_global (Σ : PCUICEnvironment.global_env_ext) : global_env_ext :=
-  (trans_global_decls (fst Σ), snd Σ).
+  (trans_global_env (fst Σ), snd Σ).

--- a/pcuic/theories/PCUICUnivLevels.v
+++ b/pcuic/theories/PCUICUnivLevels.v
@@ -1,0 +1,306 @@
+
+Definition fresh_levels global_levels levels := 
+    LevelSet.For_all (fun l => ~ LevelSet.In l global_levels) levels.
+  
+  Definition declared_constraints_levels levels cstrs := 
+    ConstraintSet.For_all (declared_cstr_levels levels) cstrs.
+  
+  Definition declared_constraints_levels_union levels cstrs cstrs' :
+    declared_constraints_levels levels cstrs ->
+    declared_constraints_levels levels cstrs' ->
+    declared_constraints_levels levels (ConstraintSet.union cstrs cstrs').
+  Proof.
+    intros decl decl'.
+    rewrite /declared_constraints_levels.
+    intros x inx.
+    eapply ConstraintSetProp.FM.union_1 in inx as [].
+    now eapply decl. now eapply decl'.
+  Qed.
+    
+  Definition declared_constraints_levels_union_left levels levels' cstrs :
+    declared_constraints_levels levels cstrs ->
+    declared_constraints_levels (LevelSet.union levels levels') cstrs.
+  Proof.
+    rewrite /declared_constraints_levels.
+    intros hx x inx.
+    specialize (hx x inx).
+    destruct x as [[l d] r]. split.
+    destruct hx. now eapply LevelSetFact.union_2.
+    destruct hx.
+    now eapply LevelSetFact.union_2.
+  Qed.
+    
+  Definition declared_constraints_levels_union_right levels levels' cstrs :
+    declared_constraints_levels levels' cstrs ->
+    declared_constraints_levels (LevelSet.union levels levels') cstrs.
+  Proof.
+    rewrite /declared_constraints_levels.
+    intros hx x inx.
+    specialize (hx x inx).
+    destruct x as [[l d] r]. 
+    destruct hx; split. now eapply LevelSetFact.union_3.
+    now eapply LevelSetFact.union_3.
+  Qed.
+  
+  Definition declared_constraints_levels_subset levels levels' cstrs :
+    declared_constraints_levels levels cstrs ->
+    LevelSet.Subset levels levels' ->
+    declared_constraints_levels levels' cstrs.
+  Proof.
+    rewrite /declared_constraints_levels.
+    intros hx sub x inx.
+    specialize (hx x inx). red in hx.
+    destruct x as [[l d] r]; cbn in *.
+    split.
+    red in inx.
+    now eapply sub.
+    now eapply sub.
+  Qed.
+  
+  Lemma on_udecl_spec `{checker_flags} Σ (udecl : universes_decl) :
+    on_udecl Σ udecl =
+    let levels := levels_of_udecl udecl in
+    let global_levels := global_levels Σ in
+    let all_levels := LevelSet.union levels global_levels in
+    fresh_levels global_levels levels 
+    /\ declared_constraints_levels all_levels (constraints_of_udecl udecl)
+    /\ satisfiable_udecl Σ udecl.
+  Proof. unfold on_udecl. reflexivity. Qed.
+  
+  Lemma on_udecl_prop_spec `{checker_flags} Σ (udecl : universes_decl) :
+    on_udecl_prop Σ udecl = 
+      let levels := levels_of_udecl udecl in
+      let global_levels := global_levels Σ in
+      let all_levels := LevelSet.union levels global_levels in
+      declared_constraints_levels all_levels (constraints_of_udecl udecl).
+  Proof. reflexivity. Qed.
+  
+  Notation levels_of_list := LevelSetProp.of_list.
+  
+  Lemma levels_of_list_app l l' : 
+    levels_of_list (l ++ l') = 
+    LevelSet.union (levels_of_list l) 
+      (levels_of_list l').
+  Proof.
+    rewrite /LevelSetProp.of_list fold_right_app.
+    induction l; cbn.
+    apply LevelSet.eq_leibniz. red.
+    rewrite LevelSet_union_empty //.
+    apply LevelSet.eq_leibniz. red.
+    rewrite IHl. rewrite LevelSetProp.union_add //.
+  Qed.
+  
+  Definition aulevels inst cstrs : 
+    AUContext.levels (inst, cstrs) = 
+    LevelSetProp.of_list (unfold #|inst| Level.Var).
+  Proof.
+    cbn.
+    now rewrite mapi_unfold.
+  Qed.
+  
+  #[global] Instance unfold_proper {A} : Proper (eq ==> `=1` ==> eq) (@unfold A).
+  Proof.
+    intros x y -> f g eqfg.
+    induction y; cbn; auto. f_equal; auto. f_equal. apply eqfg.
+  Qed.
+  
+  (* sLemma unfold_add {A} n k (f : nat -> A) : skipn k (unfold (k + n) f) = unfold k (fun x => f (x + n)). *)
+  
+  Lemma unfold_add {A} n k (f : nat -> A) : unfold (n + k) f = unfold k f ++ unfold n (fun x => f (x + k)).
+  Proof.
+    induction n in k |- *.
+    cbn. now rewrite app_nil_r.
+    cbn. rewrite IHn. now rewrite app_assoc.
+  Qed.
+  
+  
+  Definition unfold_levels_app n k : 
+    LevelSetProp.of_list (unfold (n + k) Level.Var) = 
+    LevelSet.union (LevelSetProp.of_list (unfold k Level.Var))
+      (LevelSetProp.of_list (unfold n (fun i => Level.Var (k + i)))).
+  Proof.
+    rewrite unfold_add levels_of_list_app //.
+    now setoid_rewrite Nat.add_comm at 1.
+  Qed.
+  
+  Lemma levels_of_list_spec l ls : 
+    LevelSet.In l (levels_of_list ls) <-> In l ls.
+  Proof.
+    now rewrite LevelSetProp.of_list_1 InA_In_eq.
+  Qed.
+  
+  Lemma In_unfold k l n : 
+    In l (unfold n (λ i : nat, Level.Var (k + i))) <-> ∃ k' : nat, l = Level.Var k' ∧ k <= k' < k + n.
+  Proof.
+    induction n; cbn => //. firstorder. lia.
+    split. intros [] % in_app_or => //.
+    eapply IHn in H as [k' [eq lt]]. subst l; exists k'. intuition lia.
+    destruct H as []; subst => //.
+    exists (k + n). intuition lia.
+    intros [k' [-> lt]].
+    apply/in_or_app.
+    destruct (eq_dec k' (k + n)). subst k'.
+    right => //. cbn; auto.
+    left. eapply IHn. exists k'; intuition lia.
+  Qed.
+  
+  Lemma In_levels_of_list k l n : 
+    LevelSet.In l (levels_of_list (unfold n (fun i => Level.Var (k + i)))) <->
+    exists k', l = Level.Var k' /\ k <= k' < k + n. 
+  Proof.
+    rewrite LevelSetProp.of_list_1 InA_In_eq. now apply In_unfold.
+  Qed.
+  
+  Lemma In_lift_level k l n : LevelSet.In l (levels_of_list (unfold n (λ i : nat, Level.Var i))) <->
+    LevelSet.In (lift_level k l) (levels_of_list (unfold n (λ i : nat, Level.Var (k + i)))).
+  Proof.
+    split.
+    - move/(In_levels_of_list 0) => [k' [-> l'lt]].
+      eapply In_levels_of_list. exists (k + k'); cbn; intuition lia.
+    - move/(In_levels_of_list k) => [k' [eq l'lt]].
+      eapply (In_levels_of_list 0).
+      destruct l; noconf eq. exists n0; cbn; intuition lia.
+  Qed.
+  
+  Lemma not_var_lift l k s : 
+    LS.For_all (λ x : LS.elt, ~~ Level.is_var x) s ->
+    LevelSet.In l s ->
+    LevelSet.In (lift_level k l) s.
+  Proof.
+    intros.
+    specialize (H _ H0). cbn in H.
+    destruct l; cbn => //.
+  Qed.
+  
+  Lemma declared_constraints_levels_lift s n k cstrs : 
+    LS.For_all (λ x : LS.elt, (negb ∘ Level.is_var) x) s ->
+    declared_constraints_levels
+      (LevelSet.union (levels_of_list (unfold n (λ i : nat, Level.Var i))) s) cstrs ->
+    declared_constraints_levels
+      (LevelSet.union (levels_of_list (unfold n (λ i : nat, Level.Var (k + i)))) s)
+      (lift_constraints k cstrs).
+  Proof.
+    rewrite /declared_constraints_levels.
+    intros hs ha [[l d] r] inx.
+    eapply In_lift_constraints in inx as [c' [eq incs]].
+    specialize (ha _ incs). destruct c' as [[l' d'] r']; cbn in eq; noconf eq.
+    destruct ha as [inl' inr'].
+    apply LevelSetFact.union_1 in inl'. apply LevelSetFact.union_1 in inr'.
+    split.
+    - apply LevelSet.union_spec.
+      destruct inl'.
+      + left. now apply In_lift_level.
+      + right. apply not_var_lift => //.
+    - apply LevelSet.union_spec.
+      destruct inr'.
+      + left. now apply In_lift_level.
+      + right. apply not_var_lift => //.
+  Qed.
+  
+  Definition levels_of_cstr (c : ConstraintSet.elt) :=
+    let '(l, d, r) := c in
+    LevelSet.add l (LevelSet.add r LevelSet.empty).
+  
+  Definition levels_of_cstrs cstrs := 
+    ConstraintSet.fold (fun c acc => LevelSet.union (levels_of_cstr c) acc) cstrs.
+  
+  Lemma levels_of_cstrs_acc l cstrs acc :
+    LevelSet.In l acc \/ LevelSet.In l (levels_of_cstrs cstrs LevelSet.empty) <->
+    LevelSet.In l (levels_of_cstrs cstrs acc).
+  Proof.
+    rewrite /levels_of_cstrs.
+    rewrite !ConstraintSet.fold_spec.
+    induction (ConstraintSet.elements cstrs) in acc |- * => /=.
+    split. intros []; auto. inversion H. firstorder.
+    split.
+    intros []. apply IHl0. left. now eapply LevelSetFact.union_3.
+    apply IHl0 in H as []. apply IHl0. left.
+    eapply LevelSet.union_spec. left. 
+    eapply LevelSet.union_spec in H. destruct H => //. inversion H.
+    apply IHl0. right => //.
+    intros. apply IHl0 in H as [].
+    eapply LevelSet.union_spec in H. destruct H => //.
+    right. apply IHl0. left. apply LevelSet.union_spec. now left.
+    now left. right.
+    eapply IHl0. now right.
+  Qed.
+  
+  Lemma levels_of_cstrs_spec l cstrs : 
+    LevelSet.In l (levels_of_cstrs cstrs LevelSet.empty) <-> 
+    exists d r, ConstraintSet.In (l, d, r) cstrs \/ ConstraintSet.In (r, d, l) cstrs.
+  Proof.
+    rewrite -levels_of_cstrs_acc.
+    split.
+    - intros []. inversion H.
+      move: H.
+      rewrite /levels_of_cstrs.
+      eapply ConstraintSetProp.fold_rec.
+      + intros s' em inl. inversion inl.
+      + intros x a s' s'' inx ninx na.
+        intros.
+        destruct x as [[l' d] r].
+        eapply LevelSet.union_spec in H0 as [].
+        eapply LevelSet.add_spec in H0 as []; subst.
+        exists d, r. left. now apply na.
+        eapply LevelSet.add_spec in H0 as []; subst.
+        exists d, l'. right; now apply na. inversion H0.
+        specialize (H H0) as [d' [r' h]].
+        exists d', r'. red in na.
+        destruct h. destruct (na (l, d', r')).
+        firstorder. firstorder.
+    
+    - intros [d [r [indr|indr]]].
+      rewrite /levels_of_cstrs. right.
+      move: indr; eapply ConstraintSetProp.fold_rec.
+      intros. now specialize (H _ indr).
+      intros x a s' s'' inx inx' add inih ihih'.
+      eapply LevelSet.union_spec.
+      eapply add in ihih' as []; subst. left.
+      eapply LevelSet.add_spec. now left. firstorder.
+      right.
+      rewrite /levels_of_cstrs.
+      move: indr; eapply ConstraintSetProp.fold_rec.
+      intros. now specialize (H _ indr).
+      intros x a s' s'' inx inx' add inih ihih'.
+      eapply LevelSet.union_spec.
+      eapply add in ihih' as []; subst. left.
+      eapply LevelSet.add_spec. right. eapply LevelSet.add_spec; now left. firstorder.
+  Qed.
+  
+  Lemma declared_constraints_levels_in levels cstrs : 
+    LevelSet.Subset (levels_of_cstrs cstrs LevelSet.empty) levels ->
+    declared_constraints_levels levels cstrs.
+  Proof.
+    rewrite /declared_constraints_levels.
+    intros sub [[l d] r] inx. red in sub.
+    split. apply (sub l). eapply levels_of_cstrs_spec. do 2 eexists; firstorder eauto.
+    apply (sub r). eapply levels_of_cstrs_spec. do 2 eexists; firstorder eauto.
+  Qed.
+  
+  Lemma In_variance_cstrs l d r v i i' : 
+    ConstraintSet.In (l, d, r) (variance_cstrs v i i') ->
+      (In l i \/ In l i') /\ (In r i \/ In r i').
+  Proof.
+    induction v in i, i' |- *; destruct i, i'; intros; try solve [inversion H].
+    cbn in H.
+    destruct a. apply IHv in H. cbn. firstorder auto.
+    eapply ConstraintSet.add_spec in H as []. noconf H. cbn; firstorder.
+    eapply IHv in H; firstorder.
+    eapply ConstraintSet.add_spec in H as []. noconf H. cbn; firstorder.
+    eapply IHv in H; firstorder.
+  Qed.
+  
+  Lemma In_lift l n k : In l (map (lift_level k) (unfold n Level.Var)) <->
+    In l (unfold n (fun i => Level.Var (k + i))).
+  Proof.
+    induction n; cbn; auto. firstorder.
+    firstorder.
+    move: H1; rewrite map_app. 
+    intros [] % in_app_or.
+    apply/in_or_app. firstorder.
+    apply/in_or_app. firstorder.
+    move: H1; intros [] % in_app_or.
+    rewrite map_app. apply/in_or_app. firstorder.
+    rewrite map_app. apply/in_or_app. firstorder.
+  Qed.
+  

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -27,8 +27,8 @@ Section Validity.
   Lemma isType_weaken_full : weaken_env_prop_full (fun Σ Γ t T => isType Σ Γ T).
   Proof.
     red. intros.
-    destruct X1 as [u Hu]; exists u; pcuic.
-    unshelve eapply (weaken_env_prop_typing _ _ _ _ X0 _ _ (Some (tSort u))); eauto with pcuic.
+    destruct X2 as [u Hu]; exists u; pcuic.
+    unshelve eapply (weaken_env_prop_typing _ _ _ _ _ X1 _ _ (Some (tSort u))); eauto with pcuic.
     red. simpl. destruct Σ. eapply Hu.
   Qed.
 
@@ -39,23 +39,21 @@ Section Validity.
       (lift_typing (fun Σ Γ (_ T : term) => isType Σ Γ T)).
   Proof.
     red. intros.
-    unfold lift_typing in *. destruct T. now eapply (isType_weaken_full (_, _)).
-    destruct X1 as [s Hs]; exists s. now eapply (isType_weaken_full (_, _)).
+    unfold lift_typing in *. destruct T. now eapply (isType_weaken_full (Σ, _)).
+    destruct X2 as [s Hs]; exists s. now eapply (isType_weaken_full (Σ, _)).
   Qed.
   Hint Resolve isType_weaken : pcuic.
 
-  Lemma isType_extends (Σ : global_env) (Σ' : PCUICEnvironment.global_env) (φ : universes_decl) :
-    wf Σ' ->
+  Lemma isType_extends (Σ : global_env) (Σ' : global_env) (φ : universes_decl) :
+    wf Σ -> wf Σ' ->
     extends Σ Σ' ->
     forall Γ : context,
     forall t0 : term,
     isType (Σ, φ) Γ t0 -> isType (Σ', φ) Γ t0.
   Proof.
-    intros.
-    destruct X1 as [s Hs].
+    intros wfΣ wfΣ' ext Γ t [s Hs].
     exists s.
     eapply (env_prop_typing weakening_env (Σ, φ)); auto.
-    simpl; auto. now eapply wf_extends.
   Qed.
 
   Lemma weaken_env_prop_isType :
@@ -65,10 +63,9 @@ Section Validity.
           (Γ0 : PCUICEnvironment.context) (_ T : term) =>
         isType Σ0 Γ0 T)).
   Proof.
-    red. intros.
-    red in X1 |- *.
+    red. intros Σ Σ' ϕ wfΣ wfΣ' ext *. unfold lift_typing.
     destruct T. now eapply isType_extends.
-    destruct X1 as [s Hs]; exists s; now eapply isType_extends.
+    intros [s Hs]; exists s. now eapply (isType_extends (empty_ext Σ)).
   Qed.
 
   Lemma isType_Sort_inv {Σ : global_env_ext} {Γ s} : wf Σ -> isType Σ Γ (tSort s) -> wf_universe Σ s.

--- a/pcuic/theories/README.md
+++ b/pcuic/theories/README.md
@@ -92,13 +92,13 @@
 [PCUICNamelessTyp]: ./Typing/PCUICNamelessTyp.v
 
 
-## ws_cumul_pb up to universes
+## Equality up to universes
 
 | File                  | Description
 | ----------------------| --------------------
-| [PCUICEquality]       | ws_cumul_pb up to universes between terms (`eq_term`)
+| [PCUICEquality]       | Equality up to universes between terms (`eq_term`)
 | [PCUICCasesContexts]  | Helper lemmas for the handling of case branche and predicate contexts
-| [PCUICEqualityDec]    | Decidability of ws_cumul_pb up to universes
+| [PCUICEqualityDec]    | Decidability of equality up to universes
 
 [PCUICCasesContexts]: ./PCUICCasesContexts.v
 [PCUICEquality]: ./PCUICEquality.v
@@ -113,7 +113,7 @@
 | [PCUICContextReduction] | Properties of reduction between contexts
 | [PCUICParallelReduction] | Definition of parallel reduction, and stability by weakening and substitution
 | [PCUICParallelReductionConfluence] | Proof of the diamond property for parallel reduction
-| [PCUICConfluence] | Proof of confluence for reduction and that ws_cumul_pb up to universes is a simulation for reduction
+| [PCUICConfluence] | Proof of confluence for reduction and that equality up to universes is a simulation for reduction
 | [PCUICRedTypeIrrelevance] | Types and names in the context are irrelevant for reduction, only the bodies of definitions are used
 
 

--- a/pcuic/theories/Syntax/PCUICLiftSubst.v
+++ b/pcuic/theories/Syntax/PCUICLiftSubst.v
@@ -207,7 +207,7 @@ Lemma commut_lift_subst_rec M N n p k :
   k <= p -> lift n k (subst N p M) = subst N (p + n) (lift n k M).
 Proof.
   revert N n p k; elim M using term_forall_list_ind; intros; cbnr;
-    f_equal; auto; solve_all; rewrite ?plus_Snm_nSm -?Nat.add_assoc; eauto with all.
+    f_equal; auto; solve_all; rewrite ?Nat.add_succ_r -?Nat.add_assoc; eauto with all.
 
   - repeat nth_leb_simpl.
     rewrite -> simpl_lift by easy. f_equal; lia.

--- a/pcuic/theories/Syntax/PCUICNamelessDef.v
+++ b/pcuic/theories/Syntax/PCUICNamelessDef.v
@@ -147,9 +147,13 @@ Definition nl_global_decl (d : global_decl) : global_decl :=
   | InductiveDecl mib => InductiveDecl (nl_mutual_inductive_body mib)
   end.
 
-Definition nl_global_env (Σ : global_env) : global_env :=
+Definition nl_global_declarations (Σ : global_declarations) : global_declarations :=
   (map (on_snd nl_global_decl) Σ).
 
+Definition nl_global_env (Σ : global_env) : global_env :=
+  {| universes := Σ.(universes); 
+     declarations := nl_global_declarations Σ.(declarations) |}.
+  
 Definition nlg (Σ : global_env_ext) : global_env_ext :=
   let '(Σ, φ) := Σ in
   (nl_global_env Σ, φ).

--- a/pcuic/theories/Syntax/PCUICOnFreeVars.v
+++ b/pcuic/theories/Syntax/PCUICOnFreeVars.v
@@ -42,7 +42,7 @@ Proof.
   rewrite !/shiftnP /shiftn.
   destruct (Nat.ltb_spec k i) => /=.
   all: nat_compare_specs => //=.
-  by rewrite minus_plus.
+  by rewrite Nat.add_comm Nat.add_sub.
 Qed.
 
 Lemma shiftnP_impl (p q : nat -> bool) : (forall i, p i -> q i) ->

--- a/pcuic/theories/TemplateToPCUIC.v
+++ b/pcuic/theories/TemplateToPCUIC.v
@@ -146,8 +146,12 @@ Section Trans.
     end.
 End Trans.
 
-Definition trans_global_decls (d : Ast.Env.global_env) : global_env :=
-  fold_right (fun decl Σ' => on_snd (trans_global_decl Σ') decl :: Σ') [] d.
+Definition trans_global_decls univs (d : Ast.Env.global_declarations) : global_declarations :=
+  fold_right (fun decl Σ' => on_snd (trans_global_decl {| universes := univs; declarations := Σ' |}) decl :: Σ') [] d.
+
+Definition trans_global_env (d : Ast.Env.global_env) : global_env :=
+  {| universes := d.(Ast.Env.universes); 
+     declarations := trans_global_decls d.(Ast.Env.universes) d.(Ast.Env.declarations) |}.
 
 Definition trans_global (Σ : Ast.Env.global_env_ext) : global_env_ext :=
-  (trans_global_decls (fst Σ), snd Σ).
+  (trans_global_env (fst Σ), snd Σ).

--- a/pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -121,7 +121,7 @@ Ltac dest_lookup :=
   
 Lemma trans_csubst {cf} Σ a k b :
   Typing.wf Σ ->
-  let Σ' := trans_global_decls Σ in
+  let Σ' := trans_global_env Σ in
   wf Σ' ->
   WfAst.wf Σ a ->
   trans Σ' (WcbvEval.csubst a k b) = csubst (trans Σ' a) k (trans Σ' b).
@@ -158,7 +158,7 @@ Qed.
 
 Lemma trans_substl {cf} Σ a b :
   Typing.wf Σ ->
-  let Σ' := trans_global_decls Σ in
+  let Σ' := trans_global_env Σ in
   wf Σ' ->
   All (WfAst.wf Σ) a ->
   trans Σ' (WcbvEval.substl a b) = substl (map (trans Σ') a) (trans Σ' b).
@@ -328,8 +328,8 @@ Proof.
 Qed.
 
 Lemma trans_fix_subst Σ mfix :
-  fix_subst (map (map_def (trans (trans_global_decls Σ)) (trans (trans_global_decls Σ))) mfix) = 
-  map (trans (trans_global_decls Σ)) (Typing.fix_subst mfix).
+  fix_subst (map (map_def (trans (trans_global_env Σ)) (trans (trans_global_env Σ))) mfix) = 
+  map (trans (trans_global_env Σ)) (Typing.fix_subst mfix).
 Proof.
   unfold Typing.fix_subst, fix_subst.
   len. generalize #|mfix|; induction n; simpl; auto.
@@ -337,8 +337,8 @@ Proof.
 Qed.
 
 Lemma trans_cofix_subst Σ mfix :
-  cofix_subst (map (map_def (trans (trans_global_decls Σ)) (trans (trans_global_decls Σ))) mfix) = 
-  map (trans (trans_global_decls Σ)) (Typing.cofix_subst mfix).
+  cofix_subst (map (map_def (trans (trans_global_env Σ)) (trans (trans_global_env Σ))) mfix) = 
+  map (trans (trans_global_env Σ)) (Typing.cofix_subst mfix).
 Proof.
   unfold Typing.cofix_subst, cofix_subst.
   len. generalize #|mfix|; induction n; simpl; auto.
@@ -377,13 +377,13 @@ Qed.
 
 Lemma trans_cunfold_fix {cf} {Σ mfix idx narg fn} :
   Typing.wf Σ -> 
-  wf (trans_global_decls Σ) ->
+  wf (trans_global_env Σ) ->
   All (fun def : def Ast.term => Swf_fix Σ def) mfix ->
   WcbvEval.cunfold_fix mfix idx = Some (narg, fn) ->
   cunfold_fix
     (map
-    (map_def (trans (trans_global_decls Σ)) (trans (trans_global_decls Σ)))
-      mfix) idx = Some (narg, trans (trans_global_decls Σ) fn).
+    (map_def (trans (trans_global_env Σ)) (trans (trans_global_env Σ)))
+      mfix) idx = Some (narg, trans (trans_global_env Σ) fn).
 Proof.
   intros wfΣ wfΣ'.
   unfold WcbvEval.cunfold_fix, cunfold_fix.
@@ -397,13 +397,13 @@ Qed.
 
 Lemma trans_cunfold_cofix {cf} {Σ mfix idx narg fn} :
   Typing.wf Σ -> 
-  wf (trans_global_decls Σ) ->
+  wf (trans_global_env Σ) ->
   All (fun def : def Ast.term => Swf_fix Σ def) mfix ->
   WcbvEval.cunfold_cofix mfix idx = Some (narg, fn) ->
   cunfold_cofix
     (map
-    (map_def (trans (trans_global_decls Σ)) (trans (trans_global_decls Σ)))
-      mfix) idx = Some (narg, trans (trans_global_decls Σ) fn).
+    (map_def (trans (trans_global_env Σ)) (trans (trans_global_env Σ)))
+      mfix) idx = Some (narg, trans (trans_global_env Σ) fn).
 Proof.
   intros wfΣ wfΣ'.
   unfold WcbvEval.cunfold_cofix, cunfold_cofix.
@@ -560,7 +560,7 @@ Proof.
 Qed.
 
 Lemma trans_wcbvEval {cf} {Σ} {wfΣ : ST.wf Σ} T U :
-  let Σ' := trans_global_decls Σ in
+  let Σ' := trans_global_env Σ in
   wf Σ' ->
   WfAst.wf Σ T ->
   WcbvEval.eval Σ T U ->

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -79,13 +79,11 @@ Lemma declared_decl_closed_ind `{checker_flags} {Σ : global_env} {wfΣ : wf Σ}
                  (Σ, universes_decl_of_decl decl) cst decl.
 Proof.
   intros.
-  eapply weaken_lookup_on_global_env; try red; eauto.
-  eapply on_global_env_impl; cycle 1. tea.
+  eapply weaken_lookup_on_global_env; eauto. red; eauto.
+  eapply (on_global_env_impl (empty_ext Σ)); cycle 1. tea.
   red; intros. unfold lift_typing in *. destruct T; intuition auto with wf.
-  destruct X1 as [s0 Hs0]. simpl. rtoProp; intuition.
+  destruct X2 as [s0 Hs0]. simpl. rtoProp; intuition.
 Qed.
- 
-
 
 Lemma declared_minductive_closed_ind {cf:checker_flags} {Σ : global_env} {wfΣ : wf Σ}{mdecl mind} : 
   Forall_decls_typing
@@ -192,7 +190,7 @@ Proof.
 
   - rewrite closedn_subst_instance.
     eapply lookup_on_global_env in X0; eauto.
-    destruct X0 as [Σ' [HΣ' IH]].
+    destruct X0 as [Σ' [hext [onu HΣ'] IH]].
     repeat red in IH. destruct decl, cst_body0. simpl in *.
     rewrite -> andb_and in IH. intuition auto.
     eauto using closed_upwards with arith.
@@ -495,7 +493,7 @@ Proof.
   intros h.
   unfold declared_constant in h.
   eapply lookup_on_global_env in h. 2: eauto.
-  destruct h as [Σ' [wfΣ' decl']].
+  destruct h as [Σ' [ext wfΣ' decl']].
   red in decl'. red in decl'.
   destruct decl as [ty bo un]. simpl in *.
   destruct bo as [t|].
@@ -515,7 +513,7 @@ Proof.
   intros Σ cst decl body hΣ h e.
   unfold declared_constant in h.
   eapply lookup_on_global_env in h. 2: eauto.
-  destruct h as [Σ' [wfΣ' decl']].
+  destruct h as [Σ' [ext wfΣ' decl']].
   red in decl'. red in decl'.
   destruct decl as [ty bo un]. simpl in *.
   rewrite e in decl'.
@@ -535,7 +533,7 @@ Proof.
   destruct h as [h1 h2].
   unfold declared_minductive in h1.
   eapply lookup_on_global_env in h1. 2: eauto.
-  destruct h1 as [Σ' [wfΣ' decl']].
+  destruct h1 as [Σ' [ext wfΣ' decl']].
   red in decl'. destruct decl' as [h ? ? ?].
   eapply Alli_nth_error in h. 2: eassumption.
   simpl in h. destruct h as [? [? h] ? ? ?].

--- a/pcuic/theories/Typing/PCUICInstTyp.v
+++ b/pcuic/theories/Typing/PCUICInstTyp.v
@@ -527,7 +527,7 @@ Proof.
       eapply inst_ext_closed.
       intros x Hx.
       rewrite subst_consn_lt /=; len; try lia.
-      rewrite Upn_comp; try now repeat len. 2:cbn; len.
+      rewrite Upn_comp; try now repeat len. 1:cbn; len.
       rewrite subst_consn_lt /=; len; try lia.
       now rewrite map_rev.
   - intros Σ wfΣ Γ wfΓ mfix n decl types hguard hnth htypes hmfix ihmfix wffix Δ σ hΔ hσ.

--- a/pcuic/theories/Typing/PCUICInstTyp.v
+++ b/pcuic/theories/Typing/PCUICInstTyp.v
@@ -527,8 +527,8 @@ Proof.
       eapply inst_ext_closed.
       intros x Hx.
       rewrite subst_consn_lt /=; len; try lia.
-      rewrite Upn_comp; try now repeat len. 1:cbn; len.
-      rewrite subst_consn_lt /=; len; try lia.
+      rewrite Upn_comp; cbn; try now repeat len.
+      rewrite subst_consn_lt /=; cbn; len; try lia.
       now rewrite map_rev.
   - intros Σ wfΣ Γ wfΓ mfix n decl types hguard hnth htypes hmfix ihmfix wffix Δ σ hΔ hσ.
     simpl. eapply meta_conv; [econstructor;eauto|].

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -209,15 +209,11 @@ Hint Resolve declared_inductive_wf_ext_wk declared_inductive_wf_global_ext : pcu
 Lemma typing_subst_instance :
   env_prop (fun Σ Γ t T => forall u univs,
                 wf_ext_wk Σ ->
-                sub_context_set (monomorphic_udecl Σ.2)
-                                (global_ext_context_set (Σ.1, univs)) ->
                 consistent_instance_ext (Σ.1, univs) Σ.2 u ->
                 (Σ.1,univs) ;;; subst_instance u Γ
                 |- subst_instance u t : subst_instance u T)
           (fun Σ Γ => forall u univs,
           wf_ext_wk Σ ->
-          sub_context_set (monomorphic_udecl Σ.2)
-                          (global_ext_context_set (Σ.1, univs)) ->
           consistent_instance_ext (Σ.1, univs) Σ.2 u ->
           wf_local(Σ.1,univs) (subst_instance u Γ)).
 Proof.
@@ -231,26 +227,26 @@ Proof.
       ++ exists (subst_instance_univ u tu.π1). eapply p0; auto.
       ++ apply p; auto.
 
-  - intros n decl eq X u univs wfΣ' H Hsub. rewrite subst_instance_lift.
+  - intros n decl eq X u univs wfΣ' H. rewrite subst_instance_lift.
     rewrite map_decl_type. econstructor; aa.
     unfold subst_instance, map_context.
     now rewrite nth_error_map eq.
-  - intros l X Hl u univs wfΣ' HSub H.
+  - intros l X Hl u univs wfΣ' H.
     rewrite subst_instance_univ_super.
     + econstructor.
       * aa.
       * now apply wf_universe_subst_instance.
-  - intros n t0 b s1 s2 X X0 X1 X2 X3 u univs wfΣ' HSub H.
+  - intros n t0 b s1 s2 X X0 X1 X2 X3 u univs wfΣ' H.
     rewrite product_subst_instance; aa. econstructor.
     + eapply X1; eauto.
     + eapply X3; eauto.
-  - intros n t0 b s1 bty X X0 X1 X2 X3 u univs wfΣ' HSub H.
+  - intros n t0 b s1 bty X X0 X1 X2 X3 u univs wfΣ' H.
     econstructor.
     + eapply X1; aa.
     + eapply X3; aa.
-  - intros n b b_ty b' s1 b'_ty X X0 X1 X2 X3 X4 X5 u univs wfΣ' HSub H.
+  - intros n b b_ty b' s1 b'_ty X X0 X1 X2 X3 X4 X5 u univs wfΣ' H.
     econstructor; eauto. eapply X5; aa.
-  - intros t0 na A B s u X X0 X1 X2 X3 X4 X5 u0 univs wfΣ' HSub H.
+  - intros t0 na A B s u X X0 X1 X2 X3 X4 X5 u0 univs wfΣ' H.
     rewrite subst_instance_subst. cbn. econstructor.
     + eapply X1; eauto.
     + eapply X3; eauto.
@@ -271,7 +267,7 @@ Proof.
 
   - intros ci p c brs args u mdecl idecl isdecl hΣ hΓ indnp eqpctx wfp cup
       wfpctx pty Hpty Hcpc kelim
-      Hctxi IHctxi Hc IHc notCoFinite wfbrs hbrs i univs wfext Hsub cu.
+      Hctxi IHctxi Hc IHc notCoFinite wfbrs hbrs i univs wfext cu.
     rewrite subst_instance_mkApps subst_instance_it_mkLambda_or_LetIn map_app.
     cbn.
     change (subst_instance i (preturn p)) with (preturn (subst_instance i p)).
@@ -287,14 +283,13 @@ Proof.
       now rewrite subst_instance_mkApps map_app in cu.
     + simpl. eapply consistent_ext_trans; tea.
     + now rewrite -subst_instance_case_predicate_context -subst_instance_app_ctx.
-    + destruct Hsub.
-      cbn in *.
+    + cbn in *.
       eapply is_allowed_elimination_subst_instance; aa.
     + move: IHctxi. simpl.
       rewrite -subst_instance_app.
       rewrite -subst_instance_two_context.
       rewrite -[List.rev (subst_instance i _)]map_rev.
-      clear -wfext Hsub cu. induction 1; cbn; constructor; simpl; eauto.
+      clear -wfext cu. induction 1; cbn; constructor; simpl; eauto.
       all:now rewrite -(subst_instance_subst_telescope i [_]).
     + rewrite -{1}(map_id (ind_ctors idecl)).
       eapply All2i_map. eapply All2i_impl; eauto. 
@@ -304,11 +299,11 @@ Proof.
       rewrite - !subst_instance_case_branch_context - !subst_instance_app_ctx.
       rewrite -subst_instance_case_predicate_context subst_instance_case_branch_type.
       repeat split; auto.
-      * specialize (ihbod i univs wfext Hsub cu).
+      * specialize (ihbod i univs wfext cu).
         cbn. eapply ihbod.
-      * specialize (ihbty i univs wfext Hsub cu).
+      * specialize (ihbty i univs wfext cu).
         cbn. eapply ihbty.
-  - intros p c u mdecl idecl cdecl pdecl isdecl args X X0 X1 X2 H u0 univs wfΣ' HSub H0.
+  - intros p c u mdecl idecl cdecl pdecl isdecl args X X0 X1 X2 H u0 univs wfΣ' H0.
     rewrite subst_instance_subst. cbn.
     rewrite !subst_instance_two.
     rewrite {4}/subst_instance /subst_instance_list /=.
@@ -317,9 +312,9 @@ Proof.
     eapply X2 in H0; tas. rewrite subst_instance_mkApps in H0.
     eassumption.
 
-  - intros mfix n decl H H0 H1 X X0 wffix u univs wfΣ' HSub.
+  - intros mfix n decl H H0 H1 X X0 wffix u univs wfΣ'.
     rewrite (map_dtype _ (subst_instance u)). econstructor.
-    + specialize (H1 u univs wfΣ' HSub H2).
+    + specialize (H1 u univs wfΣ' H2).
       rewrite subst_instance_app in H1.
       now eapply wf_local_app_inv in H1 as [].
     + now eapply fix_guard_subst_instance.
@@ -329,7 +324,7 @@ Proof.
       now apply Hs.
     + eapply All_map, All_impl; tea.
       intros x [X1 X3]. 
-      specialize (X3 u univs wfΣ' HSub H2). 
+      specialize (X3 u univs wfΣ' H2). 
       rewrite (map_dbody (subst_instance u)) in X3.
       rewrite subst_instance_lift in X3.
       rewrite fix_context_length ?map_length in X0, X1, X3.
@@ -342,9 +337,9 @@ Proof.
       rewrite map_map_compose.
       now rewrite subst_instance_check_one_fix.
 
-      - intros mfix n decl H H0 H1 X X0 wffix u univs wfΣ' HSub.
+      - intros mfix n decl H H0 H1 X X0 wffix u univs wfΣ'.
       rewrite (map_dtype _ (subst_instance u)). econstructor.
-      + specialize (H1 u univs wfΣ' HSub H2).
+      + specialize (H1 u univs wfΣ' H2).
         rewrite subst_instance_app in H1.
         now eapply wf_local_app_inv in H1 as [].
       + now eapply cofix_guard_subst_instance.
@@ -354,7 +349,7 @@ Proof.
         now apply Hs.
       + eapply All_map, All_impl; tea.
         intros x [X1 X3]. 
-        specialize (X3 u univs wfΣ' HSub H2). 
+        specialize (X3 u univs wfΣ' H2). 
         rewrite (map_dbody (subst_instance u)) in X3.
         rewrite subst_instance_lift in X3.
         rewrite fix_context_length ?map_length in X0, X1, X3.
@@ -367,17 +362,16 @@ Proof.
         rewrite map_map_compose.
         now rewrite subst_instance_check_one_cofix.
       
-  - intros t0 A B X X0 X1 X2 X3 X4 cum u univs wfΣ' HSub H.
+  - intros t0 A B X X0 X1 X2 X3 X4 cum u univs wfΣ' H.
     econstructor.
     + eapply X2; aa.
     + eapply X4; aa.
-    + destruct HSub. eapply cumulSpec_subst_instance; aa.
+    + eapply cumulSpec_subst_instance; aa.
 Qed.
 
 Lemma typing_subst_instance' Σ φ Γ t T u univs :
   wf_ext_wk (Σ, univs) ->
   (Σ, univs) ;;; Γ |- t : T ->
-  sub_context_set (monomorphic_udecl univs) (global_ext_context_set (Σ, φ)) ->
   consistent_instance_ext (Σ, φ) univs u ->
   (Σ, φ) ;;; subst_instance u Γ
             |- subst_instance u t : subst_instance u T.
@@ -389,7 +383,6 @@ Qed.
 Lemma typing_subst_instance_wf_local Σ φ Γ u univs :
   wf_ext_wk (Σ, univs) ->
   wf_local (Σ, univs) Γ ->
-  sub_context_set (monomorphic_udecl univs) (global_ext_context_set (Σ, φ)) ->
   consistent_instance_ext (Σ, φ) univs u ->
   wf_local (Σ, φ) (subst_instance u Γ).
 Proof.
@@ -400,14 +393,12 @@ Qed.
 Lemma typing_subst_instance'' Σ φ Γ t T u univs :
   wf_ext_wk (Σ, univs) ->
   (Σ, univs) ;;; Γ |- t : T ->
-  sub_context_set (monomorphic_udecl univs) (global_context_set Σ) ->
   consistent_instance_ext (Σ, φ) univs u ->
   (Σ, φ) ;;; subst_instance u Γ
             |- subst_instance u t : subst_instance u T.
 Proof.
   intros X X0 X1.
   eapply (typing_subst_instance (Σ, univs)); tas. 1: apply X.
-  etransitivity; tea. apply global_context_set_sub_ext.
 Qed.
 
 Lemma typing_subst_instance_ctx (Σ : global_env_ext) Γ t T ctx u :
@@ -420,10 +411,7 @@ Lemma typing_subst_instance_ctx (Σ : global_env_ext) Γ t T ctx u :
 Proof.
   destruct Σ as [Σ φ]. intros X X0 X1.
   eapply typing_subst_instance''; tea.
-  - split; tas.
-  - simpl. unfold sub_context_set. split; simpl.
-    * intros x hx. now eapply LS.empty_spec in hx.
-    * intros x hx. now eapply CS.empty_spec in hx. 
+  split; tas.
 Qed.
 
 Lemma typing_subst_instance_decl Σ Γ t T c decl u :
@@ -436,9 +424,8 @@ Lemma typing_subst_instance_decl Σ Γ t T c decl u :
 Proof.
   destruct Σ as [Σ φ]. intros X X0 X1 X2.
   eapply typing_subst_instance''; tea.
-  - split; tas.
-    eapply weaken_lookup_on_global_env'; tea.
-  - eapply weaken_lookup_on_global_env''; tea.
+  split; tas.
+  eapply weaken_lookup_on_global_env'; tea.
 Qed.
 
 
@@ -544,7 +531,7 @@ Qed.
       simpl in H; noconf H. apply H0.
     - destruct decli as [declm _].
       eapply declared_inductive_wf_global_ext in declm; auto.
-      destruct declm. apply w.
+      destruct declm. apply o.
   Qed.
 
   Lemma subst_instance_ind_type_id Σ mdecl ind idecl :
@@ -561,7 +548,6 @@ Qed.
     eapply typed_subst_abstract_instance in t; eauto.
     destruct decli as [declm _].
     eapply declared_inductive_wf_global_ext in declm; auto.
-    destruct declm. apply w.
   Qed.
 
   Lemma isType_subst_instance_id Σ Γ T :

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -15,16 +15,12 @@ Implicit Types (cf : checker_flags).
 Lemma subrelations_extends `{CF:checker_flags} Σ Σ' φ :
   extends Σ Σ' ->
   RelationClasses.subrelation (eq_universe (global_ext_constraints (Σ,φ))) (eq_universe (global_ext_constraints (Σ',φ))).
-Proof. 
-  intros [Σ'' ->] x y e. eapply eq_universe_subset; eauto.  eapply global_ext_constraints_app.
-Defined. 
+Proof. typeclasses eauto. Qed.
 
-Lemma subrelations_leq__extends `{CF:checker_flags} Σ Σ' φ :
+Lemma subrelations_leq_extends `{CF:checker_flags} Σ Σ' φ :
   extends Σ Σ' ->
   RelationClasses.subrelation (leq_universe (global_ext_constraints (Σ,φ))) (leq_universe (global_ext_constraints (Σ',φ))).
-Proof. 
-  intros [Σ'' ->] x y e. eapply leq_universe_subset; eauto.  eapply global_ext_constraints_app.
-Defined.
+Proof. typeclasses eauto. Qed.
 
 Lemma weakening_env_convSpec `{CF:checker_flags} Σ Σ' φ Γ M N :
   wf Σ' ->
@@ -34,8 +30,9 @@ Lemma weakening_env_convSpec `{CF:checker_flags} Σ Σ' φ Γ M N :
 Proof. 
   intros HΣ' Hextends Ind. 
   revert Γ M N Ind Σ' HΣ' Hextends. 
-  eapply (convSpec0_ind_all (Σ,φ )
-            (fun Γ M N => forall Σ' : global_env, wf Σ' -> extends Σ Σ' -> (Σ', φ);;; Γ |- M =s N)); intros; try solve [econstructor; eauto with extends; intuition]. 
+  eapply (convSpec0_ind_all (Σ,φ ) 
+            (fun Γ M N => forall Σ' : global_env, wf Σ' -> extends Σ Σ' -> (Σ', φ);;; Γ |- M =s N)); 
+    intros; try solve [econstructor; eauto with extends; intuition]. 
   - eapply cumul_Evar. eapply All2_impl. 1: tea. cbn; intros. apply X2.2; eauto.    
   - eapply cumul_Case; intuition.
     * destruct X. repeat split; intuition. 
@@ -50,7 +47,8 @@ Proof.
   - eapply cumul_Construct.
     * eapply R_global_instance_weaken_env; eauto. all: apply subrelations_extends; eauto. 
     * eapply All2_impl. 1: tea. cbn; intros. intuition.  
-  - eapply cumul_Sort. eapply eq_universe_subset; eauto. destruct X0. rewrite e. eapply global_ext_constraints_app.
+  - eapply cumul_Sort. eapply eq_universe_subset; eauto.
+    now eapply weakening_env_global_ext_constraints.
   - eapply cumul_Const. eapply R_universe_instance_impl'; eauto. apply subrelations_extends; eauto. 
   Defined. 
 
@@ -61,10 +59,10 @@ Lemma subrelations_compare_extends `{CF:checker_flags} Σ Σ' pb φ :
   RelationClasses.subrelation (compare_universe pb (global_ext_constraints (Σ,φ))) 
     (compare_universe pb (global_ext_constraints (Σ',φ))).
 Proof. 
-  intros [Σ'' ->] x y e.
+  intros [cu [Σ'' eq]] x y e.
   destruct pb; cbn in *. 
-  - eapply eq_universe_subset; eauto. eapply global_ext_constraints_app.
-  - eapply leq_universe_subset; eauto. eapply global_ext_constraints_app.
+  - eapply eq_universe_subset; eauto. eapply global_ext_constraints_app, cu.
+  - eapply leq_universe_subset; eauto. eapply global_ext_constraints_app, cu.
 Qed.
 
 Lemma subrelations_eq_compare_extends `{CF:checker_flags} Σ Σ' pb φ :
@@ -72,11 +70,11 @@ Lemma subrelations_eq_compare_extends `{CF:checker_flags} Σ Σ' pb φ :
   RelationClasses.subrelation (eq_universe (global_ext_constraints (Σ,φ))) 
     (compare_universe pb (global_ext_constraints (Σ',φ))).
 Proof. 
-  intros [Σ'' ->] x y e.
+  intros [cu [Σ'' eq]] x y e.
   destruct pb; cbn in *. 
-  - eapply eq_universe_subset; eauto. eapply global_ext_constraints_app.
+  - eapply eq_universe_subset; eauto. eapply global_ext_constraints_app, cu.
   - eapply leq_universe_subset; eauto. 2:eapply eq_universe_leq_universe; tea.
-    eapply global_ext_constraints_app.
+    eapply global_ext_constraints_app, cu.
 Qed.
 
 Lemma weakening_env_cumulSpec `{CF:checker_flags} Σ Σ' φ Γ pb M N :
@@ -86,14 +84,23 @@ Lemma weakening_env_cumulSpec `{CF:checker_flags} Σ Σ' φ Γ pb M N :
   cumulSpec0 (Σ', φ) Γ pb M N.
 Proof.
   intros HΣ' Hextends Ind.
-  revert pb Γ M N Ind Σ' HΣ' Hextends.
+  unfold cumulSpec. 
+  pose proof (subrelations_leq_extends _ _  φ Hextends). revert H.
+  assert (RelationClasses.subrelation 
+          (eq_universe (global_ext_constraints (Σ,φ)))
+          (leq_universe (global_ext_constraints (Σ',φ)))). 
+  { etransitivity; try apply subrelations_leq_extends; eauto. 
+    apply eq_universe_leq_universe.  } revert H.
+  generalize (leq_universe (global_ext_constraints (Σ',φ))); intros Rle Hlee Hle . 
+  revert pb Γ M N Ind Σ' Rle Hle Hlee HΣ' Hextends. 
   apply: (cumulSpec0_ind_all (Σ,φ)).
-  all:intros; try solve [econstructor; eauto with extends; intuition auto].
+  all:intros; try solve [econstructor; eauto with extends; intuition auto]. 
   - eapply cumul_Evar. solve_all.
   - eapply cumul_Case; intuition auto.
-    * destruct X. repeat split; intuition auto.
+    * destruct X. repeat split; intuition.
       + solve_all.
       + eapply R_universe_instance_impl'; eauto; subrel.
+    * solve_all.
     * solve_all.
   - eapply cumul_Fix; solve_all.
   - eapply cumul_CoFix; solve_all.
@@ -192,19 +199,19 @@ Qed.
 
 Lemma weakening_on_global_decl `{checker_flags} P Σ Σ' φ kn decl :
   weaken_env_prop P ->
-  wf Σ' -> extends Σ Σ' ->
+  wf Σ -> wf Σ' -> extends Σ Σ' ->
   on_global_decl P (Σ, φ) kn decl ->
   on_global_decl P (Σ', φ) kn decl.
 Proof.
   unfold weaken_env_prop.
-  intros HPΣ wfΣ' Hext Hdecl.
+  intros HPΣ wfΣ wfΣ' Hext Hdecl.
   destruct decl.
   1:{
     destruct c. destruct cst_body0.
     - simpl in *.
       red in Hdecl |- *. simpl in *.
-      eapply HPΣ; eauto.
-    - eapply HPΣ; eauto.
+      eapply (HPΣ Σ Σ'); eauto.
+    - eapply (HPΣ Σ Σ'); eauto.
   }
   simpl in *.
   destruct Hdecl as [onI onP onnP]; constructor; eauto.
@@ -245,7 +252,7 @@ Proof.
         intros. eapply Forall_impl; tea; simpl; intros.
         eapply leq_universe_subset; tea.
         apply weakening_env_global_ext_constraints; tea.
-      * destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ' Hext.
+      * destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ wfΣ' Hext.
         induction ind_indices; simpl in *; auto.
         -- eapply (extends_wf_universe (Σ:=(Σ,φ)) Σ'); auto.
         -- destruct a as [na [b|] ty]; simpl in *; intuition eauto.
@@ -266,22 +273,125 @@ Proof.
     all:eapply weakening_env_consistent_instance; tea.
 Qed.
 
-Lemma weakening_env_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
-  weaken_env_prop P ->
-  wf Σ' -> extends Σ Σ' -> on_global_env P Σ ->
+Lemma weakening_on_global_decl_ext `{checker_flags} P Σ Σ' φ kn decl :
+  weaken_env_decls_prop P ->
+  wf Σ' -> extends_decls Σ Σ' ->
+  on_global_decl P (Σ, φ) kn decl ->
+  on_global_decl P (Σ', φ) kn decl.
+Proof.
+  unfold weaken_env_prop.
+  intros HPΣ wfΣ' Hext Hdecl.
+  pose proof (wfΣ := extends_decls_wf _ _ wfΣ' Hext).
+  destruct decl.
+  1:{
+    destruct c. destruct cst_body0.
+    - simpl in *.
+      red in Hdecl |- *. simpl in *.
+      eapply (HPΣ Σ Σ'); eauto.
+    - eapply (HPΣ Σ Σ'); eauto.
+  }
+  simpl in *.
+  destruct Hdecl as [onI onP onnP]; constructor; eauto.
+  - eapply Alli_impl; eauto. intros.
+    destruct X. unshelve econstructor; eauto.
+    + unfold on_type in *; intuition eauto.
+    + unfold on_constructors in *. eapply All2_impl; eauto.
+      intros.
+      destruct X as [? ? ? ?]. unshelve econstructor; eauto.
+      * unfold on_type in *; eauto.
+      * clear on_cindices cstr_eq cstr_args_length.
+        revert on_cargs.
+        induction (cstr_args x0) in y |- *; destruct y; simpl in *; eauto.
+        ** destruct a as [na [b|] ty]; simpl in *; intuition eauto.
+        ** destruct a as [na [b|] ty]; simpl in *; intuition eauto.
+      * clear on_ctype on_cargs.
+        revert on_cindices.
+        generalize (List.rev (lift_context #|cstr_args x0| 0 (ind_indices x))).
+        generalize (cstr_indices x0).
+        induction 1; constructor; eauto.
+      * simpl.
+        intros v indv. specialize (on_ctype_variance v indv).
+        simpl in *. move: on_ctype_variance.
+        unfold cstr_respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
+        intros [args idxs]. split.
+        ** eapply (All2_fold_impl args); intros.
+           inversion X; constructor; auto.
+           ++ eapply weakening_env_cumulSpec; eauto. tc.
+           ++ eapply weakening_env_convSpec; eauto. tc.
+           ++ eapply weakening_env_cumulSpec; eauto. tc.
+        ** eapply (All2_impl idxs); intros.
+          eapply weakening_env_convSpec; eauto. tc.
+    + unfold check_ind_sorts in *.
+      destruct Universe.is_prop; auto.
+      destruct Universe.is_sprop; auto.
+      split; [apply fst in ind_sorts|apply snd in ind_sorts].
+      * eapply Forall_impl; tea; cbn.
+        intros. eapply Forall_impl; tea; simpl; intros.
+        eapply leq_universe_subset; tea.
+        apply weakening_env_global_ext_constraints; tea. tc.
+      * destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ wfΣ' Hext.
+        induction ind_indices; simpl in *; auto.
+        -- eapply (extends_wf_universe (Σ:=(Σ,φ)) Σ'); auto. tc.
+        -- destruct a as [na [b|] ty]; simpl in *; intuition eauto.
+    + intros v onv.
+      move: (onIndices v onv). unfold ind_respects_variance.
+      destruct variance_universes as [[[univs u] u']|] => //.
+      intros idx; eapply (All2_fold_impl idx); simpl.
+      intros par par' t t' d.
+      inv d; constructor; auto.
+      ++ eapply weakening_env_cumulSpec; eauto; tc.
+      ++ eapply weakening_env_convSpec; eauto; tc.
+      ++ eapply weakening_env_cumulSpec; eauto; tc.
+  - red in onP |- *. eapply All_local_env_impl; eauto.
+  - move: onVariance.
+    rewrite /on_variance. destruct ind_universes => //.
+    destruct ind_variance => //.
+    intros [univs' [i [i' []]]]. exists univs', i, i'. split => //.
+    all:eapply weakening_env_consistent_instance; tea; tc.
+Qed.
+
+Lemma weakening_env_decls_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
+  weaken_env_decls_prop P ->
+  wf Σ' -> extends_decls Σ Σ' -> on_global_env P Σ ->
   lookup_env Σ c = Some decl ->
   on_global_decl P (Σ', universes_decl_of_decl decl) c decl.
 Proof.
-  intros HP wfΣ Hext HΣ.
-  induction HΣ; simpl. 1: congruence.
-  assert (HH: extends Σ Σ'). {
-    destruct Hext as [Σ'' HΣ''].
+  intros HP wfΣ' Hext HΣ.
+  assert (wfΣ := extends_decls_wf _ _ wfΣ' Hext).
+  destruct HΣ as [onu onΣ].
+  destruct Σ as [univs Σ]; cbn in *.
+  induction onΣ; simpl. 1: congruence.
+  assert (HH: extends_decls {| universes := univs; declarations := Σ |} Σ'). {
+    destruct Hext as [univs' [Σ'' HΣ'']]. split; eauto.
     exists (Σ'' ++ [(kn, d)]). now rewrite <- app_assoc.
   }
   unfold eq_kername; destruct kername_eq_dec; subst.
   - intros [= ->]. subst.
-    clear Hext; eapply weakening_on_global_decl; eauto.
-  - now apply IHHΣ.
+    clear Hext; eapply weakening_on_global_decl_ext. 3:tea. all:eauto.
+  - apply IHonΣ; auto.
+    destruct wfΣ. split => //. now depelim o2.
+Qed.
+
+Lemma weakening_env_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
+  weaken_env_prop P ->
+  wf Σ -> wf Σ' -> extends Σ Σ' -> on_global_env P Σ ->
+  lookup_env Σ c = Some decl ->
+  on_global_decl P (Σ', universes_decl_of_decl decl) c decl.
+Proof.
+  intros HP wfΣ wfΣ' Hext HΣ.
+  destruct HΣ as [onu onΣ].
+  destruct Σ as [univs Σ]; cbn in *.
+  induction onΣ; simpl. 1: congruence.
+  assert (HH: extends {| universes := univs; declarations := Σ |} Σ'). {
+    destruct Hext as [univs' [Σ'' HΣ'']]. split; eauto.
+    exists (Σ'' ++ [(kn, d)]). now rewrite <- app_assoc.
+  }
+  unfold eq_kername; destruct kername_eq_dec; subst.
+  - intros [= ->]. subst.
+    clear Hext; eapply weakening_on_global_decl. 5:tea. all:eauto.
+    destruct wfΣ. split => //. now depelim o2.
+  - apply IHonΣ; auto.
+    destruct wfΣ. split => //. now depelim o2.
 Qed.
 
 Lemma weaken_lookup_on_global_env `{checker_flags} P Σ c decl :
@@ -291,7 +401,20 @@ Lemma weaken_lookup_on_global_env `{checker_flags} P Σ c decl :
   on_global_decl P (Σ, universes_decl_of_decl decl) c decl.
 Proof.
   intros. eapply weakening_env_lookup_on_global_env; eauto.
-  exists []; simpl; destruct Σ; eauto.
+  split => //. 
+  - split; [lsets|csets].
+  - exists []; simpl; destruct Σ; eauto.
+Qed.
+
+Lemma weaken_decls_lookup_on_global_env `{checker_flags} P Σ c decl :
+  weaken_env_decls_prop P ->
+  wf Σ -> on_global_env P Σ ->
+  lookup_env Σ c = Some decl ->
+  on_global_decl P (Σ, universes_decl_of_decl decl) c decl.
+Proof.
+  intros. eapply weakening_env_decls_lookup_on_global_env; eauto.
+  split => //. 
+  - exists []; simpl; destruct Σ; eauto.
 Qed.
 
 Lemma declared_constant_inv `{checker_flags} Σ P cst decl :
@@ -303,7 +426,6 @@ Proof.
   intros.
   eapply weaken_lookup_on_global_env in X1; eauto. apply X1.
 Qed.
-
 
 Lemma declared_minductive_inv `{checker_flags} {Σ P ind mdecl} :
   weaken_env_prop (lift_typing P) ->
@@ -329,7 +451,6 @@ Proof.
   apply Hidecl.
 Qed.
 
-
 Lemma declared_constructor_inv `{checker_flags} {Σ P mdecl idecl ref cdecl}
   (HP : weaken_env_prop (lift_typing P))
   (wfΣ : wf Σ)
@@ -344,6 +465,48 @@ Proof.
   intros.
   destruct Hdecl as [Hidecl Hcdecl].
   set (declared_inductive_inv HP wfΣ HΣ Hidecl) as HH.
+  clearbody HH. pose proof HH.(onConstructors) as HH'.
+  eapply All2_nth_error_Some in Hcdecl; tea.
+Defined.
+
+Lemma declared_minductive_inv_decls `{checker_flags} {Σ P ind mdecl} :
+  weaken_env_decls_prop (lift_typing P) ->
+  wf Σ -> Forall_decls_typing P Σ ->
+  declared_minductive Σ ind mdecl ->
+  on_inductive (lift_typing P) (Σ, ind_universes mdecl) ind mdecl.
+Proof.
+  intros.
+  eapply weaken_decls_lookup_on_global_env in X1; eauto. apply X1.
+Qed.
+
+Lemma declared_inductive_inv_decls `{checker_flags} {Σ P ind mdecl idecl} :
+  weaken_env_decls_prop (lift_typing P) ->
+  wf Σ -> Forall_decls_typing P Σ ->
+  declared_inductive Σ ind mdecl idecl ->
+  on_ind_body (lift_typing P) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl (inductive_ind ind) idecl.
+Proof.
+  intros.
+  destruct H0 as [Hmdecl Hidecl].
+  eapply declared_minductive_inv_decls in Hmdecl; eauto.
+  apply onInductives in Hmdecl.
+  eapply nth_error_alli in Hidecl; eauto.
+  apply Hidecl.
+Qed.
+
+Lemma declared_constructor_inv_decls `{checker_flags} {Σ P mdecl idecl ref cdecl}
+  (HP : weaken_env_decls_prop (lift_typing P))
+  (wfΣ : wf Σ)
+  (HΣ : Forall_decls_typing P Σ)
+  (Hdecl : declared_constructor Σ ref mdecl idecl cdecl) :
+  ∑ cs,
+  let onib := declared_inductive_inv_decls HP wfΣ HΣ (let (x, _) := Hdecl in x) in
+  nth_error onib.(ind_cunivs) ref.2 = Some cs
+  × on_constructor (lift_typing P) (Σ, ind_universes mdecl) mdecl
+                   (inductive_ind ref.1) idecl idecl.(ind_indices) cdecl cs.
+Proof.
+  intros.
+  destruct Hdecl as [Hidecl Hcdecl].
+  set (declared_inductive_inv_decls HP wfΣ HΣ Hidecl) as HH.
   clearbody HH. pose proof HH.(onConstructors) as HH'.
   eapply All2_nth_error_Some in Hcdecl; tea.
 Defined.
@@ -391,10 +554,24 @@ Lemma weaken_env_prop_typing `{checker_flags} : weaken_env_prop (lift_typing typ
 Proof.
   red. intros * wfΣ' Hext *.
   destruct T; simpl.
-  - intros Ht. pose proof (wf_extends wfΣ' Hext).
-    eapply (weakening_env (_, _)); eauto.
-  - intros [s Ht]. pose proof (wf_extends wfΣ' Hext). exists s.
-    eapply (weakening_env (_, _)); eauto.
+  - intros Ht.
+    eapply (weakening_env (_, _)). 2:eauto. all:auto.
+  - intros [s Ht]. exists s.
+    eapply (weakening_env (_, _)). 4: eauto. all:auto.
+Qed.
+
+Lemma weaken_env_decls_prop_typing `{checker_flags} : weaken_env_decls_prop (lift_typing typing).
+Proof.
+  red. intros * wfΣ' Hext *.
+  destruct T; simpl.
+  - intros Ht.
+    eapply (weakening_env (_, _)). 2:eauto. all:auto.
+    * cbn. now eapply extends_decls_wf.
+    * tc.
+  - intros [s Ht]. exists s.
+    eapply (weakening_env (_, _)). 2: eauto. all:auto.
+    * cbn. now eapply extends_decls_wf.
+    * tc.
 Qed.
 
 #[global]
@@ -412,12 +589,11 @@ Qed.
 
 
 Lemma weaken_wf_local `{checker_flags} (Σ : global_env_ext) Σ' Γ :
-  extends Σ Σ' -> wf Σ' -> wf_local Σ Γ -> wf_local (Σ', Σ.2) Γ.
+  wf Σ -> extends Σ Σ' -> wf Σ' -> wf_local Σ Γ -> wf_local (Σ', Σ.2) Γ.
 Proof.
-  intros * Hext wfΣ' *.
+  intros * wfΣ Hext wfΣ' *.
   intros wfΓ.
   eapply (env_prop_wf_local weakening_env); eauto.
-  now eapply wf_extends.
 Qed.
 
 #[global]

--- a/pcuic/theories/utils/PCUICAstUtils.v
+++ b/pcuic/theories/utils/PCUICAstUtils.v
@@ -82,15 +82,14 @@ Ltac solve_all_one :=
 Ltac solve_all := repeat (progress solve_all_one).
 #[global] Hint Extern 10 => rewrite !map_branch_map_branch : all.
 #[global] Hint Extern 10 => rewrite !map_predicate_map_predicate : all.
-  
 
-Lemma lookup_env_nil c s : lookup_env [] c = Some s -> False.
+Lemma lookup_env_nil c s : lookup_global [] c = Some s -> False.
 Proof.
   induction c; simpl; auto => //.
 Qed.
 
-Lemma lookup_env_cons {kn d Σ kn' d'} : lookup_env ((kn, d) :: Σ) kn' = Some d' ->
-  (kn = kn' /\ d = d') \/ (kn <> kn' /\ lookup_env Σ kn' = Some d').
+Lemma lookup_env_cons {kn d Σ kn' d'} : lookup_global ((kn, d) :: Σ) kn' = Some d' ->
+  (kn = kn' /\ d = d') \/ (kn <> kn' /\ lookup_global Σ kn' = Some d').
 Proof.
   simpl.
   epose proof (Reflect.eqb_spec (A:=kername) kn' kn). simpl in H.
@@ -100,7 +99,7 @@ Qed.
 
 Lemma lookup_env_cons_fresh {kn d Σ kn'} : 
   kn <> kn' ->
-  lookup_env ((kn, d) :: Σ) kn' = lookup_env Σ kn'.
+  lookup_global ((kn, d) :: Σ) kn' = lookup_global Σ kn'.
 Proof.
   simpl.
   epose proof (Reflect.eqb_spec (A:=kername) kn' kn). simpl in H.
@@ -330,7 +329,7 @@ Lemma reln_list_lift_above l p Γ :
   Forall (fun x => exists n, x = tRel n /\ p <= n /\ n < p + length Γ) l ->
   Forall (fun x => exists n, x = tRel n /\ p <= n /\ n < p + length Γ) (reln l p Γ).
 Proof.
-  generalize (le_refl p).
+  generalize (Nat.le_refl p).
   generalize p at 1 3 5.
   induction Γ in p, l |- *. simpl. auto.
   intros. destruct a. destruct decl_body. simpl.
@@ -821,7 +820,7 @@ Definition fst_ctx : global_env_ext -> global_env := fst.
 Coercion fst_ctx : global_env_ext >-> global_env.
 
 Definition empty_ext (Σ : global_env) : global_env_ext
-  := (Σ, Monomorphic_ctx ContextSet.empty).
+  := (Σ, Monomorphic_ctx).
 
 (** Decompose an arity into a context and a sort *)
 

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -273,22 +273,22 @@ Definition print_one_ind (short : bool) Σ Γ (mib : mutual_inductive_body) (oib
   if short then "..."
   else print_list (print_one_cstr Σ Γpars mib) nl oib.(ind_ctors).
 
-Fixpoint print_env_aux (short : bool) (prefix : nat) (Σ : global_env) (acc : string) := 
+Fixpoint print_env_aux (short : bool) (prefix : nat) univs (Σ : global_declarations) (acc : string) := 
   match prefix with 
   | 0 => match Σ with [] => acc | _ => ("..." ++ nl ++ acc)%string end
   | S n => 
   match Σ with
   | [] => acc
   | (kn, InductiveDecl mib) :: Σ => 
-    let Σ' := (Σ, mib.(ind_universes)) in
+    let Σ' := ({| universes := univs; declarations := Σ |}, mib.(ind_universes)) in
     let names := fresh_names Σ' [] (arities_context mib.(ind_bodies)) in
-    print_env_aux short n Σ
+    print_env_aux short n univs Σ
       ("Inductive " ++ 
        print_list (print_one_ind short Σ' names mib) nl mib.(ind_bodies) ++ "." ++ 
        nl ++ acc)%string
   | (kn, ConstantDecl cb) :: Σ =>
-    let Σ' := (Σ, cb.(cst_universes)) in
-    print_env_aux short n Σ
+    let Σ' := ({| universes := univs; declarations := Σ |}, cb.(cst_universes)) in
+    print_env_aux short n univs Σ
       ((match cb.(cst_body) with 
         | Some _ => "Definition "
         | None => "Axiom "
@@ -302,7 +302,7 @@ Fixpoint print_env_aux (short : bool) (prefix : nat) (Σ : global_env) (acc : st
   end
   end.
 
-Definition print_env (short : bool) (prefix : nat) Σ := print_env_aux short prefix Σ EmptyString.
+Definition print_env (short : bool) (prefix : nat) Σ := print_env_aux short prefix Σ.(universes) Σ.(declarations) EmptyString.
 
 Definition print_program (short : bool) (prefix : nat) (p : program) : string := 
   print_env short prefix (fst p) ++ nl ++

--- a/safechecker/src/g_metacoq_safechecker.mlg
+++ b/safechecker/src/g_metacoq_safechecker.mlg
@@ -2,7 +2,7 @@
 DECLARE PLUGIN "metacoq_safechecker_plugin"
 
 {
-
+open Attributes
 open Stdarg
 open Pp
 open PeanoNat.Nat
@@ -29,29 +29,38 @@ let time prefix f x =
   let () = Feedback.msg_debug (prefix ++ str " executed in: " ++ Pp.real (stop -. start) ++ str "s") in
   res
 
-let check env evm (c, ustate) =
+let check env evm poly (c, ustate) =
   Feedback.msg_debug (str"Quoting");
-  let term = time (str"Quoting") (Ast_quoter.quote_term_rec true env) (EConstr.to_constr evm c) in
-  let uctx = UState.context_set ustate in
-  Feedback.msg_debug (str"Universes added: " ++ Printer.pr_universe_ctx_set evm uctx);
-  let uctx = Universes0.Monomorphic_ctx (Ast_quoter.quote_univ_contextset uctx) in
+  let uctx = Evd.universe_context_set evm in
+  let env = if poly then env else Environ.push_context_set ~strict:true uctx env in
+  let prog = time (str"Quoting") (Ast_quoter.quote_term_rec true env) (EConstr.to_constr evm c) in
+  let uctx =
+    if poly then
+      let uctx = Evd.to_universe_context evm in
+      let names = Array.map (fun _ -> Names.Name.Anonymous) (Univ.Instance.to_array (Univ.UContext.instance uctx)) in
+      let inst, auctx = Univ.abstract_universes names uctx in
+      Ast_quoter.mkPolymorphic_ctx (Ast_quoter.quote_abstract_univ_context auctx)
+    else Ast_quoter.mkMonomorphic_ctx ()
+  in
   let check =
     time (str"Checking")
       (SafeTemplateChecker.infer_and_print_template_program
-        Config0.default_checker_flags term)
+        Config0.default_checker_flags
+        (* Config0.type_in_type *)
+         prog)
       uctx
   in
   match check with
   | Coq_inl s -> Feedback.msg_info (pr_char_list s)
-  | Coq_inr s -> CErrors.user_err ~hdr:"metacoq" (pr_char_list s)
+  | Coq_inr s -> CErrors.user_err (pr_char_list s)
 }
 
 VERNAC COMMAND EXTEND MetaCoqSafeCheck CLASSIFIED AS QUERY
-| [ "MetaCoq" "SafeCheck" constr(c) ] -> {
+| #[ poly = polymorphic ] [ "MetaCoq" "SafeCheck" constr(c) ] -> {
     let env = Global.env () in
     let evm = Evd.from_env env in
     let c = Constrintern.interp_constr env evm c in
-    check env evm c
+    check env evm poly c
   }
 END
 

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import OrdersTac ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlInt63 ExtrOCamlFloats.
-From MetaCoq.Template Require Import utils.
+From Coq Require Import OrdersTac Ascii ExtrOcamlBasic ExtrOcamlString ExtrOcamlZInt ExtrOCamlInt63 ExtrOCamlFloats.
+From MetaCoq.Template Require Import utils MC_ExtrOCamlZPosInt.
 From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion
      SafeTemplateChecker.
 
@@ -9,84 +9,17 @@ From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion
     Any extracted code planning to link with the plugin's OCaml reifier
     should use these same directives for consistency.
 *)
-
-(** Here we could extract uint63_from/to_model to the identity *)
-
-(** Disclaimer: trying to obtain efficient certified programs
-    by extracting [Z] into [int] is definitively *not* a good idea.
-    See the Disclaimer in [ExtrOcamlNatInt]. *)
-
-(** Mapping of [positive], [Z], [N] into [int]. The last strings
-    emulate the matching, see documentation of [Extract Inductive]. *)
-
-Extract Inductive positive => int
-[ "(fun p->1+2*p)" "(fun p->2*p)" "1" ]
-"(fun f2p1 f2p f1 p ->
-    if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))".
-
-Extract Inductive Z => int [ "0" "" "(~-)" ]
-"(fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))".
-
-Extract Inductive N => int [ "0" "" ]
-"(fun f0 fp n -> if n=0 then f0 () else fp n)".
-
-(** Nota: the "" above is used as an identity function "(fun p->p)" *)
-
-(** Efficient (but uncertified) versions for usual functions *)
-
-Extract Constant Pos.add => "(+)".
-Extract Constant Pos.succ => "Pervasives.succ".
-Extract Constant Pos.pred => "fun n -> Pervasives.max 1 (n-1)".
-Extract Constant Pos.sub => "fun n m -> Pervasives.max 1 (n-m)".
-Extract Constant Pos.mul => "( * )".
-Extract Constant Pos.min => "Pervasives.min".
-Extract Constant Pos.max => "Pervasives.max".
-Extract Constant Pos.compare =>
-    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
-Extract Constant Pos.compare_cont =>
-    "fun c x y -> if x=y then c else if x<y then -1 else 1".
-
-
-Extract Constant N.add => "(+)".
-Extract Constant N.succ => "Pervasives.succ".
-Extract Constant N.pred => "fun n -> Pervasives.max 0 (n-1)".
-Extract Constant N.sub => "fun n m -> Pervasives.max 0 (n-m)".
-Extract Constant N.mul => "( * )".
-Extract Constant N.min => "Pervasives.min".
-Extract Constant N.max => "Pervasives.max".
-Extract Constant N.div => "fun a b -> if b=0 then 0 else a/b".
-Extract Constant N.modulo => "fun a b -> if b=0 then a else a mod b".
-Extract Constant N.compare =>
-    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
-
-
-Extract Constant Z.add => "(+)".
-Extract Constant Z.succ => "Pervasives.succ".
-Extract Constant Z.pred => "Pervasives.pred".
-Extract Constant Z.sub => "(-)".
-Extract Constant Z.mul => "( * )".
-Extract Constant Z.opp => "(~-)".
-Extract Constant Z.abs => "Pervasives.abs".
-Extract Constant Z.min => "Pervasives.min".
-Extract Constant Z.max => "Pervasives.max".
-Extract Constant Z.compare =>
-    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
-
-Extract Constant Z.of_N => "fun p -> p".
-Extract Constant Z.abs_N => "Pervasives.abs".
-
-(** Z.div and Z.modulo are quite complex to define in terms of (/) and (mod).
-    For the moment we don't even try *)
-
-    
+        
 (* Ignore [Decimal.int] before the extraction issue is solved:
-   https://github.com/coq/coq/issues/7017. *)
+    https://github.com/coq/coq/issues/7017. *)
 Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
 
+(** Here we could extract uint63_from/to_model to the identity *)
+
 Extract Constant ascii_compare =>
- "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
+ "fun x y -> Char.compare".
 
 Extraction Blacklist Classes config uGraph Universes Ast String List Nat Int Init
            UnivSubst Typing Checker Retyping OrderedType Logic Common Equality Classes

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -8,108 +8,23 @@ From MetaCoq.SafeChecker Require Import PCUICErrors PCUICSafeChecker.
 
 Import MCMonadNotation.
 
+Definition trans_program (p : Ast.Env.program) : program := 
+  let Σ' := trans_global_env p.1 in
+  (Σ', trans Σ' p.2).
+
 Program Definition infer_template_program {cf : checker_flags} {nor : normalizing_flags} (p : Ast.Env.program) φ
-  : EnvCheck (
-    let Σ' := trans_global_decls p.1 in
-    ∑ A, ∥ (Σ', φ) ;;; [] |- trans Σ' p.2 : A ∥) :=
-  let Σ' := trans_global_decls p.1 in
-  p <- typecheck_program (cf:=cf) (Σ', trans Σ' p.2) φ ;;
+  : EnvCheck (let p' := trans_program p in ∑ A, ∥ (p'.1, φ) ;;; [] |- p'.2 : A ∥) :=
+  p <- typecheck_program (trans_program p) φ ;;
   ret (p.π1 ; _).
 Next Obligation.
   sq. destruct X. eapply infering_typing; tea. eapply w. constructor.
 Qed.
 
-(** In Coq until 8.11 at least, programs can be ill-formed w.r.t. universes as they don't include
-    all declarations of universes and constraints coming from section variable declarations.
-    We hence write a program that computes the dangling universes in an Ast.Env.program and registers
-    them appropriately. *)
-
-Definition update_cst_universes univs cb :=
-  {| Ast.Env.cst_type := cb.(Ast.Env.cst_type);
-     Ast.Env.cst_body := cb.(Ast.Env.cst_body);
-     Ast.Env.cst_universes := match cb.(Ast.Env.cst_universes) with
-                      | Monomorphic_ctx _ => Monomorphic_ctx univs
-                      | x => x
-                      end |}.
-
-Definition update_mib_universes univs mib :=
-  {| Ast.Env.ind_finite := mib.(Ast.Env.ind_finite);
-     Ast.Env.ind_npars := mib.(Ast.Env.ind_npars);
-     Ast.Env.ind_params := mib.(Ast.Env.ind_params);
-     Ast.Env.ind_bodies := mib.(Ast.Env.ind_bodies);
-     Ast.Env.ind_universes := match mib.(Ast.Env.ind_universes) with
-                          | Monomorphic_ctx _ => Monomorphic_ctx univs
-                          | x => x
-                          end;
-     Ast.Env.ind_variance := mib.(Ast.Env.ind_variance) |}.
-
-Definition update_universes (univs : ContextSet.t) (cb : Ast.Env.global_decl)  :=
-  match cb with
-  | Ast.Env.ConstantDecl cb => Ast.Env.ConstantDecl (update_cst_universes univs cb)
-  | Ast.Env.InductiveDecl mib => Ast.Env.InductiveDecl (update_mib_universes univs mib)
-  end.
-
-Definition is_unbound_level declared (l : Level.t) :=
-  match l with
-  | Level.Level _ => negb (LevelSet.mem l declared)
-  | _ => false
-  end.
-
-(** We compute the dangling universes in the constraints only for now. *)
-Definition dangling_universes declared cstrs :=
-  ConstraintSet.fold (fun '(l, d, r) acc =>
-                        let acc :=
-                            if is_unbound_level declared l then
-                              LevelSet.add l acc
-                            else acc
-                        in
-                        if is_unbound_level declared r then
-                          LevelSet.add r acc
-                        else acc) cstrs LevelSet.empty.
-
-Section FoldMap.
-  Context {A B C} (f : A -> B -> C * B).
-
-  Fixpoint fold_map_left (l : list A) (acc : B) : list C * B :=
-    match l with
-    | [] => ([], acc)
-    | hd :: tl =>
-      let (hd', acc) := f hd acc in
-      let (tl', acc') := fold_map_left tl acc in
-      (hd' :: tl', acc')
-    end.
-
-
-  Fixpoint fold_map_right (l : list A) (acc : B) : list C * B :=
-    match l with
-    | [] => ([], acc)
-    | hd :: tl =>
-      let (tl', acc) := fold_map_right tl acc in
-      let (hd', acc') := f hd acc in
-      (hd' :: tl', acc')
-    end.
-
-End FoldMap.
-
-Definition fix_global_env_universes (Σ : Ast.Env.global_env) : Ast.Env.global_env :=
-  let fix_decl '(kn, decl) declared :=
-    let '(declu, declcstrs) := Ast.monomorphic_udecl_decl decl in
-    let declared := LevelSet.union declu declared in
-    let dangling := dangling_universes declared declcstrs in
-    ((kn, update_universes (LevelSet.union declu dangling, declcstrs) decl), LevelSet.union declared dangling)
-  in
-  fst (fold_map_right fix_decl Σ LevelSet.empty).
-
-Definition fix_program_universes (p : Ast.Env.program) : Ast.Env.program :=
-  let '(Σ, t) := p in
-  (fix_global_env_universes Σ, t).
-
 Program Definition infer_and_print_template_program {cf : checker_flags} {nor : normalizing_flags} (p : Ast.Env.program) φ
   : string + string :=
-  let p := fix_program_universes p in
   match infer_template_program (cf:=cf) p φ return string + string with
   | CorrectDecl t =>
-    let Σ' := trans_global_decls p.1 in
+    let Σ' := trans_global_env p.1 in
     inl ("Environment is well-formed and " ^ string_of_term (trans Σ' p.2) ^
          " has type: " ^ string_of_term t.π1)
   | EnvError Σ (AlreadyDeclared id) =>

--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -23,6 +23,7 @@ theories/utils/MCString.v
 theories/utils/wGraph.v
 theories/utils/MCUtils.v
 #theories/utils/MC_ExtrOCamlInt63.v
+theories/utils/MC_ExtrOCamlZPosInt.v
 
 # common
 theories/common/uGraph.v

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -49,6 +49,7 @@ struct
   type quoted_mutual_inductive_body = mutual_inductive_body
   type quoted_constant_body = constant_body
   type quoted_global_decl = global_decl
+  type quoted_global_declarations = (kername * global_decl) list
   type quoted_global_env = global_env
   type quoted_program = program
 
@@ -141,7 +142,7 @@ struct
     {Context.binder_name = unquote_name q.binder_name;
      Context.binder_relevance = unquote_relevance q.binder_relevance}
 
-  let rec unquote_int (q: quoted_int) : int =
+  let rec unquote_int (q: quoted_int) : int = 
     match q with
     | Datatypes.O -> 0
     | Datatypes.S x -> succ (unquote_int x)
@@ -201,7 +202,7 @@ struct
       Univ.Level.make (Univ.Level.UGlobal.make dp "" idx)
     | Universes0.Level.Var n -> Univ.Level.var (unquote_int n)
 
-  let unquote_level_expr (trm : Universes0.Level.t * Datatypes.nat) : Univ.Universe.t =
+  let unquote_level_expr (trm : Universes0.Level.t * quoted_int) : Univ.Universe.t =
     let l = unquote_level (fst trm) in
     let u = Univ.Universe.make l in
     let n = unquote_int (snd trm) in

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -49,6 +49,7 @@ struct
   type quoted_mutual_inductive_body = mutual_inductive_body
   type quoted_constant_body = constant_body
   type quoted_global_decl = global_decl
+  type quoted_global_declarations = global_declarations
   type quoted_global_env = global_env
   type quoted_program = program
 
@@ -59,7 +60,7 @@ struct
     | Sorts.Relevant -> BasicAst.Relevant
     | Sorts.Irrelevant -> BasicAst.Irrelevant
 
-  let quote_name = function
+  let quote_name : Names.Name.t -> BasicAst.name = function
     | Anonymous -> Coq_nAnon
     | Name i -> Coq_nNamed (quote_ident i)
 
@@ -67,7 +68,7 @@ struct
     let {Context.binder_name = n; Context.binder_relevance = relevance} = ann_n in
     { BasicAst.binder_name = quote_name n; BasicAst.binder_relevance = quote_relevance relevance }
 
- let quote_int i =
+  let quote_int i =
     let rec aux acc i =
       if i < 0 then acc
       else aux (Datatypes.S acc) (i - 1)
@@ -92,19 +93,18 @@ struct
     if Univ.Level.is_prop l then Coq_inl Universes0.PropLevel.Coq_lProp
     else if Univ.Level.is_sprop l then Coq_inl Universes0.PropLevel.Coq_lSProp
     else (* NOTE: in this branch we know that [l] is neither [SProp] nor [Prop]*)
-      Coq_inr (quote_nonprop_level l)
-    (* else if Univ.Level.is_set l then Coq_inr Universes0.Level.Coq_lzero
-     * else let l' = match Univ.Level.var_index l with
-     *         | Some x -> Universes0.Level.Var (quote_int x)
-     *         | None -> Universes0.Level.Level (string_to_list (Univ.Level.to_string l))
-     *      in Coq_inr l' *)
-
+      try Coq_inr (quote_nonprop_level l)
+      with e -> assert false
+    
   let quote_universe s : Universes0.Universe.t =
     match Univ.Universe.level s with
       Some l -> Universes0.Universe.of_levels (quote_level l)
-    | _ -> let univs =
-          List.map (fun (l,i) -> (quote_nonprop_level l, i > 0)) (Univ.Universe.repr s) in
-    Universes0.Universe.from_kernel_repr (List.hd univs) (List.tl univs)
+    | _ -> 
+      let univs = List.map (fun (l,i) -> 
+          match quote_level l with
+          | Coq_inl lprop -> assert false
+          | Coq_inr ql -> (ql, i > 0)) (Univ.Universe.repr s) in
+      Universes0.Universe.from_kernel_repr (List.hd univs) (List.tl univs)
 
   let quote_sort s =
     quote_universe (Sorts.univ_of_sort s)
@@ -158,12 +158,14 @@ struct
     | _ -> false
 
   let quote_univ_constraint ((l, ct, l') : Univ.univ_constraint) : quoted_univ_constraint =
-    ((quote_nonprop_level l, quote_constraint_type ct), quote_nonprop_level l')
+    try ((quote_nonprop_level l, quote_constraint_type ct), quote_nonprop_level l')
+    with e -> assert false
 
   let quote_univ_instance (i : Univ.Instance.t) : quoted_univ_instance =
     let arr = Univ.Instance.to_array i in
     (* we assume that valid instances do not contain [Prop] or [SProp] *)
-    CArray.map_to_list quote_nonprop_level arr
+    try CArray.map_to_list quote_nonprop_level arr
+    with e -> assert false
 
    (* (Prop, Le | Lt, l),  (Prop, Eq, Prop) -- trivial, (l, c, Prop)  -- unsatisfiable  *)
   let rec constraints_ (cs : Univ.univ_constraint list) : quoted_univ_constraint list =
@@ -174,9 +176,11 @@ struct
          (Univ.Level.is_prop l && (is_Le ct || is_Lt ct)) ||
           (Univ.Level.is_prop l && is_Eq ct && Univ.Level.is_prop l')
        then constraints_ cs'
-       else if (* fail on unisatisfiable ones -- well-typed term is expected *)
+       else if (* fail on unsatisfiable ones -- well-typed term is expected *)
          Univ.Level.is_prop l' then failwith "Unsatisfiable constraint (l <= Prop)"
-       else (* NOTE:SPROP: we don't expect SProp to be in the constraint set *)
+       else if (* fail on unsatisfiable ones -- well-typed term is expected *)
+          Univ.Level.is_prop l then failwith "Unsatisfiable constraint (Prop = l')"
+        else (* NOTE:SPROP: we don't expect SProp to be in the constraint set *)
          quote_univ_constraint (l,ct,l') :: constraints_ cs'
 
   let quote_univ_constraints (c : Univ.Constraint.t) : quoted_univ_constraints =
@@ -196,11 +200,15 @@ struct
 
   let quote_univ_contextset (uctx : Univ.ContextSet.t) : quoted_univ_contextset =
     (* CHECKME: is is safe to assume that there will be no Prop or SProp? *)
-    let levels = List.map quote_nonprop_level (Univ.LSet.elements (Univ.ContextSet.levels uctx)) in
+    let levels = filter_map 
+      (fun l -> match quote_level l with
+        | Coq_inl _ -> None
+        | Coq_inr l -> Some l)
+      (Univ.LSet.elements (Univ.ContextSet.levels uctx)) in
     let constraints = Univ.ContextSet.constraints uctx in
     (Universes0.LevelSetProp.of_list levels, quote_univ_constraints constraints)
 
-  let quote_abstract_univ_context uctx =
+  let quote_abstract_univ_context uctx : quoted_abstract_univ_context =
     let names = Univ.AUContext.names uctx in
     let levels = CArray.map_to_list quote_name names in
     let constraints = Univ.UContext.constraints (Univ.AUContext.repr uctx) in
@@ -280,7 +288,7 @@ struct
   let mkProj p c = Coq_tProj (p,c)
 
 
-  let mkMonomorphic_ctx tm = Universes0.Monomorphic_ctx tm
+  let mkMonomorphic_ctx () = Universes0.Monomorphic_ctx
   let mkPolymorphic_ctx tm = Universes0.Polymorphic_ctx tm
 
   let mk_one_inductive_body (id, indices, sort, ty, kel, ctr, proj, relevance) =
@@ -313,6 +321,7 @@ struct
 
   let add_global_decl kn a b = (kn, a) :: b
 
+  let mk_global_env universes declarations = { universes; declarations }
   let mk_program decls tm = (decls, tm)
 
   let quote_mind_finiteness = function

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -212,7 +212,7 @@ struct
            constr_mkApp (tfrom_kernel_repr, [| hd ; tl |])
 
   let quote_levelset s =
-    let levels = LSet.elements s in
+    let levels = Univ.LSet.elements s in
     let levels' =  to_coq_listl tlevel (List.map quote_nonprop_level levels) in
     constr_mkApp (tLevelSet_of_list, [|levels'|])
 
@@ -257,7 +257,9 @@ struct
        then constraints_ cs'
        else if (* fail on unisatisfiable ones -- well-typed term is expected *)
          Univ.Level.is_prop l' then failwith "Unisatisfiable constraint (l <= Prop)"
-       else (* NOTE:SPROP: we don't expect SProp to be in the constraint set *)
+      else if (* fail on unisatisfiable ones -- well-typed term is expected *)
+        Univ.Level.is_prop l then failwith "Unisatisfiable constraint (Prop = l)"
+      else (* NOTE:SPROP: we don't expect SProp to be in the constraint set *)
          quote_univ_constraint (l,ct,l') :: constraints_ cs'
 
   let quote_univ_constraints const =
@@ -305,8 +307,7 @@ struct
     let const' = quote_univ_constraints (UContext.constraints (AUContext.repr uctx)) in
     constr_mkApp (tAUContextmake, [|idents; const'|])
 
-  let mkMonomorphic_ctx t =
-    constr_mkApp (cMonomorphic_ctx, [|t|])
+  let mkMonomorphic_ctx () = Lazy.force cMonomorphic_ctx
 
   let mkPolymorphic_ctx t =
     constr_mkApp (cPolymorphic_ctx, [|t|])
@@ -416,6 +417,9 @@ struct
   let add_global_decl kn d l =
     let pair = pairl tkername tglobal_decl kn d in
     constr_mkApp (c_cons, [| global_pairty (); pair; l|])
+
+  let mk_global_env univs decls =
+    constr_mkApp (tBuild_global_env, [| univs; decls |])
 
   let mk_program f s = pairl tglobal_env tTerm f s
 

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -46,6 +46,7 @@ struct
   type quoted_mutual_inductive_body = Constr.t (* of type Ast.mutual_inductive_body *)
   type quoted_constant_body = Constr.t (* of type Ast.constant_body *)
   type quoted_global_decl = Constr.t (* of type Ast.global_decl *)
+  type quoted_global_declarations = Constr.t (* of type Ast.global_declarations *)
   type quoted_global_env = Constr.t (* of type Ast.global_env *)
   type quoted_program = Constr.t (* of type Ast.program *)
 
@@ -189,6 +190,7 @@ struct
   let cMonomorphic_ctx = ast "Monomorphic_ctx"
   let cPolymorphic_ctx = ast "Polymorphic_ctx"
   let tUContext = ast "UContext.t"
+  let tUContextmake' = ast "UContext.make'"
   let tAUContext = ast "AUContext.t"
   let tUContextmake = ast "UContext.make"
   let tAUContextmake = ast "AUContext.make"
@@ -215,6 +217,7 @@ struct
   let tglobal_decl = ast "global_decl"
   let tConstantDecl = ast "ConstantDecl"
   let tInductiveDecl = ast "InductiveDecl"
+  let tBuild_global_env = ast "Build_global_env"
   let tglobal_env = ast "global_env"
 
   let (tglobal_reference, tVarRef, tConstRef, tIndRef, tConstructRef) =

--- a/template-coq/src/g_template_coq.mlg
+++ b/template-coq/src/g_template_coq.mlg
@@ -1,4 +1,3 @@
-
 DECLARE PLUGIN "template_coq"
 
 {

--- a/template-coq/src/reification.ml
+++ b/template-coq/src/reification.ml
@@ -47,6 +47,7 @@ sig
   type quoted_mutual_inductive_body
   type quoted_constant_body
   type quoted_global_decl
+  type quoted_global_declarations
   type quoted_global_env
   type quoted_program  (* the return type of quote_recursively *)
 

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -137,7 +137,7 @@ let of_constant_body (env : Environ.env) (cd : Plugin_core.constant_body) : Ast0
   let {const_body = body; const_type = typ; const_universes = univs} = cd in
   Ast0.Env.({cst_type = quote_term env typ;
          cst_body = Option.map (quote_term env) (get_constant_body body);
-         cst_universes = quote_universes_decl univs})
+         cst_universes = quote_universes_decl univs None})
 
 (* what about the overflow?
   efficiency? extract to bigint using Coq directives and convert to int here? *)

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -1,5 +1,12 @@
 open Pp
 
+let time prefix f x =
+  let start = Unix.gettimeofday () in
+  let res = f x in
+  let stop = Unix.gettimeofday () in
+  let () = Feedback.msg_debug (prefix ++ str " executed in: " ++ Pp.real (stop -. start) ++ str "s") in
+  res
+  
 let contrib_name = "template-coq"
 
 let gen_constant_in_modules s =
@@ -39,7 +46,14 @@ let list_to_string (l : char list) : string =
   aux 0 l;
   Bytes.to_string buf
 
-
+let rec filter_map f l =
+  match l with
+  | [] -> []
+  | x :: xs ->
+    match f x with
+    | Some x' -> x' :: filter_map f xs
+    | None -> filter_map f xs
+    
 let rec app_full trm acc =
   match Constr.kind trm with
     Constr.App (f, xs) -> app_full f (Array.to_list xs @ acc)

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -188,12 +188,6 @@ Fixpoint lookup_mind_decl (id : kername) (decls : global_declarations)
     | _ :: tl => lookup_mind_decl id tl
     end.
 
-Definition universes_entry_of_decl (u : universes_decl) : universes_entry :=
-  match u with
-  | Polymorphic_ctx ctx => Polymorphic_entry (Universes.AUContext.repr ctx)
-  | Monomorphic_ctx => Monomorphic_entry ContextSet.empty
-  end.
-
 (* TODO factorize in Environment *)
 (* was mind_decl_to_entry *)
 Definition mind_body_to_entry (decl : mutual_inductive_body)

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -180,7 +180,7 @@ Fixpoint remove_arity (n : nat) (t : term) : term :=
           end
   end.
 
-Fixpoint lookup_mind_decl (id : kername) (decls : global_env)
+Fixpoint lookup_mind_decl (id : kername) (decls : global_declarations)
  := match decls with
     | nil => None
     | (kn, InductiveDecl d) :: tl =>
@@ -190,8 +190,8 @@ Fixpoint lookup_mind_decl (id : kername) (decls : global_env)
 
 Definition universes_entry_of_decl (u : universes_decl) : universes_entry :=
   match u with
-  | Polymorphic_ctx ctx => Polymorphic_entry (fst ctx) (Universes.AUContext.repr ctx)
-  | Monomorphic_ctx ctx => Monomorphic_entry ctx
+  | Polymorphic_ctx ctx => Polymorphic_entry (Universes.AUContext.repr ctx)
+  | Monomorphic_ctx => Monomorphic_entry ContextSet.empty
   end.
 
 (* TODO factorize in Environment *)

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -101,7 +101,7 @@ Section Lookups.
   Definition polymorphic_constraints u :=
     match u with
     | Monomorphic_ctx => ConstraintSet.empty
-    | Polymorphic_ctx ctx => (AUContext.repr ctx).2.2
+    | Polymorphic_ctx ctx => (AUContext.repr ctx).2
     end.
 
   Definition lookup_constant_type cst u :=

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -214,6 +214,7 @@ Register MetaCoq.Template.Ast.Env.Build_constant_body as metacoq.ast.Build_const
 Register MetaCoq.Template.Ast.Env.global_decl as metacoq.ast.global_decl.
 Register MetaCoq.Template.Ast.Env.ConstantDecl as metacoq.ast.ConstantDecl.
 Register MetaCoq.Template.Ast.Env.InductiveDecl as metacoq.ast.InductiveDecl.
+Register MetaCoq.Template.Ast.Env.Build_global_env as metacoq.ast.Build_global_env.
 Register MetaCoq.Template.Ast.Env.global_env as metacoq.ast.global_env.
 Register MetaCoq.Template.Ast.Env.global_env_ext as metacoq.ast.global_env_ext.
 Register MetaCoq.Template.Ast.Env.program as metacoq.ast.program.

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -33,30 +33,20 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
   | ConstantDecl cb => F cb.(cst_universes)
   | InductiveDecl mb => F mb.(ind_universes)
   end.
-
-  Definition monomorphic_udecl_decl := on_udecl_decl monomorphic_udecl.
-
-  Definition monomorphic_levels_decl := fst ∘ monomorphic_udecl_decl.
-
-  Definition monomorphic_constraints_decl := snd ∘ monomorphic_udecl_decl.
-
+  
   Definition universes_decl_of_decl := on_udecl_decl (fun x => x).
 
   (* Definition LevelSet_add_list l := LevelSet.union (LevelSetProp.of_list l). *)
 
-  Definition global_levels (Σ : global_env) : LevelSet.t :=
-    fold_right
-      (fun decl lvls => LevelSet.union (monomorphic_levels_decl decl.2) lvls)
-      (LevelSet.singleton (Level.lzero)) Σ.
+  Definition global_levels (univs : ContextSet.t) : LevelSet.t :=
+    LevelSet.union (ContextSet.levels univs) (LevelSet.singleton (Level.lzero)).
 
-  Lemma global_levels_Set Σ :
-    LevelSet.mem Level.lzero (global_levels Σ) = true.
+  Lemma global_levels_Set univs :
+    LevelSet.mem Level.lzero (global_levels univs) = true.
   Proof.
-    induction Σ; simpl. reflexivity.
     apply LevelSet.mem_spec, LevelSet.union_spec; right.
-    now apply LevelSet.mem_spec in IHΣ.
+    now apply LevelSet.singleton_spec.
   Qed.
-
 
   (** One can compute the constraints associated to a global environment or its
       extension by folding over its constituent definitions.
@@ -68,15 +58,13 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
       would forget the extension's constraints. *)
 
   Definition global_constraints (Σ : global_env) : ConstraintSet.t :=
-    fold_right (fun decl ctrs =>
-        ConstraintSet.union (monomorphic_constraints_decl decl.2) ctrs
-      ) ConstraintSet.empty Σ.
+    snd Σ.(universes).
 
   Definition global_uctx (Σ : global_env) : ContextSet.t :=
-    (global_levels Σ, global_constraints Σ).
+    (global_levels Σ.(universes), global_constraints Σ).
 
   Definition global_ext_levels (Σ : global_env_ext) : LevelSet.t :=
-    LevelSet.union (levels_of_udecl (snd Σ)) (global_levels Σ.1).
+    LevelSet.union (levels_of_udecl (snd Σ)) (global_levels Σ.1.(universes)).
 
   Definition global_ext_constraints (Σ : global_env_ext) : ConstraintSet.t :=
     ConstraintSet.union
@@ -94,7 +82,7 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
 
   Definition consistent_instance `{checker_flags} (lvs : LevelSet.t) (φ : ConstraintSet.t) uctx (u : Instance.t) :=
     match uctx with
-    | Monomorphic_ctx c => List.length u = 0
+    | Monomorphic_ctx => List.length u = 0
     | Polymorphic_ctx c =>
       (* levels of the instance already declared *)
       forallb (fun l => LevelSet.mem l lvs) u /\
@@ -357,26 +345,22 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Open Scope type_scope.
 
-    Definition satisfiable_udecl `{checker_flags} Σ φ
-      := consistent (global_ext_constraints (Σ, φ)).
+    Definition univs_ext_constraints univs φ :=
+      ConstraintSet.union (constraints_of_udecl φ) univs.
+
+    Definition satisfiable_udecl (univs : ContextSet.t) φ
+      := consistent (univs_ext_constraints (ContextSet.constraints univs) φ).
 
     (* Check that: *)
     (*   - declared levels are fresh *)
     (*   - all levels used in constraints are declared *)
-    (*   - level used in monomorphic contexts are only monomorphic *)
-    Definition on_udecl Σ (udecl : universes_decl)
+    Definition on_udecl (univs : ContextSet.t) (udecl : universes_decl)
       := let levels := levels_of_udecl udecl in
-        let global_levels := global_levels Σ in
+        let global_levels := global_levels univs in
         let all_levels := LevelSet.union levels global_levels in
         LevelSet.For_all (fun l => ~ LevelSet.In l global_levels) levels
-        /\ ConstraintSet.For_all (fun '(l1,_,l2) => LevelSet.In l1 all_levels
-                                                /\ LevelSet.In l2 all_levels)
-                                (constraints_of_udecl udecl)
-        /\ match udecl with
-          | Monomorphic_ctx ctx =>  LevelSet.for_all (negb ∘ Level.is_var) ctx.1
-          | _ => True
-          end
-        /\ satisfiable_udecl Σ udecl.
+        /\ ConstraintSet.For_all (declared_cstr_levels all_levels) (constraints_of_udecl udecl)
+        /\ satisfiable_udecl univs udecl.
 
     (** Positivity checking of the inductive, ensuring that the inductive itself 
       can only appear at the right of an arrow in each argument's types. *)
@@ -515,7 +499,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Definition variance_universes univs v :=
       match univs with
-      | Monomorphic_ctx ctx => None
+      | Monomorphic_ctx => None
       | Polymorphic_ctx auctx =>
         let (inst, cstrs) := auctx in
         let u' := level_var_instance 0 inst in
@@ -747,7 +731,7 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     Definition on_variance Σ univs (variances : option (list Variance.t)) :=
       match univs return Type with
-      | Monomorphic_ctx _ => variances = None
+      | Monomorphic_ctx => variances = None
       | Polymorphic_ctx auctx => 
         match variances with
         | None => unit
@@ -795,22 +779,32 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
 
     (** Well-formed global environments have no name clash. *)
 
-    Definition fresh_global (s : kername) : global_env -> Prop :=
-      Forall (fun g => g.1 <> s).
+    Definition fresh_global (s : kername) (g : global_declarations) : Prop :=
+      Forall (fun g => g.1 <> s) g.
 
-    Inductive on_global_env `{checker_flags} : global_env -> Type :=
-    | globenv_nil : on_global_env []
+    Inductive on_global_decls (univs : ContextSet.t) : global_declarations -> Type :=
+    | globenv_nil : on_global_decls univs []
     | globenv_decl Σ kn d :
-        on_global_env Σ ->
+        on_global_decls univs Σ ->
         fresh_global kn Σ ->
         let udecl := universes_decl_of_decl d in
-        on_udecl Σ udecl ->
-        on_global_decl (Σ, udecl) kn d ->
-        on_global_env (Σ ,, (kn, d)).
-    Derive Signature for on_global_env.
+        on_udecl univs udecl ->
+        on_global_decl ({| universes := univs; declarations := Σ |}, udecl) kn d ->
+        on_global_decls univs (Σ ,, (kn, d)).
+    Derive Signature for on_global_decls.
 
-    Definition on_global_env_ext `{checker_flags} (Σ : global_env_ext) :=
-      on_global_env Σ.1 × on_udecl Σ.1 Σ.2.
+    Definition on_global_univs (c : ContextSet.t) := 
+      let levels := global_levels c in
+      let cstrs := ContextSet.constraints c in
+      ConstraintSet.For_all (declared_cstr_levels levels) cstrs /\ 
+      LS.For_all (negb ∘ Level.is_var) levels /\
+      consistent cstrs.
+
+    Definition on_global_env (g : global_env) : Type :=
+      on_global_univs g.(universes) × on_global_decls g.(universes) g.(declarations).
+
+    Definition on_global_env_ext (Σ : global_env_ext) :=
+      on_global_env Σ.1 × on_udecl Σ.(universes) Σ.2.
 
   End GlobalMaps.
 
@@ -974,11 +968,15 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
         P Σ Γ t T -> Q Σ Γ t T) ->
     on_global_env P Σ -> on_global_env Q Σ.
   Proof.
-    intros X X0.
-    simpl in *. revert wfΣ. induction X0; constructor; eauto.
+    unfold on_global_env in *.
+    intros X [hu X0]. split; auto.
+    simpl in *. destruct wfΣ as [cu wfΣ]. revert cu wfΣ.
+    revert X0. generalize (universes Σ) as univs, (declarations Σ). clear hu Σ.
+    induction 1; constructor; auto.
     { depelim wfΣ. eauto. }
-    depelim wfΣ. specialize (IHX0 wfΣ).
-    assert (X' := fun Γ t T => X (Σ, udecl0) Γ t T wfΣ X0 IHX0); clear X.
+    depelim wfΣ. specialize (IHX0 cu wfΣ).
+    assert (X' := fun Γ t T => X ({| universes := univs; declarations := Σ |}, udecl0) Γ t T 
+      (cu, wfΣ) (cu, X0) (cu, IHX0)); clear X.
     rename X' into X.
     clear IHX0. destruct d; simpl.
     - destruct c; simpl. destruct cst_body0; simpl in *; now eapply X.

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -13,9 +13,15 @@ From MetaCoq.Template Require Import MC_ExtrOCamlZPosInt.
 
 Extract Constant ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
-Extract Constant Ascii.compare =>
- "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
+Extract Constant Ascii.eqb =>
+ "fun x y -> x = y".
  
+(* Ignore [Decimal.int] before the extraction issue is solved:
+  https://github.com/coq/coq/issues/7017. *)
+Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
+Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
+Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
+
 Extract Inductive Equations.Init.sigma => "( * )" ["(,)"].
 Extract Constant Equations.Init.pr1 => "fst".
 Extract Constant Equations.Init.pr2 => "snd".

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -1,107 +1,21 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import utils Ast Reflect Induction.
-From Coq Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOCamlFloats
-    ExtrOCamlInt63.
-From Coq Require Extraction.
 (** * Extraction setup for template-coq.
 
     Any extracted code planning to link with the plugin's OCaml reifier
     should use these same directives for consistency.
 *)
 
-(************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
-(*  v      *         Copyright INRIA, CNRS and contributors             *)
-(* <O___,, * (see version control and CREDITS file for authors & dates) *)
-(*   \VV/  **************************************************************)
-(*    //   *    This file is distributed under the terms of the         *)
-(*         *     GNU Lesser General Public License Version 2.1          *)
-(*         *     (see LICENSE file for the text of the license)         *)
-(************************************************************************)
-
-(** Extraction of [positive], [N] and [Z] into Ocaml's [int] *)
-
-Require Coq.extraction.Extraction.
-
-Require Import ZArith NArith.
-Require Import ExtrOcamlBasic.
-
-(** Disclaimer: trying to obtain efficient certified programs
-    by extracting [Z] into [int] is definitively *not* a good idea.
-    See the Disclaimer in [ExtrOcamlNatInt]. *)
-
-(** Mapping of [positive], [Z], [N] into [int]. The last strings
-    emulate the matching, see documentation of [Extract Inductive]. *)
-
-Extract Inductive positive => int
-[ "(fun p->1+2*p)" "(fun p->2*p)" "1" ]
-"(fun f2p1 f2p f1 p ->
-  if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))".
-
-Extract Inductive Z => int [ "0" "" "(~-)" ]
-"(fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))".
-
-Extract Inductive N => int [ "0" "" ]
-"(fun f0 fp n -> if n=0 then f0 () else fp n)".
-
-(** Nota: the "" above is used as an identity function "(fun p->p)" *)
-
-(** Efficient (but uncertified) versions for usual functions *)
-
-Extract Constant Pos.add => "(+)".
-Extract Constant Pos.succ => "Pervasives.succ".
-Extract Constant Pos.pred => "fun n -> Pervasives.max 1 (n-1)".
-Extract Constant Pos.sub => "fun n m -> Pervasives.max 1 (n-m)".
-Extract Constant Pos.mul => "( * )".
-Extract Constant Pos.min => "Pervasives.min".
-Extract Constant Pos.max => "Pervasives.max".
-Extract Constant Pos.compare =>
- "fun x y -> if x=y then 0 else if x<y then -1 else 1".
-Extract Constant Pos.compare_cont =>
- "fun c x y -> if x=y then c else if x<y then -1 else 1".
-
-
-Extract Constant N.add => "(+)".
-Extract Constant N.succ => "Pervasives.succ".
-Extract Constant N.pred => "fun n -> Pervasives.max 0 (n-1)".
-Extract Constant N.sub => "fun n m -> Pervasives.max 0 (n-m)".
-Extract Constant N.mul => "( * )".
-Extract Constant N.min => "Pervasives.min".
-Extract Constant N.max => "Pervasives.max".
-Extract Constant N.div => "fun a b -> if b=0 then 0 else a/b".
-Extract Constant N.modulo => "fun a b -> if b=0 then a else a mod b".
-Extract Constant N.compare =>
- "fun x y -> if x=y then 0 else if x<y then -1 else 1".
-
-
-Extract Constant Z.add => "(+)".
-Extract Constant Z.succ => "Pervasives.succ".
-Extract Constant Z.pred => "Pervasives.pred".
-Extract Constant Z.sub => "(-)".
-Extract Constant Z.mul => "( * )".
-Extract Constant Z.opp => "(~-)".
-Extract Constant Z.abs => "Pervasives.abs".
-Extract Constant Z.min => "Pervasives.min".
-Extract Constant Z.max => "Pervasives.max".
-Extract Constant Z.compare =>
- "fun x y -> if x=y then 0 else if x<y then -1 else 1".
-
-Extract Constant Z.of_N => "fun p -> p".
-Extract Constant Z.abs_N => "Pervasives.abs".
-
-(** Z.div and Z.modulo are quite complex to define in terms of (/) and (mod).
-    For the moment we don't even try *)
-
-
-(* Ignore [Decimal.int] before the extraction issue is solved:
-   https://github.com/coq/coq/issues/7017. *)
-Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-Extract Inductive Hexadecimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
-Extract Inductive Number.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".
+From Coq Require Ascii Extraction ZArith NArith.
+From MetaCoq.Template Require Import utils Ast Reflect Induction.
+From Coq Require Import FSets ExtrOcamlBasic ExtrOcamlString ExtrOCamlFloats
+    ExtrOCamlInt63.
+From MetaCoq.Template Require Import MC_ExtrOCamlZPosInt.
 
 Extract Constant ascii_compare =>
  "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
-
+Extract Constant Ascii.compare =>
+ "fun x y -> match Char.compare x y with 0 -> 0 | x when x < 0 -> -1 | _ -> 1".
+ 
 Extract Inductive Equations.Init.sigma => "( * )" ["(,)"].
 Extract Constant Equations.Init.pr1 => "fst".
 Extract Constant Equations.Init.pr2 => "snd".

--- a/template-coq/theories/Reflect.v
+++ b/template-coq/theories/Reflect.v
@@ -482,6 +482,7 @@ Proof.
 Qed.
 
 Require Import RelationClasses.
+Existing Instance ConstraintType.lt_strorder.
     
 Lemma constraint_lt_irrel (x y : UnivConstraint.t) (l l' : UnivConstraint.lt_ x y) : l = l'.
 Proof.
@@ -610,13 +611,6 @@ Module ConstraintSetsUIP.
   Defined.
 
 End ConstraintSetsUIP.
- 
-Definition eqb_universes_decl x y :=
-  match x, y with
-  | Monomorphic_ctx cx, Monomorphic_ctx cy => eqb cx cy
-  | Polymorphic_ctx cx, Polymorphic_ctx cy => eqb cx cy
-  | _, _ => false
-  end.
 
 Ltac finish_reflect :=
   (repeat
@@ -624,7 +618,14 @@ Ltac finish_reflect :=
     | |- context[eqb ?a ?b] => destruct (eqb_spec a b); [subst|constructor; congruence]
     end);
   constructor; trivial; congruence.
- 
+
+Definition eqb_universes_decl x y :=
+  match x, y with
+  | Monomorphic_ctx, Monomorphic_ctx => true
+  | Polymorphic_ctx cx, Polymorphic_ctx cy => eqb cx cy
+  | _, _ => false
+  end.
+  
 #[global] Instance reflect_universes_decl : ReflectEq universes_decl.
 Proof.
   refine {| eqb := eqb_universes_decl |}.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -542,7 +542,9 @@ End TemplateConversionPar.
 Module TemplateConversion := Conversion TemplateTerm Env TemplateEnvTyping TemplateConversionPar.
 Include TemplateConversion.  
 
-Definition extends (Σ Σ' : global_env) := { Σ'' & Σ' = Σ'' ++ Σ }.
+Definition extends (Σ Σ' : global_env) :=
+  Σ.(universes) = Σ'.(universes) ×
+  { Σ'' & Σ'.(declarations) = Σ'' ++ Σ.(declarations) }.
 
 Class GuardChecker := 
 { (* Structural recursion check *)
@@ -946,11 +948,15 @@ Proof.
   induction d; simpl; try lia.
 Qed.
 
-Fixpoint globenv_size (Σ : global_env) : size :=
+Fixpoint globdecls_size (Σ : global_declarations) : size :=
   match Σ with
   | [] => 1
-  | d :: Σ => S (globenv_size Σ)
+  | d :: Σ => S (globdecls_size Σ)
   end.
+
+Definition globenv_size (Σ : global_env) : size := 
+  globdecls_size Σ.(declarations).
+
 
 (** To get a good induction principle for typing derivations,
      we need:
@@ -959,7 +965,7 @@ Fixpoint globenv_size (Σ : global_env) : size :=
 
 Arguments lexprod [A B].
 
-Definition wf `{checker_flags} := Forall_decls_typing typing.
+Definition wf `{checker_flags} Σ := on_global_env (lift_typing typing) Σ.
 Definition wf_ext `{checker_flags} := on_global_env_ext (lift_typing typing).
 
 Lemma typing_wf_local `{checker_flags} {Σ} {Γ t T} :
@@ -984,9 +990,7 @@ Defined.
 
 Definition env_prop `{checker_flags} (P : forall Σ Γ t T, Type) (PΓ : forall Σ Γ (wfΓ : wf_local Σ Γ), Type):=
   forall Σ (wfΣ : wf Σ.1) Γ (wfΓ : wf_local Σ Γ) t T (ty : Σ ;;; Γ |- t : T),
-    Forall_decls_typing P Σ.1 * 
-    (PΓ Σ Γ (typing_wf_local ty) *
-    P Σ Γ t T).
+    on_global_env (lift_typing P) Σ.1 * (PΓ Σ Γ (typing_wf_local ty) * P Σ Γ t T).
 
 Lemma env_prop_typing `{checker_flags} {P PΓ} : env_prop P PΓ ->
   forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t T : term),
@@ -998,7 +1002,7 @@ Lemma env_prop_wf_local `{checker_flags} {P PΓ} : env_prop P PΓ ->
 Proof. intros. red in X. now apply (X _ wfΣ _ wfΓ _ _ (type_Prop_wf Σ Γ wfΓ)). Qed.
 
 Lemma env_prop_sigma `{checker_flags} {P PΓ} : env_prop P PΓ ->
-  forall Σ (wfΣ : wf Σ), Forall_decls_typing P Σ.
+  forall Σ (wfΣ : wf Σ), on_global_env (lift_typing P) Σ.
 Proof.
   intros. eapply (X (empty_ext Σ)).
   apply wfΣ. constructor.
@@ -1130,7 +1134,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
         P Σ Γ (tApp t l) t') ->
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) cst u (decl : constant_body),
-        Forall_decls_typing P Σ.1 ->
+        on_global_env (lift_typing P) Σ.1 ->
         PΓ Σ Γ wfΓ ->
         declared_constant Σ.1 cst decl ->
         consistent_instance_ext Σ decl.(cst_universes) u ->
@@ -1138,14 +1142,14 @@ Lemma typing_ind_env `{cf : checker_flags} :
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) u
           mdecl idecl (isdecl : declared_inductive Σ.1 ind mdecl idecl),
-        Forall_decls_typing P Σ.1 ->
+        on_global_env (lift_typing P) Σ.1 ->
         PΓ Σ Γ wfΓ ->
         consistent_instance_ext Σ mdecl.(ind_universes) u ->
         P Σ Γ (tInd ind u) (subst_instance u (ind_type idecl))) ->
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (ind : inductive) (i : nat) u
             mdecl idecl cdecl (isdecl : declared_constructor Σ.1 (ind, i) mdecl idecl cdecl),
-        Forall_decls_typing P Σ.1 ->
+        on_global_env (lift_typing P) Σ.1 ->
         PΓ Σ Γ wfΓ ->
         consistent_instance_ext Σ mdecl.(ind_universes) u ->
         P Σ Γ (tConstruct ind i u) (type_of_constructor mdecl cdecl (ind, i) u)) ->
@@ -1153,7 +1157,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
      (forall (Σ : global_env_ext) (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ),     
       forall (ci : case_info) p c brs indices ps mdecl idecl
         (isdecl : declared_inductive Σ.1 ci.(ci_ind) mdecl idecl),
-        Forall_decls_typing P Σ.1 -> 
+        on_global_env (lift_typing P) Σ.1 -> 
         PΓ Σ Γ wfΓ ->
         mdecl.(ind_npars) = ci.(ci_npar) ->
         wf_nactx p.(pcontext) (ind_predicate_context ci.(ci_ind) mdecl idecl) ->
@@ -1180,7 +1184,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : projection) (c : term) u
           mdecl idecl cdecl pdecl (isdecl : declared_projection Σ.1 p mdecl idecl cdecl pdecl) args,
-        Forall_decls_typing P Σ.1 -> 
+        on_global_env (lift_typing P) Σ.1 -> 
         PΓ Σ Γ wfΓ ->
         Σ ;;; Γ |- c : mkApps (tInd (fst (fst p)) u) args ->
         P Σ Γ c (mkApps (tInd (fst (fst p)) u) args) ->
@@ -1245,13 +1249,18 @@ Proof.
   intros (Σ & wfΣ & Γ & t & t0 & H). simpl.
   intros IH. simpl in IH.
   split.
-  destruct Σ as [Σ φ]. destruct Σ.
-  constructor.
-  cbn in wfΣ; inversion_clear wfΣ. auto.
-  inv wfΣ.
-  rename X14 into Xg.
-  constructor; auto. unfold Forall_decls_typing in IH.
-  - simple refine (let IH' := IH ((Σ, udecl); (X13; []; (tSort Universe.lProp); _; _)) in _).
+  destruct Σ as [Σ φ]. 
+  red. cbn. do 2 red in wfΣ. cbn in wfΣ.
+  destruct Σ as [univs Σ]; cbn in *.
+  set (Σg:= {| universes := univs; declarations := Σ |}) in *.
+  destruct wfΣ; split => //.
+  rename o into ongu. rename o0 into o.
+  destruct o. { constructor. }
+  rename o1 into Xg. set (wfΣ := (ongu, o) : on_global_env (lift_typing typing) {| universes := univs; declarations := Σ |}).
+  set (Σ':= {| universes := univs; declarations := Σ |}) in *.
+  constructor; auto.
+  - simple refine (let IH' := IH ((Σ', udecl); 
+      (wfΣ; []; (tSort Universe.lProp); _; _)) in _).
     shelve. simpl. apply type_Prop.
     forward IH'. constructor 1; cbn. lia.
     apply IH'; auto.
@@ -1261,71 +1270,69 @@ Proof.
       destruct cst_body0; simpl in *.
       simpl.
       intros. red in Xg. simpl in Xg.
-      specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Xg)))))).
+      specialize (IH (existT _ (Σ', udecl) (existT _ wfΣ (existT _ _ (existT _ _ (existT _ _ Xg)))))).
       simpl in IH.
-      forward IH. constructor 1. simpl; lia.
+      forward IH. constructor 1. simpl; subst Σ' Σg. cbn. lia.
       apply IH.
       red. simpl. red in Xg; simpl in Xg.
       destruct Xg as [s Hs]. red. simpl.
-      specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Hs)))))).
+      specialize (IH (existT _ (Σ', udecl) (existT _ wfΣ (existT _ _ (existT _ _ (existT _ _ Hs)))))).
       simpl in IH.
-      forward IH. constructor 1. simpl; lia. exists s. eapply IH.
+      forward IH. constructor 1. simpl; subst Σ' Σg; cbn; lia. exists s. eapply IH.
     + red in Xg.
       destruct Xg as [onI onP onnp]; constructor; eauto.
-      * eapply Alli_impl; eauto. clear onI onP onnp; intros n x Xg.
+      * unshelve eset (IH' := fun p => IH (existT _ (Σ', udecl) (existT _ wfΣ p)) _).
+        constructor. cbn; subst Σ' Σg; lia. clearbody IH'. cbn in IH'.
+        clear IH; rename IH' into IH.
+        eapply Alli_impl; eauto. cbn in IH. clear onI onP onnp. intros n x Xg.
         refine {| ind_arity_eq := Xg.(ind_arity_eq);
                   ind_cunivs := Xg.(ind_cunivs) |}.
         -- apply onArity in Xg. destruct Xg as [s Hs]. exists s; auto.
-          specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Hs)))))).
-          simpl in IH. simpl. apply IH; constructor 1; simpl; lia.
+           apply (IH (_; _; _; Hs)).
         -- pose proof Xg.(onConstructors) as Xg'.
            eapply All2_impl; eauto. intros.
-           destruct X14 as [cass tyeq onctyp oncargs oncind].
+           destruct X13 as [cass tyeq onctyp oncargs oncind].
            unshelve econstructor; eauto.
-           destruct onctyp as [s Hs].
-           pose proof (typing_wf_local (Σ:= (Σ, udecl)) Hs). simpl in Hs.
-           specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Hs)))))).
-           simpl in IH. red. simpl. exists s. simpl. apply IH; constructor 1; simpl; auto with arith.
-           eapply sorts_local_ctx_impl; eauto. simpl. intros. red in X14.
-           destruct T.
-           specialize (IH ((Σ, udecl); (X13; _; _; _; X14))).
-           apply IH. simpl. constructor 1. simpl. auto with arith.
-           destruct X14 as [u Hu]. exists u.
-           specialize (IH ((Σ, udecl); (X13; _; _; _; Hu))).
-           apply IH. simpl. constructor 1. simpl. auto with arith.
-           clear -X13 IH oncind.
-           revert oncind.
-           generalize (List.rev (lift_context #|cstr_args x0| 0 (ind_indices x))).
-           generalize (cstr_indices x0). induction 1; constructor; auto.
-           red in t2 |- *.
-           specialize (IH ((Σ, udecl); (X13; (_; (_; (_; t2)))))). simpl in IH.
-           apply IH. simpl. constructor 1. simpl. auto with arith.
+           { destruct onctyp as [s Hs].
+            pose proof (typing_wf_local (Σ:= (Σ', udecl)) Hs). simpl in Hs.
+            exists s; apply (IH (_; _; _; Hs)). }
+           { eapply sorts_local_ctx_impl; eauto. simpl. intros. red in X13.
+             destruct T.
+             specialize (IH (_; _; _; X13)).
+             apply IH.
+             destruct X13 as [u Hu]. exists u.
+             apply (IH (_; _; _; Hu)). }
+           { clear -IH oncind.
+             revert oncind.
+             generalize (List.rev (lift_context #|cstr_args x0| 0 (ind_indices x))).
+             generalize (cstr_indices x0). induction 1; constructor; auto.
+             red in t0 |- *.
+             apply (IH (_; (_; (_; t0)))). }
         -- intros Hprojs; pose proof (onProjections Xg Hprojs); auto.
         -- destruct Xg. simpl. unfold check_ind_sorts in *.
            destruct Universe.is_prop; auto.
            destruct Universe.is_sprop; auto.
            split. apply ind_sorts0. destruct indices_matter; auto.
            eapply type_local_ctx_impl. eapply ind_sorts0.
-           intros. red in X14.
+           intros. red in X13.
            destruct T.
-           specialize (IH ((Σ, udecl); (X13; _; _; _; X14))).
-           apply IH. simpl. constructor 1. simpl. auto with arith.
-           destruct X14 as [u Hu]. exists u.
-           specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Hu)))))).
-           apply IH. simpl. constructor 1. simpl. auto with arith.
+           specialize (IH (_; _; _; X13)).
+           apply IH.
+           destruct X13 as [u Hu]. exists u.
+           apply (IH (_; _; _; Hu)).
         -- apply (onIndices Xg).
       * red in onP |- *.
         eapply All_local_env_impl; eauto.
-        intros. destruct T; simpl in X14.
-        specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ X14)))))).
-        simpl in IH. apply IH. constructor 1. simpl. lia.
-        destruct X14 as [u Hu].
-        specialize (IH (existT _ (Σ, udecl) (existT _ X13 (existT _ _ (existT _ _ (existT _ _ Hu)))))).
-        simpl in IH. simpl. exists u. apply IH. constructor 1. simpl. lia.
+        intros. destruct T; simpl in X13.
+        apply (IH ((Σ', udecl); (wfΣ; _; _; _; X13))).
+        constructor 1. simpl. subst Σ' Σg; cbn; lia.
+        destruct X13 as [u Hu].
+        exists u; apply (IH ((Σ', udecl); (wfΣ; _; _; _; Hu))).
+        constructor 1. simpl. subst Σ' Σg; cbn; lia.
 
   - assert (forall Γ t T (Hty : Σ ;;; Γ |- t : T),
                typing_size Hty < typing_size H ->
-               Forall_decls_typing P Σ.1 * P Σ Γ t T).
+               on_global_env (lift_typing P) Σ.1 * P Σ Γ t T).
     { intros.
       specialize (IH (existT _ Σ (existT _ wfΣ (existT _ _ (existT _ _ (existT _ _ Hty)))))).
       simpl in IH.
@@ -1381,7 +1388,7 @@ Proof.
                   ((typing_spine_size
                       (fun x (x0 : context) (x1 x2 : term) (x3 : x;;; x0 |- x1 : x2) =>
                          typing_size x3) Σ Γ t_ty l t' t0)) ->
-                Forall_decls_typing P Σ.1 * P Σ Γ0 t1 T). {
+                on_global_env (lift_typing P) Σ.1 * P Σ Γ0 t1 T). {
        intros. unshelve eapply X14; eauto. lia. }
        clear X14. simpl in pΓ. clear n e H pΓ.
        induction t0; constructor.
@@ -1438,7 +1445,7 @@ Proof.
                     (fun (x : def term)
                     (p : ∑ s : Universe.t, Σ;;; Γ |- dtype x : tSort s) =>
                   typing_size p.π2) a0) ->
-                   Forall_decls_typing P Σ.1 * P Σ Γ t T).
+                  on_global_env (lift_typing P) Σ.1 * P Σ Γ t T).
         intros; eauto. eapply (X14 _ _ _ Hty); eauto. lia.
         clear X13 X14 a pΓ.
         clear -a0 X.
@@ -1456,7 +1463,7 @@ Proof.
                         (all_size (fun x : def term => (Σ;;; Γ ,,, fix_context mfix |- dbody x : lift0 #|fix_context mfix| (dtype x))%type
                                                        )%type
                                    (fun (x : def term) p => typing_size p) a1) ->
-                       Forall_decls_typing P Σ.1 * P Σ Γ0 t T).
+                       on_global_env (lift_typing P) Σ.1 * P Σ Γ0 t T).
         {intros. eapply (X14 _ _ _ Hty); eauto. lia. }
         clear X14 X13.
         clear e decl i a0 i0 pΓ.
@@ -1477,7 +1484,7 @@ Proof.
                        (fun (x : def term)
                        (p : ∑ s : Universe.t, Σ;;; Γ |- dtype x : tSort s) =>
                      typing_size p.π2) a0) ->
-                      Forall_decls_typing P Σ.1 * P Σ Γ t T).
+                     on_global_env (lift_typing P) Σ.1 * P Σ Γ t T).
            intros; eauto. eapply (X14 _ _ _ Hty); eauto. lia.
            clear X13 X14 a pΓ.
            clear -a0 X.
@@ -1494,7 +1501,7 @@ Proof.
                          S
                            (all_size (fun x : def term => (Σ;;; Γ ,,, fix_context mfix |- dbody x : lift0 #|fix_context mfix| (dtype x))%type)
                                       (fun (x : def term) p => typing_size p) a1) ->
-                          Forall_decls_typing P Σ.1 * P Σ Γ0 t T).
+                          on_global_env (lift_typing P) Σ.1 * P Σ Γ0 t T).
            { intros. eapply (X14 _ _ _ Hty); eauto. lia. }
            clear X14 X13.
            clear e decl a0 i i0 pΓ.
@@ -1521,20 +1528,25 @@ Proof.
     apply IHX. simpl in *. lia.
 Qed.
 
-Lemma lookup_on_global_env `{checker_flags} P Σ c decl :
+Arguments on_global_env {cf} P !g.
+
+Lemma lookup_on_global_env `{checker_flags} {P Σ c decl} :
   on_global_env P Σ ->
   lookup_env Σ c = Some decl ->
   { Σ' & on_global_env P Σ'.1 × extends Σ'.1 Σ × on_global_decl P Σ' c decl }.
 Proof.
-  induction 1; simpl.
-  congruence.
-  unfold eq_kername. destruct kername_eq_dec.
-  - intros [= ->]. subst c.
-    exists (Σ, udecl). split; try constructor; tas.
-    cbn. now exists [(kn, decl)].
-  - intros hl. destruct (IHX hl) as [[Σ' univs] [ong [ext ond]]].
-    exists (Σ', univs). repeat split; auto.
-    cbn. destruct ext as [Σ'' ->]. cbn.
+  unfold on_global_env.
+  destruct Σ as [univs Σ]; cbn. intros [cu ond].
+  induction ond; simpl in * => //.
+  unfold eq_kername. destruct kername_eq_dec; subst.
+  - intros [= ->].
+    exists ({| universes := univs; declarations := Σ |}, udecl).
+    split; try constructor; tas.
+    cbn. now split => //; exists [(kn, decl)].
+  - intros hl.
+    destruct (IHond hl) as [[Σ' udecl'] [ong [[equ ext] ond']]].
+    exists (Σ', udecl'). cbn in equ |- *. subst univs. repeat split; cbn; auto; try apply ong.
+    cbn in ext. destruct ext as [Σ'' ->]. cbn.
     now exists ((kn, d) :: Σ'').
 Qed.
 

--- a/template-coq/theories/utils/LibHypsNaming.v
+++ b/template-coq/theories/utils/LibHypsNaming.v
@@ -65,11 +65,11 @@ Ltac rename_hyp_prefx h ht :=
 Ltac fallback_rename_hyp h th :=
   match th with
     | _ => rename_hyp h th
-    | true = beq_nat _ _ => fresh "beqnat_true"
-    | beq_nat _ _ = true => fresh "beqnat_true"
-    | false = beq_nat _ _ => fresh "beqnat_false"
-    | beq_nat _ _ = false => fresh "beqnat_false"
-    | beq_nat _ _ = _ => fresh "beqnat"
+    | true = Nat.eqb _ _ => fresh "beqnat_true"
+    | Nat.eqb _ _ = true => fresh "beqnat_true"
+    | false = Nat.eqb _ _ => fresh "beqnat_false"
+    | Nat.eqb _ _ = false => fresh "beqnat_false"
+    | Nat.eqb _ _ = _ => fresh "beqnat"
     | Zeq_bool _ _ = true => fresh "eq_Z_true"
     | Zeq_bool _ _ = false => fresh "eq_Z_false"
     | true = Zeq_bool _ _ => fresh "eq_Z_true"

--- a/template-coq/theories/utils/MCList.v
+++ b/template-coq/theories/utils/MCList.v
@@ -244,7 +244,7 @@ Lemma mapi_ext_size {A B} (f g : nat -> A -> B) l k :
   (forall k' x, k' < k + #|l| -> f k' x = g k' x) ->
   mapi_rec f l k = mapi_rec g l k.
 Proof.
-  intros Hl. generalize (Le.le_refl k). generalize k at 1 3 4.
+  intros Hl. generalize (Nat.le_refl k). generalize k at 1 3 4.
   induction l in k, Hl |- *. simpl. auto.
   intros. simpl in *. erewrite Hl; try lia.
   f_equal. eapply (IHl (S k)); try lia. intros. apply Hl. lia.

--- a/template-coq/theories/utils/MCRelations.v
+++ b/template-coq/theories/utils/MCRelations.v
@@ -3,6 +3,8 @@ Require Import ssreflect.
 Require Import Equations.Type.Relation Equations.Type.Relation_Properties.
 Require Import CRelationClasses.
 
+#[global] Hint Mode Reflexive ! ! : typeclass_instances.
+
 Infix "<~>" := iffT (at level 90).
 
 Definition iffT_l {P Q} : P <~> Q -> P -> Q.

--- a/template-coq/theories/utils/MC_ExtrOCamlNatInt.v
+++ b/template-coq/theories/utils/MC_ExtrOCamlNatInt.v
@@ -1,0 +1,84 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Extraction of [nat] into Ocaml's [int] *)
+
+Require Coq.extraction.Extraction.
+
+Require Import Arith Even Div2 EqNat Euclid.
+Require Import ExtrOcamlBasic.
+
+(** Disclaimer: trying to obtain efficient certified programs
+    by extracting [nat] into [int] is definitively *not* a good idea:
+
+    - This is just a syntactic adaptation, many things can go wrong,
+    such as name captures (e.g. if you have a constant named "int"
+    in your development, or a module named "Pervasives"). See bug #2878.
+
+    - Since [int] is bounded while [nat] is (theoretically) infinite,
+    you have to make sure by yourself that your program will not
+    manipulate numbers greater than [max_int]. Otherwise you should
+    consider the translation of [nat] into [big_int].
+
+    - Moreover, the mere translation of [nat] into [int] does not
+    change the complexity of functions. For instance, [mult] stays
+    quadratic. To mitigate this, we propose here a few efficient (but
+    uncertified) realizers for some common functions over [nat].
+
+    This file is hence provided mainly for testing / prototyping
+    purpose. For serious use of numbers in extracted programs,
+    you are advised to use either coq advanced representations
+    (positive, Z, N, BigN, BigZ) or modular/axiomatic representation.
+*)
+
+
+(** Mapping of [nat] into [int]. The last string corresponds to
+    a [nat_case], see documentation of [Extract Inductive]. *)
+
+Extract Inductive nat => int [ "0" "Stdlib.succ" ]
+ "(fun fO fS n -> if n=0 then fO () else fS (n-1))".
+
+(** Efficient (but uncertified) versions for usual [nat] functions *)
+
+Extract Constant plus => "(+)".
+Extract Constant pred => "fun n -> Stdlib.max 0 (n-1)".
+Extract Constant minus => "fun n m -> Stdlib.max 0 (n-m)".
+Extract Constant mult => "( * )".
+Extract Inlined Constant max => "Stdlib.max".
+Extract Inlined Constant min => "Stdlib.min".
+(*Extract Inlined Constant nat_beq => "(=)".*)
+Extract Inlined Constant Nat.eqb => "(=)".
+Extract Inlined Constant EqNat.eq_nat_decide => "(=)".
+
+Extract Inlined Constant Peano_dec.eq_nat_dec => "(=)".
+
+Extract Constant Nat.compare =>
+ "fun n m -> if n=m then Eq else if n<m then Lt else Gt".
+Extract Inlined Constant Compare_dec.leb => "(<=)".
+Extract Inlined Constant Compare_dec.le_lt_dec => "(<=)".
+Extract Inlined Constant Compare_dec.lt_dec => "(<)".
+Extract Constant Compare_dec.lt_eq_lt_dec =>
+ "fun n m -> if n>m then None else Some (n<m)".
+
+Extract Constant Nat.Even_or_Odd => "fun n -> n mod 2 = 0".
+Extract Constant Nat.div2 => "fun n -> n/2".
+
+Extract Inductive Euclid.diveucl => "(int * int)" [ "" ].
+Extract Constant Euclid.eucl_dev => "fun n m -> (m/n, m mod n)".
+Extract Constant Euclid.quotient => "fun n m -> m/n".
+Extract Constant Euclid.modulo => "fun n m -> m mod n".
+
+(*
+Definition test n m (H:m>0) :=
+ let (q,r,_,_) := eucl_dev m H n in
+ nat_compare n (q*m+r).
+
+Recursive Extraction test fact.
+*)

--- a/template-coq/theories/utils/MC_ExtrOCamlZPosInt.v
+++ b/template-coq/theories/utils/MC_ExtrOCamlZPosInt.v
@@ -1,0 +1,69 @@
+
+From Coq Require Import Extraction NArith ZArith.
+
+(** Disclaimer: trying to obtain efficient certified programs
+    by extracting [Z] into [int] is definitively *not* a good idea.
+    See the Disclaimer in [ExtrOcamlNatInt]. *)
+
+(** Mapping of [positive], [Z], [N] into [int]. The last strings
+    emulate the matching, see documentation of [Extract Inductive]. *)
+
+Extract Inductive positive => int
+[ "(fun p->1+2*p)" "(fun p->2*p)" "1" ]
+"(fun f2p1 f2p f1 p ->
+    if p<=1 then f1 () else if p mod 2 = 0 then f2p (p/2) else f2p1 (p/2))".
+
+Extract Inductive Z => int [ "0" "" "(~-)" ]
+"(fun f0 fp fn z -> if z=0 then f0 () else if z>0 then fp z else fn (-z))".
+
+Extract Inductive N => int [ "0" "" ]
+"(fun f0 fp n -> if n=0 then f0 () else fp n)".
+
+(** Nota: the "" above is used as an identity function "(fun p->p)" *)
+
+(** Efficient (but uncertified) versions for usual functions *)
+
+Extract Constant Pos.add => "(+)".
+Extract Constant Pos.succ => "Stdlib.succ".
+Extract Constant Pos.pred => "fun n -> Stdlib.max 1 (n-1)".
+Extract Constant Pos.sub => "fun n m -> Stdlib.max 1 (n-m)".
+Extract Constant Pos.mul => "( * )".
+Extract Constant Pos.min => "Stdlib.min".
+Extract Constant Pos.max => "Stdlib.max".
+Extract Constant Pos.compare =>
+    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+Extract Constant Pos.compare_cont =>
+    "fun c x y -> if x=y then c else if x<y then -1 else 1".
+
+
+Extract Constant N.add => "(+)".
+Extract Constant N.succ => "Stdlib.succ".
+Extract Constant N.pred => "fun n -> Stdlib.max 0 (n-1)".
+Extract Constant N.sub => "fun n m -> Stdlib.max 0 (n-m)".
+Extract Constant N.mul => "( * )".
+Extract Constant N.min => "Stdlib.min".
+Extract Constant N.max => "Stdlib.max".
+Extract Constant N.div => "fun a b -> if b=0 then 0 else a/b".
+Extract Constant N.modulo => "fun a b -> if b=0 then a else a mod b".
+Extract Constant N.compare =>
+    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+
+
+Extract Constant Z.add => "(+)".
+Extract Constant Z.succ => "Stdlib.succ".
+Extract Constant Z.pred => "Stdlib.pred".
+Extract Constant Z.sub => "(-)".
+Extract Constant Z.mul => "( * )".
+Extract Constant Z.opp => "(~-)".
+Extract Constant Z.abs => "Stdlib.abs".
+Extract Constant Z.min => "Stdlib.min".
+Extract Constant Z.max => "Stdlib.max".
+Extract Constant Z.compare =>
+    "fun x y -> if x=y then 0 else if x<y then -1 else 1".
+
+Extract Constant Z.of_N => "fun p -> p".
+Extract Constant Z.abs_N => "Stdlib.abs".
+
+(** Z.div and Z.modulo are quite complex to define in terms of (/) and (mod).
+    For the moment we don't even try *)
+    

--- a/test-suite/bugkncst.v
+++ b/test-suite/bugkncst.v
@@ -59,7 +59,7 @@ Fixpoint pocc_term (n:nat) (t:term): bool :=
 Definition bound_global_decl (d : kername * global_decl) : bool :=
   if kername_eq_dec str (fst d) then true else false.
 
-Definition bound_program (p : program) := List.existsb bound_global_decl (fst p).
+Definition bound_program (p : program) := List.existsb bound_global_decl (fst p).(declarations).
 
 Definition pocc_global_decl (d : kername * global_decl) : bool :=
 match snd d with
@@ -68,7 +68,7 @@ match snd d with
 | InductiveDecl _ => false
 end.
 
-Definition pocc_program p := pocc_term 2000 (snd p) || List.existsb pocc_global_decl (fst p).
+Definition pocc_program p := pocc_term 2000 (snd p) || List.existsb pocc_global_decl (fst p).(declarations).
 
 End occ_term_Sec.
 

--- a/test-suite/modules_sections.v
+++ b/test-suite/modules_sections.v
@@ -56,7 +56,7 @@ MetaCoq Run (bc <- tmQuote b ;;
                 tmPrint bc).
 
 Require Import MetaCoq.Template.Pretty.
-Check (eq_refl : print_term (empty_ext []) [] true
+Check (eq_refl : print_term (empty_ext empty_global_env) [] true
                       (tConst (MPfile ["test"; "Examples"; "MetaCoq"], "b") [])
                  = "MetaCoq.Examples.test.b").
 

--- a/test-suite/order_rec.v
+++ b/test-suite/order_rec.v
@@ -2,7 +2,7 @@ From MetaCoq.Template Require Import utils All.
 
 MetaCoq Quote Recursively Definition plus_syntax := plus.
 
-Goal ∑ s1 t1 s2 t2, fst plus_syntax = [(s1, ConstantDecl t1); (s2, InductiveDecl t2)].
+Goal ∑ s1 t1 s2 t2, plus_syntax.1.(declarations) = [(s1, ConstantDecl t1); (s2, InductiveDecl t2)].
 Proof.
   repeat eexists.
 Qed.

--- a/translations/param_cheap_packed.v
+++ b/translations/param_cheap_packed.v
@@ -158,7 +158,7 @@ Definition tsl_mind_body (ΣE : tsl_context) (mp : modpath)
                  ret (_, [{| ind_npars := mind.(ind_npars);
                              ind_bodies := bodies ;
                  ind_universes := match mind.(ind_universes) with 
-                  | Monomorphic_ctx _ => Monomorphic_ctx ContextSet.empty (* Don't redeclare universes *)
+                  | Monomorphic_ctx => Monomorphic_ctx
                   | Polymorphic_ctx ctx => Polymorphic_ctx ctx
                  end;
                  ind_variance := mind.(ind_variance) |}])).  (* FIXME always ok? *)

--- a/translations/translation_utils.v
+++ b/translations/translation_utils.v
@@ -25,7 +25,7 @@ Fixpoint lookup_tsl_table (E : tsl_table) (gr : global_reference)
 
 Definition tsl_context := (global_env_ext * tsl_table)%type.
 
-Definition emptyTC : tsl_context := (empty_ext [], []).
+Definition emptyTC : tsl_context := (empty_ext empty_global_env, []).
 
 Inductive tsl_error :=
 | NotEnoughFuel
@@ -97,7 +97,7 @@ Definition tmDebug {A} : A -> TemplateMonad unit
 
 
 Definition add_global_decl d (Σ : global_env_ext) : global_env_ext
-  := (d :: Σ.1, Σ.2).
+  := (add_global_decl Σ.1 d, Σ.2).
 
 Definition tmLocateCst (q : qualid) : TemplateMonad kername :=
   l <- tmLocate q ;;
@@ -198,7 +198,7 @@ Definition Implement {tsl : Translation} (ΣE : tsl_context)
       tmAxiom id A ;;
       kn <- tmLocateCst id ;;
       gr' <- tmLocate1 id' ;;
-      let decl := {| cst_universes := Monomorphic_ctx ContextSet.empty;
+      let decl := {| cst_universes := Monomorphic_ctx;
                      cst_type := tA; cst_body := None |} in
       let Σ' := add_global_decl (kn, ConstantDecl decl) (fst ΣE) in
       let E' := (ConstRef kn, monomorph_globref_term gr') :: (snd ΣE) in
@@ -236,7 +236,7 @@ Definition ImplementExisting {tsl : Translation} (ΣE : tsl_context) (id : ident
       tmDebug "plop3" ;;
       tmLemma id' A' ;;
       gr' <- tmLocate1 id' ;;
-      let decl := {| cst_universes := Monomorphic_ctx ContextSet.empty;
+      let decl := {| cst_universes := Monomorphic_ctx;
                      cst_type := A; cst_body := e.(cst_body) |} in
       let Σ' := add_global_decl (kn, ConstantDecl decl) (fst ΣE) in
       let E' := (ConstRef kn, monomorph_globref_term gr') :: (snd ΣE) in
@@ -302,9 +302,6 @@ Definition ImplementExisting {tsl : Translation} (ΣE : tsl_context) (id : ident
     end
   end
   end.
-
-
-
 
 Definition TranslateRec {tsl : Translation} (ΣE : tsl_context) {A} (t : A) := 
   p <- tmQuoteRec t ;;
@@ -372,4 +369,4 @@ Definition TranslateRec {tsl : Translation} (ΣE : tsl_context) {A} (t : A) :=
          end
       end
     end)
-  (fst p) ΣE.
+  (fst p).(declarations) ΣE.


### PR DESCRIPTION
The global env is now a record of a context of universes (for the global ones) + a list of declarations (monomorphic ones don't have universes attached), modelling Coq's global environment faithfully.
This basically synchronises 8.14 and master.