### PR TITLE
Strict eta expanded constructors

### DIFF
--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -73,8 +73,6 @@ src/templateToPCUIC.mli
 src/templateToPCUIC.ml
 src/pCUICExpandLets.mli
 src/pCUICExpandLets.ml
-src/pCUICExpandLetsCorrectness.mli
-src/pCUICExpandLetsCorrectness.ml
 src/pCUICProgram.mli
 src/pCUICProgram.ml
 src/pCUICTransform.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -27,7 +27,6 @@ PCUICWcbvEval
 PCUICProgram
 TemplateToPCUIC
 PCUICExpandLets
-PCUICExpandLetsCorrectness
 PCUICTransform
 
 PCUICErrors

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -326,12 +326,11 @@ Proof.
     intuition auto.
     apply erases_deps_mkApps_inv in H3 as (? & ?).
     apply IHev2.
-    rewrite nth_nth_error.
-    destruct nth_error eqn:nth; [|now constructor].
-    now eapply nth_error_forall in nth.
+    now eapply nth_error_forall in e1.
   - constructor.
   - depelim er.
     now constructor.
+  - depelim er. now constructor.
   - easy.
 Qed.
 
@@ -559,7 +558,7 @@ Lemma erases_declared_constructor {Σ : global_env_ext} Σ' kn k mind idecl cdec
   globals_erased_with_deps Σ Σ' ->
   exists mind' idecl', (* declared_inductive Σ' (kn, k).1 mind' idecl' ->
   erases_one_inductive_body idecl idecl' -> *)
-  declared_constructor Σ' (kn, k) mind' idecl' (cstr_name cdecl, cstr_arity cdecl) /\
+  declared_constructor Σ' (kn, k) mind' idecl' (cstr_name cdecl, PCUICEnvironment.cstr_arity cdecl) /\
   erases_one_inductive_body idecl idecl' /\
   erases_mutual_inductive_body mind mind'.
 Proof.

--- a/erasure/theories/EEnvMap.v
+++ b/erasure/theories/EEnvMap.v
@@ -45,6 +45,17 @@ Module GlobalContextMap.
     rewrite /lookup_inductive /EGlobalEnv.lookup_inductive.
     rewrite lookup_minductive_spec //.
   Qed.
+
+  Definition lookup_constructor Σ kn c : option (mutual_inductive_body * one_inductive_body * (ident * nat)) :=
+    '(mdecl, idecl) <- lookup_inductive Σ kn ;;
+    cdecl <- nth_error idecl.(ind_ctors) c ;;
+    ret (mdecl, idecl, cdecl).  
+
+  Lemma lookup_constructor_spec Σ kn : lookup_constructor Σ kn = EGlobalEnv.lookup_constructor Σ kn.
+  Proof.
+    rewrite /lookup_constructor /EGlobalEnv.lookup_constructor.
+    rewrite lookup_inductive_spec //.
+  Qed.
     
   Definition lookup_inductive_pars Σ kn : option nat := 
     mdecl <- lookup_minductive Σ kn ;;
@@ -65,6 +76,17 @@ Module GlobalContextMap.
   Proof.
     rewrite /inductive_isprop_and_pars /EGlobalEnv.inductive_isprop_and_pars.
     now rewrite lookup_inductive_spec.
+  Qed.
+
+  Definition constructor_isprop_pars_decl Σ (ind : inductive) (c : nat) :=
+    '(mdecl, idecl, cdecl) <- lookup_constructor Σ ind c ;;
+    ret (ind_propositional idecl, ind_npars mdecl, cdecl).
+  
+  Lemma constructor_isprop_pars_decl_spec Σ kn : 
+    constructor_isprop_pars_decl Σ kn = EGlobalEnv.constructor_isprop_pars_decl Σ kn.
+  Proof.
+    rewrite /constructor_isprop_pars_decl /EGlobalEnv.constructor_isprop_pars_decl.
+    rewrite lookup_constructor_spec //.
   Qed.
 
   Program Definition make (g : global_declarations) (Hg : EnvMap.fresh_globals g): t :=

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -139,7 +139,7 @@ Section isEtaExp.
     intros napp.
     destruct v using rev_case; simp_eta.
     - destruct construct_viewc; rewrite andb_true_r //.
-    - rewrite isEtaExp_mkApps_nonnil //. now destruct v; cbn; congruence.
+    - rewrite isEtaExp_mkApps_nonnil //.
   Qed.
 
   Lemma isEtaExp_Constructor ind i v :
@@ -634,7 +634,7 @@ Proof.
     noconf H3.
     eapply expanded_tConstruct_app; tea. cbn in H0. lia. solve_all.
   - destruct args using rev_ind; cbn => //.
-    eapply expanded_mkApps => //. now rewrite eqc. eapply app_tip_nil. solve_all.
+    eapply expanded_mkApps => //. now rewrite eqc. solve_all.
 Qed.
 
 From MetaCoq.Erasure Require Import EEtaExpandedFix.

--- a/erasure/theories/EGlobalEnv.v
+++ b/erasure/theories/EGlobalEnv.v
@@ -88,6 +88,10 @@ Definition inductive_isprop_and_pars Σ ind :=
   '(mdecl, idecl) <- lookup_inductive Σ ind ;;
   ret (idecl.(ind_propositional), mdecl.(ind_npars)).
 
+Definition constructor_isprop_pars_decl Σ ind c :=
+  '(mdecl, idecl, cdecl) <- lookup_constructor Σ ind c ;;
+  ret (idecl.(ind_propositional), mdecl.(ind_npars), cdecl).
+  
 Definition closed_decl (d : EAst.global_decl) := 
   match d with
   | EAst.ConstantDecl cb => 

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -61,7 +61,7 @@ Definition all_term_flags :=
   |}.
 
 Definition all_env_flags := 
