### PR TITLE
Parameter stripping integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,11 @@ erasure/src/pCUICWfEnv.ml
 erasure/src/pCUICWfEnv.mli
 erasure/src/orderedType0.ml
 erasure/src/orderedType0.mli
+erasure/src/eRemoveParams.ml
+erasure/src/eRemoveParams.mli
+erasure/src/eSpineView.ml
+erasure/src/eSpineView.mli
+erasure/src/eWcbvEval.ml
+erasure/src/eWcbvEval.mli
+erasure/src/wcbvEval.ml
+erasure/src/wcbvEval.mli

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -37,6 +37,8 @@ src/kernames.ml
 # src/typing0.mli
 # src/typing0.ml
 
+src/wcbvEval.mli
+src/wcbvEval.ml
 # From PCUIC
 # src/pCUICPrimitive.mli
 # src/pCUICPrimitive.ml
@@ -115,6 +117,15 @@ src/eTyping.ml
 src/eTyping.mli
 src/extract.mli
 src/extract.ml
+src/eWcbvEval.mli
+src/eWcbvEval.ml
+src/eInduction.mli
+src/eInduction.ml
+src/eSpineView.mli
+src/eSpineView.ml
+src/eRemoveParams.mli
+src/eRemoveParams.ml
+
 src/erasureFunction.mli
 src/erasureFunction.ml
 src/ePretty.mli

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -119,10 +119,8 @@ src/extract.mli
 src/extract.ml
 src/eWcbvEval.mli
 src/eWcbvEval.ml
-src/eInduction.mli
-src/eInduction.ml
-src/eSpineView.mli
-src/eSpineView.ml
+# src/eSpineView.mli
+# src/eSpineView.ml
 src/eRemoveParams.mli
 src/eRemoveParams.ml
 

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -14,6 +14,8 @@ FMapInterface
 FMapAVL
 FMapFacts
 
+WcbvEval
+
 Classes0
 Logic1
 Relation
@@ -43,10 +45,14 @@ PCUICSafeRetyping
 EAst
 EAstUtils
 ELiftSubst
+EInduction
 ECSubst
 ETyping
+EWcbvEval
+ESpineView
 EPretty
 Extract
+ERemoveParams
 ErasureFunction
 EOptimizePropDiscr
 Erasure

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -199,4 +199,4 @@ Definition print_decl Σ '(kn, d) :=
   end.
 
 Definition print_global_context (g : global_context) := 
-  print_list (print_decl g) nl g.
+  print_list (print_decl g) nl (List.rev g).

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -1,5 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import Program ssreflect.
+From Coq Require Import Program ssreflect ssrbool.
 From MetaCoq.Template Require Import config utils uGraph Pretty Environment Typing WcbvEval.
 Set Warnings "-notation-overridden".
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping
@@ -8,7 +8,7 @@ From MetaCoq.PCUIC Require PCUICExpandLets PCUICExpandLetsCorrectness.
 Set Warnings "+notation-overridden".
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICWfEnv.
 From MetaCoq.Erasure Require Import EAstUtils ErasureFunction ErasureCorrectness EPretty Extract.
-From MetaCoq.Erasure Require ErasureFunction EOptimizePropDiscr EWcbvEval EDeps.
+From MetaCoq.Erasure Require ErasureFunction EOptimizePropDiscr ERemoveParams EWcbvEval EDeps.
 
 #[local] Instance extraction_checker_flags : checker_flags := 
   {| check_univs := true;
@@ -21,18 +21,127 @@ From MetaCoq.Erasure Require ErasureFunction EOptimizePropDiscr EWcbvEval EDeps.
   shrinking of the global environment dependencies +
   the optimization that removes all pattern-matches on propositions. *)
 
