### PR TITLE
Remove primitives

### DIFF
--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -38,8 +38,8 @@ src/kernames.ml
 # src/typing0.ml
 
 # From PCUIC
-src/pCUICPrimitive.mli
-src/pCUICPrimitive.ml
+# src/pCUICPrimitive.mli
+# src/pCUICPrimitive.ml
 src/pCUICAst.ml
 src/pCUICAst.mli
 src/pCUICCases.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -18,7 +18,6 @@ Classes0
 Logic1
 Relation
 Relation_Properties
-PCUICPrimitive
 PCUICAst
 PCUICCases
 PCUICAstUtils

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -39,8 +39,8 @@ Inductive term : Set :=
                term (* discriminee *) -> list (list name * term) (* branches *) -> term
 | tProj      : projection -> term -> term
 | tFix       : mfixpoint term -> nat -> term
-| tCoFix     : mfixpoint term -> nat -> term
-| tPrim      : prim_val term -> term.
+| tCoFix     : mfixpoint term -> nat -> term.
+(* | tPrim      : prim_val term -> term. *)
 
 Bind Scope erasure with term.
 

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -262,7 +262,7 @@ Fixpoint string_of_term (t : term) : string :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  | tPrim p => "Prim(" ^ PCUICPrimitive.string_of_prim string_of_term p ^ ")"
+  (* | tPrim p => "Prim(" ^ PCUICPrimitive.string_of_prim string_of_term p ^ ")" *)
   end.
 
 (** Compute all the global environment dependencies of the term *)

--- a/erasure/theories/EInduction.v
+++ b/erasure/theories/EInduction.v
@@ -29,7 +29,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n)) ->
-    (forall p, P (tPrim p)) ->
+    (* (forall p, P (tPrim p)) -> *)
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -34,7 +34,7 @@ Fixpoint lift n k t : term :=
   | tVar _ => t
   | tConst _ => t
   | tConstruct _ _ => t
-  | tPrim _ => t
+  (* | tPrim _ => t *)
   end.
 
 Notation lift0 n := (lift n 0).

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -164,7 +164,7 @@ Section optimize.
     | tVar _ => t
     | tConst _ => t
     | tConstruct _ _ => t
-    | tPrim _ => t
+    (* | tPrim _ => t *)
     end.
 
   Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -154,8 +154,8 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ dname) l) n)
-  | tPrim p => 
-    parens top (string_of_prim (print_term Γ false false) p)
+  (* | tPrim p =>  *)
+    (* parens top (string_of_prim (print_term Γ false false) p) *)
   end.
 
 End print_term.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -483,7 +483,7 @@ Section Erase.
       erase Γ (tCoFix mfix n) Ht _ :=
         let mfix' := erase_mfix (erase) Γ mfix _ in
         E.tCoFix mfix' n;
-      erase Γ (tPrim p) Ht _ := E.tPrim (erase_prim p)
+      (* erase Γ (tPrim p) Ht _ := E.tPrim (erase_prim p) *)
     }.
   Proof.
     all:try clear b'; try clear f'; try clear brs'; try clear erase.

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -206,9 +206,9 @@ Inductive term :=
 | tCase (indn : case_info) (p : predicate term) (c : term) (brs : list (branch term))
 | tProj (p : projection) (c : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
-| tCoFix (mfix : mfixpoint term) (idx : nat)
+| tCoFix (mfix : mfixpoint term) (idx : nat).
 (** We use faithful models of primitive type values in PCUIC *)
-| tPrim (prim : prim_val term).
+(* | tPrim (prim : prim_val term). *)
 
 Derive NoConfusion for term.
 
@@ -484,7 +484,7 @@ Instance subst_instance_constr : UnivSubst term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def (subst_instance_constr u) (subst_instance_constr u)) mfix in
     tCoFix mfix' idx
-  | tPrim _ => c
+  (* | tPrim _ => c *)
   end.
 
 (** Tests that the term is closed over [k] universe variables *)

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -990,7 +990,7 @@ Section WeakNormalization.
     - exfalso; eapply invert_ind_ind; eauto.
     - exfalso; eapply invert_fix_ind; eauto.
     - now rewrite head_mkApps /head /=.
-    - now eapply inversion_Prim in typed.
+    (* - now eapply inversion_Prim in typed. *)
   Qed.
 
   Lemma whnf_ind_finite t ind u indargs : 

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -360,7 +360,7 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
     ) mfix mfix' ->
     Σ ⊢ tCoFix mfix idx <==[ Rle , napp ] tCoFix mfix' idx
     
-| eq_Prim i : eq_term_upto_univ_napp Σ Re Rle napp (tPrim i) (tPrim i)
+(* | eq_Prim i : eq_term_upto_univ_napp Σ Re Rle napp (tPrim i) (tPrim i) *)
 where " Σ ⊢ t <==[ Rle , napp ] u " := (eq_term_upto_univ_napp Σ _ Rle napp t u) : type_scope.
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).

--- a/pcuic/theories/PCUICEqualityDec.v
+++ b/pcuic/theories/PCUICEqualityDec.v
@@ -154,7 +154,7 @@ Fixpoint eqb_term_upto_univ_napp Σ (equ lequ : Universe.t -> Universe.t -> bool
       eqb_binder_annot x.(dname) y.(dname)
     ) mfix mfix'
 
-  | tPrim p, tPrim p' => eqb p p'
+  (* | tPrim p, tPrim p' => eqb p p' *)
 
   | _, _ => false
   end.