-  {| has_axioms := true; 
+  {| has_axioms := true;
      term_switches := all_term_flags;
      has_cstr_params := true |}.
     
@@ -367,6 +367,29 @@ Proof.
       inv wfΣ'. simpl in *.
       case: eqb_spec; intros e; subst; auto.
       apply lookup_env_Some_fresh in IHΣ''; contradiction.
+Qed.
+
+
+Lemma extends_lookup_constructor {efl} {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind c b, lookup_constructor Σ ind c = Some b -> 
+    lookup_constructor Σ' ind c = Some b.
+Proof.
+  intros wf ex ind c b.
+  rewrite /lookup_constructor /lookup_inductive /lookup_minductive.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+Qed.
+
+Lemma extends_constructor_isprop_pars_decl {efl} {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind c b, constructor_isprop_pars_decl Σ ind c = Some b -> 
+    constructor_isprop_pars_decl Σ' ind c = Some b.
+Proof.
+  intros wf ex ind c b.
+  rewrite /constructor_isprop_pars_decl.
+  destruct lookup_constructor eqn:lookup => //.
+  now rewrite (extends_lookup_constructor wf ex _ _ _ lookup).
 Qed.
 
 Lemma extends_is_propositional {efl} {Σ Σ'} : 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1358,8 +1358,6 @@ Proof.
   rewrite (edeclared_inductive_lookup H) /= H0 //.
 Qed.
 
-From MetaCoq.PCUIC Require PCUICExpandLetsCorrectness.
-
 Arguments inductive_isprop_and_pars : simpl never.
 
 Lemma erases_correct (wfl := default_wcbv_flags) Σ t T t' v Σ' :
@@ -1666,9 +1664,7 @@ Proof.
           with (context_assumptions (cstr_branch_context ind mdecl cdecl)).
          2:{ eapply assumption_context_assumptions.
              eapply (assumption_context_cstr_branch_context d). }
-         rewrite e0 /cstr_arity e1.
-         rewrite PCUICExpandLetsCorrectness.cstr_branch_context_assumptions.
-         lia.
+         rewrite e0 /cstr_arity e1 cstr_branch_context_assumptions; lia.
       -- eapply Is_type_app in X1 as []; auto.
          2:{ eapply subject_reduction_eval. 2:eassumption. eauto. }
          assert (ispind : inductive_isprop_and_pars Σ' ind = Some (true, ind_npars mdecl)).

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -437,11 +437,16 @@ Lemma is_FixApp_erases Σ Γ t t' :
   negb (isFixApp t) -> negb (Ee.isFixApp t').
 Proof.
   induction 1; cbn; try congruence.
-  - unfold isFixApp in *. clear IHerases2.
+  - unfold isFixApp, head in *. cbn. clear IHerases2.
     cbn. rewrite PCUICAstUtils.fst_decompose_app_rec.
-    unfold Ee.isFixApp in *.
+    unfold Ee.isFixApp, EAstUtils.head in *.
     cbn. rewrite fst_decompose_app_rec. eassumption.
 Qed.
+
+Lemma is_ConstructApp_erases Σ Γ t t' :
+  Σ;;; Γ |- t ⇝ℇ t' ->
+  negb (isConstructApp t) -> negb (Ee.isConstructApp t').
+Proof. apply is_construct_erases. Qed.
 
 Lemma type_closed_subst {Σ t T} u : wf_ext Σ ->
   Σ ;;; [] |- t : T ->
@@ -960,6 +965,44 @@ Proof.
   rewrite isP. intros ->. f_equal. f_equal. now rewrite indp.
 Qed.
 
+Lemma declared_inductive_lookup_inductive {Σ ind mdecl idecl} :
+  EGlobalEnv.declared_inductive Σ ind mdecl idecl ->
+  EGlobalEnv.lookup_inductive Σ ind = Some (mdecl, idecl).
+Proof.
+  rewrite /EGlobalEnv.declared_inductive /EGlobalEnv.lookup_inductive.
+  intros []. red in H. rewrite /EGlobalEnv.lookup_minductive H /= H0 //.
+Qed.
+
+
+Lemma isPropositional_propositional_cstr Σ Σ' ind c mdecl idecl cdecl mdecl' idecl' : 
+  wf Σ ->
+  PCUICAst.declared_constructor Σ (ind, c) mdecl idecl cdecl ->
+  EGlobalEnv.declared_inductive Σ' ind mdecl' idecl' ->
+  erases_mutual_inductive_body mdecl mdecl' ->
+  erases_one_inductive_body idecl idecl' ->
+  forall b, isPropositional Σ ind b -> 
+  constructor_isprop_pars_decl Σ' ind c = 
+  Some (b, mdecl.(ind_npars), (cdecl.(cstr_name), context_assumptions cdecl.(cstr_args))).
+Proof.
+  intros wfΣ [decli declc] decli' em ei b isp.
+  pose proof decli as decli''.
+  eapply isPropositional_propositional in decli''; tea.
+  move: decli''.
+  rewrite /inductive_isprop_and_pars.
+  unfold constructor_isprop_pars_decl.
+  unfold EGlobalEnv.lookup_constructor.
+  rewrite (declared_inductive_lookup_inductive decli') /=.
+  intros [= <- <-].
+  destruct ei. clear H0.
+  eapply Forall2_nth_error_Some in H as [cdecl' []]; tea.
+  rewrite H //. f_equal. f_equal.
+  destruct cdecl'. destruct H0. subst. f_equal.
+  assert (declared_constructor Σ (ind, c) mdecl idecl cdecl).
+  split => //.
+  destruct (on_declared_constructor H0) as [[] [? []]].
+  now eapply cstr_args_length in o1.
+Qed.
+
 Lemma is_assumption_context_spec Γ :
 is_true (is_assumption_context Γ) <-> PCUICLiftSubst.assumption_context Γ.
 Proof.
@@ -1299,6 +1342,26 @@ Proof.
   exists Tty. split => //. eapply subject_reduction; tea.
 Qed.
 
+Lemma edeclared_inductive_lookup {Σ id mdecl idecl} :
+    EGlobalEnv.declared_inductive Σ id mdecl idecl ->
+    EGlobalEnv.lookup_inductive Σ id = Some (mdecl, idecl).
+Proof.
+  intros []. unfold EGlobalEnv.lookup_inductive.
+  red in H. cbn. rewrite H H0 //.
+Qed.
+
+Lemma edeclared_constructor_lookup {Σ id mdecl idecl cdecl} :
+    EGlobalEnv.declared_constructor Σ id mdecl idecl cdecl -> 
+    EGlobalEnv.lookup_constructor Σ id.1 id.2 = Some (mdecl, idecl, cdecl).
+Proof.
+  intros []. unfold EGlobalEnv.lookup_constructor.
+  rewrite (edeclared_inductive_lookup H) /= H0 //.
+Qed.
+
+From MetaCoq.PCUIC Require PCUICExpandLetsCorrectness.
+
+Arguments inductive_isprop_and_pars : simpl never.
+
 Lemma erases_correct (wfl := default_wcbv_flags) Σ t T t' v Σ' :
   wf_ext Σ ->
   Σ;;; [] |- t : T ->
@@ -1471,14 +1534,15 @@ Proof.
       depelim H5.
       subst c1.
       destruct y0 as [n br']; cbn in *.
+      rename y into br.
       edestruct IHeval2 as (? & ? & [?]).
       eapply subject_reduction. eauto. exact Hty.
       etransitivity.
       eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto.
       econstructor. econstructor.
-      eauto. eauto.
-      rename y into br.
+      eauto.
       all:unfold iota_red in *. all:cbn in *.
+      { rewrite e3 e1. now f_equal. }
       {
         assert (expand_lets (inst_case_branch_context p br) (br.(PCUICAst.bbody)) = br.(PCUICAst.bbody)) as ->. {
           unshelve edestruct @on_declared_constructor as (? & ? & ? & []). 8: exact d. all: eauto.
@@ -1517,18 +1581,17 @@ Proof.
       rewrite -eq_npars.
       eapply isPropositional_propositional; eauto.
       invs e. cbn in *.
-      rewrite -eq_npars in e0.
-      rewrite skipn_length e0 in H11.
       rewrite map_length.
-      rewrite (@assumption_context_assumptions (bcontext y)) // ?rev_repeat in H11 => //.
+      rewrite skipn_length e3 e2 in H11.
+      rewrite (@assumption_context_assumptions (bcontext br)) // ?rev_repeat in H11 => //.
       { eapply assumption_context_compare_decls. symmetry in a. exact a.
         rewrite /cstr_branch_context. eapply assumption_context_expand_lets_ctx.
         eapply assumption_context_subst_context.
         apply (declared_constructor_assumption_context d). }
       rewrite ECSubst.substl_subst //.
       { eapply All_Forall, All_repeat. econstructor. }
-      replace (ind_npars mdecl + #|bcontext y| - ind_npars mdecl) 
-      with #|bcontext y| in H11 by lia. eauto.
+      replace (ind_npars mdecl + #|bcontext br| - ind_npars mdecl) 
+      with #|bcontext br| in H11 by lia. eauto.
       }
       depelim H4.
       cbn in H1.
@@ -1549,7 +1612,8 @@ Proof.
       eauto. eauto.
 
       etransitivity. constructor. constructor.
-      eauto. eauto.
+      eauto.
+      { rewrite e0 /cstr_arity e2 e1 //. } 
       unfold iota_red. reflexivity. 
       
       {
@@ -1585,7 +1649,7 @@ Proof.
       invs H2.
       -- exists x2. split; eauto.
          constructor. econstructor. eauto. 2:eauto.
-         3:{ unfold EGlobalEnv.iota_red.
+         4:{ unfold EGlobalEnv.iota_red.
           rewrite ECSubst.substl_subst //.
           eapply Forall_rev, Forall_skipn.
           assert (Forall (closedn 0) args).
@@ -1594,15 +1658,17 @@ Proof.
             rewrite closedn_mkApps /=. solve_all. } 
           solve_all. eapply (erases_closed _ []); tea. } 
          rewrite -eq_npars.
-         eapply isPropositional_propositional; eauto.
-         rewrite -e4 List.skipn_length - (Forall2_length H3) -List.skipn_length.
-         rewrite skipn_length e0.
-         replace (ci_npar ind + context_assumptions (bcontext br) - ci_npar ind)
-    with (context_assumptions (bcontext br)) by lia.  
-         rewrite map_length.
-         eapply assumption_context_assumptions.
-         eapply assumption_context_compare_decls. symmetry; tea.
-         eapply (assumption_context_cstr_branch_context d).
+         eapply isPropositional_propositional_cstr; eauto.
+         rewrite  -(Forall2_length H3) /= e1 //.
+         rewrite skipn_length -(Forall2_length H3) -e6 /= map_length.
+         rewrite (All2_length a).
+         replace #|cstr_branch_context ind mdecl cdecl| 
+          with (context_assumptions (cstr_branch_context ind mdecl cdecl)).
+         2:{ eapply assumption_context_assumptions.
+             eapply (assumption_context_cstr_branch_context d). }
+         rewrite e0 /cstr_arity e1.
+         rewrite PCUICExpandLetsCorrectness.cstr_branch_context_assumptions.
+         lia.
       -- eapply Is_type_app in X1 as []; auto.
          2:{ eapply subject_reduction_eval. 2:eassumption. eauto. }
          assert (ispind : inductive_isprop_and_pars Σ' ind = Some (true, ind_npars mdecl)).
@@ -1611,11 +1677,11 @@ Proof.
          eapply tConstruct_no_Type in X1; auto.
          eapply H6 in X1 as []; eauto. 2:reflexivity.
 
-         destruct (ind_ctors idecl) eqn:hctors. cbn in *. destruct c; invs e5.
-         destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in *; invs e5.
+         destruct (ind_ctors idecl) eqn:hctors. cbn in *. destruct c; invs e7.
+         destruct l; cbn in *; try lia. destruct c as [ | []]; cbn in *; invs e7.
 
          (* destruct btys as [ | ? []]; cbn in *; try discriminate. *)
-         destruct brs'; invs e2.
+         destruct brs'; invs e4.
          destruct brs; invs Hnth.
          destruct H9.
          depelim brs_ty. depelim brs_ty.
@@ -1627,8 +1693,8 @@ Proof.
          eapply PCUICReduction.red_case_c. eapply wcbeval_red. eauto.
          eauto. eauto.
          etransitivity. constructor. constructor. cbn. reflexivity.
+         { rewrite e0 /cstr_arity e2 e1 //. }
          eauto.
-         unfold iota_red. reflexivity.
 
          {
           assert (expand_lets (inst_case_branch_context p br) (br.(PCUICAst.bbody)) = br.(PCUICAst.bbody)) as ->. {
@@ -1686,7 +1752,7 @@ Proof.
          { eapply subject_reduction. eauto. exact Hty.
            eapply PCUICReduction.red_case_c. eapply wcbeval_red; eauto. }
 
-        rewrite eq_npars. rewrite List.skipn_length e0.
+        rewrite eq_npars. rewrite List.skipn_length e0 /cstr_arity -e1 e2.
         replace (ci_npar ind + context_assumptions (bcontext br) - ci_npar ind)
     with (context_assumptions (bcontext br)) by lia.
         subst n. rewrite map_length. 
@@ -1696,9 +1762,10 @@ Proof.
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval; eauto. constructor. econstructor; eauto.
   - pose (Hty' := Hty).
+    rename e0 into eqpars. rename e1 into hnth. rename e into eargs.
     eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ?); [|easy].
     assert (Hpars : pars = ind_npars x0).
-    { destruct d as [? []]. now rewrite H3. }
+    { destruct (declared_constructor_inj d0 d). now subst. }
     invs He.
 
     + depelim Hed.
@@ -1708,16 +1775,16 @@ Proof.
       2: eapply subject_reduction_eval; eauto.
       destruct Hvc' as [ (? & ? & ? & ? & [] & ? & ? & ?) | (? & ? & ? & ? & ?)]; subst.
       * exists EAst.tBox.
-        assert (isprop : inductive_isprop_and_pars Σ' i = Some (true, ind_npars mdecl)).
-        { eapply isPropositional_propositional; eauto. eapply isErasable_Propositional; eauto. }
         destruct (declared_inductive_inj decli d) as [<- <-].
+        assert (isprop : inductive_isprop_and_pars Σ' i = Some (true, ind_npars mdecl)).
+        { eapply isPropositional_propositional. exact d. all:eauto. eapply isErasable_Propositional; eauto. }
         split.
         eapply Is_type_app in X as []; eauto. 2:{ rewrite -mkApps_app. eapply subject_reduction_eval; eauto. }
         rewrite -mkApps_app in X.
 
         eapply tConstruct_no_Type in X; eauto. eapply H3 in X as [? []]; eauto.
         2: split; auto; now exists []; destruct Σ.
-        destruct d as (? & ? & ?).
+        destruct d0 as (? & ? & ?).
         
         econstructor.
         eapply Is_type_eval; eauto.
@@ -1732,21 +1799,24 @@ Proof.
         pose proof (Ee.eval_to_value _ _ _ Hty_vc').
         eapply value_app_inv in X0. subst. eassumption.
       * rename H3 into Hinf.
+        assert (lenx5 := Forall2_length H4).
         eapply Forall2_nth_error_Some in H4 as (? & ? & ?); eauto.
         assert (Σ ;;; [] |- mkApps (tConstruct i 0 u) args : mkApps (tInd i x) x3).
-        eapply subject_reduction_eval; eauto.        
+        eapply subject_reduction_eval; eauto.     
         eapply inversion_mkApps in X as (? & ? & ?); eauto.
         eapply Prelim.typing_spine_inv in t1 as []; eauto.
         eapply IHeval2 in H3 as (? & ? & [?]); eauto.
         invs H2.
-        -- exists x9. split; eauto. constructor. eapply Ee.eval_proj; eauto.
-            destruct (declared_inductive_inj decli d); subst x0 x1.
-            now eapply isPropositional_propositional; eauto.
-            rewrite <- nth_default_eq. unfold nth_default. now rewrite H1.
+        -- exists x9. split; eauto. constructor.
+            destruct (declared_inductive_inj decli d0); subst x0 x1.
+            destruct (declared_inductive_inj d d0); subst mdecl0 idecl0.
+            eapply Ee.eval_proj; eauto.
+            eapply isPropositional_propositional_cstr; eauto.
+            cbn. destruct p. rewrite -lenx5 //.
         -- exists EAst.tBox.
-            assert (isprop : inductive_isprop_and_pars Σ' i = Some (true, ind_npars mdecl)).
-            { eapply isPropositional_propositional; eauto; eapply (isErasable_Propositional (args:=[])); eauto. }
-            destruct (declared_inductive_inj decli d) as [<- <-].
+          destruct (declared_inductive_inj decli d) as [<- <-].
+          assert (isprop : inductive_isprop_and_pars Σ' i = Some (true, ind_npars mdecl)).
+        { eapply isPropositional_propositional; eauto. eapply (isErasable_Propositional (args:=[])); eauto. }
             split.
             eapply Is_type_app in X as []; eauto. 2:{ eapply subject_reduction_eval; [|eauto]; eauto. }
 
@@ -2255,7 +2325,64 @@ Proof.
       eapply IHeval2 in t0 as (? & ? & [?]); eauto.
       destruct (EAstUtils.isBox x2) eqn:E.
       * destruct x2; invs E. exists EAst.tBox. split. 2: now constructor; econstructor; eauto.
-        pose proof (Is_type_app Σ [] f'[a']).
+        pose proof (Is_type_app Σ [] (mkApps (tConstruct ind c u) args) [a']).
+        inversion H1.
+        edestruct H7; eauto. cbn. eapply subject_reduction. eauto.
+        exact Hty. eapply PCUICReduction.red_app.
+        eapply wcbeval_red; eauto.
+        eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; eauto.
+        eapply wcbeval_red; eauto. constructor. rewrite mkApps_app //.
+      * exists (E.tApp x2 x3).
+        rewrite mkApps_app.
+        split; [econstructor; eauto|].
+        eapply erases_mkApps_inv in H1; eauto.
+        2:{ eapply subject_reduction_eval; tea. }
+        destruct H1 as [].
+        { destruct H1 as (? & ? & ? & ? & ? & ? & ? & ?). subst.
+          eapply eval_to_mkApps_tBox_inv in H2 as H'. subst. depelim H9.
+          now cbn in E. }
+        destruct H1 as [f'' [L' [eq []]]].
+        subst x2.
+        depelim H1.
+        2:{ eapply eval_to_mkApps_tBox_inv in H2 as H'. subst. now cbn in E. }
+        eapply erases_deps_eval in Hed1; tea.
+        eapply erases_deps_mkApps_inv in Hed1 as [].
+        depelim H8.
+        constructor. eapply Ee.eval_construct; tea.
+        eapply (edeclared_constructor_lookup H9).
+        rewrite -(Forall2_length H7).
+        rewrite /Ee.cstr_arity.
+        destruct (declared_constructor_inj H8 d) as [? []]. subst mdecl0 idecl0 cdecl0.
+        destruct H8, H9, H11 as [Hc _].
+        eapply Forall2_nth_error_Some in Hc as [? []]; tea.
+        rewrite H14 in H11. noconf H11.
+        destruct cdecl' as [cname cargs]; cbn.
+        destruct H15 as [<- _].
+        destruct H10 as [_ <-].
+        move: l. rewrite /cstr_arity.
+        clear -d wfΣ.
+        destruct (on_declared_constructor d) as [_ [? []]].
+        eapply cstr_args_length in o. lia.
+    + exists E.tBox. split => //. 2:repeat constructor.
+      econstructor.
+      eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; auto.
+      eapply Is_type_red. 3:eauto. eauto.
+      rewrite mkApps_app.
+      eapply PCUICReduction.red_app.
+      eapply subject_closed in Hf; auto.
+      eapply wcbeval_red; eauto.
+      eapply subject_closed in Ha; auto.
+      eapply wcbeval_red; eauto.
+
+  - pose (Hty' := Hty).
+    eapply inversion_App in Hty' as (? & ? & ? & ? & ? & ?); eauto.
+    invs He.
+    + depelim Hed.
+      assert (t' := t). eapply IHeval1 in t as (? & ? & [?]); eauto.
+      eapply IHeval2 in t0 as (? & ? & [?]); eauto.
+      destruct (EAstUtils.isBox x2) eqn:E.
+      * destruct x2; invs E. exists EAst.tBox. split. 2: now constructor; econstructor; eauto.
+        pose proof (Is_type_app Σ [] f' [a']).
         inversion H1.
         edestruct H7; eauto. cbn. eapply subject_reduction. eauto.
         exact Hty. eapply PCUICReduction.red_app.
@@ -2273,10 +2400,14 @@ Proof.
           ++ cbn. invs H1. cbn in *.
             eapply ssrbool.negbTE, is_FixApp_erases.
             econstructor; eauto.
-            now rewrite orb_false_r in i.
+            rewrite orb_false_r !negb_or in i. now move/andP: i => [].
           ++ cbn in *.
             invs H1. invs i.
         -- eauto.
+        -- rewrite !negb_or in i.
+           rtoProp; intuition auto.
+           eapply is_ConstructApp_erases in H8; tea.
+           now move/negbTE: H8.
     + exists EAst.tBox. split. 2: now constructor; econstructor.
       econstructor.
       eapply inversion_App in Hty as [na [A [B [Hf [Ha _]]]]]; auto.

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -211,7 +211,7 @@ Definition erases_constant_body (Σ : global_env_ext) (cb : constant_body) (cb' 
   end.
 
 Definition erases_one_inductive_body (oib : one_inductive_body) (oib' : E.one_inductive_body) :=
-  Forall2 (fun cdecl '(i', n') => cdecl.(cstr_arity) = n' /\ cdecl.(cstr_name) = i') oib.(ind_ctors) oib'.(E.ind_ctors) /\
+  Forall2 (fun cdecl '(i', n') => cdecl.(PCUICEnvironment.cstr_arity) = n' /\ cdecl.(cstr_name) = i') oib.(ind_ctors) oib'.(E.ind_ctors) /\
   Forall2 (fun '(i,t) i' => i = i') oib.(ind_projs) oib'.(E.ind_projs) /\
   oib'.(E.ind_name) = oib.(ind_name) /\
   oib'.(E.ind_kelim) = oib.(ind_kelim) /\ 

--- a/erasure/theories/Prelim.v
+++ b/erasure/theories/Prelim.v
@@ -86,22 +86,19 @@ Proof.
   unfold decompose_app. simpl. now rewrite (IHt1 [t2]).
 Qed.
 
-Lemma value_app_inv {wfl : Ee.WcbvFlags} L :
-  Ee.value (EAst.mkApps EAst.tBox L) ->
+Lemma value_app_inv {wfl : Ee.WcbvFlags} Σ L :
+  Ee.value Σ (EAst.mkApps EAst.tBox L) ->
   L = nil.
 Proof.
   intros. depelim X.
   - destruct L using rev_ind.
     reflexivity.
     rewrite emkApps_snoc in i. inv i.
-  - destruct (EAstUtils.mkApps_elim t l). EAstUtils.solve_discr.
-    rewrite Ee.value_head_spec in i.
-    move/andb_and: i => [H H'].
+  - destruct (EAstUtils.mkApps_elim f args). EAstUtils.solve_discr.
+    eapply value_head_spec' in v.
+    move/andb_and: v => [H H'].
     eapply Ee.atom_mkApps in H' as [H1 _].
-    destruct n, L; discriminate.
-  - unfold Ee.isStuckFix in i. destruct f; try now inversion i.
-    assert (EAstUtils.decompose_app (EAst.mkApps (EAst.tFix m n) args) = EAstUtils.decompose_app (EAst.mkApps EAst.tBox L)) by congruence.
-    rewrite !EAstUtils.decompose_app_mkApps in H; eauto. inv H.
+    destruct n0, L; discriminate.
 Qed.
 
 (** ** Prelim on fixpoints *)

--- a/pcuic/theories/PCUICExpandLets.v
+++ b/pcuic/theories/PCUICExpandLets.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Int63 FloatOps FloatAxioms.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCases PCUICTyping.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCases PCUICTyping PCUICProgram.
 
 (** This translation expands lets in constructor arguments, so that 
   iota reduction reduces to a simple substitution operation with no
@@ -107,3 +107,8 @@ Definition trans_global_env (d : PCUICEnvironment.global_env) : global_env :=
   
 Definition trans_global (Σ : PCUICEnvironment.global_env_ext) : global_env_ext :=
   (trans_global_env (fst Σ), snd Σ).
+
+Definition expand_lets_program (p : pcuic_program) : pcuic_program :=
+  let Σ' := PCUICExpandLets.trans_global p.1 in 
+  ((build_global_env_map Σ', p.1.2), PCUICExpandLets.trans p.2).
+  

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -1178,25 +1178,7 @@ Proof.
   now rewrite (declared_minductive_ind_npars declc).
 Qed.
 
-Lemma context_assumptions_map2_set_binder_name nas Γ :
-  #|nas| = #|Γ| ->
-  context_assumptions (map2 set_binder_name nas Γ) = context_assumptions Γ.
-Proof.
-  induction Γ in nas |- *; destruct nas; simpl; auto; try discriminate.
-  intros [=]. destruct (decl_body a); auto.
-  f_equal; auto.
-Qed.
-
 Require Import PCUICSpine.
-
-Lemma cstr_branch_context_assumptions ci mdecl cdecl : 
-  SE.context_assumptions (PCUICCases.cstr_branch_context ci mdecl cdecl) =
-  SE.context_assumptions (SE.cstr_args cdecl).
-Proof.
-  rewrite /cstr_branch_context /PCUICEnvironment.expand_lets_ctx
-    /PCUICEnvironment.expand_lets_k_ctx.
-  now do 2 rewrite !SE.context_assumptions_subst_context ?SE.context_assumptions_lift_context.
-Qed.
 
 Lemma trans_reln l p Γ : map trans (SE.reln l p Γ) = 
   reln (map trans l) p (trans_local Γ).

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -5437,10 +5437,6 @@ Proof.
 Qed.
 
 From MetaCoq.PCUIC Require Import PCUICProgram.
-
-Definition expand_lets_program (p : pcuic_program) : pcuic_program :=
-  let Σ' := PCUICExpandLets.trans_global p.1 in 
-  ((build_global_env_map Σ', p.1.2), PCUICExpandLets.trans p.2).
     
 Lemma expanded_expand_lets_program {cf : checker_flags} p (wtp : wt_pcuic_program p) :
   expanded_pcuic_program p ->

--- a/pcuic/theories/Syntax/PCUICCases.v
+++ b/pcuic/theories/Syntax/PCUICCases.v
@@ -113,6 +113,14 @@ Proof. rewrite /cstr_branch_context. now len. Qed.
 #[global]
 Hint Rewrite cstr_branch_context_length : len.
 
+Lemma cstr_branch_context_assumptions ci mdecl cdecl : 
+  context_assumptions (cstr_branch_context ci mdecl cdecl) =
+  context_assumptions (cstr_args cdecl).
+Proof.
+  rewrite /cstr_branch_context /expand_lets_ctx /expand_lets_k_ctx.
+  now do 2 rewrite !context_assumptions_subst_context ?context_assumptions_lift_context.
+Qed.
+
 Definition pre_case_branch_context_gen ind mdecl cdecl params puinst : context :=
   inst_case_context params puinst (cstr_branch_context ind mdecl cdecl).
 

--- a/pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -47,6 +47,10 @@ Proof.
       exists f'; split => //.
       rewrite mkApps_app.
       eapply eval_fix_value; tea.
+    + specialize (IHargs _ _ ev1) as [f' [evf' ev]].
+      exists f'; split => //.
+      rewrite mkApps_app.
+      eapply eval_construct; tea.
     + specialize (IHargs _ _ ev1) as [f'' [evf' ev]].
       exists f''; split => //.
       rewrite mkApps_app.
@@ -89,6 +93,8 @@ Proof.
     eapply eval_fix; tea.
   - pose proof (eval_eval evf eva1); subst.
     eapply eval_fix_value; tea.
+  - pose proof (eval_eval evf eva1); subst.
+    eapply eval_construct; tea.
   - pose proof (eval_eval evf eva1); subst.
     eapply eval_app_cong; tea.
   - now cbn in i.
@@ -174,10 +180,8 @@ Lemma eval_to_stuck_fix_inv {Σ mfix idx narg fn t args} :
 Proof.
   intros uf ev.
   apply eval_to_value in ev.
-  apply value_mkApps_inv in ev as [[(-> & ?)|]|]; try (cbn; easy).
-  unfold isStuckFix in *.
-  rewrite uf in p.
-  destruct p. now eapply Nat.leb_le in i.
+  apply value_mkApps_inv in ev as [(-> & ?)|[]]; try (cbn; easy).
+  depelim v. rewrite uf in e. now noconf e.
 Qed.
 
 Lemma eval_stuck_fix {Σ mfix idx narg fn args args'} :
@@ -201,7 +205,7 @@ Proof.
 Qed.
  
 Lemma eval_value_cong Σ f x y res : 
-  value f -> 
+  value Σ f -> 
   eval Σ x y ->
   eval Σ (tApp f y) res ->
   eval Σ (tApp f x) res.
@@ -215,12 +219,14 @@ Proof.
   - pose proof (eval_eval X0 X1_2). subst av.
     eapply eval_fix_value; tea.
   - pose proof (eval_eval X0 X1_2). subst a'.
+    eapply eval_construct; tea.
+  - pose proof (eval_eval X0 X1_2). subst a'.
     eapply eval_app_cong; tea.
   - now cbn in i.
 Qed.
 
 Lemma eval_mkApps_value_cong Σ f x y res : 
-  value f -> 
+  value Σ f -> 
   All2 (eval Σ) x y ->
   eval Σ (mkApps f y) res ->
   eval Σ (mkApps f x) res.
@@ -266,10 +272,9 @@ Proof.
       rewrite -mkApps_app.
       eapply eval_stuck_fix. eapply All2_app; tea.
       { eapply eval_to_value in X.
-        eapply value_mkApps_inv in X as  [[(-> & ?)|]|]; auto.
-        destruct p. eapply All_All2_refl, All_impl; tea; cbv beta.
-        intros. now eapply value_final.
-        destruct p. eapply All_All2_refl, All_impl; tea; cbv beta.
+        eapply value_mkApps_inv in X as  [(-> & ?)|[]]; auto.
+        depelim v. rewrite e in H; noconf H.
+        eapply All_All2_refl, All_impl; tea; cbv beta.
         intros. now eapply value_final. }
       tea. len.
       rewrite -mkApps_app in X1.
@@ -425,17 +430,9 @@ Proof.
   now rewrite Sfst_decompose_app_rec.
 Qed.
 
-Lemma isFixApp_mkApps f l : isFixApp (mkApps f l) = isFixApp f.
-Proof.
-  unfold isFixApp.
-  erewrite <- (fst_decompose_app_rec _ []).
-  rewrite /decompose_app decompose_app_rec_mkApps.
-  now rewrite fst_decompose_app_rec.
-Qed.
-
 Lemma eval_mkApps_cong Σ f args : 
-  value f -> All value args ->
-  ~~ (isLambda f || isFixApp f || isArityHead f) ->
+  value Σ f -> All (value Σ) args ->
+  ~~ (isLambda f || isFixApp f || isArityHead f || isConstructApp f) ->
   eval Σ (mkApps f args) (mkApps f args).
 Proof.
   intros vf a. move: a.
@@ -450,8 +447,8 @@ Proof.
     destruct args using rev_case; cbn in hf' => //.
     rewrite !mkApps_app /= orb_false_r in hf'.
     rewrite -[tApp _ _](mkApps_app _ _ [x0]) in hf'.
-    rewrite isFixApp_mkApps in hf'. rewrite hf'.
-    now rewrite orb_true_r orb_true_l.
+    rewrite isFixApp_mkApps isConstructApp_mkApps in hf'.
+    move/orP: hf' => [] ->; now rewrite !orb_true_r.
 Qed.
 
 Lemma isLambda_mkApps {f args} : args <> [] -> ~~ isLambda (mkApps f args).
@@ -550,7 +547,11 @@ Proof.
     wf_inv wf [hfix hargs].
     eapply WfAst.wf_mkApps => //.
     eapply wf_cunfold_cofix; tea. now depelim hfix.
-    
+
+  - wf_inv wf [hf ha].
+    apply WfAst.wf_mkApps => //. constructor.
+    solve_all.
+  
   - wf_inv wf [[[hf ?]] ha].
     eapply WfAst.wf_mkApps; eauto.
     eapply All2_All_mix_left in X0; tea.
@@ -558,6 +559,33 @@ Proof.
 
   - auto.
 Qed.
+
+Lemma value_mkApps_tFix Σ mfix idx args rarg fn :
+  cunfold_fix mfix idx = Some (rarg, fn) ->
+  #|args| <= rarg -> 
+  All (value Σ) args ->
+  value Σ (mkApps (tFix mfix idx) args).
+Proof.
+  intros hc hargs vargs.
+  destruct (is_nil args).
+  - subst args. constructor => //.
+  - eapply value_app => //. econstructor; tea.
+Qed.
+
+Definition heads (t : Ast.term) := (AstUtils.decompose_app t).1.
+
+(* 
+Lemma trans_head Σ t : head (trans Σ t) = trans Σ (heads t).
+Proof.
+  rewrite /head /heads.
+  destruct t => /= //. *)
+ 
+(* Lemma trans_isFixApp Σ t : isFixApp (trans (trans_global_env Σ) t) -> WcbvEval.isFixApp t.
+Proof.
+  rewrite /isFixApp /WcbvEval.isFixApp.
+  destruct t => /= //. rewrite head_mkApps.
+  destruct t => //.
+  cbn. *)
 
 Lemma trans_wcbvEval {cf} {Σ} {wfΣ : ST.wf Σ} T U :
   let Σ' := trans_global_env Σ in
@@ -616,9 +644,18 @@ Proof.
     reflexivity.
     rewrite nth_error_map H /=. reflexivity.
     len. rewrite H1.
-    { eapply All2_length in a1. len in a1.
+    { rewrite /cstr_arity. cbn.
+      eapply All2_length in a1. len in a1.
       rewrite /bctx case_branch_context_assumptions //.
       rewrite /trans_branch /=.
+      rewrite context_assumptions_map. f_equal.
+      todo "ci_npar ci invariant". }
+    { eapply All2_length in a1. len in a1.
+      todo "ind_npars". }
+    { eapply All2_length in a1. len in a1.
+      rewrite /bctx.
+      rewrite /trans_branch /=.
+      rewrite context_assumptions_map. f_equal.
       rewrite map2_map2_bias_left. len.
       rewrite PCUICCases.map2_set_binder_name_context_assumptions. len.
       len. now rewrite context_assumptions_map. }
@@ -641,14 +678,15 @@ Proof.
 
   - wf_inv wf hdiscr.
     destruct indnpararg as ((?&?)&?).
-    cbn in *; eapply eval_proj; tea.
+    todo "projs".
+    (*cbn in *; eapply eval_proj; tea.
     rewrite trans_mkApps in IHev1. 
     now eapply IHev1.
     rewrite nth_error_map H //.
     eapply IHev2.
     eapply eval_wf in ev1; tea.
     eapply WfAst.wf_mkApps_inv in ev1.
-    eapply nth_error_all in ev1; tea.
+    eapply nth_error_all in ev1; tea.*)
 
   - rewrite trans_mkApps.
     eapply WfAst.wf_mkApps_napp in wf as []; tea.
@@ -686,18 +724,14 @@ Proof.
     eapply eval_mkApps_value_cong => //.
     eapply All2_map. eapply All2_All_mix_left in X0; tea.
     eapply All2_impl; tea; cbv beta. intuition eauto.
-    eapply eval_mkApps. now eapply value_final.
-    eapply value_final.
     rewrite -mkApps_app.
-    eapply value_stuck_fix.
+    eapply trans_cunfold_fix in H0; tea.
+    eapply value_final. cbn. eapply value_mkApps_tFix; tea. len. len in H1.
     eapply All_app_inv.
-    { apply value_mkApps_inv in IHev as [[(-> & ?)|]|]; try (cbn; easy). }
+    { apply value_mkApps_inv in IHev as [(-> & ?)|[]]; try (cbn; easy). }
     eapply All2_All_mix_left in X0; tea.
     eapply All_map, All2_All_right; tea; cbv beta.
     { intuition auto. eapply eval_to_value; tea. }
-    unfold isStuckFix; cbn.
-    eapply trans_cunfold_fix in H0; tea. rewrite H0. len.
-    eapply Nat.leb_le. len in H1.
     now wf_inv w0 x.
   
   - wf_inv wf [mdecl' [idecl' [decli ?]]].
@@ -730,6 +764,14 @@ Proof.
     econstructor.
     eapply WfAst.wf_mkApps => //.
     eapply wf_cunfold_cofix; tea.
+  - wf_inv wf [wff wfa].
+    rewrite !trans_mkApps.
+    eapply forall_decls_declared_constructor in H; tea.
+    eapply eval_mkApps_Construct; tea. now eapply IHev. len.
+    { move: H2; unfold WcbvEval.cstr_arity, cstr_arity. cbn.
+      rewrite context_assumptions_map //. }
+    solve_all.
+
   - wf_inv wf [[[] ?] ?].
     eapply All2_All_mix_left in X; tea.
     rewrite trans_mkApps.
@@ -740,28 +782,23 @@ Proof.
     eapply All2_map.
     eapply All2_impl; tea; cbv beta.
     intuition eauto.
-    eapply eval_mkApps_cong.
+    eapply eval_mkApps_cong => //.
     { eapply eval_to_value; tea. }
     { eapply All_map, All2_All_right; tea; cbv beta; intuition auto. now eapply eval_to_value. }
-    eapply eval_wf in ev; tea.
-    clear -Σ' ev H1.
-    destruct f' => //. cbn. cbn in H1.
-    rewrite orb_false_r in H1. inv ev.
-    apply/negP => hp.
-    assert (map (trans Σ') args <> []).
-    { intros ha; apply H0. destruct args; cbn in *; congruence. }
-    move/negPf: (isLambda_mkApps (f:=trans Σ' f') H2) => hf. rewrite hf in hp.
-    move/negPf: (isArityHead_mkApps (f:=trans Σ' f') H2) => hf'. rewrite hf' in hp.
-    rewrite orb_false_r /= in hp.
-    rewrite isFixApp_mkApps in hp.
-    move/negP: H1 => H1. apply H1.
-    rewrite AstUtils.mkApps_tApp //.
-    rewrite H //. unfold AstUtils.is_empty. destruct args; try congruence => //.
-    auto. rewrite SisFixApp_mkApps.
-    eapply isFixApp_trans in hp => //.
-    rewrite H //.
-    cbn. destruct TransLookup.lookup_inductive as [[mdecl idecl]|]=> //.
-    
+    move: H1. rewrite !negb_or.
+    eapply WcbvEval.eval_to_value in ev.
+    destruct ev. destruct t => //.
+    pose proof (WcbvEval.value_head_nApp _ v).
+    rewrite trans_mkApps isFixApp_mkApps WcbvEval.isFixApp_mkApps // WcbvEval.isConstructApp_mkApps //.
+    pose proof (WcbvEval.value_head_spec _ _ _ v).
+    destruct v => /= //; rtoProp; intuition auto.
+    eapply isLambda_mkApps. destruct args => //.
+    eapply isArityHead_mkApps. destruct args => //.
+    rewrite isConstructApp_mkApps //.
+    eapply isLambda_mkApps. destruct args => //.
+    eapply isArityHead_mkApps. destruct args => //.
+    rewrite isConstructApp_mkApps //.
+      
   - eapply eval_atom.
     destruct t => //.
 Qed.


### PR DESCRIPTION
Evaluation could in principle produce over-applied constructors, preventing translation to CertiCoq's language which only allows strictly eta-expanded constructors during evaluation (they are always applied to exactly the right number of arguments). We refine the evaluation relations to maintain that constructors can never be overapplied (typing ensures that). If the input terms to evaluation are additionally (weakly) eta-expanded, then only strictly eta-expanded constructors appear during evaluation. We also improve the "value" datatype to carry this information: values that can be applied are shown to be only stuck fixpoints, cofixpoints or constructors and inductive type constructors. After erasure, thanks to the box application rule, values that can be applied are only fixpoints, cofixpoints and constructors.