### PR TITLE
Erasure optimizations preserves wellformedness and expansion

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,1 @@
+- Change the "version:" fields in opam files.

--- a/coq-metacoq-erasure.opam
+++ b/coq-metacoq-erasure.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "8.14.dev"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"

--- a/coq-metacoq-pcuic.opam
+++ b/coq-metacoq-pcuic.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "8.14.dev"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"

--- a/coq-metacoq-safechecker.opam
+++ b/coq-metacoq-safechecker.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "8.14.dev"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"

--- a/coq-metacoq-template.opam
+++ b/coq-metacoq-template.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "8.14.dev"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#master"

--- a/coq-metacoq-translations.opam
+++ b/coq-metacoq-translations.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "8.14.dev"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"

--- a/coq-metacoq.opam
+++ b/coq-metacoq.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"              
+version: "8.14.dev"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://metacoq.github.io/metacoq"
 dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"

--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -12,6 +12,7 @@ theories/EWcbvEval.v
 # theories/EWtAst.v
 theories/EWndEval.v
 theories/EGlobalEnv.v
+theories/EWellformed.v
 theories/EEnvMap.v
 theories/EWcbvEvalInd.v
 theories/EWcbvEvalEtaInd.v

--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -30,7 +30,7 @@ theories/EExtends.v
 theories/EOptimizePropDiscr.v
 theories/EEtaExpandedFix.v
 theories/EEtaExpanded.v
-theories/ERemoveParams.v
 theories/EProgram.v
+theories/ERemoveParams.v
 theories/ETransform.v
 theories/Erasure.v

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -114,6 +114,8 @@ src/eCSubst.mli
 src/eCSubst.ml
 src/eGlobalEnv.ml
 src/eGlobalEnv.mli
+src/eWellformed.mli
+src/eWellformed.ml
 src/eEnvMap.mli
 src/eEnvMap.ml
 src/extract.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -45,6 +45,7 @@ EInduction
 ECSubst
 EGlobalEnv
 EEnvMap
+EWellformed
 EWcbvEval
 ESpineView
 EPretty

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -192,12 +192,12 @@ Inductive global_decl :=
 | ConstantDecl : constant_body -> global_decl
 | InductiveDecl : mutual_inductive_body -> global_decl.
 
+
+(** A context of global declarations *)
+
 Definition global_declarations := list (kername * global_decl).
 
-(** A context of global declarations +
-    i.e. a global environment *)
-
-Definition global_context : Type := global_declarations.
+Notation global_context := global_declarations.
 
 (** *** Programs
 

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -238,6 +238,23 @@ Definition isBox t :=
   | _ => false
   end.
 
+Definition is_box c :=
+  match head c with
+  | tBox => true
+  | _ => false
+  end.
+
+
+Lemma is_box_mkApps f a : is_box (mkApps f a) = is_box f.
+Proof.
+  now rewrite /is_box head_mkApps.
+Qed.
+
+Lemma is_box_tApp f a : is_box (tApp f a) = is_box f.
+Proof.
+  now rewrite /is_box head_tApp.
+Qed.
+
 Definition string_of_def {A : Set} (f : A -> string) (def : def A) :=
   "(" ^ string_of_name (dname def) ^ "," ^ f (dbody def) ^ ","
       ^ string_of_nat (rarg def) ^ ")".

--- a/erasure/theories/ECSubst.v
+++ b/erasure/theories/ECSubst.v
@@ -157,3 +157,6 @@ Proof.
   rewrite mkApps_app /= IHl.
   now rewrite -[EAst.tApp _ _](mkApps_app _ _ [_]) map_app.
 Qed.
+
+Lemma isLambda_csubst a k t : isLambda t -> isLambda (csubst a k t).
+Proof. destruct t => //. Qed.

--- a/erasure/theories/ECSubst.v
+++ b/erasure/theories/ECSubst.v
@@ -160,3 +160,5 @@ Qed.
 
 Lemma isLambda_csubst a k t : isLambda t -> isLambda (csubst a k t).
 Proof. destruct t => //. Qed.
+Lemma isBox_csubst a k t : isBox t -> isBox (csubst a k t).
+Proof. destruct t => //. Qed.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -637,7 +637,7 @@ Proof.
     depelim typ.
     depelim er.
     depelim all_deps.
-    destruct p as (?&?&?).
+    destruct a0 as [? ? ? ?].
     now constructor; eauto.
   - constructor.
     apply inversion_CoFix in wt as (?&?&?&?&?&?&?); eauto.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -1,13 +1,10 @@
 From Coq Require Import Arith List.
 From Equations Require Import Equations.
 From MetaCoq.PCUIC Require Import
-     PCUICAst PCUICAstUtils PCUICTyping
-     PCUICInversion PCUICWeakeningEnvConv PCUICWeakeningEnvTyp.
+     PCUICAst PCUICAstUtils PCUICTyping PCUICInversion PCUICWeakeningEnvConv PCUICWeakeningEnvTyp.
 Set Warnings "-notation-overridden".
-From MetaCoq.Erasure Require Import
-     EAst EAstUtils ECSubst EInduction
-     ELiftSubst ESubstitution EGlobalEnv Extract
-     EWcbvEval Prelim.
+From MetaCoq.Erasure Require Import EAst EAstUtils ECSubst EInduction
+  ELiftSubst EGlobalEnv EWcbvEval Extract ESubstitution.
 From MetaCoq.Erasure Require EExtends.
 Set Warnings "+notation-overridden".
 From MetaCoq.Template Require Import config utils monad_utils.

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -81,7 +81,7 @@ Section isEtaExp.
     | tLetIn na b b' => isEtaExp b && isEtaExp b'
     | tCase ind c brs => isEtaExp c && forallb_InP brs (fun x H => isEtaExp x.2)
     | tProj p c => isEtaExp c
-    | tFix mfix idx => forallb_InP mfix (fun x H => isLambda x.(dbody) && isEtaExp x.(dbody))
+    | tFix mfix idx => forallb_InP mfix (fun x H => (isLambda x.(dbody) || isBox x.(dbody)) && isEtaExp x.(dbody))
     | tCoFix mfix idx => forallb_InP mfix (fun x H => isEtaExp x.(dbody))
     | tBox => true
     | tVar _ => true
@@ -189,8 +189,10 @@ Section isEtaExp.
       solve_all.
     - move/andP: b => [] etaexp h.
       apply/andP; split.
-      now eapply isLambda_csubst.
-      eapply a0 => //.
+      apply/orP. move: etaexp => /orP[H|H].
+      * left; now eapply isLambda_csubst.
+      * right; now eapply isBox_csubst.
+      * eapply a0 => //.
     - move/andP: H1 => [] etaexp h.
       rewrite csubst_mkApps /=.
       rewrite isEtaExp_Constructor. solve_all.
@@ -219,7 +221,7 @@ Section isEtaExp.
   Qed.
   
   Lemma isEtaExp_fix_subst mfix : 
-    forallb (fun d => isLambda (dbody d) && isEtaExp (dbody d)) mfix ->
+    forallb (fun d => (isLambda (dbody d) || isBox d.(dbody)) && isEtaExp (dbody d)) mfix ->
     forallb isEtaExp (EGlobalEnv.fix_subst mfix).
   Proof.
     unfold EGlobalEnv.fix_subst. generalize #|mfix|.
@@ -239,7 +241,7 @@ Section isEtaExp.
   Qed.
   
   Lemma isEtaExp_cunfold_fix mfix idx n f : 
-    forallb (fun d => isLambda (dbody d) && isEtaExp (dbody d)) mfix ->
+    forallb (fun d => (isLambda (dbody d) || isBox (dbody d)) && isEtaExp (dbody d)) mfix ->
     EGlobalEnv.cunfold_fix mfix idx = Some (n, f) ->
     isEtaExp f.
   Proof.
@@ -436,7 +438,7 @@ Inductive expanded : term -> Prop :=
     expanded discr -> Forall (fun br => expanded br.2) branches -> expanded (tCase (ind, pars) discr branches)
 | expanded_tProj (proj : projection) (t : term) : expanded t -> expanded (tProj proj t)
 | expanded_tFix (mfix : mfixpoint term) (idx : nat) :  
-  Forall (fun d => isLambda d.(dbody) /\ expanded d.(dbody)) mfix -> expanded (tFix mfix idx)
+  Forall (fun d => (isLambda d.(dbody) \/ isBox d.(dbody)) /\ expanded d.(dbody)) mfix -> expanded (tFix mfix idx)
 | expanded_tCoFix (mfix : mfixpoint term) (idx : nat) : Forall (fun d => expanded d.(dbody)) mfix -> expanded (tCoFix mfix idx)
 | expanded_tConstruct_app ind idx mind idecl cname c args :
     declared_constructor Σ (ind, idx) mind idecl (cname, c) ->
@@ -472,7 +474,7 @@ forall (Σ : global_declarations) (P : term -> Prop),
 (forall (proj : projection) (t : term),
  expanded Σ t -> P t -> P (tProj proj t)) ->
 (forall (mfix : mfixpoint term) (idx : nat),
- Forall (fun d : def term => isLambda (dbody d) /\ expanded Σ (dbody d)) mfix ->  Forall (fun d : def term => P (dbody d)) mfix  -> P (tFix mfix idx)) ->
+ Forall (fun d : def term => (isLambda (dbody d) \/ isBox (dbody d)) /\ expanded Σ (dbody d)) mfix ->  Forall (fun d : def term => P (dbody d)) mfix  -> P (tFix mfix idx)) ->
 (forall (mfix : mfixpoint term) (idx : nat),
  Forall (fun d : def term => expanded Σ (dbody d)) mfix ->  Forall (fun d : def term => P (dbody d)) mfix ->
  P (tCoFix mfix idx)) ->
@@ -551,7 +553,9 @@ Proof.
     rewrite forallb_InP_spec in H2. eapply forallb_Forall in H2. 
     eapply In_All in H0. solve_all.
   - econstructor. rewrite forallb_InP_spec in H0. eapply forallb_Forall in H0. 
-    eapply In_All in H. rtoProp; intuition auto; solve_all; now move/andP: b.
+    eapply In_All in H. rtoProp; intuition auto; solve_all.
+    all: move/andP: b. 2:{ now intros []. }
+    move=> [] /orP[H|H]; intuition auto.
   - econstructor. rewrite forallb_InP_spec in H0. eapply forallb_Forall in H0. 
     eapply In_All in H. solve_all.
   - eapply andb_true_iff in H0 as []. eapply In_All in H.
@@ -574,7 +578,8 @@ Proof.
     (try eapply forallb_Forall); 
     eauto).
   - eapply isEtaExp_mkApps_intro; eauto. solve_all.
-  - solve_all. rewrite H //.
+  - solve_all; rewrite H1 /= //.
+    rewrite orb_true_r //.
   - rewrite isEtaExp_Constructor. eapply andb_true_iff.
     split. 2: eapply forallb_Forall.
     2: solve_all. eapply expanded_isEtaExp_app_; eauto.
@@ -634,7 +639,7 @@ Proof.
   - eapply In_All in H, H0. simp_eta.
     move => /andP[] /andP[] etafix etamfix etav.
     eapply EEtaExpanded.isEtaExp_mkApps_intro. simp_eta.
-    clear -H etamfix. solve_all. 
+    clear -H etamfix. solve_all. rtoProp; intuition eauto.
     solve_all.
   - eapply In_All in H. simp_eta.
     move=> /andP[] etarel etav.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -73,7 +73,7 @@ Inductive expanded (Γ : list nat): term -> Prop :=
     expanded Γ (tCase (ind, pars) discr branches)
 | expanded_tProj (proj : projection) (t : term) : expanded Γ t -> expanded Γ (tProj proj t)
 | expanded_tFix (mfix : mfixpoint term) (idx : nat) args d : 
