### PR TITLE
Self erasure

### DIFF
--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -114,5 +114,4 @@ Local Open Scope string_scope.
 Program Definition erase_and_print_template_program {cf : checker_flags} (p : Ast.Env.program)
   : string :=
   let (Σ', t) := erase_template_program p (todo "wf_env") (todo "welltyped") in
-  Pretty.print_term (Ast.Env.empty_ext p.1) [] true p.2 ^ nl ^
-  " erases to: " ^ nl ^ print_term Σ' [] true false t.
+  print_term Σ' [] true false t ^ nl ^ "in:" ^ nl ^ print_global_context Σ'.

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -184,14 +184,14 @@ struct
     | Polymorphic ctx -> Q.mkPolymorphic_ctx (Q.quote_abstract_univ_context ctx)
 
   let quote_ugraph ?kept (g : UGraph.t) =
-    Feedback.msg_debug (Pp.str"Quoting ugraph");
+    debug Pp.(fun () -> str"Quoting ugraph");
     let levels, cstrs, eqs = 
       match kept with
       | None ->
         let cstrs, eqs = UGraph.constraints_of_universes g in
         UGraph.domain g, cstrs, eqs
       | Some l -> 
-        Feedback.msg_debug Pp.(str"Quoting graph restricted to: " ++ Univ.LSet.pr Univ.Level.pr l);
+        debug Pp.(fun () -> str"Quoting graph restricted to: " ++ Univ.LSet.pr Univ.Level.pr l);
         (* Feedback.msg_debug Pp.(str"Graph is: "  ++ UGraph.pr_universes Univ.Level.pr (UGraph.repr g)); *)
         let dom = UGraph.domain g in
         let kept = Univ.LSet.inter dom l in
@@ -213,7 +213,7 @@ struct
     let levels = Univ.LSet.remove Univ.Level.prop levels in
     let levels = Univ.LSet.remove Univ.Level.sprop levels in
     let cstrs = Univ.Constraint.remove (Univ.Level.prop, Univ.Lt, Univ.Level.set) cstrs in
-    Feedback.msg_debug (Pp.str"Universe context: " ++ Univ.pr_universe_context_set Univ.Level.pr (levels, cstrs));
+    debug Pp.(fun () -> str"Universe context: " ++ Univ.pr_universe_context_set Univ.Level.pr (levels, cstrs));
     time (Pp.str"Quoting universe context") 
       (fun uctx -> Q.quote_univ_contextset uctx) (levels, cstrs)
 

--- a/test-suite/self_erasure.v
+++ b/test-suite/self_erasure.v
@@ -1,0 +1,8 @@
+From MetaCoq.Erasure Require Import Loader Erasure.
+From MetaCoq.SafeChecker Require Import PCUICSafeChecker.
+
+(* 32sec *)
+MetaCoq Erase @erase_and_print_template_program.
+
+(* 40sec *)
+Time MetaCoq Erase @typecheck_program.


### PR DESCRIPTION
Support printing of the erased global environment in `MetaCoq Erase` and add a test-suite file checking the we can erase the typechecker (40s) and erasure (30s). Not run by default as it would add another useless minute to our CI (we already check the corner cases in the test-suite).