### PR TITLE
Disambiguate Byte

### DIFF
--- a/template-coq/theories/utils/ByteCompare.v
+++ b/template-coq/theories/utils/ByteCompare.v
@@ -1,4 +1,4 @@
-From Coq Require Import Byte NArith.BinNat.
+From Coq Require Import Strings.Byte NArith.BinNat.
 
 Definition eqb (x y : byte) := 
   N.eqb (Byte.to_N x) (Byte.to_N y).

--- a/template-coq/theories/utils/ByteCompareSpec.v
+++ b/template-coq/theories/utils/ByteCompareSpec.v
@@ -1,4 +1,4 @@
-From Coq Require Import Byte NArith.
+From Coq Require Import Strings.Byte NArith.
 From MetaCoq.Template Require Import ReflectEq ByteCompare.
 From Equations Require Import Equations.
 


### PR DESCRIPTION
There seems to be an ambiguity between `Init.Byte` and `Strings.Byte` in the stdlib that breaks MetaCoq's compilation on my computer.