@@ -705,7 +705,7 @@ Proof.
         constructor. constructor. constructor ; try easy.
         now inversion e3.
 
-  - cbn - [eqb]. eqspecs. do 2 constructor.
+  (* - cbn - [eqb]. eqspecs. do 2 constructor. *)
 Qed.
 
 Lemma eqb_term_upto_univ_impl (equ lequ : _ -> _ -> bool) Σ Re Rle napp:

--- a/pcuic/theories/PCUICExpandLets.v
+++ b/pcuic/theories/PCUICExpandLets.v
@@ -40,7 +40,7 @@ Fixpoint trans (t : term) : term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  | tPrim i => tPrim i
+  (* | tPrim i => tPrim i *)
   end.
 
 Notation trans_decl := (map_decl trans).

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -314,12 +314,12 @@ Section Inversion.
   Qed.
 
   (** At this stage we don't typecheck primitive values *)
-  Lemma inversion_Prim :
+  (* Lemma inversion_Prim :
     forall {Γ i T},
       Σ ;;; Γ |- tPrim i : T -> False.
   Proof.
     intros Γ i T h. now depind h.
-  Qed.
+  Qed. *)
 
   Lemma inversion_it_mkLambda_or_LetIn :
     forall {Γ Δ t T},

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -54,7 +54,7 @@ Section Normal.
     end ->
     whnf Γ (mkApps (tFix mfix idx) v)
   | whnf_cofixapp mfix idx v : whnf Γ (mkApps (tCoFix mfix idx) v)
-  | whnf_prim p : whnf Γ (tPrim p)
+  (* | whnf_prim p : whnf Γ (tPrim p) *)
 
   with whne (Γ : context) : term -> Type :=
   | whne_rel i :
@@ -256,8 +256,8 @@ Proof.
     lia.
   - destruct (mkApps_elim t l).
     apply mkApps_eq_inj in eq as (<-&<-); auto.
-  - destruct l using MCList.rev_ind; [|now rewrite mkApps_app in eq].
-    cbn in *; subst; auto.
+  (* - destruct l using MCList.rev_ind; [|now rewrite mkApps_app in eq]. *)
+    (* cbn in *; subst; auto. *)
 Qed.
 
 Lemma whnf_fixapp' {flags} Σ Γ mfix idx narg body v :
@@ -390,11 +390,11 @@ Proof with eauto using sq with pcuic; try congruence.
                  constructor.
                  assumption.
         -- left. constructor. eapply whnf_fixapp. rewrite E1. eauto.
-      * destruct v as [ | ? v]...
+      (* * destruct v as [ | ? v]...
         right. intros [w]. depelim w. depelim w. all:help. clear IHt.
         eapply whne_mkApps_inv in w as []...
         -- depelim w. help.
-        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence.
+        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence. *)
     + right. intros [w]. eapply n. constructor. now eapply whnf_mkApps_inv. 
   - destruct (IHt Γ) as [_ []].
     + left. destruct s as [w]. constructor. now eapply whne_mkApps.
@@ -940,7 +940,7 @@ Proof.
       destruct s as [->|(?&?)]; [easy|].
       now inv e.
   - eapply red1_mkApps_tCoFix_inv in r as [[(?&->&?)|(?&->&?)]|(?&->&?)]; eauto.
-  - depelim r. solve_discr.
+  (* - depelim r. solve_discr. *)
 Qed.
 
 Lemma whnf_pres Σ Γ t t' :
@@ -1013,8 +1013,8 @@ Inductive whnf_red Σ Γ : term -> term -> Type :=
                       red Σ Γ (dtype d) (dtype d') ×
                       red Σ (Γ,,, fix_context mfix) (dbody d) (dbody d'))
          mfix mfix' ->
-    whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx)
-| whnf_red_tPrim i : whnf_red Σ Γ (tPrim i) (tPrim i).
+    whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx).
+(* | whnf_red_tPrim i : whnf_red Σ Γ (tPrim i) (tPrim i). *)
 
 Derive Signature for whnf_red.
 
@@ -1516,7 +1516,7 @@ Proof.
       cbn.
       intros ? ? (?&[= -> -> ->]).
       auto.
-  - depelim r; solve_discr.
+  (* - depelim r; solve_discr. *)
 Qed.
 
 Lemma whnf_red_inv {cf:checker_flags} {Σ : global_env_ext} Γ t t' :
@@ -1607,7 +1607,7 @@ Proof.
   - apply eq_term_upto_univ_napp_mkApps_l_inv in eq as (?&?&(?&?)&->).
     depelim e.
     apply whnf_cofixapp.
-  - depelim eq; auto.
+  (* - depelim eq; auto. *)
 Qed.
 
 Lemma whnf_eq_term {cf:checker_flags} f Σ φ Γ t t' :

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -230,8 +230,8 @@ Section ParallelReduction.
     | tVar _
     | tSort _
     | tInd _ _
-    | tConstruct _ _ _ 
-    | tPrim _ => true
+    | tConstruct _ _ _  => true
+    (* | tPrim _ => true *)
     | _ => false
     end.
 

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -1844,7 +1844,7 @@ Section Rho.
     rename r (rho Γ t) = rho Δ (rename r t).
   Proof.
     revert t Γ Δ r P.
-    refine (PCUICDepth.term_ind_depth_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
+    refine (PCUICDepth.term_ind_depth_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
       intros until Γ; intros Δ r P Hr ont; try subst Γ; try rename Γ0 into Γ; repeat inv_on_free_vars.
     all:auto 2.
 

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -332,7 +332,7 @@ Section Principality.
       rewrite nthe' in nthe; noconf nthe.
       repeat split; eauto.
       eapply type_CoFix; eauto.
-    - now apply inversion_Prim in hA.
+    (* - now apply inversion_Prim in hA. *)
   Qed.
 
   (** A weaker version that is often convenient to use. *)

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -11,11 +11,11 @@ Definition uint63_from_model (i : uint63_model) : Uint63.int :=
 Definition float64_from_model (f : float64_model) : PrimFloat.float :=
   FloatOps.SF2Prim (proj1_sig f).
     
-Definition trans_prim (t : prim_val) : Ast.term :=
+(* Definition trans_prim (t : prim_val) : Ast.term :=
   match t.π2 with
   | primIntModel i => Ast.tInt (uint63_from_model i)
   | primFloatModel f => Ast.tFloat (float64_from_model f)
-  end.
+  end. *)
 
 Definition trans_predicate (t : PCUICAst.predicate Ast.term) : predicate Ast.term :=
   {| pparams := t.(PCUICAst.pparams); 
@@ -51,7 +51,7 @@ Fixpoint trans (t : PCUICAst.term) : Ast.term :=
   | PCUICAst.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  | PCUICAst.tPrim i => trans_prim i
+  (* | PCUICAst.tPrim i => trans_prim i *)
   end.
 
 Notation trans_decl := (map_decl trans).

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -101,7 +101,7 @@ Proof.
     rewrite b. now rewrite forget_types_length map_context_length. 
   - f_equal; auto; red in X; solve_list.
   - f_equal; auto; red in X; solve_list.
-  - destruct p as [? []]; eauto.
+  (* - destruct p as [? []]; eauto. *)
 Qed.
 
 Definition on_fst {A B C} (f:A->C) (p:A×B) := (f p.1, p.2).
@@ -275,7 +275,7 @@ Proof.
       cbn in *.
       now rewrite e e0.  
     + apply IHX.
-  - destruct p as [? []]; eauto.
+  (* - destruct p as [? []]; eauto. *)
 Qed.
 
 Lemma trans_subst10 u B:
@@ -325,7 +325,7 @@ Proof.
       destruct p.
       now rewrite e e0.
     + apply IHX.
-  - destruct p as [? []]; eauto.
+  (* - destruct p as [? []]; eauto. *)
 Qed.
 
 Lemma trans_subst_instance_ctx Γ u :
@@ -443,7 +443,7 @@ Proof.
   - rewrite <- IHx3.
     reflexivity.
   - destruct (trans x1);cbn;trivial.
-  - destruct prim as [? []]; eauto.
+  (* - destruct prim as [? []]; eauto. *)
 Qed.
 
 Lemma trans_mkProd_or_LetIn a t:
@@ -476,7 +476,7 @@ Proof.
   destruct t; cbnr.
   generalize (trans t1) (trans t2); clear.
   induction t; intros; cbnr.
-  destruct prim as [? []]; cbnr.
+  (* destruct prim as [? []]; cbnr. *)
 Qed.
 
 Lemma trans_unfold_fix mfix idx narg fn :
@@ -1020,7 +1020,7 @@ Proof.
     cbn; eauto. cbn in p0. destruct p0. eauto.
   - cbn. red in X. solve_all.
   - cbn. red in X. solve_all.
-  - destruct p as [? []]; constructor.
+  (* - destruct p as [? []]; constructor. *)
 Qed.
 
 #[global] Hint Resolve trans_wf : wf.
@@ -1434,7 +1434,7 @@ Proof.
     red in X0. solve_all_one.
     eapply trans_eq_context_gen_eq_binder_annot in a.
     now rewrite !map_context_trans.
-  - destruct p as [? []]; constructor.
+  (* - destruct p as [? []]; constructor. *)
 Qed.
 
 Lemma trans_leq_term {cf} Σ ϕ T U :
@@ -1667,26 +1667,26 @@ Proof.
   - eapply IHt3 in e as e'. assumption.
   - noconf e. simpl.
     now destruct (mkApp_ex (trans t1) (trans t2)) as [f [args ->]].
-  - noconf e. now destruct prim as [? []] => /=.
+  (* - noconf e. now destruct prim as [? []] => /=. *)
 Qed.
 
 Lemma trans_isApp t : PCUICAst.isApp t = false -> Ast.isApp (trans t) = false.
 Proof.
   destruct t => //.
-  now destruct prim as [? []].
+  (* now destruct prim as [? []]. *)
 Qed.
 
 Lemma trans_nisApp t : ~~ PCUICAst.isApp t -> ~~ Ast.isApp (trans t).
 Proof.
   destruct t => //.
-  now destruct prim as [? []].
+  (* now destruct prim as [? []]. *)
 Qed.
 
 Lemma trans_destInd t : ST.destInd t = TT.destInd (trans t).
 Proof.
   destruct t => //. simpl.
   now destruct (mkApp_ex (trans t1) (trans t2)) as [f [u ->]].
-  now destruct prim as [? []].
+  (* now destruct prim as [? []]. *)
 Qed.
 
 Lemma trans_decompose_app t : 

--- a/pcuic/theories/Syntax/PCUICDepth.v
+++ b/pcuic/theories/Syntax/PCUICDepth.v
@@ -335,10 +335,10 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (m : mfixpoint term) (n : nat),
         All_local_env (PCUICInduction.on_local_decl (fun Γ' t => P (Γ ,,, Γ') t)) (fix_context m) ->
         tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
-    (forall Γ p, P Γ (tPrim p)) ->
+    (* (forall Γ p, P Γ (tPrim p)) -> *)
     forall Γ (t : term), P Γ t.
 Proof.
-  intros ????????????????? Γ t.
+  intros ???????????????? Γ t.
   revert Γ t. set(foo:=CoreTactics.the_end_of_the_section). intros.
   Subterm.rec_wf_rel aux t (MR lt depth); unfold MR in *; simpl. clear H1.
   assert (auxl : forall Γ {A} (l : list A) (f : A -> term),
@@ -456,10 +456,10 @@ Lemma term_ind_depth_app :
     (forall (m : mfixpoint term) (n : nat),
         onctx P (fix_context m) ->
         tFixProp P P m -> P (tCoFix m n)) ->
-    (forall p, P (tPrim p)) ->
+    (* (forall p, P (tPrim p)) -> *)
     forall (t : term), P t.
 Proof.
-  intros ????????????????? t.
+  intros ???????????????? t.
   revert t. set(foo:=CoreTactics.the_end_of_the_section). intros.
   Subterm.rec_wf_rel aux t (MR lt depth); unfold MR in *; simpl. clear H0.
   assert (auxl : forall {A} (l : list A) (f : A -> term),

--- a/pcuic/theories/Syntax/PCUICInduction.v
+++ b/pcuic/theories/Syntax/PCUICInduction.v
@@ -19,7 +19,7 @@ Import PCUICEnvTyping.
   Allows to get the right induction principle on lists of terms appearing
   in the term syntax (in evar, applications, branches of cases and (co-)fixpoints. *)
 
-Notation prim_ind P p := (P (tPrim p)).
+(* Notation prim_ind P p := (P (tPrim p)). *)
 
 (** Custom induction principle on syntax, dealing with the various lists appearing in terms. *)
 
@@ -43,7 +43,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall p, prim_ind P p) ->
+    (* (forall p, prim_ind P p) -> *)
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -260,11 +260,11 @@ Lemma term_forall_mkApps_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall i, prim_ind P i) ->
+    (* (forall i, prim_ind P i) -> *)
     forall t : term, P t.
 Proof.
   intros until t.
-  rename X14 into Pprim.
+  (* rename X14 into Pprim. *)
   assert (Acc (MR lt size) t) by eapply measure_wf, Wf_nat.lt_wf.
   induction H. rename X14 into auxt. clear H. rename x into t.
   move auxt at top.
@@ -486,10 +486,10 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (m : mfixpoint term) (n : nat),
         All_local_env (on_local_decl (fun Γ' t => P (Γ ,,, Γ') t)) (fix_context m) ->
         tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
-    (forall Γ p, P Γ (tPrim p)) ->
+    (* (forall Γ p, P Γ (tPrim p)) -> *)
     forall Γ (t : term), P Γ t.
 Proof.
-  intros ????????????????? Γ t.
+  intros ???????????????? Γ t.
   revert Γ t. set(foo:=CoreTactics.the_end_of_the_section). intros.
   Subterm.rec_wf_rel aux t (MR lt size); unfold MR in *; simpl. clear H1.
   assert (auxl : forall Γ {A} (l : list A) (f : A -> term),
@@ -593,7 +593,7 @@ Lemma term_ind_size_app :
         tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat),
         tFixProp (P) P m -> P (tCoFix m n)) ->
-    (forall p, P (tPrim p)) ->
+    (* (forall p, P (tPrim p)) -> *)
     forall (t : term), P t.
 Proof.
   intros.

--- a/pcuic/theories/Syntax/PCUICNamelessDef.v
+++ b/pcuic/theories/Syntax/PCUICNamelessDef.v
@@ -57,7 +57,7 @@ Fixpoint nameless (t : term) : bool :=
   | tCoFix mfix idx =>
     forallb (fun d => banon d.(dname)) mfix &&
     forallb (test_def nameless nameless) mfix
-  | tPrim _ => true
+  (* | tPrim _ => true *)
   end.
 
 Notation nameless_ctx := (forallb (nameless_decl nameless)).
@@ -105,7 +105,7 @@ Fixpoint nl (t : term) : term :=
   | tProj p c => tProj p (nl c)
   | tFix mfix idx => tFix (map (map_def_anon nl nl) mfix) idx
   | tCoFix mfix idx => tCoFix (map (map_def_anon nl nl) mfix) idx
-  | tPrim p => tPrim p
+  (* | tPrim p => tPrim p *)
   end.
 
 Definition nlctx (Γ : context) : context :=

--- a/pcuic/theories/Syntax/PCUICOnFreeVars.v
+++ b/pcuic/theories/Syntax/PCUICOnFreeVars.v
@@ -86,8 +86,8 @@ Fixpoint on_free_vars (p : nat -> bool) (t : term) : bool :=
   | tProj _ c => on_free_vars p c
   | tFix mfix idx | tCoFix mfix idx =>
     List.forallb (test_def (on_free_vars p) (on_free_vars (shiftnP #|mfix| p))) mfix
-  | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ 
-  | tPrim _ => true
+  | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => true
+  (* | tPrim _ => true *)
   end.
 
 Lemma on_free_vars_ext (p q : nat -> bool) t : 
@@ -1379,7 +1379,7 @@ Lemma term_on_free_vars_ind :
     (forall p (m : mfixpoint term) (i : nat), 
       tFixProp (on_free_vars p) (on_free_vars (shiftnP #|fix_context m| p)) m ->
       tFixProp (P p) (P (shiftnP #|fix_context m| p)) m -> P p (tCoFix m i)) ->
-    (forall p pr, P p (tPrim pr)) ->
+    (* (forall p pr, P p (tPrim pr)) -> *)
     forall p (t : term), on_free_vars p t -> P p t.
 Proof.
   intros until t. revert p t.

--- a/pcuic/theories/TemplateToPCUIC.v
+++ b/pcuic/theories/TemplateToPCUIC.v
@@ -99,8 +99,8 @@ Section Trans.
   | Ast.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  | Ast.tInt n => tPrim (primInt; primIntModel (uint63_to_model n))
-  | Ast.tFloat n => tPrim (primFloat; primFloatModel (float64_to_model n))
+  (* | Ast.tInt n => tPrim (primInt; primIntModel (uint63_to_model n)) *)
+  (* | Ast.tFloat n => tPrim (primFloat; primFloatModel (float64_to_model n)) *)
   end.
 
   Definition trans_decl (d : Ast.Env.context_decl) :=

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -835,7 +835,7 @@ Lemma term_closedn_list_ind :
     (forall k (s : projection) (t : term), P k t -> P k (tProj s t)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tFix m n)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tCoFix m n)) ->
-    (forall k p, P k (tPrim p)) ->
+    (* (forall k p, P k (tPrim p)) -> *)
     forall k (t : term), closedn k t -> P k t.
 Proof.
   intros until t. revert k t.
@@ -947,7 +947,7 @@ Lemma term_noccur_between_list_ind :
     (forall k n (s : projection) (t : term), P k n t -> P k n (tProj s t)) ->
     (forall k n (m : mfixpoint term) (i : nat), tFixProp (P k n) (P (#|fix_context m| + k) n) m -> P k n (tFix m i)) ->
     (forall k n (m : mfixpoint term) (i : nat), tFixProp (P k n) (P (#|fix_context m| + k) n) m -> P k n (tCoFix m i)) ->
-    (forall k n p, P k n (tPrim p)) ->
+    (* (forall k n p, P k n (tPrim p)) -> *)
     forall k n (t : term), noccur_between k n t -> P k n t.
 Proof.
   intros until t. revert k n t.

--- a/pcuic/theories/utils/PCUICAstUtils.v
+++ b/pcuic/theories/utils/PCUICAstUtils.v
@@ -40,7 +40,7 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  | tPrim i => "Int(" ^ string_of_prim string_of_term i ^ ")"
+  (* | tPrim i => "Int(" ^ string_of_prim string_of_term i ^ ")" *)
   end.
 
 Ltac change_Sk :=

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -253,7 +253,7 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_aname ∘ dname) l) n)
-  | tPrim i => parens top (string_of_prim (print_term Γ true false) i)
+  (* | tPrim i => parens top (string_of_prim (print_term Γ true false) i) *)
   end.
 
 End print_term.

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -22,8 +22,8 @@ src/wGraph.ml
 src/wGraph.mli
 
 # From PCUIC
-src/pCUICPrimitive.mli
-src/pCUICPrimitive.ml
+# src/pCUICPrimitive.mli
+# src/pCUICPrimitive.ml
 src/pCUICAst.ml
 src/pCUICAst.mli
 src/pCUICAstUtils.ml

--- a/safechecker/src/metacoq_safechecker_plugin.mlpack
+++ b/safechecker/src/metacoq_safechecker_plugin.mlpack
@@ -14,7 +14,6 @@ Classes0
 Logic1
 Relation
 Relation_Properties
-PCUICPrimitive
 PCUICAst
 PCUICCases
 PCUICAstUtils

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -4683,7 +4683,7 @@ Section Conversion.
   Qed.
 
   (* TODO move to PCUICNormal *)
-  Lemma whnf_mkApps_tPrim_inv : 
+  (*Lemma whnf_mkApps_tPrim_inv : 
     forall (f : RedFlags.t) (Σ : global_env) (Γ : context) p (args : list term),
       whnf f Σ Γ (mkApps (tPrim p) args) -> args = [].
   Proof.
@@ -4698,7 +4698,7 @@ Section Conversion.
     rewrite mkApps_app in teq.
     cbn in teq. noconf teq.
     eauto.
-  Qed.
+  Qed.*)
 
   Lemma reducible_head_None Γ t π h :
     isApp t = false ->
@@ -4759,9 +4759,9 @@ Section Conversion.
     - constructor; eexists _, (decompose_stack π).1.
       split; [constructor; eauto with pcuic|].
       eauto with pcuic.
-    - apply whnf_mkApps_tPrim_inv in wh as ->.
+    (* - apply whnf_mkApps_tPrim_inv in wh as ->.
       constructor; eexists _, [].
-      eauto using whnf_red with pcuic.
+      eauto using whnf_red with pcuic. *)
     - constructor; eexists _, (decompose_stack π).1.
       split; [econstructor|]; eauto.
       split; [eauto with pcuic|].

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1267,7 +1267,7 @@ Section Reduce.
       unfold is_true in typ.
       unfold PCUICAst.PCUICEnvironment.fst_ctx in *.
       congruence.
-    - now eapply inversion_Prim in typ.
+    (* - now eapply inversion_Prim in typ. *)
   Qed.
   
   Definition isCoFix_app t :=
@@ -1299,7 +1299,7 @@ Section Reduce.
     - exfalso; eapply invert_fix_ind; eauto.
     - unfold isCoFix_app in cof.
       now rewrite decompose_app_mkApps in cof.
-    - now eapply inversion_Prim in typ.
+    (* - now eapply inversion_Prim in typ. *)
   Qed.
   
   Lemma whnf_fix_arg_whne mfix idx body Γ t before args aftr ty :
@@ -1450,11 +1450,11 @@ Section Reduce.
           apply inversion_App in h as (?&?&?&?&?); auto.
           apply inversion_Prod in t0 as (?&?&?&?&?); auto.
           eapply PCUICConversion.ws_cumul_pb_Sort_Prod_inv; eauto.
-      + pose proof hΣ.
+      (* + pose proof hΣ.
         sq.
         exfalso.
         eapply welltyped_context in h as [s Hs]; tas.
-        now eapply inversion_Prim in Hs.
+        now eapply inversion_Prim in Hs. *)
     - unfold zipp. case_eq (decompose_stack π). intros l ρ e.
       constructor. constructor. eapply whne_mkApps.
       eapply whne_rel_nozeta. assumption.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -335,9 +335,9 @@ Qed.
 
     infer Γ wfΓ (tCoFix mfix n) wt with inspect (nth_error mfix n) :=
       { | exist (Some f) _ => ret f.(dtype);
-        | exist None _ => ! };
+        | exist None _ => ! }.
 
-    infer Γ wfΓ (tPrim p) wt := !.
+    (* infer Γ wfΓ (tPrim p) wt := !. *)
 
   Next Obligation.
     sq.
@@ -662,9 +662,9 @@ Qed.
     congruence.
   Qed.
 
-  Next Obligation.
+  (* Next Obligation.
     inversion HT.
-  Qed.
+  Qed. *)
 
   Definition type_of Γ wfΓ t wt : term := (infer Γ wfΓ t wt).
   

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -1418,9 +1418,9 @@ Section Typecheck.
       guarded <- check_eq_true (cofix_guard Σ Γ mfix) (Msg "Unguarded cofixpoint") ;;
       wfcofix <- check_eq_true (wf_cofixpoint Σ mfix) (Msg "Ill-formed cofixpoint: not producing values in a mutually coinductive family") ;;
       ret (dtype decl; _)
-    } ;
+    }.
 
-  infer Γ HΓ (tPrim _) := raise (Msg "Primitive types are not supported").
+  (* infer Γ HΓ (tPrim _) := raise (Msg "Primitive types are not supported"). *)
 
   (* tRel *)
   Next Obligation. intros; sq; now econstructor. Defined.
@@ -2329,10 +2329,10 @@ Section Typecheck.
     inversion X0 ; subst.
     congruence.
   Qed.
-  Next Obligation.
+  (* Next Obligation.
     sq.
     inversion X0.
-  Qed.
+  Qed. *)
 
 (* 
   Program Definition check_isWfArity Γ (HΓ : ∥ wf_local Σ Γ ∥) A

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -121,8 +121,8 @@ struct
     | Coq_tProj (a,b) -> ACoq_tProj (a,b)
     | Coq_tFix (a,b) -> ACoq_tFix (List.map unquote_def a,b)
     | Coq_tCoFix (a,b) -> ACoq_tCoFix (List.map unquote_def a,b)
-    | Coq_tInt i -> ACoq_tInt i
-    | Coq_tFloat f -> ACoq_tFloat f
+    (* | Coq_tInt i -> ACoq_tInt i *)
+    (* | Coq_tFloat f -> ACoq_tFloat f *)
 
   let unquote_ident (qi: quoted_ident) : Id.t =
     let s = list_to_string qi in

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -246,8 +246,8 @@ struct
   let mkInd i u = Coq_tInd (i, u)
   let mkConstruct (ind, i) u = Coq_tConstruct (ind, i, u)
   let mkLetIn na b t t' = Coq_tLetIn (na,b,t,t')
-  let mkInt i = Coq_tInt i
-  let mkFloat f = Coq_tFloat f
+  (* let mkInt i = Coq_tInt i
+  let mkFloat f = Coq_tFloat f *)
 
   let rec seq f t =
     if f < t then

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -461,14 +461,14 @@ struct
       match args with
         proj::t::_ -> ACoq_tProj (proj, t)
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
-    else if constr_equall h tInt then
+    (* else if constr_equall h tInt then
       match args with
         t::_ -> ACoq_tInt t
       | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
     else if constr_equall h tFloat then
       match args with
         t::_ -> ACoq_tFloat t
-      | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
+      | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure")) *)
     else
       CErrors.user_err (str"inspect_term: cannot recognize " ++ print_term t ++ str" (maybe you forgot to reduce it?)")
 

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -159,8 +159,8 @@ struct
          let p' = Names.Projection.make (Projection.Repr.make ind' ~proj_npars ~proj_arg l) false in
          let evm, t' = aux env evm t in
          evm, Constr.mkProj (p', t')
-      | ACoq_tInt x -> evm, Constr.mkInt (D.unquote_int63 x)
-      | ACoq_tFloat x -> evm, Constr.mkFloat (D.unquote_float64 x)
+      (* | ACoq_tInt x -> evm, Constr.mkInt (D.unquote_int63 x) *)
+      (* | ACoq_tFloat x -> evm, Constr.mkFloat (D.unquote_float64 x) *)
 
     in aux env evm trm
 

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -70,8 +70,8 @@ sig
   val mkProj : quoted_proj -> t -> t
   val mkFix : (quoted_int array * quoted_int) * (quoted_aname array * t array * t array) -> t
   val mkCoFix : quoted_int * (quoted_aname array * t array * t array) -> t
-  val mkInt : quoted_int63 -> t
-  val mkFloat : quoted_float64 -> t
+  (* val mkInt : quoted_int63 -> t
+  val mkFloat : quoted_float64 -> t *)
 
   val mkBindAnn : quoted_name -> quoted_relevance -> quoted_aname
   val mkName : quoted_ident -> quoted_name
@@ -333,10 +333,12 @@ struct
          let t', acc = quote_term acc env c in
          let mib = Environ.lookup_mind (fst (Projection.inductive p)) (snd env) in
          (Q.mkProj p' t', add_inductive (Projection.inductive p) mib acc)
-      | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
-      | Constr.Float f -> (Q.mkFloat (Q.quote_float64 f), acc)
+      (* | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
+      | Constr.Float f -> (Q.mkFloat (Q.quote_float64 f), acc) *)
       | Constr.Meta _ -> failwith "Meta not supported by TemplateCoq"
-      | Constr.Array _ -> failwith "Array not supported by TemplateCoq"
+      | Constr.Int _ -> failwith "Primitive ints not supported by TemplateCoq"
+      | Constr.Float _ -> failwith "Primitive floats not supported by TemplateCoq"
+      | Constr.Array _ -> failwith "Primitive arrays not supported by TemplateCoq"
       in
       aux acc env trm
     and quote_recdecl (acc : 'a) env b (ns,ts,ds) =

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -190,6 +190,6 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | ACoq_tProj of 'projection * 'term
   | ACoq_tFix of ('term, 'name, 'nat) amfixpoint * 'nat
   | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
-  | ACoq_tInt of 'int63
-  | ACoq_tFloat of 'float64
+  (* | ACoq_tInt of 'int63 *)
+  (* | ACoq_tFloat of 'float64 *)
 

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -415,9 +415,10 @@ Inductive term : Type :=
         (discr:term) (branches : list (branch term))
 | tProj (proj : projection) (t : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
-| tCoFix (mfix : mfixpoint term) (idx : nat)
-| tInt (i : Int63.int)
-| tFloat (f : PrimFloat.float).
+| tCoFix (mfix : mfixpoint term) (idx : nat).
+(* Not supported yet *)
+(* | tInt (i : Int63.int) *)
+(* | tFloat (f : PrimFloat.float). *)
 
 (** This can be used to represent holes, that, when unquoted, turn into fresh existential variables. 
     The fresh evar will depend on the whole context at this point in the term, despite the empty instance.
@@ -556,7 +557,8 @@ Fixpoint noccur_between k n (t : term) : bool :=
 #[global] Instance subst_instance_constr : UnivSubst term :=
   fix subst_instance_constr u c {struct c} : term :=
   match c with
-  | tRel _ | tVar _  | tInt _ | tFloat _ => c
+  | tRel _ | tVar _  => c
+  (* | tInt _ | tFloat _ => c *)
   | tEvar ev args => tEvar ev (List.map (subst_instance_constr u) args)
   | tSort s => tSort (subst_instance_univ u s)
   | tConst c u' => tConst c (subst_instance_instance u u')

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -50,8 +50,8 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
-  | tFloat f => "Float(" ^ string_of_float f ^ ")"
+  (* | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
+  | tFloat f => "Float(" ^ string_of_float f ^ ")" *)
   end.
   
 Fixpoint destArity Γ (t : term) :=
@@ -241,8 +241,8 @@ Fixpoint strip_casts t :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def strip_casts strip_casts) mfix in
     tCoFix mfix' idx
-  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ 
-  | tInt _ | tFloat _ => t
+  | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => t
+  (* | tInt _ | tFloat _ => t *)
   end.
   
 Fixpoint decompose_prod_assum (Γ : context) (t : term) : context * term :=

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -818,7 +818,7 @@ Section Typecheck.
       | None => raise (IllFormedFix mfix n)
       end
 
-    | tInt _ | tFloat _ => raise (NotSupported "primitive types")
+    (* | tInt _ | tFloat _ => raise (NotSupported "primitive types") *)
     end.
 
   Definition check (Γ : context) (t : term) (ty : term) : typing_result unit :=

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -176,8 +176,8 @@ Register MetaCoq.Template.Ast.tCase as metacoq.ast.tCase.
 Register MetaCoq.Template.Ast.tProj as metacoq.ast.tProj.
 Register MetaCoq.Template.Ast.tFix as metacoq.ast.tFix.
 Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tCoFix.
-Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
-Register MetaCoq.Template.Ast.tFloat as metacoq.ast.tFloat.
+(* Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
+Register MetaCoq.Template.Ast.tFloat as metacoq.ast.tFloat. *)
 
 (* Local and global declarations *)
 Register MetaCoq.Template.Ast.parameter_entry as metacoq.ast.parameter_entry.

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -30,8 +30,8 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->    
+    (* (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->     *)
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -73,8 +73,8 @@ Lemma term_forall_list_rect :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->    
+    (* (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->     *)
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -46,7 +46,7 @@ Section print_term.
       | Some body => substring 0 1 (body.(ind_name))
       | None => "X"
       end
-    | tInt _ => "i"
+    (* | tInt _ => "i" *)
     | _ => "U"
     end.
 
@@ -230,8 +230,8 @@ Section print_term.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ binder_name ∘ dname) l) n)
-  | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
-  | tFloat f => "Float(" ^ string_of_float f ^ ")"
+  (* | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
+  | tFloat f => "Float(" ^ string_of_float f ^ ")" *)
   end.
 
 End print_term.

--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -152,10 +152,10 @@ Proof.
         subst. inversion e1. subst.
         destruct (eq_dec rarg rarg0) ; nodec.
         subst. left. reflexivity.
-  - destruct (Int63.eqs i i0) ; nodec.
+  (* - destruct (Int63.eqs i i0) ; nodec.
     subst. left. reflexivity.
   - destruct (eq_dec f f0) ; nodec.
-    subst. left. reflexivity.
+    subst. left. reflexivity. *)
 Defined.
 
 #[global] Instance reflect_term : ReflectEq term :=

--- a/template-coq/theories/TermEquality.v
+++ b/template-coq/theories/TermEquality.v
@@ -256,10 +256,10 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
   eq_term_upto_univ_napp Σ Re Re 0 t1 t1' ->
   eq_cast_kind c c' ->
   eq_term_upto_univ_napp Σ Re Re 0 t2 t2' ->
-  eq_term_upto_univ_napp Σ Re Rle napp (tCast t1 c t2) (tCast t1' c' t2')
+  eq_term_upto_univ_napp Σ Re Rle napp (tCast t1 c t2) (tCast t1' c' t2').
 
-| eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
-| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f).
+(* | eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
+| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f). *)
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 

--- a/template-coq/theories/WfAst.v
+++ b/template-coq/theories/WfAst.v
@@ -51,9 +51,9 @@ Inductive wf {Σ} : term -> Type :=
 | wf_tProj p t : wf t -> wf (tProj p t)
 | wf_tFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix ->
                    wf (tFix mfix k)
-| wf_tCoFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix -> wf (tCoFix mfix k)
-| wf_tInt i : wf (tInt i)
-| wf_tFloat f : wf (tFloat f).
+| wf_tCoFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix -> wf (tCoFix mfix k).
+(* | wf_tInt i : wf (tInt i) *)
+(* | wf_tFloat f : wf (tFloat f). *)
 Arguments wf : clear implicits.
 Derive Signature for wf.
 
@@ -61,7 +61,8 @@ Derive Signature for wf.
 
 Definition wf_Inv Σ (t : term) : Type :=
   match t with
-  | tRel _ | tVar _ | tSort _ | tInt _ | tFloat _ => unit
+  | tRel _ | tVar _ | tSort _ => unit
+  (* | tInt _ | tFloat _  *)
   | tEvar n l => All (wf Σ) l
   | tCast t k t' => wf Σ t * wf Σ t'
   | tProd na t b => wf Σ t * wf Σ b
@@ -139,11 +140,11 @@ Lemma term_wf_forall_list_ind Σ :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->
+    (* (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) -> *)
     forall t : term, wf Σ t -> P t.
 Proof.
-  intros P H2 H3 H4 H5 H6 H7 H8 H9 H10 H11 H12 H13 H14 H15 H16 H17 H18 H19.
+  intros P H2 H3 H4 H5 H6 H7 H8 H9 H10 H11 H12 H13 H14 H15 H16 H17 (*H18 H19*).
   intros until t. revert t.
   apply (term_forall_list_rect (fun t => wf Σ t -> P t));
     intros; try solve [match goal with

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -42,4 +42,4 @@ unfold.v
 univ.v
 tmVariable.v
 order_rec.v
-primitive.v
+# primitive.v

--- a/translations/param_binary.v
+++ b/translations/param_binary.v
@@ -144,7 +144,7 @@ Fixpoint tsl_rec1_app (app : list term) (E : tsl_table) (t : term) : term :=
   | tFix _ _ | tCoFix _ _ => todo "tsl"
   | tVar _ | tEvar _ _ => todo "tsl"
   | tLambda _ _ _ => tVar "impossible"
-  | tInt _ | tFloat _ => todo "impossible"
+  (* | tInt _ | tFloat _ => todo "impossible" *)
   end
   in apply app t1
   end.

--- a/translations/param_original.v
+++ b/translations/param_original.v
@@ -105,7 +105,7 @@ Fixpoint tsl_rec1_app (app : option term) (E : tsl_table) (t : term) : term :=
   | tFix _ _ | tCoFix _ _ => todo "tsl"
   | tVar _ | tEvar _ _ => todo "tsl"
   | tLambda _ _ _ => tVar "impossible"
-  | tInt _ | tFloat _ => todo "impossible"
+  (* | tInt _ | tFloat _ => todo "impossible" *)
   end in
   match app with Some t' => mkApp t1 (t' {3 := tRel 1} {2 := tRel 0})
                | None => t1 end


### PR DESCRIPTION
We comment the partial handling of primitive types from MetaCoq: as they can't be typechecked, this prevents e.g. erasing the erasure and type-checker procedures. We'll need to extend the global environment with structures to handle primitive types to treat them correctly.