+Definition eprogram := 
+  (EAst.global_context * EAst.term).
+
+Import EOptimizePropDiscr.
+
+Module Transform.
+  Section Opt.
+     Context {program program' : Type}.
+     Context {value value' : Type}.
+     Context {eval :  program -> value -> Type}.
+     Context {eval' : program' -> value' -> Type}.
+     
+     Definition preserves_eval pre (transform : forall p : program, pre p -> program') obseq :=
+      forall p v (pr : pre p),
+        eval p v ->
+        let p' := transform p pr in
+        exists v',
+        ∥ eval' p' v' × obseq p p' v v' ∥.
+
+    Record t := 
+    { pre : program -> Prop; 
+      transform : forall p : program, pre p -> program';
+      post : program' -> Prop;
+      correctness : forall input (p : pre input), post (transform input p);
+      obseq : program -> program' -> value -> value' -> Prop;
+      preservation : preserves_eval pre transform obseq; 
+      }.
+
+  End Opt.
+  Arguments t : clear implicits.
+
+  Section Comp.
+    Context {program program' program'' : Type}.
+    Context {value value' value'' : Type}.
+    Context {eval : program -> value -> Type}.
+    Context {eval' : program' -> value' -> Type}.
+    Context {eval'' : program'' -> value'' -> Type}.
+    
+  Definition compose (o : t program program' value value' eval eval') (o' : t program' program'' value' value'' eval' eval'') :
+    (forall p, o.(post) p -> o'.(pre) p) -> t program program'' value value'' eval eval''.
+  Proof.
+    intros hpp.
+    refine {| 
+      transform p hp := o'.(transform) (o.(transform) p hp) (hpp _ (o.(correctness) _ hp));
+      pre := o.(pre);
+      post := o'.(post);
+      obseq g g' v v' := exists g'' v'', o.(obseq) g g'' v v'' × o'.(obseq) g'' g' v'' v'
+      |}.
+    * intros inp pre.
+      eapply o'.(correctness).
+    * red.
+      intros p v pr ev.
+      eapply o.(preservation) in ev; auto.
+      cbn in ev. destruct ev as [v' [ev]].
+      epose proof (o'.(preservation) (o.(transform) p pr) v').
+      specialize (H (hpp _ (o.(correctness) _ pr))).
+      destruct ev. specialize (H e).
+      destruct H as [v'' [[ev' obs']]].
+      exists v''. constructor. split => //.
+      exists (transform o p pr), v'. now split.
+  Defined.
+  End Comp.
+End Transform.
+Import ETyping.
+
+Definition self_optimization program value eval eval' := Transform.t program program value value eval eval'.
+
+Definition eval_eprogram (wfl : EWcbvEval.WcbvFlags) (p : eprogram) (t : EAst.term) := 
+  EWcbvEval.eval (wfl:=wfl) p.1 p.2 t.
+
+Definition optimize_prop_discr_optimization : self_optimization eprogram EAst.term (eval_eprogram EWcbvEval.default_wcbv_flags) (eval_eprogram EWcbvEval.opt_wcbv_flags).
+Import Transform.
+  refine {|
+    transform p _ := (EOptimizePropDiscr.optimize_env p.1, EOptimizePropDiscr.optimize p.1 p.2);
+    pre p := (closed_env p.1 /\ ELiftSubst.closedn 0 p.2);
+    post p := (closed_env p.1 /\ ELiftSubst.closedn 0 p.2);
+    obseq g g' v v' := v' = EOptimizePropDiscr.optimize g.1 v
+    |}.
+  * intros [Σ t] [cle clt].
+    cbn in *. split.
+    move: cle. induction Σ at 1 3; cbn; auto.
+    move/andP => [] cla clg. rewrite (IHg clg) andb_true_r.
+    destruct a as [kn []]; cbn in * => //.
+    destruct E.cst_body => //. cbn in cla |- *.
+    now eapply EOptimizePropDiscr.closed_optimize.
+    now eapply EOptimizePropDiscr.closed_optimize.
+  * red. move=> [Σ t] /= v [cle clt] ev.
+    eapply EOptimizePropDiscr.optimize_correct in ev; eauto.
+Defined.
+
+Definition remove_params_optimization (fl : EWcbvEval.WcbvFlags) : self_optimization eprogram EAst.term (eval_eprogram fl) (eval_eprogram fl).
+Import Transform.
+  refine {|
+    transform p _ := (ERemoveParams.strip_env p.1, ERemoveParams.strip p.1 p.2);
+    pre p := [/\ wf_glob p.1, ERemoveParams.isEtaExp_env p.1, ERemoveParams.isEtaExp p.1 p.2, closed_env p.1 & ELiftSubst.closedn 0 p.2];
+    post p := (closed_env p.1 /\ ELiftSubst.closedn 0 p.2);
+    obseq g g' v v' := v' = (ERemoveParams.strip g.1 v) |}.
+  * intros [Σ t] [wfe etae etat cle clt].
+    cbn -[ERemoveParams.strip] in *. split.
+    move: cle. induction Σ at 1 3; cbn; auto.
+    move/andP => [] cla clg. rewrite (IHg clg) andb_true_r.
+    destruct a as [kn []]; cbn in * => //.
+    destruct E.cst_body => //. cbn -[ERemoveParams.strip] in cla |- *.
+    now eapply ERemoveParams.closed_strip.
+    now eapply ERemoveParams.closed_strip.
+  * red. move=> [Σ t] /= v [wfe etae etat cle clt] ev.
+    eapply ERemoveParams.strip_eval in ev; eauto.
+Defined.
+
 Program Definition erase_template_program (p : Ast.Env.program) 
   (wfΣ : ∥ Typing.wf_ext (Ast.Env.empty_ext p.1) ∥)
   (wt : ∥ ∑ T, Typing.typing (Ast.Env.empty_ext p.1) [] p.2 T ∥)
-  : (EAst.global_context * EAst.term) :=
+  : eprogram :=
   let Σ0 := (trans_global (Ast.Env.empty_ext p.1)).1 in
   let Σ := (PCUICExpandLets.trans_global_env Σ0) in
   let wfΣ := map_squash (PCUICExpandLetsCorrectness.trans_wf_ext ∘
     (template_to_pcuic_env_ext (Ast.Env.empty_ext p.1))) wfΣ in
   let t := ErasureFunction.erase (build_wf_env_ext (empty_ext Σ) wfΣ) nil (PCUICExpandLets.trans (trans Σ0 p.2)) _ in
   let Σ' := ErasureFunction.erase_global (term_global_deps t) Σ (sq_wf_ext wfΣ) in
-  (EOptimizePropDiscr.optimize_env Σ', EOptimizePropDiscr.optimize Σ' t).
-
+  (Σ', t).
+  
 Next Obligation.
   sq. destruct wt as [T Ht].
   cbn.
@@ -45,20 +154,18 @@ Next Obligation.
   apply Ht. Unshelve. now eapply template_to_pcuic_env.
 Defined.
 
-Import EOptimizePropDiscr.
-
 (** The full correctness lemma of erasure from Template programs do λ-box *)
 
-Lemma erase_template_program_correctness (wfl := EWcbvEval.default_wcbv_flags) {p : Ast.Env.program}
+Lemma erase_template_program_correctness {p : Ast.Env.program}
   (Σ := Ast.Env.empty_ext p.1)
   {wfΣ : ∥ Typing.wf_ext Σ ∥}
   {wt : ∥ ∑ T, Typing.typing (Ast.Env.empty_ext p.1) [] p.2 T ∥} {Σ' t'} :
   erase_template_program p wfΣ wt = (Σ', t') ->
   forall v, WcbvEval.eval p.1 p.2 v ->
-  exists Σ'' v',
+  exists v',
     PCUICExpandLets.trans_global (trans_global Σ) ;;; [] |- 
       PCUICExpandLets.trans (trans (trans_global Σ) v) ⇝ℇ v' /\ 
-    ∥ EWcbvEval.eval (wfl := EWcbvEval.opt_wcbv_flags) Σ' t' (optimize Σ'' v') ∥.
+    ∥ EWcbvEval.eval (wfl:=EWcbvEval.default_wcbv_flags) Σ' t' v' ∥.
 Proof.
   unfold erase_template_program.
   intros [= <- <-] v ev.
@@ -92,18 +199,61 @@ Proof.
     clear -w HT. now eapply TypingWf.typing_wf in HT. }  
   destruct H as [v' [Hv He]].
   sq.
-  eapply EOptimizePropDiscr.optimize_correct in He.
   change (empty_ext (trans_global_env p.1)) with (trans_global Σ).
-  set (eΣ := erase_global _ _ _) in *. eexists; exists v'. split => //.
-  constructor. exact He. eapply erase_global_closed.
-  eapply (erases_closed _ []).
-  2:eapply erases_erase.
-  destruct s as [T HT].
-  clear -w wftΣ HT; unshelve eapply (template_to_pcuic_typing _ []) in HT; eauto.
-  unshelve eapply PCUICClosedTyp.subject_closed in HT.
-  now eapply template_to_pcuic_env_ext. simpl in HT.
-  now eapply PCUICExpandLetsCorrectness.trans_closedn.
+  set (eΣ := erase_global _ _ _) in *. exists v'. split => //.
 Qed.
+
+Definition eval_program (p : Ast.Env.program) (v : Ast.term) :=
+  WcbvEval.eval p.1 p.2 v.
+
+Definition erase_transform : Transform.t Ast.Env.program eprogram Ast.term EAst.term eval_program (eval_eprogram EWcbvEval.default_wcbv_flags).
+Import Transform.
+  unshelve refine {|
+    pre p :=  
+      let Σ := Ast.Env.empty_ext p.1 in
+      ∥ Typing.wf_ext Σ × ∑ T, Typing.typing (Ast.Env.empty_ext p.1) [] p.2 T ∥;
+    transform p hp := erase_template_program p (map_squash fst hp) (map_squash snd hp) ;
+    post p := (wf_glob p.1 /\ closed_env p.1 /\ ELiftSubst.closedn 0 p.2);
+    obseq g g' v v' :=
+      let Σ := Ast.Env.empty_ext g.1 in
+      PCUICExpandLets.trans_global (trans_global Σ) ;;; [] |- 
+      PCUICExpandLets.trans (trans (trans_global Σ) v) ⇝ℇ v' /\ 
+      ∥ EWcbvEval.eval (wfl:=EWcbvEval.default_wcbv_flags) g'.1 g'.2 v' ∥ |}.
+  * intros [Σ t] [[wfext ht]].
+    destruct erase_template_program eqn:e.
+    unfold erase_template_program in e. simpl. injection e. intros <- <-. split.
+    eapply ERemoveParams.erase_global_wf_glob. split.
+    eapply erase_global_closed.
+    eapply (erases_closed _ []). 2:eapply erases_erase.
+    clear e. destruct ht as [T HT].
+    unshelve eapply (template_to_pcuic_typing _ []) in HT; eauto.
+    unshelve eapply PCUICClosedTyp.subject_closed in HT.
+    now eapply template_to_pcuic_env_ext. simpl in HT.
+    now eapply PCUICExpandLetsCorrectness.trans_closedn.  
+  * red. move=> [Σ t] v [[wf [T HT]]]. unfold eval_program.
+    intros ev.
+    destruct erase_template_program eqn:e.
+    eapply (erase_template_program_correctness) in e; tea.
+    destruct e as [v' [he [hev]]]. exists v'; split; split => //.
+Defined.
+
+(* Lemma optimize_correctness (o : Transform.t) (p : eprogram) : 
+  o.(pre) p ->
+  let p' := o.(optimize) p in
+  forall v,
+    EWcbvEval.eval (wfl:=o.(input_flags)) p.1 p.2 v -> 
+    exists v', ∥ EWcbvEval.eval (wfl:=o.(output_flags)) p'.1 p'.2 v' × o.(obseq) p.1 p'.1 v v' ∥.
+Proof.
+  intros. now eapply o.(preservation).
+Qed. *)
+
+Program Definition erasure_pipeline := 
+  Transform.compose erase_transform (Transform.compose (remove_params_optimization _) optimize_prop_discr_optimization _) _.
+Next Obligation.
+  split => //. all:todo "etaexp".
+Qed.
+
+Definition erase_program := erasure_pipeline.(transform).
 
 Local Open Scope string_scope.
 
@@ -113,5 +263,5 @@ Local Open Scope string_scope.
   Coq definition). *)
 Program Definition erase_and_print_template_program {cf : checker_flags} (p : Ast.Env.program)
   : string :=
-  let (Σ', t) := erase_template_program p (todo "wf_env") (todo "welltyped") in
+  let (Σ', t) := erase_program p (todo "wf_env and welltyped term") in
   print_term Σ' [] true false t ^ nl ^ "in:" ^ nl ^ print_global_context Σ'.

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -28,7 +28,7 @@ Definition exintrotest := Eval lazy in test exintro.
 Definition idnat := ((fun (X : Set) (x : X) => x) nat).
 
 MetaCoq Quote Recursively Definition idnatc := idnat.
-Definition test_idnat := Eval lazy in test idnatc.
+Time Definition test_idnat := Eval lazy in test idnatc.
 
 (** Check that optimization of singleton pattern-matchings work *)
 Definition singlelim := ((fun (X : Set) (x : X) (e : x = x) =>
@@ -308,7 +308,6 @@ Require Import Coq.Arith.Peano_dec.
 Require Import Arith.
 Program Fixpoint provedCopy (n:nat) {wf lt n} : nat :=
   match n with 0 => 0 | S k => S (provedCopy k) end.
-  Next Obligation.  apply lt_wf. Defined.
 Print Assumptions provedCopy.
 MetaCoq Quote Recursively Definition pCopy := provedCopy. (* program *)
 
@@ -320,9 +319,9 @@ MetaCoq Quote Recursively Definition cbv_provedCopyx :=
 Definition ans_provedCopyx :=
   Eval lazy in (test cbv_provedCopyx).
 MetaCoq Quote Recursively Definition p_provedCopyx := provedCopyx. (* program *)
-(* We don't run those every time as they are really expensive *)
 Time Definition P_provedCopyx := Eval lazy in (test cbv_provedCopyx).
-(* Time Definition P_provedCopyxvm := Eval vm_compute in (test p_provedCopyx). *)
+(* We don't run this one every time as it is really expensive *)
+(*Time Definition P_provedCopyxvm := Eval vm_compute in (test p_provedCopyx).*)
 
 From MetaCoq.Erasure Require Import Loader.
 MetaCoq Erase provedCopyx.

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -8,7 +8,7 @@ Local Open Scope string_scope.
 
 From MetaCoq.Template Require Import utils.
 Import MCMonadNotation.
-
+Unset MetaCoq Debug.
 (* We're doing erasure assuming no Prop <= Type rule and lets can appear in constructor types. *)
 #[local] Existing Instance extraction_checker_flags.
 

--- a/test-suite/erasure_test.v
+++ b/test-suite/erasure_test.v
@@ -1,6 +1,6 @@
 From MetaCoq.Template Require Import Loader.
 From MetaCoq.Erasure Require Import Loader.
-(* From MetaCoq.SafeChecker Require Import Loader. *)
+From MetaCoq.SafeChecker Require Import Loader.
 Local Open Scope string_scope.
 
 MetaCoq Erase nat.

--- a/test-suite/erasure_test.v
+++ b/test-suite/erasure_test.v
@@ -1,6 +1,6 @@
 From MetaCoq.Template Require Import Loader.
 From MetaCoq.Erasure Require Import Loader.
-From MetaCoq.SafeChecker Require Import Loader.
+(* From MetaCoq.SafeChecker Require Import Loader. *)
 Local Open Scope string_scope.
 
 MetaCoq Erase nat.


### PR DESCRIPTION
We integrate parameter stripping in the erasure pipeline, also factoring a bit the proofs that transformations compose. We now have three transformations: erasure, removal of cases on propositions and stripping of constructors of parameters. We show that they all preserve a notion of observational equality (expressed as equalities for the optimizations, and a slightly more complex invariant for erasure). Using a view in the stripping function, which eases the definitions and proofs degrades performance significantly when running erasure in Coq, so we show that a faster implementation of stripping using an accumulator for applications is equivalent to it and use that instead in the pipeline. 