### PR TITLE
Fix build on case-insensitive filesystems

### DIFF
--- a/checker/src/to-lower.sh
+++ b/checker/src/to-lower.sh
@@ -4,6 +4,7 @@ do
     if [ $i != $newi ]
     then
         echo "Moving " $i "to" $newi;
-        mv $i $newi;
+        mv $i tmp;
+        mv tmp $newi;
     fi
 done

--- a/erasure/clean_extraction.sh
+++ b/erasure/clean_extraction.sh
@@ -22,8 +22,12 @@ then
     for i in *.ml*
       do
       newi=`echo $i | cut -b 1 | tr '[:upper:]' '[:lower:]'``echo $i | cut -b 2-`;
-      # echo "Moving " $i "to" $newi;
-      mv $i $newi;
+      if [ $i != $newi ]
+      then
+          # echo "Moving " $i "to" $newi;
+          mv $i tmp;
+          mv tmp $newi;
+      fi
     done
     cd ..
 

--- a/pcuic/clean_extraction.sh
+++ b/pcuic/clean_extraction.sh
@@ -14,8 +14,12 @@ cd src
 for i in *.ml*
 do
   newi=`echo $i | cut -b 1 | tr '[:upper:]' '[:lower:]'``echo $i | cut -b 2-`;
-  echo "Moving " $i "to" $newi;
-  mv $i $newi;
+  if [ $i != $newi ]
+  then
+      echo "Moving " $i "to" $newi;
+      mv $i tmp;
+      mv tmp $newi;
+  fi
 done
 cd ..
 

--- a/safechecker/clean_extraction.sh
+++ b/safechecker/clean_extraction.sh
@@ -22,8 +22,12 @@ then
     for i in *.ml*
       do
       newi=`echo $i | cut -b 1 | tr '[:upper:]' '[:lower:]'``echo $i | cut -b 2-`;
-      # echo "Moving " $i "to" $newi;
-      mv $i $newi;
+      if [ $i != $newi ]
+      then
+          # echo "Moving " $i "to" $newi;
+          mv $i tmp;
+          mv tmp $newi;
+      fi
     done
     cd ..
 

--- a/template-coq/gen-src/to-lower.sh
+++ b/template-coq/gen-src/to-lower.sh
@@ -4,6 +4,7 @@ do
     if [ $i != $newi ]
     then
         # echo "Moving " $i "to" $newi;
-        mv $i $newi;
+        mv $i tmp;
+        mv tmp $newi;
     fi
 done

--- a/test-suite/plugin-demo/gen-src/to-lower.sh
+++ b/test-suite/plugin-demo/gen-src/to-lower.sh
@@ -4,6 +4,7 @@ do
     if [ $i != $newi ]
     then
         echo "Moving " $i "to" $newi;
-        mv $i $newi;
+        mv $i tmp;
+        mv tmp $newi;
     fi
 done


### PR DESCRIPTION
MetaCoq procedure renaming files to camelCase does not seem to handle case-insensitive filesystem.
This PR patches that behaviour using a temporary file when moving files which seems to work according to [nixpkgs' CI](https://github.com/NixOS/nixpkgs/pull/162639).

