### PR TITLE
Refinements of EWellformed and EWcbvEvalEtaInd

### DIFF
--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -22,7 +22,7 @@ Proof.
 Qed.
 
 Lemma decompose_app_mkApps f l :
-  isApp f = false -> decompose_app (mkApps f l) = (f, l).
+  ~~ isApp f -> decompose_app (mkApps f l) = (f, l).
 Proof.
   intros Hf. unfold decompose_app. rewrite decompose_app_rec_mkApps. rewrite app_nil_r.
   destruct f; simpl in *; (discriminate || reflexivity).

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -58,18 +58,12 @@ Ltac toAll :=
 
 Import ECSubst.
 
-Class EtaExpFlag := mkEtaExpFlags { strict_eta : bool }.
-Definition strong_eta_flag := {| strict_eta := true |}.
-Definition weak_eta_flag := {| strict_eta := false |}.
-
 Section isEtaExp.
-  Context {etafl : EtaExpFlag}.
   Context (Σ : global_declarations).
   
   Definition isEtaExp_app ind c k :=
     match EGlobalEnv.lookup_constructor_pars_args Σ ind c with
-    | Some (npars, nargs) =>
-      (if strict_eta then eqb else leb) (npars + nargs) k
+    | Some (npars, nargs) => leb (npars + nargs) k
     | None => false
     end.
     
@@ -116,7 +110,6 @@ Tactic Notation "simp_eta" "in" hyp(H) := simp isEtaExp in H; rewrite -?isEtaExp
 Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.
 
 Section isEtaExp.
-  Context {efl : EtaExpFlag}.
   Context (Σ : global_context).
   Notation isEtaExp := (isEtaExp Σ).
 
@@ -231,8 +224,6 @@ Section isEtaExp.
 End isEtaExp.
 
 Section WeakEtaExp.
-  Context (efl := weak_eta_flag).
-  Existing Instance efl.
   Context (Σ : global_context).
   Notation isEtaExp := (isEtaExp Σ).
 

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -477,12 +477,6 @@ Section isEtaExp.
     - rewrite isEtaExp_mkApps => //. rewrite Heq. rtoProp; repeat solve_all.
   Qed.
 