-  Forall (fun d => (isLambda d.(dbody) || isBox d.(dbody)) /\
+  Forall (fun d => isLambda d.(dbody) /\
            let ctx := rev_map (fun  d => 1 + d.(rarg)) mfix in
           expanded (ctx ++ Γ) d.(dbody)) mfix ->
   Forall (expanded Γ) args ->
@@ -135,7 +135,7 @@ Lemma expanded_ind :
          (d : def term),
           Forall
             (λ d0 : def term,
-                (isLambda d0.(dbody) || isBox d0.(dbody)) /\
+                isLambda d0.(dbody) /\
                 let ctx := rev_map (fun  d => 1 + d.(rarg)) mfix in
                 expanded Σ (ctx ++ Γ) (dbody d0)) mfix
           → Forall
@@ -306,7 +306,7 @@ Section isEtaExp.
       { | expanded_head_construct ind i => isEtaExp_app ind i (List.length v) && forallb_InP v (fun x H => isEtaExp Γ x)
         | expanded_head_fix mfix idx => 
           isEtaExp_fixapp mfix idx (List.length v) && 
-          forallb_InP mfix (fun x H => (isLambda x.(dbody) || isBox x.(dbody)) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) && forallb_InP v (fun x H => isEtaExp Γ x)
+          forallb_InP mfix (fun x H => isLambda x.(dbody) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) && forallb_InP v (fun x H => isEtaExp Γ x)
         | expanded_head_rel n => option_default (fun m => m <=? List.length v) (nth_error Γ n) false && forallb_InP v (fun x H => isEtaExp Γ x) 
         | expanded_head_other _ _ => isEtaExp Γ u && forallb_InP v (fun x H => isEtaExp Γ x) }
     | tLetIn na b b' => isEtaExp Γ b && isEtaExp (0 :: Γ) b'
@@ -357,7 +357,7 @@ Section isEtaExp.
     isEtaExp Γ (mkApps f v) = match expanded_head_viewc f with 
       | expanded_head_construct ind i => isEtaExp_app ind i #|v| && forallb (isEtaExp Γ) v
       | expanded_head_fix mfix idx => isEtaExp_fixapp mfix idx #|v| && 
-        forallb (fun x => (isLambda x.(dbody) || isBox x.(dbody)) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) mfix && forallb (isEtaExp Γ) v
+        forallb (fun x => isLambda x.(dbody) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) mfix && forallb (isEtaExp Γ) v
       | expanded_head_rel n => option_default (fun m => m <=? List.length v) (nth_error Γ n) false && forallb (fun x => isEtaExp Γ x) v
       | expanded_head_other t discr => isEtaExp Γ f && forallb (isEtaExp Γ) v
     end.
@@ -378,7 +378,7 @@ Section isEtaExp.
       | expanded_head_construct ind i => isEtaExp_app ind i #|v| && forallb (isEtaExp Γ) v
       | expanded_head_fix mfix idx => 
         isEtaExp_fixapp mfix idx #|v| && 
-        forallb (fun x => (isLambda x.(dbody) || isBox x.(dbody)) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) mfix && forallb (isEtaExp Γ) v
+        forallb (fun x => isLambda x.(dbody) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) mfix && forallb (isEtaExp Γ) v
       | expanded_head_rel n => option_default (fun m => m <=? List.length v) (nth_error Γ n) false && forallb (fun x => isEtaExp Γ x) v
       | expanded_head_other t discr => isEtaExp Γ f && forallb (isEtaExp Γ) v
     end.
@@ -525,7 +525,7 @@ Section isEtaExp.
       + rewrite /isEtaExp_fixapp in eu |- *. rewrite nth_error_map. destruct nth_error; try congruence.
         cbn. now len.
       + solve_all. rtoProp; intuition auto.
-        apply/orP. move/orP: H => [H|H]; [left; eapply isLambda_csubst | right;eapply isBox_csubst] => //.
+        now eapply isLambda_csubst.
         rewrite app_assoc.  eapply a0; len; eauto. cbn. f_equal.
         rewrite app_assoc. do 2 f_equal.
         rewrite !rev_map_spec. f_equal. rewrite map_map. now eapply map_ext.      
@@ -557,8 +557,7 @@ Section isEtaExp.
     #|Γ| = k ->
     nth_error mfix idx = Some d ->
     closed (EAst.tFix mfix idx) ->
-    forallb (fun x => (isLambda x.(dbody) || isBox x.(dbody)) && 
-    isEtaExp (rev_map (S ∘ rarg) mfix) x.(dbody)) mfix ->
+    forallb (fun x => isLambda x.(dbody) &&  isEtaExp (rev_map (S ∘ rarg) mfix) x.(dbody)) mfix ->
     isEtaExp (Γ ++ [1 + d.(EAst.rarg)] ++ Δ) b -> isEtaExp (Γ ++ Δ) (ECSubst.csubst (EAst.tFix mfix idx) k b).
   Proof using Type*.
     intros Hk Hnth Hcl. 
@@ -605,8 +604,7 @@ Section isEtaExp.
       + rewrite /isEtaExp_fixapp in eu |- *. rewrite nth_error_map.
         destruct (nth_error mfix idx); try congruence.
         cbn. now len.
-      + solve_all. rtoProp; intuition auto. 
-        apply/orP. move/orP: H => [H|H]; [left; eapply isLambda_csubst | right;eapply isBox_csubst] => //.
+      + solve_all. rtoProp; intuition auto. now eapply isLambda_csubst.
         rewrite app_assoc.  eapply a; len; eauto.
         { cbn in Hcl. solve_all. rewrite Nat.add_0_r in a0. eauto. }
         cbn. f_equal.
@@ -665,7 +663,7 @@ Section isEtaExp.
   Qed.
 
   Lemma isEtaExp_fixsubstl Δ mfix t : 
-    forallb (fun x => (isLambda x.(dbody) || isBox x.(dbody)) && 
+    forallb (fun x => isLambda x.(dbody) &&
       isEtaExp (rev_map (S ∘ rarg) mfix) x.(dbody)) mfix ->
     isEtaExp ((rev_map (S ∘ rarg) mfix) ++ Δ) t ->
     isEtaExp Δ (substl (fix_subst mfix) t).
@@ -743,7 +741,7 @@ Section isEtaExp.
   Qed. 
   
   Lemma isEtaExp_cunfold_fix mfix idx n f : 
-    forallb (fun d => (isLambda d.(dbody) || isBox d.(dbody)) && isEtaExp (rev_map (S ∘ rarg) mfix) d.(dbody)) mfix ->
+    forallb (fun d => isLambda d.(dbody) && isEtaExp (rev_map (S ∘ rarg) mfix) d.(dbody)) mfix ->
     EGlobalEnv.cunfold_fix mfix idx = Some (n, f) ->
     isEtaExp [] f.
   Proof.
@@ -778,7 +776,7 @@ Section isEtaExp.
     match expanded_head_viewc hd with
       | expanded_head_construct ind i => isEtaExp_app ind i #|v| && forallb (isEtaExp Γ) v
       | expanded_head_fix mfix idx => isEtaExp_fixapp mfix idx #|v| && 
-        forallb (fun x => (isLambda x.(dbody) || isBox x.(dbody)) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) mfix && forallb (isEtaExp Γ) v
+        forallb (fun x => isLambda x.(dbody) && isEtaExp (rev_map (S ∘ rarg) mfix ++ Γ) x.(dbody)) mfix && forallb (isEtaExp Γ) v
       | expanded_head_rel n => (option_default (fun m => m <=? List.length v) (nth_error Γ n) false) && forallb (fun x => isEtaExp Γ x) v
       | expanded_head_other t discr => isEtaExp Γ hd && forallb (isEtaExp Γ) v
       end. (* 
@@ -922,7 +920,7 @@ Lemma isEtaExp_tApp' {Σ} {Γ} {f u} : isEtaExp Σ Γ (tApp f u) ->
     isEtaExp_app Σ kn c #|args| && forallb (isEtaExp Σ Γ) args
   | expanded_head_fix mfix idx => 
     args <> [] /\ f = mkApps hd (remove_last args) /\ u = last args u /\ 
-    isEtaExp_fixapp mfix idx #|args| && forallb (fun d => (isLambda d.(dbody) || isBox d.(dbody)) && isEtaExp Σ (rev_map (fun  d => 1 + d.(rarg)) mfix ++ Γ) d.(dbody)) mfix && forallb (isEtaExp Σ Γ) args
+    isEtaExp_fixapp mfix idx #|args| && forallb (fun d => isLambda d.(dbody) && isEtaExp Σ (rev_map (fun  d => 1 + d.(rarg)) mfix ++ Γ) d.(dbody)) mfix && forallb (isEtaExp Σ Γ) args
   | expanded_head_rel n => 
     args <> [] /\ f = mkApps hd (remove_last args) /\ u = last args u /\ 
     option_default (fun m => m <=? List.length args) (nth_error Γ n) false && forallb (fun x => isEtaExp Σ Γ x) args
@@ -1455,7 +1453,7 @@ Qed.
 
 Lemma isEtaExp_FixApp {Σ mfix idx l} :
   isEtaExp_fixapp mfix idx #|l| ->
-  forallb (λ d : def EAst.term, (isLambda d.(dbody) || isBox d.(dbody)) && isEtaExp Σ (rev_map (λ d0 : def term, 1 + rarg d0) mfix ++ []) (dbody d)) mfix ->
+  forallb (λ d : def EAst.term, isLambda d.(dbody) && isEtaExp Σ (rev_map (λ d0 : def term, 1 + rarg d0) mfix ++ []) (dbody d)) mfix ->
   forallb (isEtaExp Σ []) l ->
   isEtaExp Σ [] (mkApps (tFix mfix idx) l).
 Proof.
@@ -1533,7 +1531,7 @@ Lemma isEtaExp_tApp_eval {fl} {Σ} {f u v} :
   | expanded_head_fix mfix idx =>
     args <> [] /\ f = mkApps hd (remove_last args) /\ u = last args u /\ 
     [&& isEtaExp_fixapp mfix idx #|remove_last args|,
-    forallb (fun d => (isLambda d.(dbody) || isBox d.(dbody)) && isEtaExp Σ (rev_map (fun  d => 1 + d.(rarg)) mfix ++ []) d.(dbody)) mfix,
+    forallb (fun d => isLambda d.(dbody) && isEtaExp Σ (rev_map (fun  d => 1 + d.(rarg)) mfix ++ []) d.(dbody)) mfix,
     forallb (isEtaExp Σ []) (remove_last args) & isEtaExp Σ [] u]
   | expanded_head_rel n => False
   | expanded_head_other _ discr => 
@@ -2118,13 +2116,6 @@ Qed.
 From MetaCoq.PCUIC Require Import PCUICEtaExpand. 
 From MetaCoq.Erasure Require Import EDeps.
 
-Lemma erases_isLambda {Σ Γ t u} :
-  Σ ;;; Γ |- t ⇝ℇ u -> isLambda t -> EAst.isLambda u || isBox u.
-Proof.
-  intros hf.
-  induction hf => //.
-Qed.
-
 Lemma expanded_erases (cf := config.extraction_checker_flags) {Σ : global_env_ext} Σ' Γ Γ' t v :
   wf Σ ->
   Σ ;;; Γ |- t ⇝ℇ v ->
@@ -2172,13 +2163,14 @@ Proof.
       eapply All_app in H2 as []. solve_all.
     * eapply erases_deps_mkApps_inv in etaΣ as [].
       depelim H7; simp_eta => //.
-      + eapply All2_nth_error_Some in H4; tea. destruct H4 as [? [? [? []]]]; tea.
+      + eapply All2_nth_error_Some in H4; tea. destruct H4 as [? [? []]]; tea.
         assert (rev_map (fun d1 : def term => S (rarg d1)) mfix = rev_map (fun d1 => S (EAst.rarg d1)) mfix').
-        { rewrite !rev_map_spec. f_equal. clear -X. induction X; cbn; auto. destruct r as [? []]. rewrite e0 IHX //. }
+        { rewrite !rev_map_spec. f_equal. clear -X. induction X; cbn; auto. destruct r as [eqb eqrar isl isl' e].
+          rewrite eqrar IHX //. }
         depelim H6.
         eapply EEtaExpandedFix.expanded_tFix; tea.
-        ++ cbn. rewrite -H6. solve_all.
-          eapply erases_isLambda in b0; tea.
+        ++ cbn. rewrite -H6. solve_all. apply b0.
+          eapply b1 => //. eapply b0.
         ++ solve_all.
         ++ intros hx0. subst x0. depelim H8 => //.
         ++ now rewrite -(Forall2_length H8) -e1.

--- a/erasure/theories/EExtends.v
+++ b/erasure/theories/EExtends.v
@@ -1,7 +1,7 @@
 From Coq Require Import ssreflect.
 From Equations Require Import Equations.
 From MetaCoq.Template Require Import config utils Kernames.
-From MetaCoq.Erasure Require Import EGlobalEnv EAst Extract.
+From MetaCoq.Erasure Require Import EGlobalEnv EAst Extract EWellformed.
 
 Section EEnvFlags.
   Context (efl : EEnvFlags).

--- a/erasure/theories/EExtends.v
+++ b/erasure/theories/EExtends.v
@@ -3,113 +3,118 @@ From Equations Require Import Equations.
 From MetaCoq.Template Require Import config utils Kernames.
 From MetaCoq.Erasure Require Import EGlobalEnv EAst Extract.
 
-Lemma weakening_env_declared_constant :
-  forall Σ cst decl,
-    declared_constant Σ cst decl ->
-    forall Σ', wf_glob Σ' -> extends Σ Σ' -> declared_constant Σ' cst decl.
-Proof.
-  intros Σ cst decl H0 Σ' X2 H2.
-  eapply extends_lookup; eauto.
-Qed.
+Section EEnvFlags.
+  Context (efl : EEnvFlags).
 
-Lemma weakening_env_declared_minductive :
-  forall Σ ind decl,
-    declared_minductive Σ ind decl ->
-    forall Σ', wf_glob Σ' -> extends Σ Σ' -> declared_minductive Σ' ind decl.
-Proof.
-  intros Σ cst decl H0 Σ' X2 H2.
-  eapply extends_lookup; eauto.
-Qed.
+  Lemma weakening_env_declared_constant :
+    forall Σ cst decl,
+      declared_constant Σ cst decl ->
+      forall Σ', wf_glob Σ' -> extends Σ Σ' -> declared_constant Σ' cst decl.
+  Proof.
+    intros Σ cst decl H0 Σ' X2 H2.
+    eapply extends_lookup; eauto.
+  Qed.
 
-Lemma weakening_env_declared_inductive:
-  forall Σ ind mdecl decl,
-    declared_inductive Σ mdecl ind decl ->
-    forall Σ', wf_glob Σ' -> extends Σ Σ' -> declared_inductive Σ' mdecl ind decl.
-Proof.
-  intros Σ cst decl H0 [Hmdecl Hidecl] Σ' X2 H2. split.
-  eapply weakening_env_declared_minductive; eauto.
-  eauto.
-Qed.
+  Lemma weakening_env_declared_minductive :
+    forall Σ ind decl,
+      declared_minductive Σ ind decl ->
+      forall Σ', wf_glob Σ' -> extends Σ Σ' -> declared_minductive Σ' ind decl.
+  Proof.
+    intros Σ cst decl H0 Σ' X2 H2.
+    eapply extends_lookup; eauto.
+  Qed.
 
-Lemma weakening_env_declared_constructor :
-  forall Σ ind mdecl idecl decl,
-    declared_constructor Σ idecl ind mdecl decl ->
-    forall Σ', wf_glob Σ' -> extends Σ Σ' ->
-    declared_constructor Σ' idecl ind mdecl decl.
-Proof.
-  intros Σ cst mdecl idecl cdecl [Hidecl Hcdecl] Σ' X2 H2.
-  split; eauto. eapply weakening_env_declared_inductive; eauto.
-Qed.
+  Lemma weakening_env_declared_inductive:
+    forall Σ ind mdecl decl,
+      declared_inductive Σ mdecl ind decl ->
+      forall Σ', wf_glob Σ' -> extends Σ Σ' -> declared_inductive Σ' mdecl ind decl.
+  Proof.
+    intros Σ cst decl H0 [Hmdecl Hidecl] Σ' X2 H2. split.
+    eapply weakening_env_declared_minductive; eauto.
+    eauto.
+  Qed.
 
-Definition global_subset (Σ Σ' : global_declarations) := 
-  forall kn d, lookup_env Σ kn = Some d -> lookup_env Σ' kn = Some d.
+  Lemma weakening_env_declared_constructor :
+    forall Σ ind mdecl idecl decl,
+      declared_constructor Σ idecl ind mdecl decl ->
+      forall Σ', wf_glob Σ' -> extends Σ Σ' ->
+      declared_constructor Σ' idecl ind mdecl decl.
+  Proof.
+    intros Σ cst mdecl idecl cdecl [Hidecl Hcdecl] Σ' X2 H2.
+    split; eauto. eapply weakening_env_declared_inductive; eauto.
+  Qed.
 
-Lemma lookup_env_In d Σ : 
-  wf_glob Σ ->
-  lookup_env Σ d.1 = Some d.2 <-> In d Σ.
-Proof.
-  intros wf.
-  split.
-  - induction Σ; cbn => //.
-    destruct (eqb_spec d.1 a.1). intros [=]. destruct a, d; cbn in *; intuition auto.
-    left; subst; auto. depelim wf.
-    intros hl; specialize (IHΣ wf hl); intuition auto.
-  - induction wf => /= //.
-    intros [eq|hin]; eauto. subst d.
-    now rewrite eqb_refl.
-    specialize (IHwf hin).
-    destruct (eqb_spec d.1 kn). subst kn.
-    eapply lookup_env_Some_fresh in IHwf. contradiction.
-    exact IHwf.
-Qed.
+  Definition global_subset (Σ Σ' : global_declarations) := 
+    forall kn d, lookup_env Σ kn = Some d -> lookup_env Σ' kn = Some d.
 
-Lemma global_subset_In Σ Σ' : 
-  wf_glob Σ -> wf_glob Σ' ->
-  global_subset Σ Σ' <-> forall d, In d Σ -> In d Σ'.
-Proof.
-  split.
-  - intros g d hin.
-    specialize (g d.1 d.2).
-    eapply lookup_env_In => //.
-    apply g. apply lookup_env_In => //.
-  - intros hd kn d hl.
-    eapply (lookup_env_In (kn, d)) in hl => //.
-    eapply (lookup_env_In (kn, d)) => //. eauto.
-Qed.
+  Lemma lookup_env_In d Σ : 
+    wf_glob Σ ->
+    lookup_env Σ d.1 = Some d.2 <-> In d Σ.
+  Proof.
+    intros wf.
+    split.
+    - induction Σ; cbn => //.
+      destruct (eqb_spec d.1 a.1). intros [=]. destruct a, d; cbn in *; intuition auto.
+      left; subst; auto. depelim wf.
+      intros hl; specialize (IHΣ wf hl); intuition auto.
+    - induction wf => /= //.
+      intros [eq|hin]; eauto. subst d.
+      now rewrite eqb_refl.
+      specialize (IHwf hin).
+      destruct (eqb_spec d.1 kn). subst kn.
+      eapply lookup_env_Some_fresh in IHwf. contradiction.
+      exact IHwf.
+  Qed.
 
-Lemma global_subset_cons d Σ Σ' : 
-  global_subset Σ Σ' ->
-  global_subset (d :: Σ) (d :: Σ').
-Proof.
-  intros sub kn d'.
-  cbn. case: eqb_spec => [eq|neq] => //.
-  eapply sub.
-Qed.
+  Lemma global_subset_In Σ Σ' : 
+    wf_glob Σ -> wf_glob Σ' ->
+    global_subset Σ Σ' <-> forall d, In d Σ -> In d Σ'.
+  Proof.
+    split.
+    - intros g d hin.
+      specialize (g d.1 d.2).
+      eapply lookup_env_In => //.
+      apply g. apply lookup_env_In => //.
+    - intros hd kn d hl.
+      eapply (lookup_env_In (kn, d)) in hl => //.
+      eapply (lookup_env_In (kn, d)) => //. eauto.
+  Qed.
 
-Lemma fresh_global_subset Σ Σ' kn : 
-  wf_glob Σ -> wf_glob Σ' ->
-  global_subset Σ Σ' ->
-  fresh_global kn Σ' -> fresh_global kn Σ.
-Proof.
-  intros wfΣ wfΣ' sub fr.
-  unfold fresh_global in *.
-  eapply All_Forall, In_All.
-  intros [kn' d] hin. cbn.
-  intros eq; subst.
-  eapply global_subset_In in hin; tea.
-  eapply Forall_All in fr. eapply All_In in fr; tea.
-  destruct fr. cbn in H. congruence.
-Qed.
+  Lemma global_subset_cons d Σ Σ' : 
+    global_subset Σ Σ' ->
+    global_subset (d :: Σ) (d :: Σ').
+  Proof.
+    intros sub kn d'.
+    cbn. case: eqb_spec => [eq|neq] => //.
+    eapply sub.
+  Qed.
 
-Lemma global_subset_cons_right d Σ Σ' : 
-  wf_glob Σ -> wf_glob (d :: Σ') ->
-  global_subset Σ Σ' ->
-  global_subset Σ (d :: Σ').
-Proof.
-  intros wf wf' gs.
-  assert (wf_glob Σ'). now depelim wf'.
-  rewrite (global_subset_In _ _ wf H) in gs.
-  rewrite global_subset_In //.
-  intros decl. specialize (gs decl).
-  intros hin; specialize (gs hin). cbn. now right.
-Qed.
+  Lemma fresh_global_subset Σ Σ' kn : 
+    wf_glob Σ -> wf_glob Σ' ->
+    global_subset Σ Σ' ->
+    fresh_global kn Σ' -> fresh_global kn Σ.
+  Proof.
+    intros wfΣ wfΣ' sub fr.
+    unfold fresh_global in *.
+    eapply All_Forall, In_All.
+    intros [kn' d] hin. cbn.
+    intros eq; subst.
+    eapply global_subset_In in hin; tea.
+    eapply Forall_All in fr. eapply All_In in fr; tea.
+    destruct fr. cbn in H. congruence.
+  Qed.
+
+  Lemma global_subset_cons_right d Σ Σ' : 
+    wf_glob Σ -> wf_glob (d :: Σ') ->
+    global_subset Σ Σ' ->
+    global_subset Σ (d :: Σ').
+  Proof.
+    intros wf wf' gs.
+    assert (wf_glob Σ'). now depelim wf'.
+    rewrite (global_subset_In _ _ wf H) in gs.
+    rewrite global_subset_In //.
+    intros decl. specialize (gs decl).
+    intros hin; specialize (gs hin). cbn. now right.
+  Qed.
+
+End EEnvFlags.

--- a/erasure/theories/EGlobalEnv.v
+++ b/erasure/theories/EGlobalEnv.v
@@ -49,6 +49,13 @@ Qed.
 Section Lookups.
   Context (Σ : global_declarations).
 
+  Definition lookup_constant kn : option constant_body :=
+    decl <- lookup_env Σ kn;; 
+    match decl with
+    | ConstantDecl cdecl => ret cdecl
+    | InductiveDecl mdecl => None
+    end.
+
   Definition lookup_minductive kn : option mutual_inductive_body :=
     decl <- lookup_env Σ kn;; 
     match decl with
@@ -65,9 +72,13 @@ Section Lookups.
     mdecl <- lookup_minductive kn ;;
     ret mdecl.(ind_npars).
   
-  Definition lookup_constructor_pars_args kn c : option (nat * nat) := 
+  Definition lookup_constructor kn c : option (mutual_inductive_body * one_inductive_body * (ident * nat)) :=
     '(mdecl, idecl) <- lookup_inductive kn ;;
     cdecl <- nth_error idecl.(ind_ctors) c ;;
+    ret (mdecl, idecl, cdecl).
+  
+  Definition lookup_constructor_pars_args kn c : option (nat * nat) := 
+    '(mdecl, idecl, cdecl) <- lookup_constructor kn c ;;
     ret (mdecl.(ind_npars), cdecl.2).
 End Lookups.
 
@@ -100,14 +111,6 @@ Definition extends (Σ Σ' : global_declarations) := ∑ Σ'', Σ' = (Σ'' ++ Σ
 Definition fresh_global kn (Σ : global_declarations) :=
   Forall (fun x => x.1 <> kn) Σ.
 
-Inductive wf_glob : global_declarations -> Prop :=
-| wf_glob_nil : wf_glob []
-| wf_glob_cons kn d Σ : 
-  wf_glob Σ ->
-  fresh_global kn Σ ->
-  wf_glob ((kn, d) :: Σ).
-Derive Signature for wf_glob.
-
 Lemma lookup_env_Some_fresh {Σ c decl} :
   lookup_env Σ c = Some decl -> ~ (fresh_global c Σ).
 Proof.
@@ -119,32 +122,6 @@ Proof.
     now inv H2.
 Qed.
 
-Lemma extends_lookup {Σ Σ' c decl} :
-  wf_glob Σ' ->
-  extends Σ Σ' ->
-  lookup_env Σ c = Some decl ->
-  lookup_env Σ' c = Some decl.
-Proof.
-  intros wfΣ' [Σ'' ->]. simpl.
-  induction Σ'' in wfΣ', c, decl |- *.
-  - simpl. auto.
-  - specialize (IHΣ'' c decl). forward IHΣ''.
-    + now inv wfΣ'.
-    + intros HΣ. specialize (IHΣ'' HΣ).
-      inv wfΣ'. simpl in *.
-      case: eqb_spec; intros e; subst; auto.
-      apply lookup_env_Some_fresh in IHΣ''; contradiction.
-Qed.
-
-Lemma extends_is_propositional {Σ Σ'} : 
-  wf_glob Σ' -> extends Σ Σ' ->
-  forall ind b, inductive_isprop_and_pars Σ ind = Some b -> inductive_isprop_and_pars Σ' ind = Some b.
-Proof.
-  intros wf ex ind b.
-  rewrite /inductive_isprop_and_pars.
-  destruct lookup_env eqn:lookup => //.
-  now rewrite (extends_lookup wf ex lookup).
-Qed.
 
 (** ** Reduction *)
 
@@ -212,10 +189,14 @@ Definition tDummy := tVar "".
 Definition iota_red npar args (br : list name * term) :=
   substl (List.rev (List.skipn npar args)) br.2.
 
+Definition isSome {A} (o : option A) := 
+  match o with 
+  | None => false
+  | Some _ => true
+  end.
 
-  Class switchterm := 
-  { 
-  has_tBox : bool
+Class ETermFlags := 
+  { has_tBox : bool
   ; has_tRel : bool
   ; has_tVar : bool
   ; has_tEvar : bool
@@ -229,11 +210,36 @@ Definition iota_red npar args (br : list name * term) :=
   ; has_tFix : bool
   ; has_tCoFix : bool
   }.
+
+Class EEnvFlags := {
+  has_axioms : bool;
+  has_cstr_params : bool;
+  term_switches :> ETermFlags }.
   
+Definition all_term_flags := 
+  {| has_tBox := true
+    ; has_tRel := true
+    ; has_tVar := true
+    ; has_tEvar := true
+    ; has_tLambda := true
+    ; has_tLetIn := true
+    ; has_tApp := true
+    ; has_tConst := true
+    ; has_tConstruct := true
+    ; has_tCase := true
+    ; has_tProj := true
+    ; has_tFix := true
+    ; has_tCoFix := true
+  |}.
+
+Definition all_env_flags := 
+  {| has_axioms := true; 
+     term_switches := all_term_flags;
+     has_cstr_params := true |}.
+    
 Section wf.
   
-  Context {sw  : switchterm}.
-  Variable has_axioms : bool.
+  Context {sw  : EEnvFlags}.
   Variable Σ : global_context.
 
   (* a term term is wellformed if
@@ -252,8 +258,8 @@ Section wf.
     | tLetIn na b b' => has_tLetIn && wellformed k b && wellformed (S k) b'
     | tCase ind c brs => has_tCase && 
       let brs' := List.forallb (fun br => wellformed (#|br.1| + k) br.2) brs in
-      wellformed k c && brs'
-    | tProj p c => has_tProj && wellformed k c
+      isSome (lookup_inductive Σ ind.1) && wellformed k c && brs'
+    | tProj p c => has_tProj && isSome (lookup_inductive Σ p.1.1) && wellformed k c
     | tFix mfix idx => has_tFix &&
       let k' := List.length mfix + k in
       List.forallb (test_def (wellformed k')) mfix
@@ -261,19 +267,58 @@ Section wf.
       let k' := List.length mfix + k in
       List.forallb (test_def (wellformed k')) mfix
     | tBox => has_tBox
-    | tConst kn => has_tConst && match lookup_env Σ kn with Some (ConstantDecl d) => 
-        has_axioms || match d.(cst_body) with Some _ => true | _ => false end 
-        | _ => false end
-    | tConstruct ind c => has_tConstruct &&
-        match lookup_env Σ ind.(inductive_mind) with 
-        | Some (InductiveDecl mdecl) => 
-          match nth_error (ind_bodies mdecl) (inductive_ind ind) with 
-          | Some idecl => match nth_error (ind_ctors idecl) c with Some _ => true | _ => false end
-          | _ => false
-          end
-        | _ => false
-        end    
+    | tConst kn => has_tConst && 
+      match lookup_constant Σ kn with
+      | Some d => has_axioms || isSome d.(cst_body)
+      | _ => false 
+      end
+    | tConstruct ind c => has_tConstruct && isSome (lookup_constructor Σ ind c)
     | tVar _ => has_tVar
     end.
 
 End wf.
+
+Definition wf_global_decl {sw : EEnvFlags} Σ d : bool :=
+  match d with
+  | ConstantDecl cb => option_default (fun b => wellformed Σ 0 b) cb.(cst_body) has_axioms
+  | InductiveDecl idecl => has_cstr_params || (idecl.(ind_npars) == 0)
+  end.
+
+Inductive wf_glob {efl : EEnvFlags} : global_declarations -> Prop :=
+| wf_glob_nil : wf_glob []
+| wf_glob_cons kn d Σ : 
+  wf_glob Σ ->
+  wf_global_decl Σ d ->
+  fresh_global kn Σ ->
+  wf_glob ((kn, d) :: Σ).
+Derive Signature for wf_glob.
+
+Implicit Types (efl : EEnvFlags).
+
+Lemma extends_lookup {efl} {Σ Σ' c decl} :
+  wf_glob Σ' ->
+  extends Σ Σ' ->
+  lookup_env Σ c = Some decl ->
+  lookup_env Σ' c = Some decl.
+Proof.
+  intros wfΣ' [Σ'' ->]. simpl.
+  induction Σ'' in wfΣ', c, decl |- *.
+  - simpl. auto.
+  - specialize (IHΣ'' c decl). forward IHΣ''.
+    + now inv wfΣ'.
+    + intros HΣ. specialize (IHΣ'' HΣ).
+      inv wfΣ'. simpl in *.
+      case: eqb_spec; intros e; subst; auto.
+      apply lookup_env_Some_fresh in IHΣ''; contradiction.
+Qed.
+
+Lemma extends_is_propositional {efl} {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind b, inductive_isprop_and_pars Σ ind = Some b -> inductive_isprop_and_pars Σ' ind = Some b.
+Proof.
+  intros wf ex ind b.
+  rewrite /inductive_isprop_and_pars.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+Qed.
+

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils BasicAst.
-From MetaCoq.Erasure Require Import EAst EInduction.
+From MetaCoq.Erasure Require Import EAst EAstUtils EInduction.
 Require Import ssreflect.
 
 (** * Lifting and substitution for the AST
@@ -297,6 +297,10 @@ Qed.
 Lemma isLambda_lift n k (bod : term) :
   isLambda bod = true -> isLambda (lift n k bod) = true.
 Proof. destruct bod; simpl; try congruence. Qed.
+
+Lemma isBox_lift n k (bod : term) :
+  isBox bod = isBox (lift n k bod).
+Proof. destruct bod; simpl; try congruence. destruct Nat.leb => //. Qed.
 
 #[global]
 Hint Resolve lift_isApp map_non_nil isLambda_lift : all.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -30,12 +30,6 @@ Hint Constructors eval : core.
 Section optimize.
   Context (Σ : global_context).
 
-  Definition is_box_fix mfix idx := 
-    match nth_error mfix idx with
-    | Some {| dbody := tBox |} => true
-    | _ => false
-    end.
-
   Fixpoint optimize (t : term) : term :=
     match t with
     | tRel i => tRel i
@@ -60,8 +54,7 @@ Section optimize.
       end
     | tFix mfix idx =>
       let mfix' := List.map (map_def optimize) mfix in
-      if is_box_fix mfix idx then tBox
-      else tFix mfix' idx
+      tFix mfix' idx
     | tCoFix mfix idx =>
       let mfix' := List.map (map_def optimize) mfix in
       tCoFix mfix' idx
@@ -128,8 +121,6 @@ Section optimize.
       rtoProp; solve_all. solve_all.
       rtoProp; solve_all. solve_all.
     - destruct EGlobalEnv.inductive_isprop_and_pars as [[[|] _]|]; cbn; auto.
-    - destruct is_box_fix => //.
-      cbn; auto; rewrite forallb_map; len; solve_all.
   Qed.
  
   Lemma subst_csubst_comm l t k b : 
@@ -175,33 +166,16 @@ Section optimize.
   Import EEtaExpanded.
   Ltac solve_discr' := try solve_discr; repeat solve_discr_args; try congruence.
 
-  Lemma optimize_csubst {efl : EEnvFlags} a k i b : 
+  Lemma optimize_csubst a k b : 
     closed a ->
-    wellformed Σ i b ->
     optimize (ECSubst.csubst a k b) = ECSubst.csubst (optimize a) k (optimize b).
   Proof.
-    induction b in i, k |- * using EInduction.term_forall_list_ind; simpl; auto;
-    intros cl exp; try easy; 
+    induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto;
+    intros cl; try easy; 
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
     unfold test_def in *;
-    simpl closed in *; try solve [depelim exp; try solve_discr'; simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
+    simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
     - destruct (k ?= n)%nat; auto.
-    - depelim exp.
-      * destruct args using rev_case; try congruence.
-        rewrite mkApps_app in H2. noconf H2.
-        eapply Forall_app in H1 as []. depelim H2.
-        f_equal; eauto. eapply IHb1; eauto. eapply expanded_mkApps_expanded; eauto; solve_all.
-      * destruct args using rev_case; try congruence. solve_discr.
-        rewrite mkApps_app in H2. noconf H2.
-        eapply Forall_app in H1 as []. depelim H2.
-        rewrite !csubst_mkApps /= !optimize_mkApps /=.
-        rewrite !csubst_mkApps /=. f_equal; eauto. f_equal. solve_all.
-        f_equal; eauto. eapply IHb1; eauto.
-         eapply expanded_mkApps_expanded; eauto; solve_all.
-
-      *
-         eauto.
-      eapply IHb1. auto.
     - unfold on_snd; cbn.
       destruct EGlobalEnv.inductive_isprop_and_pars as [[[|] _]|] => /= //.
       destruct l as [|[br n] [|l']] eqn:eql; simpl.
@@ -209,7 +183,7 @@ Section optimize.
       * depelim X. simpl in *.
         rewrite e //.
         assert (#|br| = #|repeat tBox #|br| |). now rewrite repeat_length.
-        rewrite {2}H0.
+        rewrite {2}H.
         rewrite substl_csubst_comm //.
         solve_all. eapply All_repeat => //.
         now eapply closed_optimize.
@@ -222,9 +196,6 @@ Section optimize.
       * rewrite ?map_map_compose; f_equal; eauto; solve_all.
     - destruct EGlobalEnv.inductive_isprop_and_pars as [[[|] _]|]=> //;
       now rewrite IHb.
-    - rewrite  !nth_error_map.
-      destruct nth_error => /= //.
-
   Qed.
 
   Lemma optimize_substl s t : 
@@ -714,8 +685,7 @@ Proof.
     destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
     constructor. all:constructor; auto.
   - cbn. eapply expanded_tFix. solve_all.
-    rewrite isLambda_optimize //. now left.
-    rewrite isBox_optimize //. now right.
+    rewrite isLambda_optimize //.
   - eapply expanded_tConstruct_app; tea.
     now len. solve_all.
 Qed.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -723,3 +723,34 @@ Proof.
   eapply optimize_expanded_decl in H0.
   depelim wf; now eapply optimize_expanded_decl_irrel.
 Qed.
+
+Lemma optimize_wellformed {efl : EEnvFlags} Σ n t :
+  has_tBox ->
+  wf_glob Σ -> wellformed Σ n t -> wellformed Σ n (optimize Σ t).
+Proof.
+  intros wfΣ hbox.
+  induction t in n |- * using EInduction.term_forall_list_ind => //.
+  all:try solve [cbn; rtoProp; intuition auto; solve_all].
+  - cbn -[lookup_inductive]. move/and3P => [] hasc /andP[]hs ht hbrs.
+    destruct EGlobalEnv.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    destruct l as [|[br n'] [|l']] eqn:eql; simpl.
+    all:rewrite ?hasc ?hs /= ?andb_true_r.
+    rewrite IHt //.
+    depelim X. cbn in hbrs.
+    rewrite andb_true_r in hbrs.
+    specialize (i _ hbrs).
+    todo "wellformed substitution". (* eapply closed_substl. solve_all. eapply All_repeat => //. *)
+    (* now rewrite repeat_length. *)
+    cbn in hbrs; rtoProp; solve_all. depelim X; depelim X. solve_all.
+    do 2 depelim X. solve_all.
+    do 2 depelim X. solve_all.
+    rtoProp; solve_all. solve_all.
+    rtoProp; solve_all. solve_all.
+  - cbn -[lookup_inductive]. move/andP => [] /andP[]hasc hs ht.
+    destruct EGlobalEnv.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    all:rewrite hasc hs /=; eauto.
+  - cbn. rtoProp; intuition auto; solve_all.
+    unfold test_def in *. len. eauto.
+  - cbn. rtoProp; intuition auto; solve_all.
+    unfold test_def in *. len. eauto.
+Qed.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -3,15 +3,12 @@ From Coq Require Import Utf8 Program.
 From MetaCoq.Template Require Import config utils Kernames.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICReflect PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
-     PCUICTyping PCUICInversion PCUICGeneration
-     PCUICConfluence PCUICConversion 
-     PCUICCumulativity PCUICSR PCUICSafeLemmata
-     PCUICValidity PCUICPrincipality PCUICElimination PCUICSN.
-
+     PCUICTyping PCUICInversion
+     PCUICSafeLemmata. (* for welltyped *)
 From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
-     
-From MetaCoq.Erasure Require Import EAstUtils EArities Extract Prelim ErasureCorrectness EDeps EExtends
-    ErasureFunction ELiftSubst ECSubst EWcbvEval.
+From MetaCoq.Erasure Require Import EAst EAstUtils EDeps EExtends
+    ELiftSubst ECSubst EWcbvEval Extract Prelim ErasureCorrectness 
+    ErasureFunction EArities.
 
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -28,11 +25,7 @@ Local Existing Instance extraction_checker_flags.
 Ltac introdep := let H := fresh in intros H; depelim H.
 
 #[global]
-Hint Constructors Ee.eval : core.
-
-Set Warnings "-notation-overridden".
-Import E.
-Set Warnings "+notation-overridden".
+Hint Constructors eval : core.
 
 Section optimize.
   Context (Σ : global_context).
@@ -49,10 +42,10 @@ Section optimize.
       match EGlobalEnv.inductive_isprop_and_pars Σ (fst ind) with
       | Some (true, npars) =>
         match brs' with
-        | [(a, b)] => ECSubst.substl (repeat E.tBox #|a|) b
-        | _ => E.tCase ind (optimize c) brs'
+        | [(a, b)] => ECSubst.substl (repeat tBox #|a|) b
+        | _ => tCase ind (optimize c) brs'
         end
-      | _ => E.tCase ind (optimize c) brs'
+      | _ => tCase ind (optimize c) brs'
       end
     | tProj p c =>
       match EGlobalEnv.inductive_isprop_and_pars Σ p.1.1 with 
@@ -106,7 +99,6 @@ Section optimize.
     - move/andP => []. intros. f_equal; solve_all; eauto.
       destruct x0; cbn in *. f_equal; auto.
   Qed.
-
 
   Lemma closed_optimize t k : closedn k t -> closedn k (optimize t).
   Proof.
@@ -240,11 +232,11 @@ Section optimize.
 
   Lemma optimize_cunfold_fix mfix idx n f : 
     forallb (closedn 0) (EGlobalEnv.fix_subst mfix) ->
-    Ee.cunfold_fix mfix idx = Some (n, f) ->
-    Ee.cunfold_fix (map (map_def optimize) mfix) idx = Some (n, optimize f).
+    cunfold_fix mfix idx = Some (n, f) ->
+    cunfold_fix (map (map_def optimize) mfix) idx = Some (n, optimize f).
   Proof.
     intros hfix.
-    unfold Ee.cunfold_fix.
+    unfold cunfold_fix.
     rewrite nth_error_map.
     destruct nth_error.
     intros [= <- <-] => /=. f_equal.
@@ -254,11 +246,11 @@ Section optimize.
 
   Lemma optimize_cunfold_cofix mfix idx n f : 
     forallb (closedn 0) (EGlobalEnv.cofix_subst mfix) ->
-    Ee.cunfold_cofix mfix idx = Some (n, f) ->
-    Ee.cunfold_cofix (map (map_def optimize) mfix) idx = Some (n, optimize f).
+    cunfold_cofix mfix idx = Some (n, f) ->
+    cunfold_cofix (map (map_def optimize) mfix) idx = Some (n, optimize f).
   Proof.
     intros hcofix.
-    unfold Ee.cunfold_cofix.
+    unfold cunfold_cofix.
     rewrite nth_error_map.
     destruct nth_error.
     intros [= <- <-] => /=. f_equal.
@@ -274,7 +266,6 @@ Section optimize.
 
 End optimize.
 
-
 Lemma is_box_inv b : is_box b -> ∑ args, b = mkApps tBox args.
 Proof.
   unfold is_box, EAstUtils.head.
@@ -284,7 +275,7 @@ Proof.
   eexists; eauto.
 Qed.
 
-Lemma eval_is_box {wfl:Ee.WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
+Lemma eval_is_box {wfl:WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
 Proof.
   intros ev; induction ev => //.
   - rewrite is_box_tApp.
@@ -348,30 +339,114 @@ Definition optimize_decl Σ d :=
   | InductiveDecl idecl => d
   end.
 
-Definition optimize_env (Σ : EAst.global_declarations) := 
-  map (on_snd (optimize_decl Σ)) Σ.
+Fixpoint optimize_env (Σ : EAst.global_declarations) := 
+  match Σ with
+  | [] => []
+  | d :: Σ => on_snd (optimize_decl Σ) d :: optimize_env Σ
+  end.
 
-Import EGlobalEnv.
+Import EGlobalEnv EExtends.
 
-(* Lemma optimize_extends Σ Σ' : extends Σ Σ' ->
-  optimize Σ t = optimize Σ' t. *)
-
-Lemma lookup_env_optimize Σ kn : 
-  lookup_env (optimize_env Σ) kn = 
-  option_map (optimize_decl Σ) (lookup_env Σ kn).
+(* Lemma extends_is_propositional {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind, 
+  match inductive_isprop_and_pars Σ ind with
+  | Some b => inductive_isprop_and_pars Σ' ind = Some b
+  | None => inductive_isprop_and_pars Σ' ind = None
+  end.
 Proof.
-  unfold optimize_env.
-  induction Σ at 2 4; simpl; auto.
-  case: eqb_spec => //.
+  intros wf ex ind.
+  rewrite /inductive_isprop_and_pars.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+
+Qed. *)
+
+Lemma extends_inductive_isprop_and_pars {efl : EEnvFlags} {Σ Σ' ind} : extends Σ Σ' -> wf_glob Σ' ->
+  isSome (lookup_inductive Σ ind) -> 
+  inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars Σ' ind.
+Proof.
+  intros ext wf; cbn.
+  unfold inductive_isprop_and_pars.
+  destruct lookup_env as [[]|] eqn:hl => //.
+  rewrite (extends_lookup wf ext hl).
+  destruct nth_error => //.
 Qed.
 
-Lemma is_propositional_optimize Σ ind : 
+Lemma wellformed_optimize_extends {wfl: EEnvFlags} Σ t : 
+  forall n, wellformed Σ n t ->
+  forall Σ', extends Σ Σ' -> wf_glob Σ' ->
+  optimize Σ t = optimize Σ' t.
+Proof.
+  induction t using EInduction.term_forall_list_ind; cbn -[lookup_constant lookup_inductive]; intros => //.
+  all:rtoProp; intuition auto.  
+  all:f_equal; eauto; solve_all.
+  - assert (map (on_snd (optimize Σ)) l = map (on_snd (optimize Σ')) l) as -> by solve_all.
+    rewrite (extends_inductive_isprop_and_pars H0 H1 H2).
+    destruct inductive_isprop_and_pars as [[[]]|].
+    destruct map => //. f_equal; eauto.
+    destruct l0 => //. destruct p0 => //. f_equal; eauto.
+    all:f_equal; eauto; solve_all.
+  - rewrite (extends_inductive_isprop_and_pars H0 H1 H3).
+    destruct inductive_isprop_and_pars as [[[]]|] => //.
+    all:f_equal; eauto.
+Qed.
+
+Lemma wellformed_optimize_decl_extends {wfl: EEnvFlags} Σ t : 
+  wf_global_decl Σ t ->
+  forall Σ', extends Σ Σ' -> wf_glob Σ' ->
+  optimize_decl Σ t = optimize_decl Σ' t.
+Proof.
+  destruct t => /= //.
+  intros wf Σ' ext wf'. f_equal. unfold optimize_constant_decl. f_equal.
+  destruct (cst_body c) => /= //. f_equal.
+  now eapply wellformed_optimize_extends.
+Qed.
+  
+
+Lemma lookup_env_optimize_env_Some {efl : EEnvFlags} Σ kn d : 
+  wf_glob Σ ->
+  lookup_env Σ kn = Some d ->
+  ∑ Σ', extends Σ' Σ × wf_global_decl Σ' d × (lookup_env (optimize_env Σ) kn) = Some (optimize_decl Σ' d).
+Proof.
+  induction Σ; simpl; auto => //.
+  intros wf.
+  case: eqb_specT => //.
+  - intros ->. cbn. intros [= <-]. exists Σ. split. now eexists [_]. split => //.
+    now depelim wf.
+  - intros _. forward IHΣ. now depelim wf.
+    intros hl. specialize (IHΣ hl) as [Σ' [[Σ'' ext] eq]].
+    subst Σ. exists Σ'. split => //. now exists (a :: Σ'').
+Qed.
+
+Lemma lookup_env_optimize_env_None {efl : EEnvFlags} Σ kn : 
+  lookup_env Σ kn = None ->
+  lookup_env (optimize_env Σ) kn = None.
+Proof.
+  induction Σ; simpl; auto => //.
+  case: eqb_specT => //.
+Qed.
+
+Lemma lookup_env_optimize {efl : EEnvFlags} Σ kn : 
+  wf_glob Σ ->
+  lookup_env (optimize_env Σ) kn = option_map (optimize_decl Σ) (lookup_env Σ kn).
+Proof.
+  intros wf.
+  destruct (lookup_env Σ kn) eqn:hl.
+  - eapply lookup_env_optimize_env_Some in hl as [Σ' [ext [wf' hl']]] => /=.
+    rewrite hl'. f_equal.
+    eapply wellformed_optimize_decl_extends; eauto. auto.
+    
+  - cbn. now eapply lookup_env_optimize_env_None in hl. 
+Qed.
+
+Lemma is_propositional_optimize {efl : EEnvFlags} Σ ind : 
+  wf_glob Σ ->
   inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars (optimize_env Σ) ind.
 Proof.
-  rewrite /inductive_isprop_and_pars.
-  rewrite lookup_env_optimize.
-  destruct lookup_env; simpl; auto.
-  destruct g; simpl; auto.
+  rewrite /inductive_isprop_and_pars => wf.
+  rewrite (lookup_env_optimize Σ (inductive_mind ind) wf).  
+  case: lookup_env => [[decl|]|] => //.
 Qed.
 
 Lemma closed_iota_red pars c args brs br :
@@ -397,13 +472,14 @@ Proof.
   - rewrite mkApps_app /=. now destruct l => /= //; rewrite andb_false_r.
 Qed.
 
-Lemma optimize_correct {fl} Σ t v :
+Lemma optimize_correct {efl : EEnvFlags} {fl} Σ t v :
+  wf_glob Σ ->
   closed_env Σ ->
   @Ee.eval fl Σ t v ->
   closed t ->
   @Ee.eval (disable_prop_cases fl) (optimize_env Σ) (optimize Σ t) (optimize Σ v).
 Proof.
-  intros clΣ ev.
+  intros wfΣ clΣ ev.
   induction ev; simpl in *.
 
   - move/andP => [] cla clt. econstructor; eauto.
@@ -512,9 +588,10 @@ Proof.
     econstructor; eauto.
     apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
   
-  - econstructor. red in isdecl |- *.
-    rewrite lookup_env_optimize isdecl //.
-    now rewrite /optimize_constant_decl e.
+  - rewrite /declared_constant in isdecl.
+    move: (lookup_env_optimize Σ c wfΣ); rewrite isdecl /= //.
+    intros hl.
+    econstructor; tea. cbn. rewrite e //.
     apply IHev.
     eapply lookup_env_closed in clΣ; tea.
     move: clΣ. rewrite /closed_decl e //.
@@ -554,4 +631,95 @@ Proof.
       discriminate.
   - destruct t => //.
     all:constructor; eauto.
+Qed.
+(* 
+Lemma optimize_extends Σ Σ' : 
+  wf_glob Σ' ->
+  extends Σ Σ' ->
+  forall t b, optimize Σ t = b -> optimize Σ' t = b.
+Proof.
+  intros wf ext.
+  induction t using EInduction.term_forall_list_ind; cbn => //.
+  all:try solve [f_equal; solve_all].
+  destruct inductive_isp
+  rewrite (extends_is_propositional wf ext).
+ *)
+
+From MetaCoq.Erasure Require Import EEtaExpanded.
+
+Lemma expanded_mkApps_expanded {Σ f args} : 
+  expanded Σ f -> All (expanded Σ) args ->
+  expanded Σ (mkApps f args).
+Proof.
+  intros.
+  destruct (isConstruct f) eqn:eqc.
+  destruct f => //.
+  - depelim H. 
+    destruct args0 using rev_case; cbn in *; subst. cbn in H. congruence.
+    rewrite mkApps_app in H2; noconf H2.
+    destruct args0 using rev_case; cbn in *; subst.
+    noconf H2. eapply expanded_tConstruct_app; tea. lia. solve_all.
+    rewrite mkApps_app in H2; noconf H2.
+  - eapply expanded_mkApps => //. now rewrite eqc. solve_all.
+Qed.
+
+Lemma optimize_expanded Σ t : expanded Σ t -> expanded Σ (optimize Σ t).
+Proof.
+  induction 1 using expanded_ind.
+  all:try solve[constructor; eauto; solve_all].
+  all:rewrite ?optimize_mkApps.
+  - eapply expanded_mkApps_expanded => //. solve_all.
+  - cbn.
+    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    2-3:constructor; eauto; solve_all.
+    destruct branches eqn:heq.
+    constructor; eauto; solve_all. cbn.
+    destruct l => /=.
+    eapply isEtaExp_expanded.
+    eapply isEtaExp_substl. eapply forallb_repeat => //.
+    destruct branches as [|[]]; cbn in heq; noconf heq.
+    cbn -[isEtaExp] in *. depelim H1. cbn in H1.
+    now eapply expanded_isEtaExp.
+    constructor; eauto; solve_all.
+    depelim H1. depelim H1. do 2 (constructor; intuition auto).
+    solve_all.
+  - cbn.
+    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    constructor. all:constructor; auto.
+  - eapply expanded_tConstruct_app; tea.
+    now len. solve_all.
+Qed.
+
+Lemma optimize_expanded_irrel {efl : EEnvFlags} Σ t : wf_glob Σ -> expanded Σ t -> expanded (optimize_env Σ) t.
+Proof.
+  intros wf; induction 1 using expanded_ind.
+  all:try solve[constructor; eauto; solve_all].
+  eapply expanded_tConstruct_app.
+  destruct H as [[H ?] ?].
+  split => //. split => //. red.
+  red in H. rewrite lookup_env_optimize // /= H //. 1-2:eauto. auto. solve_all. 
+Qed.
+
+Lemma optimize_expanded_decl Σ t : expanded_decl Σ t -> expanded_decl Σ (optimize_decl Σ t).
+Proof.
+  destruct t as [[[]]|] => /= //.
+  unfold expanded_constant_decl => /=.
+  apply optimize_expanded.
+Qed.
+
+Lemma optimize_expanded_decl_irrel {efl : EEnvFlags} Σ t : wf_glob Σ -> expanded_decl Σ t -> expanded_decl (optimize_env Σ) t.
+Proof.
+  destruct t as [[[]]|] => /= //.
+  unfold expanded_constant_decl => /=.
+  apply optimize_expanded_irrel.
+Qed.
+
+Lemma optimize_env_expanded {efl : EEnvFlags} Σ :
+  wf_glob Σ -> expanded_global_env Σ -> expanded_global_env (optimize_env Σ).
+Proof.
+  unfold expanded_global_env.
+  intros wf. induction 1; cbn; constructor; auto.
+  now depelim wf. cbn. 
+  eapply optimize_expanded_decl in H0.
+  depelim wf; now eapply optimize_expanded_decl_irrel.
 Qed.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -649,6 +649,11 @@ Proof.
 
 From MetaCoq.Erasure Require Import EEtaExpanded.
 
+Lemma isLambda_optimize Σ t : isLambda t -> isLambda (optimize Σ t).
+Proof. destruct t => //. Qed.
+Lemma isBox_optimize Σ t : isBox t -> isBox (optimize Σ t).
+Proof. destruct t => //. Qed.
+
 Lemma optimize_expanded Σ t : expanded Σ t -> expanded Σ (optimize Σ t).
 Proof.
   induction 1 using expanded_ind.
@@ -672,6 +677,9 @@ Proof.
   - cbn.
     destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
     constructor. all:constructor; auto.
+  - cbn. eapply expanded_tFix. solve_all.
+    rewrite isLambda_optimize //. now left.
+    rewrite isBox_optimize //. now right.
   - eapply expanded_tConstruct_app; tea.
     now len. solve_all.
 Qed.

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -319,7 +319,7 @@ Section strip.
 
   Lemma strip_cunfold_fix mfix idx n f : 
     forallb (closedn 0) (fix_subst mfix) ->
-    forallb (fun d =>  (isLambda (dbody d) || isBox (dbody d)) && isEtaExp Σ (dbody d)) mfix ->
+    forallb (fun d =>  isLambda (dbody d) && isEtaExp Σ (dbody d)) mfix ->
     cunfold_fix mfix idx = Some (n, f) ->
     cunfold_fix (map (map_def strip) mfix) idx = Some (n, strip f).
   Proof.
@@ -1223,8 +1223,6 @@ Proof.
   now eapply strip_wellformed.
 Qed.
 
-
-
 Lemma strip_expanded {Σ : GlobalContextMap.t} {t} : expanded Σ t -> expanded (strip_env Σ) (strip Σ t).
 Proof.
   induction 1 using expanded_ind.
@@ -1232,8 +1230,8 @@ Proof.
   - rewrite strip_mkApps_etaexp. now eapply expanded_isEtaExp.
     eapply expanded_mkApps_expanded => //. solve_all.
   - destruct proj as [[] ?]; simp_strip. constructor; eauto.
-  - simp_strip; constructor; eauto. solve_all. left.
-    rewrite -strip_isLambda //. rewrite -strip_isBox. now right.
+  - simp_strip; constructor; eauto. solve_all.
+    rewrite -strip_isLambda //.
   - rewrite strip_mkApps // /=.
     rewrite (lookup_inductive_pars_spec (proj1 (proj1 H))).
     eapply expanded_tConstruct_app.

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -159,6 +159,11 @@ Proof.
   now setoid_rewrite <- PCUICSigmaCalculus.lift_rename.
 Qed.
 
+Lemma lift_isLambda n k t : isLambda t = isLambda (lift n k t).
+Proof.
+  destruct t => //.
+Qed.
+
 Lemma erases_weakening' (Σ : global_env_ext) (Γ Γ' Γ'' : context) (t T : term) t' :
     wf Σ ->
     wf_local Σ (Γ ,,, Γ'' ,,, lift_context #|Γ''| 0 Γ') ->
@@ -247,8 +252,10 @@ Proof.
     eapply All2_map.
     eapply All2_impl. eapply All2_All_mix_left.
     eapply X1. eassumption. simpl.
-    intros [] []. simpl. intros [[Hs IH] [<- [<- IH']]].
+    intros [] []. simpl. intros [[Hs IH] [<- <- IH']].
     repeat split. unfold app_context in *.
+    eapply isLambda_lift => //.
+    eapply ELiftSubst.isLambda_lift => //.
     specialize (IH Γ (types ++ Γ') Γ'').
     subst types. rewrite app_length fix_context_length in IH.
     forward IH.
@@ -256,12 +263,12 @@ Proof.
       eapply All_mfix_wf in a; auto.
       rewrite lift_fix_context in a.
       now rewrite <- !app_assoc. }
-    forward IH by now rewrite app_assoc.
+    forward IH. now rewrite [_ ,,, _]app_assoc.
     rewrite lift_fix_context.
     rewrite lift_context_app - plus_n_O in IH.
     unfold app_context in IH. rewrite <- !app_assoc in IH.
     rewrite (All2_length X3) in IH |- *.
-    apply IH. apply IH'.
+    apply IH. apply e.
 
   - assert (HT : Σ;;; Γ ,,, Γ' |- PCUICAst.tCoFix mfix n : (decl.(dtype))).
     econstructor; eauto. eapply All_impl. eassumption. intros.
@@ -507,8 +514,10 @@ Proof.
       eapply All2_map.
       eapply All2_impl_In.
       eassumption.
-      intros. destruct H4 as (? & ? & ?).
+      intros. destruct H4 as [? ? ? ?]. 
       repeat split; eauto.
+      cbn. now eapply isLambda_subst.
+      now eapply ELiftSubst.isLambda_subst.
       eapply In_nth_error in H2 as [].
       eapply nth_error_all in X1; eauto.
       destruct X1 as [Hs IH].

--- a/erasure/theories/ETransform.v
+++ b/erasure/theories/ETransform.v
@@ -7,11 +7,11 @@ Set Warnings "-notation-overridden".
 From MetaCoq.PCUIC Require PCUICAst PCUICAstUtils PCUICProgram PCUICTransform.
 Set Warnings "+notation-overridden".
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICWfEnvImpl.
-From MetaCoq.Erasure Require EAstUtils ErasureFunction ErasureCorrectness EPretty Extract EProgram.
+From MetaCoq.Erasure Require EAstUtils ErasureFunction ErasureCorrectness EPretty Extract EOptimizePropDiscr ERemoveParams EProgram.
 
 Import PCUICAst (term) PCUICProgram PCUICTransform (eval_pcuic_program) Extract EProgram
-    EAst Transform.
-Import EEnvMap EGlobalEnv.
+    EAst Transform ERemoveParams.
+Import EEnvMap EGlobalEnv EWellformed.
 
 Program Definition erase_transform : Transform.t pcuic_program eprogram_env PCUICAst.term EAst.term 
   eval_pcuic_program (eval_eprogram_env EWcbvEval.default_wcbv_flags) :=
@@ -19,24 +19,16 @@ Program Definition erase_transform : Transform.t pcuic_program eprogram_env PCUI
     pre p :=  
       ∥ wt_pcuic_program (cf := config.extraction_checker_flags) p ∥ /\ PCUICEtaExpand.expanded_pcuic_program p ;
     transform p hp := erase_program p (proj1 hp) ;
-    post p :=
-      let decls := p.1.(GlobalContextMap.global_decls) in
-      [/\ wf_glob decls, closed_eprogram_env p & expanded_eprogram p];
+    post p := [/\ wf_eprogram_env all_env_flags p & expanded_eprogram_env p];
     obseq g g' v v' := let Σ := g.1 in Σ ;;; [] |- v ⇝ℇ v' |}.
 Next Obligation.
   cbn -[erase_program].
   intros p [wtp etap].
   destruct erase_program eqn:e.
   split; cbn.
-  - unfold erase_program, erase_pcuic_program in e. simpl. injection e. intros <- <-. 
-    eapply ErasureFunction.erase_global_wf_glob.
-  - apply/andP; split.
-    * unfold erase_program, erase_pcuic_program in e. simpl. injection e. intros <- <-. 
-      eapply ErasureFunction.erase_global_closed.
-    * unfold erase_program, erase_pcuic_program in e. simpl. injection e. intros <- <-. 
-      eapply (ErasureFunction.erases_closed _ []). eapply ErasureFunction.erases_erase.
-      clear e. destruct wtp as [[wfΣ [T HT]]].
-      now eapply (@PCUICClosedTyp.subject_closed _ _) in HT.
+  - unfold erase_program, erase_pcuic_program in e. simpl. injection e. intros <- <-.
+    split. 
+    eapply ErasureFunction.erase_global_wf_glob. eapply ErasureFunction.erase_wellformed.
   - rewrite -e. cbn.
     now eapply expanded_erase_program.
 Qed.
@@ -61,114 +53,99 @@ Qed.
 
 Import EWcbvEval (WcbvFlags, with_prop_case, with_guarded_fix).
 
-Program Definition guarded_to_unguarded_fix {fl : EWcbvEval.WcbvFlags} (wguard : with_guarded_fix) :
+Program Definition guarded_to_unguarded_fix {fl : EWcbvEval.WcbvFlags} {efl : EEnvFlags} (wguard : with_guarded_fix) :
   Transform.t eprogram_env eprogram_env EAst.term EAst.term 
     (eval_eprogram_env fl) (eval_eprogram_env (EEtaExpandedFix.switch_unguarded_fix fl)) :=
   {| name := "switching to unguarded fixpoints";
     transform p pre := p;
-    pre p := 
-    let decls := p.1.(GlobalContextMap.global_decls) in
-     [/\ wf_glob decls, closed_eprogram_env p & expanded_eprogram p ];
-    post p := let decls := p.1.(GlobalContextMap.global_decls) in
-     [/\ wf_glob decls, closed_eprogram_env p & expanded_eprogram p ];
+    pre p := wf_eprogram_env efl p /\ expanded_eprogram_env p;
+    post p := wf_eprogram_env efl p /\ expanded_eprogram_env p;
     obseq g g' v v' := v' = v |}.
 Next Obligation. cbn. eauto. Qed.
 Next Obligation.
   cbn.
-  move=> fl wguard [Σ t] v [wfe /andP[cle clt] /andP[etae etat]]. cbn in *.
+  move=> fl efl wguard [Σ t] v [wfp /andP[etae etat]]. cbn in *.
   intros [ev]. exists v. split => //.
   red. sq. cbn in *.
-  now apply EEtaExpandedFix.eval_opt_to_target.
+  apply EEtaExpandedFix.eval_opt_to_target => //. apply wfp.
 Qed.
 
-Program Definition remove_params (p : eprogram_env) : eprogram :=
-  (ERemoveParams.strip_env p.1, ERemoveParams.strip p.1 p.2).
-
-Program Definition remove_params_optimization {fl : EWcbvEval.WcbvFlags} : 
+Program Definition remove_params_optimization {fl : EWcbvEval.WcbvFlags} 
+  (efl := all_env_flags): 
   Transform.t eprogram_env eprogram EAst.term EAst.term (eval_eprogram_env fl) (eval_eprogram fl) :=
   {| name := "stripping constructor parameters";
-    transform p pre := remove_params p;
-    pre p := 
-    let decls := p.1.(GlobalContextMap.global_decls) in
-     [/\ wf_glob decls, closed_eprogram_env p & expanded_eprogram_cstrs p ];
-    post := closed_eprogram;
+    transform p pre := ERemoveParams.strip_program p;
+    pre p := wf_eprogram_env efl p /\ expanded_eprogram_env_cstrs p;
+    post p := wf_eprogram (switch_no_params efl) p /\ expanded_eprogram_cstrs p;
     obseq g g' v v' := v' = (ERemoveParams.strip g.1 v) |}.
 Next Obligation.
-  move=> fl [Σ t] [wfe /andP[cle clt] etap].
+  move=> fl efl [Σ t] [wfp etap].
   simpl.
   cbn -[ERemoveParams.strip] in *.
-  apply/andP; split; cbn.
-  move: cle. unfold closed_env. unfold ERemoveParams.strip_env.
-  rewrite forallb_map. eapply forallb_impl. intros.
-  destruct x as [kn []]; cbn in * => //.
-  destruct Extract.E.cst_body => //. cbn -[ERemoveParams.strip] in H0 |- *.
-  now eapply ERemoveParams.closed_strip.
-  now eapply ERemoveParams.closed_strip.
+  split. now eapply ERemoveParams.strip_program_wf.
+  now eapply ERemoveParams.strip_program_expanded.
 Qed.
 
 Next Obligation.
-  red. move=> ? [Σ t] /= v [wfe /andP[cle clt] etap] [ev].
+  red. move=> ? [Σ t] /= v [[wfe wft] etap] [ev].
   eapply ERemoveParams.strip_eval in ev; eauto.
-  eexists; split => //. now sq.
-  all:move/andP: etap => [] => //.
+  eexists; split => /= //. now sq. cbn in *.
+  now eapply wellformed_closed_env.
+  now move/andP: etap.
+  now eapply wellformed_closed.
+  now move/andP: etap.
 Qed.
 
-Program Definition remove_params_fast_optimization (fl : EWcbvEval.WcbvFlags) :
+Program Definition remove_params_fast_optimization (fl : EWcbvEval.WcbvFlags)
+  (efl := all_env_flags) :
   Transform.t eprogram_env eprogram EAst.term EAst.term (eval_eprogram_env fl) (eval_eprogram fl) :=
   {| name := "stripping constructor parameters (faster?)";
     transform p _ := (ERemoveParams.Fast.strip_env p.1, ERemoveParams.Fast.strip p.1 [] p.2);
-    pre p := 
-      let decls := p.1.(GlobalContextMap.global_decls) in
-      [/\ wf_glob decls, closed_eprogram_env p & expanded_eprogram_cstrs p];
-    post := closed_eprogram;
+    pre p := wf_eprogram_env efl p /\ expanded_eprogram_env_cstrs p;
+    post p := wf_eprogram (switch_no_params efl) p /\ expanded_eprogram_cstrs p;
     obseq g g' v v' := v' = (ERemoveParams.strip g.1 v) |}.
 Next Obligation.
-  move=> fl [Σ t] [wfe /andP[cle clt] etap].
+  move=> fl efl [Σ t] [wfp etap].
   simpl.
-  apply/andP.
-  rewrite -ERemoveParams.Fast.strip_fast -ERemoveParams.Fast.strip_env_fast.
   cbn -[ERemoveParams.strip] in *.
-  split.
-  move: cle. unfold closed_env. unfold ERemoveParams.strip_env.
-  rewrite forallb_map. eapply forallb_impl. intros.
-  destruct x as [kn []]; cbn in * => //.
-  destruct Extract.E.cst_body => //. cbn -[ERemoveParams.strip] in H0 |- *.
-  now eapply ERemoveParams.closed_strip.
-  now eapply ERemoveParams.closed_strip.
+  rewrite -ERemoveParams.Fast.strip_fast -ERemoveParams.Fast.strip_env_fast.
+  split. 
+  now eapply (ERemoveParams.strip_program_wf (Σ, t)).
+  now eapply (ERemoveParams.strip_program_expanded (Σ, t)).
 Qed.
+
 Next Obligation.
-  red. move=> ? [Σ t] /= v [wfe /andP[cle clt] etap] [ev].
+  red. move=> ? [Σ t] /= v [[wfe wft] etap] [ev].
   rewrite -ERemoveParams.Fast.strip_fast -ERemoveParams.Fast.strip_env_fast.
   eapply ERemoveParams.strip_eval in ev; eauto.
-  eexists; split => //. now sq.
-  all:move/andP: etap => [] => //.
+  eexists; split => /= //.
+  now sq. cbn in *.
+  now eapply wellformed_closed_env.
+  now move/andP: etap.
+  now eapply wellformed_closed.
+  now move/andP: etap.
 Qed.
 
 Import EOptimizePropDiscr EWcbvEval.
 
-Program Definition optimize_prop_discr_optimization {fl : WcbvFlags} : 
-  self_transform eprogram EAst.term (eval_eprogram fl) 
-    (eval_eprogram (disable_prop_cases fl)) := 
+Program Definition optimize_prop_discr_optimization {fl : WcbvFlags} {efl : EEnvFlags} {hastrel : has_tRel} {hastbox : has_tBox} :
+  self_transform eprogram EAst.term (eval_eprogram fl) (eval_eprogram (disable_prop_cases fl)) := 
   {| name := "optimize_prop_discr"; 
-    transform p _ := 
-      (EOptimizePropDiscr.optimize_env p.1, EOptimizePropDiscr.optimize p.1 p.2);
-    pre := closed_eprogram;
-    post := closed_eprogram;
-    obseq g g' v v' := v' = EOptimizePropDiscr.optimize g.1 v
-    |}.
+    transform p _ := optimize_program p ; 
+    pre p := wf_eprogram efl p /\ expanded_eprogram_cstrs p;
+    post p := wf_eprogram efl p /\ expanded_eprogram_cstrs p;
+    obseq g g' v v' := v' = EOptimizePropDiscr.optimize g.1 v |}.
 
 Next Obligation.
-  move=> fl [Σ t] /andP[cle clt].
-  cbn in *. apply/andP; split.
-  move: cle. cbn. induction Σ at 1 3; cbn; auto.
-  move/andP => [] cla clg. rewrite (IHg clg) andb_true_r.
-  destruct a as [kn []]; cbn in * => //.
-  destruct Extract.E.cst_body => //. cbn in cla |- *.
-  now eapply EOptimizePropDiscr.closed_optimize.
-  now eapply EOptimizePropDiscr.closed_optimize.
+  move=> fl efl hastrel hastbox [Σ t] [wfp etap].
+  cbn in *. split.
+  - now eapply optimize_program_wf.
+  - now eapply optimize_program_expanded.
 Qed.
 Next Obligation.
-  red. move=> fl [Σ t] /= v /andP[cle clt] [ev].
+  red. move=> fl efl hastrel hastbox [Σ t] /= v [wfe wft] [ev].
   eapply EOptimizePropDiscr.optimize_correct in ev; eauto.
-  eexists; split => //. red. sq; auto.
+  eexists; split => //. red. sq; auto. cbn. apply wfe.
+  eapply wellformed_closed_env, wfe.
+  eapply wellformed_closed, wfe.
 Qed.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -832,7 +832,7 @@ Arguments eval_deterministic {_ _ _ _ _}.
 Arguments eval_unique {_ _ _ _}.
 
 Section WcbvEnv.
-  Context {wfl : WcbvFlags}.
+  Context {wfl : WcbvFlags} {efl : EEnvFlags}.
 
   Lemma weakening_eval_env {Σ Σ'} : 
     wf_glob Σ' -> extends Σ Σ' ->

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -2,10 +2,13 @@
 From Coq Require Import Program.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require PCUICWcbvEval.
-From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst EReflect EGlobalEnv.
+From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst EReflect EGlobalEnv
+  EWellformed.
 
 From Equations Require Import Equations.
 Require Import ssreflect ssrbool.
+
+Set Default Proof Using "Type*".
 
 (** * Weak-head call-by-value evaluation strategy.
 
@@ -40,13 +43,6 @@ Definition isFixApp t :=
   | _ => false
   end.
 
-Definition cunfold_fix (mfix : mfixpoint term) (idx : nat) :=
-  match List.nth_error mfix idx with
-  | Some d =>
-    Some (d.(rarg), substl (fix_subst mfix) d.(dbody))
-  | None => None
-  end.
-
 Definition isStuckFix t (args : list term) :=
   match t with
   | tFix mfix idx =>
@@ -62,13 +58,6 @@ Proof.
   revert f; induction l using rev_ind. simpl. intuition auto.
   simpl. intros. now rewrite mkApps_app in H.
 Qed.
-
-Definition cunfold_cofix (mfix : mfixpoint term) (idx : nat) :=
-  match List.nth_error mfix idx with
-  | Some d =>
-    Some (d.(rarg), substl (cofix_subst mfix) d.(dbody))
-  | None => None
-  end.
 
 (* Tells if the evaluation relation should include match-prop and proj-prop reduction rules. *)
 Class WcbvFlags := { with_prop_case : bool ; with_guarded_fix : bool }.
@@ -388,7 +377,6 @@ Section Wcbv.
     f_equal. rewrite lift_closed // closed_subst //.
   Qed.
 
-
   Lemma closed_unfold_cofix_cunfold_eq mfix idx : 
     closed (tCoFix mfix idx) ->
     unfold_cofix mfix idx = cunfold_cofix mfix idx.
@@ -416,7 +404,6 @@ Section Wcbv.
         now rewrite mkApps_app.
       * easy.
   Qed.
-
   
   Lemma eval_mkApps_tFix_inv mfix idx args v :
    with_guarded_fix ->
@@ -1047,6 +1034,59 @@ Proof.
   - rtoProp; intuition auto.
 Qed.
 
+Ltac forward_keep H :=
+  match type of H with
+  ?X -> _ =>
+    let H' := fresh in 
+    assert (H' : X) ; [|specialize (H H')]
+  end.
+
+Lemma eval_wellformed (efl := all_env_flags) {wfl : WcbvFlags} Σ : 
+  wf_glob Σ ->
+  forall t u, wellformed Σ 0 t -> eval Σ t u -> wellformed Σ 0 u.
+Proof.
+  move=> clΣ t u Hc ev. move: Hc.
+  induction ev; simpl in *; auto;
+    (move/andP=> [/andP[Hc Hc'] Hc''] || move/andP=> [Hc Hc'] || move=>Hc); auto.
+  all:eauto using wellformed_csubst.
+  - specialize (IHev1 Hc').
+    move: IHev1; rewrite wellformed_mkApps // => /andP[] wfc wfargs.
+    apply IHev2.
+    eapply wellformed_iota_red_brs; tea => //.
+  - subst brs. cbn in Hc''. rewrite andb_true_r in Hc''.
+    eapply IHev2. eapply wellformed_substl => //.
+    eapply All_forallb, All_repeat => //.
+    now rewrite repeat_length.
+  - eapply IHev3. apply/andP; split; [|easy].
+    specialize (IHev1 Hc).
+    rewrite wellformed_mkApps // in IHev1.
+    move/andP: IHev1 => [clfix clargs].
+    rewrite wellformed_mkApps // clargs andb_true_r.
+    eapply wellformed_cunfold_fix; tea => //.
+  - apply andb_true_iff. split; [|easy]. solve_all.
+  - eapply IHev3. rtoProp. split; eauto.
+    eapply wellformed_cunfold_fix => //; tea. eauto.
+  - eapply IHev2. rewrite wellformed_mkApps //.
+    rewrite wellformed_mkApps // in IHev1. 
+    specialize (IHev1 Hc'). move/andP: IHev1 => [Hfix Hargs].
+    repeat (apply/andP; split; auto).
+    eapply wellformed_cunfold_cofix => //; tea. 
+  - specialize (IHev1 Hc'). eapply IHev2. rewrite wellformed_mkApps // in IHev1 *.
+    move/andP: IHev1 => [Hfix Hargs].
+    rewrite wellformed_mkApps // Hargs andb_true_r Hc /=.
+    eapply wellformed_cunfold_cofix; tea => //.
+  - apply IHev.
+    move/(lookup_env_wellformed clΣ): isdecl.
+    now rewrite /wf_global_decl /= e /=.
+  - have := (IHev1 Hc').
+    rewrite wellformed_mkApps // /= => clargs.
+    eapply IHev2; eauto.
+    rewrite nth_nth_error.
+    destruct nth_error eqn:hnth => //.
+    move/andP: clargs => [wfc wfargs].
+    eapply nth_error_forallb in wfargs; tea.
+  - rtoProp; intuition auto.
+Qed.
 
 Lemma remove_last_length {X} {l : list X} : 
   #|remove_last l| = match l with nil => 0 | _ => #|l| - 1 end.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -2,7 +2,7 @@
 From Coq Require Import Utf8 Program ssreflect ssrbool.
 From MetaCoq.Template Require Import config utils Kernames BasicAst EnvMap.
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction EWcbvEval EGlobalEnv
-   ECSubst EInduction EWcbvEvalInd EEtaExpanded.
+  EWellformed ECSubst EInduction EWcbvEvalInd EEtaExpanded.
 
 Set Asymmetric Patterns.
 From Equations Require Import Equations.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -126,7 +126,7 @@ Class Qpreserves (Q : nat -> term -> Type) Σ :=
     qpres_qdummy :> Qdummy Q }.
 
 Lemma eval_preserve_mkApps_ind :
-∀ (wfl : WcbvFlags) (Σ : global_declarations) 
+∀ (wfl : WcbvFlags) {efl : EEnvFlags} (Σ : global_declarations) 
   (P' : term → term → Type)
   (Q : nat -> term -> Type)
   {Qpres : Qpreserves Q Σ}
@@ -641,7 +641,7 @@ Ltac destruct_nary_times :=
   | [ H : [× _, _, _, _ & _] |- _ ] => destruct H 
   end.
 
-Lemma eval_etaexp {fl : WcbvFlags} {Σ a a'} : 
+Lemma eval_etaexp {fl : WcbvFlags} {efl : EEnvFlags} {Σ a a'} : 
   isEtaExp_env Σ ->
   wf_glob Σ ->
   eval Σ a a' -> isEtaExp Σ a -> isEtaExp Σ a'.

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -138,6 +138,13 @@ Section EEnvFlags.
       unfold test_def, test_snd in *;
         try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; simpl in *; solve_all)]; try easy.
   Qed.
+  
+  Lemma wellformed_closed_decl {t} : wf_global_decl Σ t -> closed_decl t.
+  Proof.
+    destruct t => /= //.
+    destruct (cst_body c) => /= //.
+    eapply wellformed_closed.
+  Qed.
 
   Lemma wellformed_up {k t} : wellformed k t -> forall k', k <= k' -> wellformed k' t.
   Proof.
@@ -335,6 +342,15 @@ Section EEnvFlags.
   Qed.
 
 End EEnvFlags.
+
+Lemma wellformed_closed_env {efl} {Σ : global_declarations} : wf_glob Σ -> closed_env Σ.
+Proof.
+  induction 1; cbn; auto. 
+  apply/andP; split.
+  - unfold test_snd => /=.
+    now eapply wellformed_closed_decl.
+  - eapply IHwf_glob.
+Qed.
 
 Lemma extends_lookup {efl} {Σ Σ' c decl} :
   wf_glob Σ' ->

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -6,8 +6,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
      PCUICTyping PCUICInversion
      PCUICSafeLemmata. (* for welltyped *)
 From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
-From MetaCoq.Erasure Require Import EAst EAstUtils EDeps EExtends
-    ELiftSubst ECSubst EWcbvEval EGlobalEnv.
+From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst EGlobalEnv.
 
 Local Open Scope string_scope.
 Set Asymmetric Patterns.
@@ -18,11 +17,119 @@ Set Equations Transparent.
 Local Set Keyed Unification.
 Require Import ssreflect ssrbool.
 
+Definition isSome {A} (o : option A) := 
+  match o with 
+  | None => false
+  | Some _ => true
+  end.
+
+Class ETermFlags := 
+  { has_tBox : bool
+  ; has_tRel : bool
+  ; has_tVar : bool
+  ; has_tEvar : bool
+  ; has_tLambda : bool
+  ; has_tLetIn : bool
+  ; has_tApp : bool
+  ; has_tConst : bool
+  ; has_tConstruct : bool
+  ; has_tCase : bool
+  ; has_tProj : bool
+  ; has_tFix : bool
+  ; has_tCoFix : bool
+  }.
+
+Class EEnvFlags := {
+  has_axioms : bool;
+  has_cstr_params : bool;
+  term_switches :> ETermFlags }.
+  
+Definition all_term_flags := 
+  {| has_tBox := true
+    ; has_tRel := true
+    ; has_tVar := true
+    ; has_tEvar := true
+    ; has_tLambda := true
+    ; has_tLetIn := true
+    ; has_tApp := true
+    ; has_tConst := true
+    ; has_tConstruct := true
+    ; has_tCase := true
+    ; has_tProj := true
+    ; has_tFix := true
+    ; has_tCoFix := true
+  |}.
+
+Definition all_env_flags := 
+  {| has_axioms := true; 
+     term_switches := all_term_flags;
+     has_cstr_params := true |}.
+    
+Section wf.
+  
+  Context {sw  : EEnvFlags}.
+  Variable Σ : global_context.
+
+  (* a term term is wellformed if
+    - it is closed up to k,
+    - it only contains constructos as indicated by sw,
+    - all occuring constructors are defined,
+    - all occuring constants are defined, and
+    - if has_axioms is false, all occuring constants have bodies *)
+  
+  Fixpoint wellformed k (t : term) : bool :=
+    match t with
+    | tRel i => has_tRel && Nat.ltb i k
+    | tEvar ev args => has_tEvar && List.forallb (wellformed k) args
+    | tLambda _ M => has_tLambda && wellformed (S k) M
+    | tApp u v => has_tApp && wellformed k u && wellformed k v
+    | tLetIn na b b' => has_tLetIn && wellformed k b && wellformed (S k) b'
+    | tCase ind c brs => has_tCase && 
+      let brs' := List.forallb (fun br => wellformed (#|br.1| + k) br.2) brs in
+      isSome (lookup_inductive Σ ind.1) && wellformed k c && brs'
+    | tProj p c => has_tProj && isSome (lookup_inductive Σ p.1.1) && wellformed k c
+    | tFix mfix idx => has_tFix &&
+      let k' := List.length mfix + k in
+      List.forallb (test_def (wellformed k')) mfix
+    | tCoFix mfix idx => has_tCoFix &&
+      let k' := List.length mfix + k in
+      List.forallb (test_def (wellformed k')) mfix
+    | tBox => has_tBox
+    | tConst kn => has_tConst && 
+      match lookup_constant Σ kn with
+      | Some d => has_axioms || isSome d.(cst_body)
+      | _ => false 
+      end
+    | tConstruct ind c => has_tConstruct && isSome (lookup_constructor Σ ind c)
+    | tVar _ => has_tVar
+    end.
+
+End wf.
+
+
+Definition wf_global_decl {sw : EEnvFlags} Σ d : bool :=
+  match d with
+  | ConstantDecl cb => option_default (fun b => wellformed Σ 0 b) cb.(cst_body) has_axioms
+  | InductiveDecl idecl => has_cstr_params || (idecl.(ind_npars) == 0)
+  end.
+
+Inductive wf_glob {efl : EEnvFlags} : global_declarations -> Prop :=
+| wf_glob_nil : wf_glob []
+| wf_glob_cons kn d Σ : 
+  wf_glob Σ ->
+  wf_global_decl Σ d ->
+  fresh_global kn Σ ->
+  wf_glob ((kn, d) :: Σ).
+Derive Signature for wf_glob.
+
+Implicit Types (efl : EEnvFlags).
+
 Section EEnvFlags.
   Context {efl : EEnvFlags}.
   Context {Σ : global_declarations}.
+  Notation wellformed := (wellformed Σ).
   
-  Lemma wellformed_closed {k t} : wellformed Σ k t -> closedn k t.
+  Lemma wellformed_closed {k t} : wellformed k t -> closedn k t.
   Proof.
     induction t in k |- * using EInduction.term_forall_list_ind; intros;
       simpl in * ; rewrite -> ?andb_and in *;
@@ -32,7 +139,7 @@ Section EEnvFlags.
         try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; simpl in *; solve_all)]; try easy.
   Qed.
 
-  Lemma wellformed_up {k t} : wellformed Σ k t -> forall k', k <= k' -> wellformed Σ k' t.
+  Lemma wellformed_up {k t} : wellformed k t -> forall k', k <= k' -> wellformed k' t.
   Proof.
     induction t in k |- * using EInduction.term_forall_list_ind; intros;
       simpl in * ; rewrite -> ?andb_and in *;
@@ -43,7 +150,7 @@ Section EEnvFlags.
     eapply Nat.ltb_lt. now eapply Nat.ltb_lt in H2.
   Qed.
 
-  Lemma wellformed_lift n k k' t : wellformed Σ k t -> wellformed Σ (k + n) (lift n k' t).
+  Lemma wellformed_lift n k k' t : wellformed k t -> wellformed (k + n) (lift n k' t).
   Proof.
     revert k.
     induction t in n, k' |- * using EInduction.term_forall_list_ind; intros;
@@ -61,9 +168,9 @@ Section EEnvFlags.
   Qed.
 
   Lemma wellformed_subst_eq {s k k' t} {hast : has_tRel} :
-    forallb (wellformed Σ k) s -> 
-    wellformed Σ (k + k' + #|s|) t =
-    wellformed Σ (k + k') (subst s k' t).
+    forallb (wellformed k) s -> 
+    wellformed (k + k' + #|s|) t =
+    wellformed (k + k') (subst s k' t).
   Proof.
     intros Hs. solve_all. revert Hs.
     induction t in k' |- * using EInduction.term_forall_list_ind; intros;
@@ -107,8 +214,8 @@ Section EEnvFlags.
   Qed.
 
   Lemma wellformed_subst s k t {hast : has_tRel}: 
-    forallb (wellformed Σ k) s -> wellformed Σ (#|s| + k) t -> 
-    wellformed Σ k (subst0 s t).
+    forallb (wellformed k) s -> wellformed (#|s| + k) t -> 
+    wellformed k (subst0 s t).
   Proof.
     intros.
     unshelve epose proof (wellformed_subst_eq (k':=0) (t:=t) H); auto.
@@ -117,9 +224,9 @@ Section EEnvFlags.
   Qed.
 
   Lemma wellformed_csubst t k u {hast : has_tRel} : 
-    wellformed Σ 0 t -> 
-    wellformed Σ (S k) u -> 
-    wellformed Σ k (ECSubst.csubst t 0 u).
+    wellformed 0 t -> 
+    wellformed (S k) u -> 
+    wellformed k (ECSubst.csubst t 0 u).
   Proof.
     intros.
     rewrite ECSubst.closed_subst //.
@@ -129,9 +236,9 @@ Section EEnvFlags.
   Qed.
 
   Lemma wellformed_substl ts k u {hast : has_tRel}: 
-    forallb (wellformed Σ 0) ts -> 
-    wellformed Σ (#|ts| + k) u -> 
-    wellformed Σ k (ECSubst.substl ts u).
+    forallb (wellformed 0) ts -> 
+    wellformed (#|ts| + k) u -> 
+    wellformed k (ECSubst.substl ts u).
   Proof.
     induction ts in u |- *; cbn => //.
     move/andP=> [] cla clts.
@@ -139,4 +246,150 @@ Section EEnvFlags.
     eapply wellformed_csubst => //.
   Qed.
 
+  Lemma wellformed_fix_subst mfix {hast : has_tFix}: 
+    forallb (EAst.test_def (wellformed (#|mfix| + 0))) mfix ->
+    forallb (wellformed 0) (fix_subst mfix).
+  Proof.
+    solve_all.
+    unfold fix_subst.
+    move: #|mfix| => n.
+    induction n. constructor.
+    cbn. rewrite H IHn //. now rewrite hast.
+  Qed.
+
+  Lemma wellformed_cofix_subst mfix {hasco : has_tCoFix}: 
+    forallb (EAst.test_def (wellformed (#|mfix| + 0))) mfix ->
+    forallb (wellformed 0) (cofix_subst mfix).
+  Proof.
+    solve_all.
+    unfold cofix_subst.
+    move: #|mfix| => n.
+    induction n. constructor.
+    cbn. rewrite H IHn // hasco //.
+  Qed.
+
+  Lemma wellformed_cunfold_fix mfix idx n f {hast : has_tRel} : 
+    wellformed 0 (EAst.tFix mfix idx) ->
+    cunfold_fix mfix idx = Some (n, f) ->
+    wellformed 0 f.
+  Proof.
+    move=> cl.
+    rewrite /cunfold_fix.
+    destruct nth_error eqn:heq => //.
+    cbn in cl. move/andP: cl => [hastf cl].
+    have := (nth_error_forallb heq cl) => cld. 
+    move=> [=] _ <-.
+    eapply wellformed_substl => //. now eapply wellformed_fix_subst.
+    rewrite fix_subst_length.
+    apply cld.
+  Qed.
+
+  Lemma wellformed_cunfold_cofix mfix idx n f {hast : has_tRel} : 
+    wellformed 0 (EAst.tCoFix mfix idx) ->
+    cunfold_cofix mfix idx = Some (n, f) ->
+    wellformed 0 f.
+  Proof.
+    move=> cl.
+    rewrite /cunfold_cofix.
+    destruct nth_error eqn:heq => //.
+    cbn in cl. move/andP: cl => [hastf cl].
+    have := (nth_error_forallb heq cl) => cld. 
+    move=> [=] _ <-.
+    eapply wellformed_substl => //. now eapply wellformed_cofix_subst.
+    rewrite cofix_subst_length.
+    apply cld.
+  Qed.
+
+  Lemma wellformed_iota_red pars c args brs br {hast : has_tRel}:
+    forallb (wellformed 0) args ->
+    nth_error brs c = Some br ->
+    #|skipn pars args| = #|br.1| ->
+    wellformed #|br.1| br.2 ->
+    wellformed 0 (iota_red pars args br).
+  Proof.
+    intros clargs hnth hskip clbr.
+    rewrite /iota_red.
+    eapply wellformed_substl => //.
+    now rewrite forallb_rev forallb_skipn.
+    now rewrite List.rev_length hskip Nat.add_0_r.
+  Qed.
+
+  Lemma wellformed_iota_red_brs pars c args brs br {hast : has_tRel}:
+    forallb (wellformed 0) args ->
+    nth_error brs c = Some br ->
+    #|skipn pars args| = #|br.1| ->
+    forallb (fun br => wellformed (#|br.1| + 0) br.2) brs ->
+    wellformed 0 (iota_red pars args br).
+  Proof.
+    intros clargs hnth hskip clbr.
+    eapply wellformed_iota_red; tea => //.
+    eapply nth_error_forallb in clbr; tea.
+    now rewrite Nat.add_0_r in clbr.
+  Qed.
+
+  Lemma wellformed_mkApps n f args {hast : has_tApp} : wellformed n (mkApps f args) = wellformed n f && forallb (wellformed n) args.
+  Proof.
+    induction args using rev_ind; cbn; auto => //.
+    - now rewrite andb_true_r.
+    - now rewrite mkApps_app /= IHargs hast /= forallb_app /= // !andb_assoc andb_true_r.
+  Qed.
+
 End EEnvFlags.
+
+Lemma extends_lookup {efl} {Σ Σ' c decl} :
+  wf_glob Σ' ->
+  extends Σ Σ' ->
+  lookup_env Σ c = Some decl ->
+  lookup_env Σ' c = Some decl.
+Proof.
+  intros wfΣ' [Σ'' ->]. simpl.
+  induction Σ'' in wfΣ', c, decl |- *.
+  - simpl. auto.
+  - specialize (IHΣ'' c decl). forward IHΣ''.
+    + now inv wfΣ'.
+    + intros HΣ. specialize (IHΣ'' HΣ).
+      inv wfΣ'. simpl in *.
+      case: eqb_spec; intros e; subst; auto.
+      apply lookup_env_Some_fresh in IHΣ''; contradiction.
+Qed.
+
+Lemma extends_is_propositional {efl} {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind b, inductive_isprop_and_pars Σ ind = Some b -> inductive_isprop_and_pars Σ' ind = Some b.
+Proof.
+  intros wf ex ind b.
+  rewrite /inductive_isprop_and_pars.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+Qed.
+
+Lemma extends_wellformed {efl} {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall t n, wellformed Σ n t -> wellformed Σ' n t.
+Proof.
+  intros wf ex t.
+  induction t using EInduction.term_forall_list_ind; cbn => //; intros; rtoProp; intuition auto; solve_all.
+  all:destruct lookup_env eqn:hl => //; rewrite (extends_lookup wf ex hl).
+  all:destruct g => //.
+Qed.
+
+Lemma extends_wf_global_decl {efl} {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall t, wf_global_decl Σ t -> wf_global_decl Σ' t.
+Proof.
+  intros wf ex []; cbn => //.
+  destruct (cst_body c) => /= //.
+  now eapply extends_wellformed.
+Qed.
+
+Lemma lookup_env_wellformed {efl} {Σ kn decl} : wf_glob Σ -> 
+  EGlobalEnv.lookup_env Σ kn = Some decl -> wf_global_decl Σ decl.
+Proof.
+  induction Σ; cbn => //.
+  intros wf. depelim wf => /=.
+  destruct (eqb_spec kn kn0).
+  move=> [= <-]. eapply extends_wf_global_decl; tea. constructor; auto. now eexists [_].
+  intros hn.
+  eapply extends_wf_global_decl; tea. 3:eapply IHΣ => //.
+  now constructor. now eexists [_].
+Qed.

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -1,0 +1,142 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import Utf8 Program.
+From MetaCoq.Template Require Import config utils Kernames.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+     PCUICReflect PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
+     PCUICTyping PCUICInversion
+     PCUICSafeLemmata. (* for welltyped *)
+From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
+From MetaCoq.Erasure Require Import EAst EAstUtils EDeps EExtends
+    ELiftSubst ECSubst EWcbvEval EGlobalEnv.
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Import MCMonadNotation.
+
+From Equations Require Import Equations.
+Set Equations Transparent.
+Local Set Keyed Unification.
+Require Import ssreflect ssrbool.
+
+Section EEnvFlags.
+  Context {efl : EEnvFlags}.
+  Context {Σ : global_declarations}.
+  
+  Lemma wellformed_closed {k t} : wellformed Σ k t -> closedn k t.
+  Proof.
+    induction t in k |- * using EInduction.term_forall_list_ind; intros;
+      simpl in * ; rewrite -> ?andb_and in *;
+      autorewrite with map;
+      simpl wellformed in *; intuition auto;
+      unfold test_def, test_snd in *;
+        try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; simpl in *; solve_all)]; try easy.
+  Qed.
+
+  Lemma wellformed_up {k t} : wellformed Σ k t -> forall k', k <= k' -> wellformed Σ k' t.
+  Proof.
+    induction t in k |- * using EInduction.term_forall_list_ind; intros;
+      simpl in * ; rewrite -> ?andb_and in *;
+      autorewrite with map;
+      simpl wellformed in *; intuition auto;
+      unfold test_def, test_snd in *;
+        try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; simpl in *; solve_all)]; try easy.
+    eapply Nat.ltb_lt. now eapply Nat.ltb_lt in H2.
+  Qed.
+
+  Lemma wellformed_lift n k k' t : wellformed Σ k t -> wellformed Σ (k + n) (lift n k' t).
+  Proof.
+    revert k.
+    induction t in n, k' |- * using EInduction.term_forall_list_ind; intros;
+      simpl in *; rewrite -> ?andb_and in *;
+      autorewrite with map;
+      simpl closed in *; solve_all;
+      unfold test_def, test_snd in *;
+        try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; simpl in *; solve_all)]; try easy.
+
+    - elim (Nat.leb_spec k' n0); intros. simpl; rewrite H0 /=.
+      elim (Nat.ltb_spec); auto. apply Nat.ltb_lt in H1. lia.
+      simpl; rewrite H0 /=. elim (Nat.ltb_spec); auto. intros.
+      apply Nat.ltb_lt in H1. lia.
+    - solve_all. rewrite Nat.add_assoc. eauto.
+  Qed.
+
+  Lemma wellformed_subst_eq {s k k' t} {hast : has_tRel} :
+    forallb (wellformed Σ k) s -> 
+    wellformed Σ (k + k' + #|s|) t =
+    wellformed Σ (k + k') (subst s k' t).
+  Proof.
+    intros Hs. solve_all. revert Hs.
+    induction t in k' |- * using EInduction.term_forall_list_ind; intros;
+      simpl in *;
+      autorewrite with map => //;
+      simpl wellformed in *; try change_Sk;
+      unfold test_def in *; simpl in *;
+      solve_all.
+
+    - elim (Nat.leb_spec k' n); intros. simpl.
+      destruct nth_error eqn:Heq.
+      -- simpl. rewrite hast /=. rewrite wellformed_lift.
+        now eapply nth_error_all in Heq; simpl; eauto; simpl in *.
+        eapply nth_error_Some_length in Heq.
+        eapply Nat.ltb_lt. lia.
+      -- simpl. elim (Nat.ltb_spec); auto. intros. f_equal.
+        apply nth_error_None in Heq. symmetry. apply Nat.ltb_lt. lia.
+        apply nth_error_None in Heq. intros. symmetry. f_equal. eapply Nat.ltb_nlt.
+        intros H'. lia.
+      -- simpl. f_equal.
+        elim: Nat.ltb_spec; symmetry. apply Nat.ltb_lt. lia.
+        apply Nat.ltb_nlt. intro. lia.
+    - f_equal. simpl. solve_all.
+      specialize (IHt (S k')).
+      rewrite <- Nat.add_succ_comm in IHt.
+      rewrite IHt //. 
+    - specialize (IHt2 (S k')).
+      rewrite <- Nat.add_succ_comm in IHt2.
+      rewrite IHt1 // IHt2 //.
+    - rewrite IHt //.
+      f_equal. f_equal. eapply All_forallb_eq_forallb; tea. cbn.
+      intros. specialize (H (#|x.1| + k')).
+      rewrite Nat.add_assoc (Nat.add_comm k) in H.
+      now rewrite !Nat.add_assoc.
+    - f_equal. eapply All_forallb_eq_forallb; tea. cbn.
+      intros. specialize (H (#|m| + k')).
+      now rewrite !Nat.add_assoc !(Nat.add_comm k) in H |- *.
+    - f_equal. eapply All_forallb_eq_forallb; tea. cbn.
+      intros. specialize (H (#|m| + k')).
+      now rewrite !Nat.add_assoc !(Nat.add_comm k) in H |- *.
+  Qed.
+
+  Lemma wellformed_subst s k t {hast : has_tRel}: 
+    forallb (wellformed Σ k) s -> wellformed Σ (#|s| + k) t -> 
+    wellformed Σ k (subst0 s t).
+  Proof.
+    intros.
+    unshelve epose proof (wellformed_subst_eq (k':=0) (t:=t) H); auto.
+    rewrite Nat.add_0_r in H1.
+    rewrite -H1 // Nat.add_comm //.
+  Qed.
+
+  Lemma wellformed_csubst t k u {hast : has_tRel} : 
+    wellformed Σ 0 t -> 
+    wellformed Σ (S k) u -> 
+    wellformed Σ k (ECSubst.csubst t 0 u).
+  Proof.
+    intros.
+    rewrite ECSubst.closed_subst //.
+    now eapply wellformed_closed.
+    eapply wellformed_subst => /= //.
+    rewrite andb_true_r. eapply wellformed_up; tea. lia.
+  Qed.
+
+  Lemma wellformed_substl ts k u {hast : has_tRel}: 
+    forallb (wellformed Σ 0) ts -> 
+    wellformed Σ (#|ts| + k) u -> 
+    wellformed Σ k (ECSubst.substl ts u).
+  Proof.
+    induction ts in u |- *; cbn => //.
+    move/andP=> [] cla clts.
+    intros clu. eapply IHts => //.
+    eapply wellformed_csubst => //.
+  Qed.
+
+End EEnvFlags.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -28,29 +28,6 @@ Local Set Keyed Unification.
 
 Local Existing Instance config.extraction_checker_flags.
 
-(** Flags governing what can appear in the target asts and global environments *)
-
-Definition erased_term_flags := 
-  {| has_tBox := true
-    ; has_tRel := true
-    ; has_tVar := true
-    ; has_tEvar := true
-    ; has_tLambda := true
-    ; has_tLetIn := true
-    ; has_tApp := true
-    ; has_tConst := true
-    ; has_tConstruct := true
-    ; has_tCase := true
-    ; has_tProj := true
-    ; has_tFix := true
-    ; has_tCoFix := true
-  |}.
-
-Definition erased_env_flags := 
-  {| has_axioms := true; 
-     term_switches := erased_term_flags;
-     has_cstr_params := true |}.
-
 (** ** Prelim on arities and proofs *)
 
 Lemma isErasable_subst_instance (Σ : global_env_ext) Γ T univs u :

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -603,7 +603,7 @@ Section trans_lookups.
 End trans_lookups.
 
 Lemma erases_wellformed {Σ : global_env_ext} {wfΣ : wf Σ} {Γ a e} : welltyped Σ Γ a -> Σ ;;; Γ |- a ⇝ℇ e -> 
-  forall Σ', globals_erased_with_deps Σ Σ' -> @EGlobalEnv.wellformed erased_env_flags Σ' #|Γ| e.
+  forall Σ', globals_erased_with_deps Σ Σ' -> @EWellformed.wellformed EWellformed.all_env_flags Σ' #|Γ| e.
 Proof.
   intros wf.
   generalize (welltyped_wellformed wf).
@@ -646,7 +646,6 @@ Proof.
     rewrite <-H0. rewrite fix_context_length in b.
     eapply b. now move: b0 => /andP[]. eauto. now rewrite app_length fix_context_length. tea.
 Qed.
-
 
 Lemma eval_to_mkApps_tBox_inv {wfl:WcbvFlags} Σ t argsv :
   Σ ⊢ t ▷ E.mkApps E.tBox argsv ->
@@ -1966,7 +1965,7 @@ Proof.
            ++ eauto.
            ++ eauto.
            ++ eauto.
-           ++ unfold Ee.cunfold_fix. now rewrite e0.
+           ++ unfold EGlobalEnv.cunfold_fix. now rewrite e0.
            ++ eapply Forall2_length in H5. noconf e. lia.
               
         -- exists E.tBox.
@@ -2077,7 +2076,7 @@ Proof.
             - now eapply nth_error_forall in H2; eauto. }
           exists v'. split => //. split.
           eapply Ee.eval_cofix_case; tea.
-          rewrite /Ee.cunfold_cofix nth' //. f_equal.
+          rewrite /EGlobalEnv.cunfold_cofix nth' //. f_equal.
           f_equal.
           rewrite -(Ee.closed_cofix_substl_subst_eq (idx:=idx)) //. }
         { eapply eval_to_mkApps_tBox_inv in H1 as H'; subst L'; cbn in *. depelim hl'.
@@ -2196,7 +2195,7 @@ Proof.
             - now eapply nth_error_forall in H1; eauto. }
           exists v'. split => //. split.
           eapply Ee.eval_cofix_proj; tea.
-          rewrite /Ee.cunfold_cofix nth' //. f_equal.
+          rewrite /EGlobalEnv.cunfold_cofix nth' //. f_equal.
           f_equal.
           rewrite -(Ee.closed_cofix_substl_subst_eq (idx:=idx)) //. }
         { eapply eval_to_mkApps_tBox_inv in H3 as H'; subst L'; cbn in *. depelim hl'.
@@ -2321,7 +2320,9 @@ Proof.
   induction 2; constructor; eauto; now depelim H.
 Qed.
 
-Lemma erases_global_wf_glob {Σ : global_env} Σ' : wf Σ -> erases_global Σ Σ' -> @wf_glob erased_env_flags Σ'.
+Import EWellformed.
+
+Lemma erases_global_wf_glob {Σ : global_env} Σ' : wf Σ -> erases_global Σ Σ' -> @wf_glob all_env_flags Σ'.
 Proof.
   destruct Σ as [univs Σ]; cbn in *.
   intros [onu wf] er; cbn in *.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -1919,9 +1919,11 @@ Proof.
            eapply expanded_tFix.
            3:{ destruct args; cbn in *; congruence. }
           { rewrite erase_mfix_eq. solve_all. eapply All_map_All.
-            intros. eapply H0. intros. cbn in H |- *. destruct H.
-            eapply apply_expanded. eapply e1. eauto.
-            2: reflexivity. 2: eauto.
+            intros. eapply H0. intros. cbn in H |- *. destruct H as [[isl H] H'].
+            split. 3:reflexivity.
+            { eapply erases_isLambda. unshelve eapply erases_erase; tea. exact isl. }
+            eapply apply_expanded. eapply H'. eauto.
+            2: eauto.
             rewrite !rev_map_spec. do 2 f_equal. clear. 
             generalize (erase_obligation_13 Σ Γ mfix idx Hyp0).
             generalize (fix_context mfix). generalize mfix. clear.
@@ -2222,11 +2224,12 @@ Lemma expanded_weakening_global Σ deps deps' Γ t :
 Proof.
   intros hs.
   eapply expanded_ind; intros; try solve [econstructor; eauto].
-  eapply expanded_tConstruct_app; tea.
-  destruct H. split; tea.
-  destruct d; split => //.
-  cbn in *. red in H.
-  eapply lookup_erase_global in H; tea.
+  - eapply expanded_tFix; tea. solve_all.
+  - eapply expanded_tConstruct_app; tea.
+    destruct H. split; tea.
+    destruct d; split => //.
+    cbn in *. red in H.
+    eapply lookup_erase_global in H; tea.
 Qed.
 
 Lemma expanded_erase (cf := config.extraction_checker_flags) {Σ : wf_env} univs wfΣ t wtp :

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -38,12 +38,6 @@ Fixpoint mkAppBox c n :=
   | S n => mkAppBox (E.tApp c E.tBox) n
   end.
 
-Definition is_box c :=
-  match EAstUtils.head c with
-  | E.tBox => true
-  | _ => false
-  end.
-
 Reserved Notation "Σ ;;; Γ |- s ⇝ℇ t" (at level 50, Γ, s, t at next level).
 
 Definition erase_context (Γ : context) : list name :=

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -80,10 +80,9 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
   | erases_tFix : forall (mfix : mfixpoint term) (n : nat) (mfix' : list (E.def E.term)),
                   All2
                     (fun (d : def term) (d' : E.def E.term) =>
-                     d.(dname).(binder_name) = E.dname d'
-                     × rarg d = E.rarg d'
-                       × Σ;;; Γ ,,, fix_context mfix |-
-                         dbody d ⇝ℇ E.dbody d') mfix mfix' ->
+                     [× d.(dname).(binder_name) = E.dname d', rarg d = E.rarg d',
+                      isLambda (dbody d), E.isLambda (E.dbody d') &
+                      Σ;;; Γ ,,, fix_context mfix |- dbody d ⇝ℇ E.dbody d']) mfix mfix' ->
                   Σ;;; Γ |- tFix mfix n ⇝ℇ E.tFix mfix' n
   | erases_tCoFix : forall (mfix : mfixpoint term) (n : nat) (mfix' : list (E.def E.term)),
                     All2
@@ -140,9 +139,10 @@ Lemma erases_forall_list_ind
       (Hfix : forall Γ mfix n mfix',
           All2
             (fun d d' =>
-               (dname d).(binder_name) = E.dname d' ×
-               rarg d = E.rarg d' ×
-               Σ;;; app_context Γ (fix_context mfix) |- dbody d ⇝ℇ E.dbody d')
+               [× (dname d).(binder_name) = E.dname d',
+                  rarg d = E.rarg d',
+                  isLambda (dbody d), E.isLambda (E.dbody d') &
+               Σ;;; app_context Γ (fix_context mfix) |- dbody d ⇝ℇ E.dbody d'])
             mfix mfix' ->
           Forall2 (fun d d' =>
                      P (app_context Γ (fix_context mfix))
@@ -192,7 +192,7 @@ Proof.
     revert mfix mfix'.
     fix f' 3.
     intros mfix mfix' []; [now constructor|].
-    constructor; [now apply f|now apply f'].
+    destruct a. constructor; [now apply f|now apply f'].
   - apply Hcofix; try assumption.
     revert X.
     generalize mfix at 1 3.

--- a/pcuic/theories/Conversion/PCUICInstConv.v
+++ b/pcuic/theories/Conversion/PCUICInstConv.v
@@ -1014,6 +1014,10 @@ Lemma inst_wf_fixpoint Σ f mfix :
   wf_fixpoint Σ (map (map_def (inst f) (inst (up #|mfix| f))) mfix).
 Proof.
   unfold wf_fixpoint, wf_fixpoint_gen.
+  move/andb_and => [] hmfix ho.
+  apply/andP; split.
+  { rewrite forallb_map; eapply forallb_impl; tea; cbn => x hx hl.
+    destruct (dbody x) => /= //. }
   rewrite map_map_compose.
   destruct (map_option_out (map check_one_fix mfix)) as [[]|] eqn:hmap => //.
   eapply map_option_out_impl in hmap.

--- a/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
+++ b/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
@@ -456,6 +456,7 @@ Lemma extends_wf_fixpoint {cf:checker_flags} (Σ Σ' : global_env_ext) mfix : ex
 Proof.
   intros ext wfΣ'.
   unfold wf_fixpoint, wf_fixpoint_gen.
+  move/andb_and => [] -> /=.
   destruct map_option_out as [[|ind inds]|]; auto.
   move/andb_and => [->] /=.
   now apply extends_check_recursivity_kind.

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -909,7 +909,13 @@ Section Alpha.
           all: intros ? ? []; reflexivity.
         * revert wffix.
           unfold wf_fixpoint, wf_fixpoint_gen.
-          enough (map check_one_fix mfix = map check_one_fix mfix') as ->; auto.
+          move/andP => [] hm ho.
+          apply/andP; split.
+          { solve_all. move: b b3.
+            generalize (dbody x) (dbody y).
+            clear=> t t' isL eq.
+            destruct t => //. now depelim eq. }
+          move: ho; enough (map check_one_fix mfix = map check_one_fix mfix') as ->; auto.
           apply upto_names_check_fix. solve_all.
         + eapply All_nth_error in ihmfix as [s [Hs _]]; eauto. exists s; apply Hs.
         + apply eq_term_upto_univ_cumulSpec, eq_term_leq_term, upto_names_impl_eq_term.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -19,6 +19,8 @@ Local Existing Instance config.extraction_checker_flags.
 Require Import Equations.Prop.DepElim.
 Require Import ssreflect ssrbool.
 
+Set Default Proof Using "Type*".
+
 Lemma negb_False (p : bool) : negb p -> p -> False.
 Proof.
 intros n pos. rewrite pos in n => //.
@@ -148,7 +150,7 @@ Section Spines.
     destruct E as [kn [Hl Hcheck]].
     destruct l as [|hd tl].
     now rewrite nth_error_nil in Hl => //.
-    move/andP=> [eqhd checkrec].
+    move/and3P=> [hmfix eqhd checkrec].
     exists kn. split; auto.
     enough (hd = kn) as -> => //.
     clear -Hl eqhd.
@@ -156,6 +158,7 @@ Section Spines.
     destruct idx; simpl in Hl; [congruence|].
     eapply All_nth_error in eqhd; eauto.
     now eapply ReflectEq.eqb_eq in eqhd.
+    rewrite andb_false_r => //.
   Qed.
 
   Lemma wf_cofixpoint_inv mfix idx decl :

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -2709,10 +2709,13 @@ Lemma trans_wf_fixpoint Σ p n mfix :
 Proof.
   intros hmfix.
   unfold ST.wf_fixpoint, TT.wf_fixpoint, ST.wf_fixpoint_gen, TT.wf_fixpoint_gen.
-  rewrite map_map_compose.
-  rewrite (map_option_out_check_one_fix hmfix).
-  destruct map_option_out as [[]|] => //.
-  now rewrite (trans_check_rec_kind Σ).
+  f_equal.
+  - rewrite forallb_map /=.
+    setoid_rewrite trans_isLambda => //.
+  - rewrite map_map_compose.
+    rewrite (map_option_out_check_one_fix hmfix).
+    destruct map_option_out as [[]|] => //.
+    now rewrite (trans_check_rec_kind Σ).
 Qed.
 
 Lemma trans_wf_cofixpoint Σ mfix :
@@ -5377,6 +5380,7 @@ Proof.
     len; exact e0.
     now len.
   - rewrite trans_mkApps. cbn. eapply expanded_tFix. solve_all.
+    rewrite trans_isLambda //.
     rewrite rev_map_spec. rewrite rev_map_spec in b.
     rewrite map_map_compose. cbn. exact b. solve_all.
     destruct args => //. now rewrite nth_error_map H4. len. now cbn.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -236,6 +236,14 @@ Proof.
   intros []. red in H. now rewrite /lookup_minductive H H0.
 Qed.
 
+Lemma declared_constructor_lookup Σ id mdecl idecl cdecl :
+  declared_constructor Σ id mdecl idecl cdecl -> 
+  lookup_constructor Σ id.1 id.2 = Some (mdecl, idecl, cdecl).
+Proof.
+  intros []. unfold lookup_constructor.
+  rewrite (declared_inductive_lookup_inductive (Σ := empty_ext Σ) H) /= H0 //.
+Qed.
+
 Section OnInductives.
   Context {cf : checker_flags} {Σ : global_env} {wfΣ : wf Σ} {mdecl ind idecl}
     (decli : declared_inductive Σ ind mdecl idecl).

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -39,6 +39,12 @@ Lemma wf_fixpoint_red1_type {cf Σ} {wfΣ : wf Σ} Γ mfix mfix1 :
 Proof.
   intros wffix o.
   move: wffix; unfold wf_fixpoint, wf_fixpoint_gen.
+  move/andb_and => [] isl wf. apply/andP; split.
+  { clear wf. solve_all.
+    revert isl. 
+    induction o; depelim isl; constructor; auto. destruct p.
+    destruct c. noconf e. congruence. }
+  clear isl. move: wf.
   enough (forall inds, map_option_out (map check_one_fix mfix) = Some inds ->
      map_option_out (map check_one_fix mfix1) = Some inds) => //.
   destruct map_option_out. now specialize (H _ eq_refl) as ->.
@@ -79,6 +85,14 @@ Lemma wf_fixpoint_red1_body {cf Σ} {wfΣ : wf Σ} Γ mfix mfix1 :
 Proof.
   intros wffix o.
   move: wffix; unfold wf_fixpoint, wf_fixpoint_gen.
+  move/andb_and => [] isl wf. apply/andP; split.
+  { clear wf. solve_all.
+    revert isl. 
+    induction o; depelim isl; constructor; auto. destruct p.
+    destruct c. noconf e.
+    destruct (dbody hd) => //. depelim clrel_rel; solve_discr.
+    now rewrite H. now rewrite H. }
+  clear isl. move: wf.
   enough (map check_one_fix mfix = map check_one_fix mfix1) as -> => //.
   induction o.
   - simpl. f_equal.

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -18,6 +18,7 @@ From MetaCoq.PCUIC Require Import PCUICEquality PCUICToTemplate.
 Import MCMonadNotation.
 
 Implicit Types cf : checker_flags. (* Use {cf} to parameterize by checker_flags where needed *)
+Set Default Proof Using "Type*".
 
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -1780,8 +1781,11 @@ Proof.
   unfold ST.wf_fixpoint, ST.wf_fixpoint_gen, TT.wf_fixpoint.
   rewrite map_map_compose.
   rewrite map_option_out_check_one_fix.
-  destruct map_option_out as [[]|] => //.
-  now rewrite trans_check_rec_kind.
+  f_equal.
+  - rewrite forallb_map. apply forallb_ext => d.
+    rewrite /= trans_isLambda //.
+  - destruct map_option_out as [[]|] => //.
+    now rewrite trans_check_rec_kind.
 Qed.
 
 Lemma trans_wf_cofixpoint Σ mfix :

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -104,6 +104,7 @@ Definition check_one_fix d :=
 
 Definition wf_fixpoint_gen
   (lookup: kername -> option global_decl) mfix :=
+  forallb (isLambda ∘ dbody) mfix &&
   let checks := map check_one_fix mfix in
   match map_option_out checks with
   | Some (ind :: inds) =>

--- a/pcuic/theories/TemplateToPCUICExpanded.v
+++ b/pcuic/theories/TemplateToPCUICExpanded.v
@@ -145,6 +145,7 @@ Proof.
   all:try solve [econstructor; eauto].
   - econstructor; eauto. solve_all. sq. eapply All_fold_impl; tea; cbn.
     intros ? ? []; constructor; auto. now rewrite <- repeat_app.
+  - eapply expanded_tFix; tea; eauto. solve_all.
   - eapply expanded_tConstruct_app; tea.
     eapply weakening_env_declared_constructor; tea. now eapply extends_decls_extends.
 Qed.
@@ -226,7 +227,9 @@ Proof with eauto using expanded.
     + eapply template_to_pcuic_env; eauto.
   - now (wf_inv wf [[]]; eauto using expanded).
   - wf_inv wf [[]]. wf_inv w ?. eapply expanded_tFix.
-    + solve_all. revert H0. now rewrite mapi_cst_map rev_map_spec map_map.
+    + solve_all.
+      * rewrite trans_isLambda //.
+      * revert H2. cbn. now rewrite mapi_cst_map rev_map_spec map_map.
     + solve_all.
     + destruct args; cbn; congruence.
     + now rewrite nth_error_map H5.

--- a/pcuic/theories/Typing/PCUICNamelessTyp.v
+++ b/pcuic/theories/Typing/PCUICNamelessTyp.v
@@ -58,6 +58,8 @@ Lemma nl_wf_fixpoint Σ mfix :
   wf_fixpoint Σ.1 mfix = wf_fixpoint (nlg Σ) (map (map_def_anon nl nl) mfix).
 Proof.
   unfold wf_fixpoint, wf_fixpoint_gen.
+  f_equal.
+  { rewrite forallb_map. eapply forallb_ext => x. cbn. destruct (dbody x) => //. }
   replace (map check_one_fix mfix) with (map check_one_fix (map (map_def_anon nl nl) mfix)) => //.
   * destruct map_option_out => //. destruct l => //.
     f_equal. rewrite /check_recursivity_kind.

--- a/pcuic/theories/Typing/PCUICRenameTyp.v
+++ b/pcuic/theories/Typing/PCUICRenameTyp.v
@@ -733,6 +733,12 @@ Lemma rename_wf_fixpoint Σ f mfix :
   wf_fixpoint Σ (map (map_def (rename f) (rename (shiftn #|mfix| f))) mfix).
 Proof.
   unfold wf_fixpoint, wf_fixpoint_gen.
+  rewrite forallb_map.
+  move/andP => [] hmfix ho.
+  apply/andP; split. 
+  { eapply forallb_impl; tea. intros. cbn in H0.
+    now eapply isLambda_rename. }
+  move: ho.
   rewrite map_map_compose.
   destruct (map_option_out (map check_one_fix mfix)) as [[]|] eqn:hmap => //.
   eapply map_option_out_impl in hmap.

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -334,6 +334,9 @@ Proof.
       now len.
     + red; rewrite <- wffix.
       unfold wf_fixpoint, wf_fixpoint_gen.
+      f_equal. 
+      { rewrite forallb_map. solve_all. cbn. 
+        destruct (dbody x) => //. }
       rewrite map_map_compose.
       now rewrite subst_instance_check_one_fix.
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -703,6 +703,7 @@ Definition check_one_fix d :=
   end.
 
 Definition wf_fixpoint (Σ : global_env) mfix :=
+  forallb (isLambda ∘ dbody) mfix &&
   let checks := map check_one_fix mfix in
   match map_option_out checks with
   | Some (ind :: inds) =>


### PR DESCRIPTION
We show that the erasure optimizations (removing singleton cases/projections and stripping parameters of constructors) preserve well-formedness of terms and eta expansion. The erasure pipeline also switches from the guarded to unguarded fixpoints, which is proved sound thanks to the eta expansion of fixpoints at the beginning of the pipeline.
At the end of erasure we now have the following properties:
- programs are well-scoped globally (global references are all declared) and locally. This is slightly tricky to prove because erasure shrinks the global context to only include the necessary dependencies of the erased term, while lookups are performed from an unmodified single global environment for efficiency.
- all constructors are eta expanded and all inductives in the environments have 0 parameters.
- the evaluation doesn't need to consider singleton elimination or guarded fixpoint rules. This matches CertiCoq's L2k evaluation rules.
- **Fixpoint bodies all start with a lambda**. This required modifying the erasure relation and function to preserve this, even when the body of a fixpoint gets erased to tBox, we introduce a dummy lambda to simplify work in target languages and keep the treatment of tBox orthogonal to fixpoints. For example, both malfunction and certicoq expect the unfolding of a fixpoint to start with a lambda.