-(*   Lemma expanded_lift Γ' Γ'' Γ t :
-    isEtaExp (Γ' ++ Γ)%list t ->
-    isEtaExp (Γ' ++ Γ'' ++ Γ)%list (lift #|Γ''| #|Γ'| t).
-  Proof.
-  Admitted.
- *)
   Lemma isEtaExp_closed Γ t : 
     isEtaExp Γ t -> closedn #|Γ| t.
   Proof.
@@ -1562,13 +1556,6 @@ Proof.
     move=> /andP[] _ hargs.
     eapply nth_error_forallb in H2; tea.
 Qed.
-
-(* Lemma isEtaExp_eval Σ {wfl : WcbvFlags} t v  :
-eval Σ t v -> isEtaExp Σ [] t -> isEtaExp Σ [] v.
-Admitted.
-
-Local Arguments eval : clear implicits.
-*)
 
 Lemma mkApps_eq f args a t : ~~ isApp f -> mkApps f args = tApp a t ->
   args <> [] /\ a = (mkApps f (remove_last args)) /\ t = last args t.

--- a/erasure/theories/EGlobalEnv.v
+++ b/erasure/theories/EGlobalEnv.v
@@ -84,6 +84,13 @@ End Lookups.
 
 (** Knowledge of propositionality status of an inductive type and parameters *)
 
+Lemma lookup_constructor_pars_args_cstr_arity Σ ind c mdecl idecl cdecl : 
+  lookup_constructor Σ ind c = Some (mdecl, idecl, cdecl) ->
+  lookup_constructor_pars_args Σ ind c = Some (mdecl.(ind_npars), cdecl.2).
+Proof.
+  rewrite /lookup_constructor_pars_args => -> /= //.
+Qed.
+
 Definition inductive_isprop_and_pars Σ ind :=
   '(mdecl, idecl) <- lookup_inductive Σ ind ;;
   ret (idecl.(ind_propositional), mdecl.(ind_npars)).

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -364,7 +364,7 @@ Lemma wellformed_optimize_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t :
 Proof.
   induction t using EInduction.term_forall_list_ind; cbn -[lookup_constant lookup_inductive
     GlobalContextMap.inductive_isprop_and_pars]; intros => //.
-  all:rtoProp; intuition auto.  
+  all:unfold wf_fix_gen in *; rtoProp; intuition auto.  
   all:f_equal; eauto; solve_all.
   - rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
     assert (map (on_snd (optimize Σ)) l = map (on_snd (optimize Σ')) l) as -> by solve_all.
@@ -857,9 +857,9 @@ Proof.
   - cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/andP => [] /andP[]hasc hs ht.
     destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
     all:rewrite hasc hs /=; eauto.
-  - cbn. rtoProp; intuition auto; solve_all.
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
     unfold test_def in *. len. eauto.
-  - cbn. rtoProp; intuition auto; solve_all.
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
     unfold test_def in *. len. eauto.
 Qed.
 
@@ -870,7 +870,7 @@ Lemma optimize_wellformed_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t :
   forall n, wellformed Σ n t -> wellformed (optimize_env Σ) n t.
 Proof.
   intros wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
-  all:try solve [intros; rtoProp; intuition eauto; solve_all].
+  all:try solve [intros; unfold wf_fix_gen in *; rtoProp; intuition eauto; solve_all].
   - rewrite lookup_env_optimize //.
     destruct lookup_env eqn:hl => // /=.
     destruct g eqn:hg => /= //. subst g.
@@ -890,7 +890,6 @@ Proof.
     destruct nth_error => /= //.
     all:intros; rtoProp; intuition auto; solve_all.
 Qed.
-
 
 Lemma optimize_wellformed_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} d :
   wf_glob Σ ->

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -764,7 +764,7 @@ Section Wcbv.
       pose proof (mkApps_eq_inj (f_equal pr1 IHev1) eq_refl eq_refl) as (? & <-).
       noconf H. noconf IHev1.
       pose proof e as e'. rewrite e2 in e'; noconf e'.
-      rewrite (uip e e2), (uip e0 e3).
+      rewrite -> (uip e e2), (uip e0 e3).
       pose proof e4 as e4'. rewrite e1 in e4'; noconf e4'.
       rewrite (uip e1 e4).
       now specialize (IHev2 _ ev'2); noconf IHev2.
@@ -1173,11 +1173,12 @@ Tactic Notation "sim" "in" hyp(H) :=
   repeat (cbn in H; autorewrite with simplifications in H).
 Ltac sim := repeat (cbn ; autorewrite with simplifications).
 
-Lemma eval_wellformed {efl : EEnvFlags} {has_app : has_tApp} {wfl : WcbvFlags} Σ : 
+Lemma eval_wellformed {efl : EEnvFlags} {wfl : WcbvFlags} Σ : 
+  forall (has_app : has_tApp), (* necessary due to mkApps *)
   wf_glob Σ ->
   forall t u, wellformed Σ 0 t -> eval Σ t u -> wellformed Σ 0 u.
 Proof.
-  move=> clΣ t u Hc ev. move: Hc.
+  move=> has_app clΣ t u Hc ev. move: Hc.
   induction ev; simpl in *; auto;
     (move/andP=> [/andP[Hc Hc'] Hc''] || move/andP=> [Hc Hc'] || move=>Hc); auto.
   all:intros; intuition auto; rtoProp; intuition auto; rtoProp; eauto using wellformed_csubst.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -513,8 +513,10 @@ Section wellscoped.
     isSome (lookup_inductive Σ ind.(ci_ind)) && wellformed c && brs'
   | tProj p c => isSome (lookup_inductive Σ p.1.1) && wellformed c
   | tFix mfix idx => 
+    (idx <? #|mfix|) &&
     List.forallb (test_def (wellformed) (fun b => (isLambda b) && wellformed b)) mfix
   | tCoFix mfix idx =>
+    (idx <? #|mfix|) &&
     List.forallb (test_def wellformed wellformed) mfix
   | tConst kn _ => isSome (lookup_constant Σ kn)
   | tConstruct ind c _ => isSome (lookup_constructor Σ ind c)
@@ -548,10 +550,12 @@ Section wellscoped.
       eapply All2i_All2_mix_left in X5; tea. clear H8.
       solve_all.
     - now rewrite (declared_inductive_lookup_inductive isdecl).
+    - now eapply nth_error_Some_length, Nat.ltb_lt in H0.
     - move/andb_and: H2 => [] hb _.
       solve_all. destruct a as [s []].
       unfold test_def. len in b0.
       rewrite b0. now rewrite i b.
+    - now eapply nth_error_Some_length, Nat.ltb_lt in H0.
     - solve_all. destruct a as [s []].
       unfold test_def. len in b0. now rewrite i b0.
   Qed.
@@ -654,17 +658,23 @@ Proof.
   - move/andP: wfa => [] hl hc.
     apply/andP; split.
     now eapply trans_lookup_inductive; tea. eauto.
-  - epose proof (All2_length X0). eapply forallb_All in wfa.
+  - epose proof (All2_length X0). 
+    unfold EWellformed.wf_fix_gen.
+    rewrite -H0. move/andP: wfa => [] ->.
+    move/forallb_All. cbn. intros wfa.
     solve_all. destruct b.
     destruct y ;  simpl in *; subst.
     unfold EAst.test_def; simpl; eauto.
-    rewrite <- H0. rewrite fix_context_length in b1.
+    rewrite fix_context_length in b1.
     move/andP: b0 => //; eauto. move=> [] wft /andP[] isl wf; eauto.
     eapply b1; tea. now rewrite app_length fix_context_length.
   - epose proof (All2_length X0).
+    unfold EWellformed.wf_fix_gen.
+    rewrite -H0. move/andP: wfa => [] ->.
+    move/forallb_All. cbn. intros wfa.
     solve_all. destruct y ;  simpl in *; subst.
     unfold EAst.test_def; simpl; eauto.
-    rewrite <-H0. rewrite fix_context_length in b.
+    rewrite fix_context_length in b.
     eapply b. now move: b0 => /andP[]. eauto. now rewrite app_length fix_context_length. tea.
 Qed.
 

--- a/examples/tauto.v
+++ b/examples/tauto.v
@@ -737,7 +737,7 @@ Proof.
   - f_equal.
     f_equal; solve_all.
     unfold predicate_size. simpl. f_equal; auto.
-    f_equal; auto. clear H0. induction a; simpl; auto.
+    f_equal; auto. clear H0 H1. induction a; simpl; auto.
     unfold branch_size.
     clear -X1.
     induction X1; simpl; auto.

--- a/pcuic/theories/PCUICProgress.v
+++ b/pcuic/theories/PCUICProgress.v
@@ -1,4 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
+From Coq Require Import ssreflect.
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICTyping PCUICEquality PCUICAst PCUICAstUtils
   PCUICWeakeningConv PCUICWeakeningTyp PCUICSubstitution PCUICGeneration PCUICArities
@@ -33,7 +34,7 @@ Proof.
       rewrite closed_unfold_cofix_cunfold_eq. eauto.
       enough (closed (mkApps (tCoFix mfix idx) args)) as Hcl by (rewrite closedn_mkApps in Hcl; solve_all).
       eapply eval_closed. eauto.
-      2: eauto. eapply @subject_closed with (Γ := []); eauto. eapply cinv.
+      2: eauto. eapply @subject_closed with (Γ := []); eauto. eapply cinv. tea.
     }
     edestruct IHeval2 as (c & u & args0 & IH); eauto using subject_reduction.
     exists c, u, args0. etransitivity; eauto.
@@ -286,7 +287,7 @@ Proof.
  destruct @inversion_Prod_size with (H0 := Hprod) as (s1 & s2 & H1 & H2 & Hs1 & Hs2 & Hsub); [ eauto | ]. 
  eapply X4. 6:eauto. 4: exact HA. all: eauto.
  - intros. eapply (IH _ _ Hf). lia.
- - Unshelve. 2:exact Hf. intros. eapply IH. rewrite H. lia.
+ - Unshelve. 2:exact Hf. intros. eapply (IH _ _ Ht'). lia.
  - clear sz_A. induction L in A', Hf, (* HA, sz_A, *) Ht, HL, t, Hf, IH (*, s' *) |- *. 
    + inversion HL; subst. inversion X13. econstructor. econstructor; eauto. eauto. eauto. eauto. eauto. eauto.
      econstructor. 1,2: eapply isType_apply; eauto. eapply ws_cumul_pb_refl.
@@ -457,18 +458,6 @@ Proof.
 Qed.
 
 Local Hint Constructors value red1 : wcbv.
-
-From Coq Require Import ssreflect.
-Lemma cum_length {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} ind u args Γ na' A' B' : 
-  Σ ;;; Γ ⊢ it_mkProd_or_LetIn Γ (mkApps (tInd ind u) args) ≤ tProd na' A' B' -> 
-  context_assumptions Γ >= 1.
-Proof.
-  induction Γ using ctx_length_rev_ind; cbn.
-  intros. now eapply invert_cumul_ind_prod in X.
-  destruct d as [na [b|] ty]. 
-  - rewrite it_mkProd_or_LetIn_app /= //. admit.
-  - admit.
-Admitted.
 
 Definition axiom_free Σ :=
   forall c decl, declared_constant Σ c decl -> cst_body decl <> None. (* TODO: consolidate with PCUICConsistency *)

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -651,10 +651,11 @@ Section wtsub.
     | tProd na A B => wt Γ A × wt (Γ ,, vass na A) B
     | tLetIn na b ty b' => [× wt Γ b, wt Γ ty & wt (Γ ,, vdef na b ty) b']
     | tApp f a => wt Γ f × wt Γ a
-    | tCase ci p c brs => 
+    | tCase ci p c brs =>
       All (wt Γ) p.(pparams) ×
       ∑ mdecl idecl, 
       [× declared_inductive Σ ci mdecl idecl,
+         ci.(ci_npar) = mdecl.(ind_npars),
          consistent_instance_ext Σ (PCUICEnvironment.ind_universes mdecl) (PCUICAst.puinst p),
          wf_predicate mdecl idecl p,
          All2 (PCUICEquality.compare_decls eq eq) (PCUICCases.ind_predicate_context ci mdecl idecl) (PCUICAst.pcontext p),
@@ -1008,7 +1009,7 @@ Proof.
   - now eapply WfAst.wf_mkApp.
   - cbn. destruct b as [mdecl [idecl []]].
     destruct X as [? []]. red in X0. econstructor; cbn; eauto; tea.
-    eapply trans_declared_inductive in d; tea.
+    eapply trans_declared_inductive in d; tea. now cbn. cbn.
     eapply trans_ind_predicate_context_eq => //. now symmetry.
     rewrite map_length. cbn. rewrite context_assumptions_map //. 
     destruct w. now rewrite -(declared_minductive_ind_npars (proj1 d)).

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -235,7 +235,7 @@ Proof.
   induction wft using WfAst.term_wf_forall_list_ind; cbn; auto; try solve [f_equal; solve_all].
   rewrite !trans_lookup_inductive.
   unshelve epose proof (trans_lookup_inductive (Σ := trans_global_env Σ) ci _); tc.
-  eapply PCUICWeakeningEnvConv.extends_decls_wf; tea. rewrite {}H1.
+  eapply PCUICWeakeningEnvConv.extends_decls_wf; tea. rewrite {}H2.
   destruct H as [H hnth]. red in H.
   generalize (trans_lookup_env (inductive_mind ci)).
   move: H.
@@ -867,8 +867,8 @@ Section Trans_Global.
     - constructor. apply trans_R_global_instance; auto.
     - constructor. apply trans_R_global_instance; auto.
     - red in X, X0.
-      destruct wt as [mdecl' [idecl' [decli hpctx lenpar eqpars eqret eqc eqbrs]]].
-      destruct wu as [mdecl'' [idecl'' [decli' hpctx' lenpars' eqpars' eqret' eqc' eqbrs']]].
+      destruct wt as [mdecl' [idecl' [decli hci hpctx lenpar eqpars eqret eqc eqbrs]]].
+      destruct wu as [mdecl'' [idecl'' [decli' hci' hpctx' lenpars' eqpars' eqret' eqc' eqbrs']]].
       destruct (declared_inductive_inj decli decli'). subst.
       eapply forall_decls_declared_inductive in decli; tea.
       rewrite trans_lookup_inductive.
@@ -1502,7 +1502,7 @@ Section Trans_Global.
       econstructor. simpl in H. discriminate.
 
     - rewrite trans_mkApps; eauto with wf; simpl.
-      destruct a as [isdecl hpctx lenpar wfpar wfret wfc wfbrs].
+      destruct a as [isdecl hci hpctx lenpar wfpar wfret wfc wfbrs].
       destruct (declared_inductive_inj isdecl (proj1 H0)). subst x x0.
       eapply forall_decls_declared_inductive in isdecl; tea.
       rewrite trans_lookup_inductive.
@@ -1525,7 +1525,7 @@ Section Trans_Global.
       apply trans_unfold_fix; eauto.
       now apply trans_is_constructor.
 
-    - destruct a as [isdecl hpctx lenpar wfpar wfret wfc wfbrs].
+    - destruct a as [isdecl hci hpctx lenpar wfpar wfret wfc wfbrs].
       eapply forall_decls_declared_inductive in isdecl; tea.
       rewrite trans_lookup_inductive.
       rewrite (declared_inductive_lookup isdecl).
@@ -1553,7 +1553,7 @@ Section Trans_Global.
 
     - constructor. apply IHX. constructor; hnf; simpl; auto. auto.
 
-    - destruct a as [isdecl hpctx lenpar wfpar wfret wfc wfbrs].
+    - destruct a as [isdecl hci hpctx lenpar wfpar wfret wfc wfbrs].
       eapply forall_decls_declared_inductive in isdecl; tea.
       rewrite trans_lookup_inductive.
       rewrite (declared_inductive_lookup isdecl).
@@ -1561,7 +1561,7 @@ Section Trans_Global.
       apply OnOne2_map. apply (OnOne2_All_mix_left wfpar) in X. clear wfpar.
       solve_all.
 
-    - destruct a as [isdecl' hpctx wfpar wfret wfc wfbrs].
+    - destruct a as [isdecl' hci hpctx wfpar wfret wfc wfbrs].
       destruct (declared_inductive_inj isdecl isdecl').
       subst x x0.
       eapply forall_decls_declared_inductive in isdecl; tea.
@@ -1575,12 +1575,12 @@ Section Trans_Global.
       eapply All_app_inv => //.
       eapply declared_inductive_wf_case_predicate_context => //.
     
-    - destruct a as [isdecl hpctx wfpar wfret wfc wfbrs].
+    - destruct a as [isdecl hci hpctx wfpar wfret wfc wfbrs].
       eapply forall_decls_declared_inductive in isdecl; tea.
       rewrite trans_lookup_inductive (declared_inductive_lookup isdecl).
       constructor. cbn. apply IHX => //. 
 
-    - destruct a as [isdecl' hpctx lenpar wfpar wfret wfc wfbrs].
+    - destruct a as [isdecl' hci hpctx lenpar wfpar wfret wfc wfbrs].
       destruct (declared_inductive_inj isdecl isdecl').
       subst x x0.
       eapply forall_decls_declared_inductive in isdecl; tea.
@@ -2542,15 +2542,14 @@ Proof.
     cbn.
     unfold test_predicate_k. cbn.
     unfold Ast.test_predicate. cbn.
-    pose proof (All2_length X). len in H1.
+    pose proof (All2_length X). len in H2.
     intros; rtoProp. intuition auto.
     * solve_all.
-    * len.
-      rewrite map2_map2_bias_left.
-      rewrite PCUICCases.ind_predicate_context_length. cbn. len.
+    * len. rewrite map2_map2_bias_left.
+      { rewrite PCUICCases.ind_predicate_context_length. cbn. len. }
       eapply PCUICInstConv.closed_ctx_args.
-      rewrite PCUICCases.ind_predicate_context_length. cbn. len.
-      rewrite H0.
+      { rewrite PCUICCases.ind_predicate_context_length. cbn. len. }
+      rewrite H1.
       relativize (Ast.Env.context_assumptions _).
       eapply (closed_ind_predicate_context wfΣ' H).
       cbn. now rewrite context_assumptions_map.
@@ -2570,7 +2569,7 @@ Proof.
       rewrite map2_map2_bias_left. len.
       apply/andP; split.
       { eapply PCUICInstConv.closed_ctx_args; len.
-        rewrite H0.
+        rewrite H1.
         relativize (Ast.Env.context_assumptions _).
         eapply (PCUICClosedTyp.closed_cstr_branch_context (Σ := trans_global (Ast.Env.empty_ext Σ)) (i:=c)); cbn; tea.
         split; cbn; tea. now rewrite nth_error_map hnth.
@@ -2592,7 +2591,7 @@ Lemma trans_cumul_ctx_rel {cf} {Σ : Ast.Env.global_env_ext} Γ Δ Δ' :
   All (WfAst.wf_decl Σ) (Ast.Env.app_context Γ Δ') ->
   cumul_ctx_rel Σ' (trans_local Σ' Γ) (trans_local Σ' Δ) (trans_local Σ' Δ').
 Proof.
-  intros Σ' wfΣ wfΣ'. 
+  intros Σ' wfΣ wfΣ'.
   induction 1; cbn; constructor; auto.
   inv_on_free_vars.
   apply IHX => //. now depelim X0. now depelim X1.

--- a/pcuic/theories/TemplateToPCUICExpanded.v
+++ b/pcuic/theories/TemplateToPCUICExpanded.v
@@ -222,8 +222,8 @@ Proof with eauto using expanded.
         - now eapply template_to_pcuic_env.
         - len. eapply All2_length in a2. len in a2.
         - split; tea. cbn; rewrite nth_error_map. erewrite Hi => //.
-        - cbn. tea. rewrite context_assumptions_map. now rewrite e. }
-      * cbn. rewrite map2_bias_left_length. now eapply e0.
+        - cbn. tea. rewrite context_assumptions_map. now rewrite e0. }
+      * cbn. rewrite map2_bias_left_length. now eapply e1.
     + eapply template_to_pcuic_env; eauto.
   - now (wf_inv wf [[]]; eauto using expanded).
   - wf_inv wf [[]]. wf_inv w ?. eapply expanded_tFix.

--- a/pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -512,7 +512,7 @@ Proof.
   - apply IHev2.
     wf_inv wf H. specialize (IHev1 wf).
     wf_inv IHev1 [hc hargs].
-    eapply nth_error_all in H; tea.
+    eapply nth_error_all in hargs; tea.
 
   - eapply IHev2.
     wf_inv wf [Hf Hargs].
@@ -572,21 +572,6 @@ Proof.
   - eapply value_app => //. econstructor; tea.
 Qed.
 
-Definition heads (t : Ast.term) := (AstUtils.decompose_app t).1.
-
-(* 
-Lemma trans_head Σ t : head (trans Σ t) = trans Σ (heads t).
-Proof.
-  rewrite /head /heads.
-  destruct t => /= //. *)
- 
-(* Lemma trans_isFixApp Σ t : isFixApp (trans (trans_global_env Σ) t) -> WcbvEval.isFixApp t.
-Proof.
-  rewrite /isFixApp /WcbvEval.isFixApp.
-  destruct t => /= //. rewrite head_mkApps.
-  destruct t => //.
-  cbn. *)
-
 Lemma trans_wcbvEval {cf} {Σ} {wfΣ : ST.wf Σ} T U :
   let Σ' := trans_global_env Σ in
   wf Σ' ->
@@ -644,14 +629,11 @@ Proof.
     reflexivity.
     rewrite nth_error_map H /=. reflexivity.
     len. rewrite H1.
-    { rewrite /cstr_arity. cbn.
+    { rewrite /cstr_arity e. cbn.
       eapply All2_length in a1. len in a1.
       rewrite /bctx case_branch_context_assumptions //.
       rewrite /trans_branch /=.
-      rewrite context_assumptions_map. f_equal.
-      todo "ci_npar ci invariant". }
-    { eapply All2_length in a1. len in a1.
-      todo "ind_npars". }
+      rewrite context_assumptions_map //. }
     { eapply All2_length in a1. len in a1.
       rewrite /bctx.
       rewrite /trans_branch /=.
@@ -677,16 +659,20 @@ Proof.
     apply IHev2.
 
   - wf_inv wf hdiscr.
-    destruct indnpararg as ((?&?)&?).
-    todo "projs".
-    (*cbn in *; eapply eval_proj; tea.
-    rewrite trans_mkApps in IHev1. 
-    now eapply IHev1.
-    rewrite nth_error_map H //.
-    eapply IHev2.
-    eapply eval_wf in ev1; tea.
-    eapply WfAst.wf_mkApps_inv in ev1.
-    eapply nth_error_all in ev1; tea.*)
+    destruct proj as ((?&?)&?).
+    cbn in *; eapply eval_proj; tea.
+    * destruct H. cbn in d. 
+      eapply forall_decls_declared_constructor in d; tea.
+    * rewrite trans_mkApps in IHev1. 
+      now eapply IHev1.
+    * cbn. len. rewrite H0 /WcbvEval.cstr_arity. f_equal.
+      now rewrite context_assumptions_map.
+    * cbn. symmetry; eapply H.
+    * rewrite nth_error_map H1 //.
+    * eapply IHev2.
+      eapply eval_wf in ev1; tea.
+      eapply WfAst.wf_mkApps_inv in ev1.
+      eapply nth_error_all in ev1; tea.
 
   - rewrite trans_mkApps.
     eapply WfAst.wf_mkApps_napp in wf as []; tea.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1654,7 +1654,51 @@ Defined.
       end
     end.
 
-    Next Obligation.
+
+  Lemma wf_decl_universes_subst_instance Σ udecl udecl' d u : 
+    wf_ext (Σ, udecl) ->
+    wf_universe_instance (Σ, udecl') u ->
+    wf_decl_universes (Σ, udecl) d ->
+    wf_decl_universes (Σ, udecl') d@[u].
+  Proof.
+    intros [wfΣ onud] cu.
+    destruct d => /=; rewrite /wf_decl_universes /on_decl_universes /= .
+    move/andP => [] ondbody ontype.
+    apply/andP; split. 
+    2:{ eapply (wf_universes_inst (Σ := (Σ, udecl')) udecl); cbn => //. apply onud. }
+    destruct decl_body as [|] => /= //.
+    eapply (wf_universes_inst (Σ := (Σ, udecl')) udecl); cbn => //. apply onud.
+  Qed.
+
+  Lemma wf_ctx_universes_subst_instance Σ udecl udecl' Γ u : 
+    wf_ext (Σ, udecl) ->
+    wf_universe_instance (Σ, udecl') u ->
+    wf_ctx_universes (Σ, udecl) Γ ->
+    wf_ctx_universes (Σ, udecl') Γ@[u].
+  Proof.
+    intros wfΣ cu.
+    induction Γ; cbn => //.
+    move/andP=> [] wfa wfΓ.
+    rewrite [forallb _ _](IHΓ wfΓ) andb_true_r.
+    eapply wf_decl_universes_subst_instance; tea.
+  Qed.
+
+  Lemma wf_local_wf_ctx_universes {Σ Γ} : wf_ext Σ -> 
+    wf_local Σ Γ -> wf_ctx_universes Σ Γ.
+  Proof.
+    intros wfΣ. unfold wf_ctx_universes.
+    induction 1 => //. cbn. rewrite IHX andb_true_r.
+    destruct t0 as [s Hs]. move/typing_wf_universes: Hs => /andP[] //.
+    cbn. move/typing_wf_universes: t1 => /=; rewrite /wf_decl_universes /on_decl_universes /= => -> /= //.
+  Qed.
+
+  Lemma wf_ctx_universes_app {Σ Γ Δ} : 
+    wf_ctx_universes Σ (Γ ,,, Δ) = wf_ctx_universes Σ Γ && wf_ctx_universes Σ Δ.
+  Proof.
+    now rewrite /wf_ctx_universes /app_context forallb_app andb_comm.
+  Qed.
+  
+  Next Obligation.
       sq. by [].
     Qed.
     Next Obligation.
@@ -1662,29 +1706,78 @@ Defined.
       specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
       destruct Xprop as [Xprop ?]; eauto. 
       unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto. 
-      sq. todo "wf_universe stuff". 
+      sq. symmetry in Heq_anonymous.
+      destruct H0. specialize (H0 _ wfΣ0).
+      apply abstract_env_ext_wf in H0. destruct H0.
+      eapply variance_universes_spec in Heq_anonymous; tea.
+      eapply wf_ctx_universes_subst_instance; tea. 
+      destruct Heq_anonymous. now eapply consistent_instance_ext_wf in c.
+      destruct wfΓ.
+      eapply wf_local_smash_end in a.
+      eapply wf_local_expand_lets in a.
+      eapply wf_local_wf_ctx_universes in a; tea.
+      rewrite wf_ctx_universes_app in a. move/andP: a => [] //.
     Qed. 
     Next Obligation.
       pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
       specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
       destruct Xprop as [Xprop ?]; eauto. 
-      unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto. 
-      sq. todo "wf_universe stuff". 
-    Qed.
-      Next Obligation.      pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
-      specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
-      destruct Xprop as [Xprop ?]; eauto. 
-      unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto. 
-      sq. todo "wf_universe stuff". 
-       Qed.
-      Next Obligation.       
+      unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto.
+      sq.
+      symmetry in Heq_anonymous.
+      destruct H0. specialize (H0 _ wfΣ0).
+      apply abstract_env_ext_wf in H0. destruct H0.
+      eapply variance_universes_spec in Heq_anonymous; tea.
+      eapply wf_ctx_universes_subst_instance; tea. 
+      destruct Heq_anonymous. now eapply consistent_instance_ext_wf in c0.
+      destruct wfΓ.
+      eapply wf_local_smash_end in a.
+      eapply wf_local_expand_lets in a.
+      eapply wf_local_wf_ctx_universes in a; tea.
+      rewrite wf_ctx_universes_app in a. move/andP: a => [] //.
+    Qed. 
+
+    Next Obligation.
       pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
       specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
       destruct Xprop as [Xprop ?]; eauto. 
       unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto. 
-      sq. todo "wf_universe stuff". 
-      Qed.
-      Next Obligation.
+      sq.
+      symmetry in Heq_anonymous.
+      destruct H0. specialize (H0 _ wfΣ0).
+      apply abstract_env_ext_wf in H0. destruct H0.
+      eapply variance_universes_spec in Heq_anonymous; tea.
+      destruct Heq_anonymous as [c c0]. 
+      destruct wfΓ as [wfargs wfinds]. eapply ctx_inst_wt in wfinds.
+      solve_all. destruct H0 as [T wt].
+      rewrite -app_context_assoc in wt.
+      eapply typing_expand_lets in wt.
+      eapply wf_universes_inst. eauto. eapply wfX.
+      now eapply consistent_instance_ext_wf in c.
+      cbn. eapply typing_wf_universes in wt; eauto.
+      move/andP: wt => [] //.
+    Qed.
+    Next Obligation.
+      pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
+      specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
+      destruct Xprop as [Xprop ?]; eauto. 
+      unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto. 
+      sq.
+      symmetry in Heq_anonymous.
+      destruct H0. specialize (H0 _ wfΣ0).
+      apply abstract_env_ext_wf in H0. destruct H0.
+      eapply variance_universes_spec in Heq_anonymous; tea.
+      destruct Heq_anonymous as [c c0]. 
+      destruct wfΓ as [wfargs wfinds]. eapply ctx_inst_wt in wfinds.
+      solve_all. destruct H0 as [T wt].
+      rewrite -app_context_assoc in wt.
+      eapply typing_expand_lets in wt.
+      eapply wf_universes_inst. eauto. eapply wfX.
+      now eapply consistent_instance_ext_wf in c0.
+      cbn. eapply typing_wf_universes in wt; eauto.
+      move/andP: wt => [] //.
+    Qed.
+    Next Obligation.
       pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
       destruct Xprop as [Xprop ?]; eauto. 
       specialize (Xprop Σ0 wfΣ0). specialize_Σ Xprop. sq.
@@ -2039,8 +2132,40 @@ End monad_Alli_nth_forall.
   Next Obligation.
     sq. discriminate.
   Qed.
-  Next Obligation. todo "wf_universe stuff". Qed.
-  Next Obligation. todo "wf_universe stuff". Qed.
+  Next Obligation.
+    pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
+    specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
+    destruct H0 as [Xprop ?]; eauto. 
+    unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto.
+    sq. symmetry in Heq_anonymous.
+    specialize (Xprop _ wfΣ0).
+    apply abstract_env_ext_wf in Xprop. destruct Xprop.
+    eapply variance_universes_spec in Heq_anonymous as [cu cu']; tea.
+    eapply wf_ctx_universes_subst_instance; tea. 
+    now eapply consistent_instance_ext_wf in cu.
+    move/wf_local_smash_end: wfΓ.
+    rewrite -[_ ,,, _]app_context_nil_l app_context_assoc.
+    move/wf_local_expand_lets; rewrite app_context_nil_l.
+    move/wf_local_wf_ctx_universes. rewrite wf_ctx_universes_app.
+    move/andP => [] //.
+  Qed. 
+  Next Obligation.
+    pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]]. 
+    specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
+    destruct H0 as [Xprop ?]; eauto. 
+    unshelve erewrite (abstract_env_ext_irr _ _ (Xprop _ _)); eauto.
+    sq. symmetry in Heq_anonymous.
+    specialize (Xprop _ wfΣ0).
+    apply abstract_env_ext_wf in Xprop. destruct Xprop.
+    eapply variance_universes_spec in Heq_anonymous as [cu cu']; tea.
+    eapply wf_ctx_universes_subst_instance; tea. 
+    now eapply consistent_instance_ext_wf in cu'.
+    move/wf_local_smash_end: wfΓ.
+    rewrite -[_ ,,, _]app_context_nil_l app_context_assoc.
+    move/wf_local_expand_lets; rewrite app_context_nil_l.
+    move/wf_local_wf_ctx_universes. rewrite wf_ctx_universes_app.
+    move/andP => [] //.
+  Qed.    
   Next Obligation.
     destruct eq as [? ?]; eauto. specialize_Σ H. 
     specialize_Σ H1. 

--- a/template-coq/theories/EtaExpand.v
+++ b/template-coq/theories/EtaExpand.v
@@ -793,16 +793,6 @@ Proof.
     eapply nth_error_repeat. lia.
 Qed.
 
-(* Lemma expanded_eta_single_app {Σ Γ} t args args' ty count :
-  expanded Σ Γ (eta_single t args ty count) ->
-  expanded Σ Γ (eta_single t (args ++ args') ty count).
-Proof.
-  unfold eta_single. rewrite !expanded_fold_lambda.
-  rewrite !combine_length, !mapi_length, !firstn_length,  !List.skipn_length.
-  intros H.
-Admitted.  
- *)
-
  Lemma to_extended_list_k_map_subst:
   forall n (k : nat) (c : context) k',
     #|c| + k' <= k ->

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -758,7 +758,7 @@ Section WfRed.
       eapply nth_error_all in X; eauto.
     - simpl in *. econstructor; eauto. cbn.
       now rewrite -(OnOne2_length X).
-      cbn. clear H0. induction X; constructor; inv X1; intuition auto.
+      cbn. clear H1. induction X; constructor; inv X1; intuition auto.
     - econstructor; eauto; simpl in *.
       apply IHred1; eauto.
       apply All_app_inv => //.
@@ -825,7 +825,7 @@ Section WfRed.
     - destruct t; try reflexivity. discriminate.
     - destruct l; simpl in *; congruence.
     - eapply All2_map_right_inv in X5. econstructor; eauto; solve_all.
-      now rewrite map_length in H0.
+      now rewrite map_length in H1.
   Qed.
 
   Lemma declared_projection_wf (p : projection)
@@ -1127,7 +1127,7 @@ Section TypingWf.
         f_equal; solve_all; eauto.
     - now noconf H1.
     - now noconf H1.
-    - now noconf H1.
+    - now noconf H2.
   Qed.
 
   Lemma mkApps_tApp f args :

--- a/template-coq/theories/utils/MCProd.v
+++ b/template-coq/theories/utils/MCProd.v
@@ -91,6 +91,8 @@ Reserved Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 , P7 & P8 ]" (at level 0, fo
 "'[hv' [ × '['  P1 , '/'  P2 , '/'  P3 , '/'  P4 , '/'  P5 , '/'  P6 , '/'  P7 ']' '/ '  &  P8 ] ']'").
 Reserved Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 , P7 , P8 & P9 ]" (at level 0, format
 "'[hv' [ × '['  P1 , '/'  P2 , '/'  P3 , '/'  P4 , '/'  P5 , '/'  P6 , '/'  P7 , '/'  P8 ']' '/ '  &  P9 ] ']'").
+Reserved Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 , P7 , P8 , P9 & P10 ]" (at level 0, format
+"'[hv' [ × '['  P1 , '/'  P2 , '/'  P3 , '/'  P4 , '/'  P5 , '/'  P6 , '/'  P7 , '/'  P8 , '/'  P9 ']' '/ '  &  P10 ] ']'").
 
 Variant and3 (P1 P2 P3 : Type) : Type := Times3 of P1 & P2 & P3.
 Variant and4 (P1 P2 P3 P4 : Type) : Type := Times4 of P1 & P2 & P3 & P4.
@@ -99,6 +101,7 @@ Variant and6 (P1 P2 P3 P4 P5 P6 : Type) : Type := Times6 of P1 & P2 & P3 & P4 & 
 Variant and7 (P1 P2 P3 P4 P5 P6 P7 : Type) : Type := Times7 of P1 & P2 & P3 & P4 & P5 & P6 & P7.
 Variant and8 (P1 P2 P3 P4 P5 P6 P7 P8 : Type) : Type := Times8 of P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8.
 Variant and9 (P1 P2 P3 P4 P5 P6 P7 P8 P9 : Type) : Type := Times9 of P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9.
+Variant and10 (P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 : Type) : Type := Times10 of P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10.
 
 #[global] Hint Constructors and3 and3 and5 and6 and7 and8 and9 : core.
 
@@ -110,6 +113,7 @@ Notation "[ × P1 , P2 , P3 , P4 , P5 & P6 ]" := (and6 P1 P2 P3 P4 P5 P6) : type
 Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 & P7 ]" := (and7 P1 P2 P3 P4 P5 P6 P7) : type_scope.
 Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 , P7 & P8 ]" := (and8 P1 P2 P3 P4 P5 P6 P7 P8) : type_scope.
 Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 , P7 , P8 & P9 ]" := (and9 P1 P2 P3 P4 P5 P6 P7 P8 P9) : type_scope.
+Notation "[ × P1 , P2 , P3 , P4 , P5 , P6 , P7 , P8 , P9 & P10 ]" := (and10 P1 P2 P3 P4 P5 P6 P7 P8 P9 P10) : type_scope.
 
 
 #[global] Instance Prod_reflexivity {A} {P Q : A -> A -> Type} :


### PR DESCRIPTION
This refines the wellformedness properties on terms to have enough information to show that the translation to the first intermediate language of CertiCoq is correct. Also fixes the last remaining wf_universes todo's in the safe checker