### PR TITLE
Inline projections optimization

### DIFF
--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -32,5 +32,6 @@ theories/EEtaExpandedFix.v
 theories/EEtaExpanded.v
 theories/EProgram.v
 theories/ERemoveParams.v
+theories/EInlineProjections.v
 theories/ETransform.v
 theories/Erasure.v

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -133,8 +133,10 @@ src/eOptimizePropDiscr.mli
 src/eOptimizePropDiscr.ml
 src/eProgram.mli
 src/eProgram.ml
-src/eEtaExpandedFix.mli
-src/eEtaExpandedFix.ml
+# src/eEtaExpandedFix.mli
+# src/eEtaExpandedFix.ml
+src/eInlineProjections.mli
+src/eInlineProjections.ml
 src/eTransform.mli
 src/eTransform.ml
 src/erasure.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -50,10 +50,10 @@ ESpineView
 EPretty
 Extract
 EEtaExpanded
-EEtaExpandedFix
 ERemoveParams
 ErasureFunction
 EOptimizePropDiscr
+EInlineProjections
 EProgram
 ETransform
 Erasure

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -191,6 +191,9 @@ Record mutual_inductive_body := {
   ind_npars : nat;
   ind_bodies : list one_inductive_body }.
 
+Definition cstr_arity (mdecl : mutual_inductive_body) (cdecl : constructor_body) := 
+  (mdecl.(ind_npars) + cdecl.(cstr_nargs))%nat.  
+  
 (** See [constant_body] from [declarations.ml] *)
 Record constant_body := { cst_body : option term }.
 

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -172,13 +172,19 @@ Notation " Γ ,, d " := (snoc Γ d) (at level 20, d at next level) : erasure.
 
 (** *** Environments *)
 
+Record constructor_body := 
+  mkConstructor {
+    cstr_name : ident;
+    cstr_nargs : nat (* arity, w/o lets, w/o parameters *)
+  }.
+
 (** See [one_inductive_body] from [declarations.ml]. *)
 Record one_inductive_body : Set := {
   ind_name : ident;
   ind_propositional : bool; (* True iff the inductive lives in Prop *)
   ind_kelim : allowed_eliminations; (* Allowed eliminations *)
-  ind_ctors : list (ident * nat (* arity, w/o lets, w/o parameters *));
-  ind_projs : list (ident) (* names of projections, if any. *) }.
+  ind_ctors : list constructor_body;
+  ind_projs : list ident (* names of projections, if any. *) }.
 
 (** See [mutual_inductive_body] from [declarations.ml]. *)
 Record mutual_inductive_body := {

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -558,7 +558,7 @@ Lemma erases_declared_constructor {Σ : global_env_ext} Σ' kn k mind idecl cdec
   globals_erased_with_deps Σ Σ' ->
   exists mind' idecl', (* declared_inductive Σ' (kn, k).1 mind' idecl' ->
   erases_one_inductive_body idecl idecl' -> *)
-  declared_constructor Σ' (kn, k) mind' idecl' (cstr_name cdecl, PCUICEnvironment.cstr_arity cdecl) /\
+  declared_constructor Σ' (kn, k) mind' idecl' (mkConstructor (PCUICEnvironment.cstr_name cdecl) (PCUICEnvironment.cstr_arity cdecl)) /\
   erases_one_inductive_body idecl idecl' /\
   erases_mutual_inductive_body mind mind'.
 Proof.
@@ -572,7 +572,7 @@ Proof.
   destruct H4 as (? & ? & ? & ? & ?).
   eapply Forall2_nth_error_Some_l in H1 as ([] & ? & ? & ?); subst; eauto.
   eexists. eexists. split; [ | split]; eauto.
-  repeat eapply conj; try eassumption.
+  repeat eapply conj; try eassumption. cbn in *. now rewrite H8, H9.
 Qed.
 
 Lemma erases_deps_single Σ Σ' Γ t T et :

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -378,9 +378,9 @@ Lemma erases_deps_forall_ind Σ Σ'
         Forall (fun br : _ × Extract.E.term => erases_deps Σ Σ' br.2) brs ->
         Forall (fun br => P br.2) brs ->
         P (Extract.E.tCase p discr brs))
-  (Hproj : forall (p : projection) mdecl idecl mdecl' idecl' (t : Extract.E.term),
-        PCUICAst.declared_inductive Σ p.1.1 mdecl idecl ->
-        EGlobalEnv.declared_inductive Σ' p.1.1 mdecl' idecl' ->
+  (Hproj : forall (p : projection) mdecl idecl cdecl pdecl mdecl' idecl' cdecl' pdecl' (t : Extract.E.term),
+        PCUICAst.declared_projection Σ p mdecl idecl cdecl pdecl ->
+        EGlobalEnv.declared_projection Σ' p mdecl' idecl' cdecl' pdecl' ->
         erases_mutual_inductive_body mdecl mdecl' ->
         erases_one_inductive_body idecl idecl' ->
         erases_deps Σ Σ' t -> P t -> P (Extract.E.tProj p t))
@@ -520,20 +520,21 @@ Proof.
     destruct H as [H _].
     eapply PCUICWeakeningEnvConv.lookup_env_Some_fresh in H. eauto. contradiction.
   - econstructor; eauto.
-    destruct H as [H H'].
-    split; eauto. red in H |- *.
-    inv wfΣ. unfold PCUICEnvironment.lookup_env.
-    simpl.
+    destruct H as [[[declm decli] declc] [declp hp]].
+    repeat split; eauto.
+    inv wfΣ. unfold PCUICAst.declared_minductive in *.
+    unfold PCUICEnvironment.lookup_env.
+    simpl in *.
     change (eq_kername (inductive_mind p.1.1) kn) with (ReflectEq.eqb (inductive_mind p.1.1) kn); auto.
     destruct (ReflectEq.eqb_spec (inductive_mind p.1.1) kn). subst.
-    eapply PCUICWeakeningEnvConv.lookup_env_Some_fresh in H; eauto. contradiction.
-    apply H.
-    destruct H0 as [H0 H0'].
-    split; eauto. red in H0 |- *.
-    inv wfΣ. simpl.
+    eapply PCUICWeakeningEnvConv.lookup_env_Some_fresh in declm; eauto. contradiction.
+    apply declm.
+    destruct H0 as [[[]]]. destruct a.
+    repeat split; eauto.
+    inv wfΣ. simpl. unfold declared_minductive. cbn.
     change (eq_kername (inductive_mind p.1.1) kn) with (ReflectEq.eqb (inductive_mind p.1.1) kn); auto.
     destruct (ReflectEq.eqb_spec (inductive_mind p.1.1) kn); auto. subst.
-    destruct H as [H _].
+    destruct H as [[[]]].
     eapply PCUICWeakeningEnvConv.lookup_env_Some_fresh in H. eauto. contradiction.
 Qed.
 
@@ -620,9 +621,14 @@ Proof.
 
   - apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?&?); eauto.
     destruct (proj2 Σer _ _ _ (proj1 (proj1 d))) as (? & ? & ? & ?).
-    econstructor; eauto. eapply d.   
-    destruct d as [[[declm decli] declc] _]. destruct H1. destruct H0.
-    eapply Forall2_All2 in H1. eapply All2_nth_error in H1; eauto.
+    destruct d as [[[declm decli] declc] [declp hp]].
+    set (H1' := H1). destruct H1'.
+    eapply Forall2_All2 in H2. eapply All2_nth_error_Some in H2 as [bod' [hnth' ebod']]; eauto.
+    set (H1' := ebod'). destruct H1' as [Hctors [Hprojs _]].
+    eapply Forall2_All2 in Hctors. eapply All2_nth_error_Some in Hctors as [ctor' [hnth'' [Hctor' Hctor'']]]; eauto.
+    eapply Forall2_All2 in Hprojs. eapply All2_nth_error_Some in Hprojs as [proj' [hnthp ?]]; eauto.
+    econstructor; eauto. repeat split; eauto.
+    repeat split; eauto. cbn. apply H0. now rewrite <- H3, hp.
  
   - constructor.
     apply inversion_Fix in wt as (?&?&?&?&?&?&?); eauto.

--- a/erasure/theories/EEnvMap.v
+++ b/erasure/theories/EEnvMap.v
@@ -56,7 +56,18 @@ Module GlobalContextMap.
     rewrite /lookup_constructor /EGlobalEnv.lookup_constructor.
     rewrite lookup_inductive_spec //.
   Qed.
-    
+
+  Definition lookup_projection Σ (p : projection) : option (mutual_inductive_body * one_inductive_body * constructor_body * ident) :=
+    '(mdecl, idecl, cdecl) <- lookup_constructor Σ p.1.1 0 ;;
+    pdecl <- nth_error idecl.(ind_projs) p.2 ;;
+    ret (mdecl, idecl, cdecl, pdecl).
+
+  Lemma lookup_projection_spec Σ kn : lookup_projection Σ kn = EGlobalEnv.lookup_projection Σ kn.
+  Proof.
+    rewrite /lookup_projection /EGlobalEnv.lookup_projection.
+    rewrite lookup_constructor_spec //.
+  Qed.
+  
   Definition lookup_inductive_pars Σ kn : option nat := 
     mdecl <- lookup_minductive Σ kn ;;
     ret mdecl.(ind_npars).

--- a/erasure/theories/EEnvMap.v
+++ b/erasure/theories/EEnvMap.v
@@ -46,7 +46,7 @@ Module GlobalContextMap.
     rewrite lookup_minductive_spec //.
   Qed.
 
-  Definition lookup_constructor Σ kn c : option (mutual_inductive_body * one_inductive_body * (ident * nat)) :=
+  Definition lookup_constructor Σ kn c : option (mutual_inductive_body * one_inductive_body * constructor_body) :=
     '(mdecl, idecl) <- lookup_inductive Σ kn ;;
     cdecl <- nth_error idecl.(ind_ctors) c ;;
     ret (mdecl, idecl, cdecl).  

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -83,9 +83,9 @@ Inductive expanded (Γ : list nat): term -> Prop :=
 | expanded_tCoFix (mfix : mfixpoint term) (idx : nat) : 
   Forall (fun d => expanded (repeat 0 #|mfix| ++ Γ) d.(dbody)) mfix ->
   expanded Γ (tCoFix mfix idx)
-| expanded_tConstruct_app ind idx mind idecl cname c args :
-    declared_constructor Σ (ind, idx) mind idecl (cname, c) ->
-    #|args| >= ind_npars mind + c -> 
+| expanded_tConstruct_app ind idx mind idecl cdecl args :
+    declared_constructor Σ (ind, idx) mind idecl cdecl ->
+    #|args| >= ind_npars mind + cdecl.(cstr_nargs) -> 
     Forall (expanded Γ) args ->
     expanded Γ (mkApps (tConstruct ind idx) args)
 | expanded_tBox : expanded Γ tBox.
@@ -158,10 +158,10 @@ Lemma expanded_ind :
     → (∀ (Γ : list nat) (ind : inductive) 
          (idx : nat) (mind : mutual_inductive_body) 
          (idecl : one_inductive_body) 
-         (cname : ident) (c : nat) 
+         cdecl
          (args : list term),
-          declared_constructor Σ (ind, idx) mind idecl (cname, c)
-        → #|args| ≥ ind_npars mind + c
+          declared_constructor Σ (ind, idx) mind idecl cdecl
+        → #|args| ≥ ind_npars mind + cdecl.(cstr_nargs)
         → Forall (expanded Σ Γ) args
         → Forall (P Γ) args
         → P Γ (mkApps (tConstruct ind idx) args))
@@ -803,8 +803,8 @@ Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.
 
 Lemma isEtaExp_app_expanded Σ ind idx n :
    isEtaExp_app Σ ind idx n = true <->
-   exists mind idecl cname c,
-   declared_constructor Σ (ind, idx) mind idecl (cname, c) /\ n ≥ ind_npars mind + c.
+   exists mind idecl cdecl,
+   declared_constructor Σ (ind, idx) mind idecl cdecl /\ n ≥ cstr_arity mind cdecl.
 Proof.
   unfold isEtaExp_app, lookup_constructor_pars_args, lookup_inductive, lookup_minductive.
   split.
@@ -813,15 +813,15 @@ Proof.
     destruct nth_error as [ idecl | ] eqn:E2; cbn in H; try congruence.
     destruct (nth_error (E.ind_ctors idecl) idx) as [ [cname ?] | ] eqn:E3; cbn in H; try congruence.
     repeat esplit.
-    red. all: eauto. eapply leb_iff in H. lia.
-  - intros (? & ? & ? & ? & [[]] & Hle).
+    red. all: eauto. eapply leb_iff in H. unfold cstr_arity; cbn. lia.
+  - intros (? & ? & ? & [[]] & Hle).
     cbn.
     rewrite H. cbn. rewrite H0. cbn. rewrite H1. cbn.
     eapply leb_iff. eauto.
 Qed.
 
-Lemma expanded_isEtaExp_app_ Σ ind idx n  mind idecl cname c :
-   declared_constructor Σ (ind, idx) mind idecl (cname, c) -> n ≥ ind_npars mind + c ->
+Lemma expanded_isEtaExp_app_ Σ ind idx n  mind idecl cdecl :
+   declared_constructor Σ (ind, idx) mind idecl cdecl -> n ≥ cstr_arity mind cdecl ->
    isEtaExp_app Σ ind idx n = true.
 Proof.
   intros. eapply isEtaExp_app_expanded. eauto 8.
@@ -834,7 +834,7 @@ Proof.
   - eapply expanded_tRel_app with (args := []). destruct (nth_error); invs H. f_equal. eapply Nat.eqb_eq in H1; eauto. cbn. lia. econstructor.
   - rewrite forallb_InP_spec in H0. eapply forallb_Forall in H0. eapply In_All in H. econstructor. solve_all.
   - eapply andb_true_iff in H1 as []; eauto.
-  - eapply isEtaExp_app_expanded in H as (? & ? & ? & ? & ? & ?).
+  - eapply isEtaExp_app_expanded in H as (? & ? & ? & ? & ?).
     eapply expanded_tConstruct_app with (args := []); eauto.
   - eapply andb_true_iff in H1 as []. destruct ind. econstructor; eauto.
     rewrite forallb_InP_spec in H2. eapply forallb_Forall in H2. 
@@ -843,7 +843,7 @@ Proof.
     eapply In_All in H. solve_all.
   - eapply andb_true_iff in H0 as []. eapply In_All in H.
     rewrite forallb_InP_spec in H1. eapply forallb_Forall in H1.
-    eapply isEtaExp_app_expanded in H0 as (? & ? & ? & ? & ? & ?).
+    eapply isEtaExp_app_expanded in H0 as (? & ? & ? & ? & ?).
     eapply expanded_tConstruct_app; eauto. solve_all.
   - rtoProp. rewrite forallb_InP_spec in H2. rewrite forallb_InP_spec in H3. eapply In_All in H. eapply In_All in H0. 
     unfold isEtaExp_fixapp in H1. destruct nth_error eqn:E; try congruence.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -14,8 +14,6 @@ From MetaCoq.Erasure Require Import EWcbvEvalInd EProgram EWcbvEval.
 
 Set Default Proof Using "Type*".
 
-Definition switch_unguarded_fix fl : EWcbvEval.WcbvFlags := EWcbvEval.Build_WcbvFlags fl.(@with_prop_case) false.
-
 Lemma eval_trans' {wfl : WcbvFlags} {Σ e e' e''} :
   eval Σ e e' -> eval Σ e' e'' -> e' = e''.
 Proof.
@@ -2290,7 +2288,7 @@ Proof.
           destruct H8 as [[i' n'] [hnth heq]].
           cbn in hnth.
           rewrite (proj2 H6) in hnth. noconf hnth.
-          destruct heq. congruence.
+          destruct heq. cbn in *. congruence.
         ++ solve_all.
         + constructor => //.
           eapply erases_deps_mkApps_inv in etaΣ as [].

--- a/erasure/theories/EGlobalEnv.v
+++ b/erasure/theories/EGlobalEnv.v
@@ -72,21 +72,21 @@ Section Lookups.
     mdecl <- lookup_minductive kn ;;
     ret mdecl.(ind_npars).
   
-  Definition lookup_constructor kn c : option (mutual_inductive_body * one_inductive_body * (ident * nat)) :=
+  Definition lookup_constructor kn c : option (mutual_inductive_body * one_inductive_body * constructor_body) :=
     '(mdecl, idecl) <- lookup_inductive kn ;;
     cdecl <- nth_error idecl.(ind_ctors) c ;;
     ret (mdecl, idecl, cdecl).
   
   Definition lookup_constructor_pars_args kn c : option (nat * nat) := 
     '(mdecl, idecl, cdecl) <- lookup_constructor kn c ;;
-    ret (mdecl.(ind_npars), cdecl.2).
+    ret (mdecl.(ind_npars), cdecl.(cstr_nargs)).
 End Lookups.
 
 (** Knowledge of propositionality status of an inductive type and parameters *)
 
 Lemma lookup_constructor_pars_args_cstr_arity Σ ind c mdecl idecl cdecl : 
   lookup_constructor Σ ind c = Some (mdecl, idecl, cdecl) ->
-  lookup_constructor_pars_args Σ ind c = Some (mdecl.(ind_npars), cdecl.2).
+  lookup_constructor_pars_args Σ ind c = Some (mdecl.(ind_npars), cdecl.(cstr_nargs)).
 Proof.
   rewrite /lookup_constructor_pars_args => -> /= //.
 Qed.
@@ -202,8 +202,6 @@ Proof.
   unfold cofix_subst. generalize (tCoFix mfix). intros.
   induction mfix; simpl; auto.
 Qed.
-
-Definition tDummy := tVar "".
 
 Definition iota_red npar args (br : list name * term) :=
   substl (List.rev (List.skipn npar args)) br.2.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -1,13 +1,8 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Utf8 Program.
-From MetaCoq.Template Require Import config utils Kernames.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
-     PCUICReflect PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
-     PCUICTyping PCUICInversion
-     PCUICSafeLemmata. (* for welltyped *)
-From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
-From MetaCoq.Erasure Require Import EAst EAstUtils EDeps EExtends
-    ELiftSubst ECSubst EGlobalEnv EWellformed EWcbvEval Extract Prelim
+From MetaCoq.Template Require Import config utils Kernames BasicAst.
+From MetaCoq.Erasure Require Import EAst EAstUtils EExtends
+    ELiftSubst ECSubst EGlobalEnv EWellformed EWcbvEval Extract
     EEnvMap EArities EProgram.
 
 Local Open Scope string_scope.
@@ -27,6 +22,48 @@ Ltac introdep := let H := fresh in intros H; depelim H.
 #[global]
 Hint Constructors eval : core.
 
+(** Allow everything in terms *)
+Local Existing Instance all_env_flags.
+
+Arguments lookup_projection : simpl never.
+Arguments GlobalContextMap.lookup_projection : simpl never.
+
+Lemma lookup_inductive_wellformed {efl : EEnvFlags} Σ (kn : kername) 
+  (decl : mutual_inductive_body) :
+  wf_glob Σ → lookup_minductive Σ kn = Some decl → wf_minductive decl.
+Proof.
+  intros wfΣ.
+  rewrite /lookup_minductive. 
+  destruct lookup_env as [[]|] eqn:hl => //=.
+  intros [= <-]. now eapply lookup_env_wellformed in hl.
+Qed.
+
+Lemma wellformed_projection_args {efl : EEnvFlags} {Σ p mdecl idecl cdecl pdecl} : 
+  wf_glob Σ ->
+  lookup_projection Σ p = Some (mdecl, idecl, cdecl, pdecl) ->
+  p.2 < cdecl.(cstr_nargs).
+Proof.
+  intros wfΣ.
+  rewrite /lookup_projection /lookup_constructor /lookup_inductive.
+  destruct lookup_minductive eqn:hl => //=.
+  eapply lookup_inductive_wellformed in hl; eauto.
+  move: hl. unfold wf_minductive.
+  destruct nth_error eqn:hnth => //.
+  destruct ind_ctors as [|? []] eqn:hnth' => //.
+  destruct (nth_error (ind_projs _) _) eqn:hnth'' => //.
+  intros wf [= <- <- <- <-].
+  move: wf => /andP[] _.
+  move/(nth_error_forallb hnth). rewrite /wf_inductive /wf_projections.
+  destruct ind_projs => //. now rewrite nth_error_nil in hnth''.
+  rewrite hnth'. cbn. move/(@eqb_eq nat). intros <-.
+  eapply nth_error_Some_length in hnth''. now cbn in hnth''.
+  destruct (nth_error (ind_projs _) _) eqn:hnth'' => //.
+  move=> /andP[] _.
+  move/(nth_error_forallb hnth). rewrite /wf_inductive /wf_projections.
+  destruct ind_projs => //. now rewrite nth_error_nil in hnth''.
+  rewrite hnth' //.
+Qed.
+
 Section optimize.
   Context (Σ : GlobalContextMap.t).
 
@@ -39,9 +76,9 @@ Section optimize.
     | tLetIn na b b' => tLetIn na (optimize b) (optimize b')
     | tCase ind c brs => tCase ind (optimize c) (map (on_snd optimize) brs)
     | tProj p c =>
-      match GlobalContextMap.lookup_constructor Σ p.1.1 0 with 
-      | Some (mdecl, idecl, cdecl) => 
-        tCase p.1 (optimize c) [(unfold cdecl.2 (fun n => nAnon), tRel (cdecl.2 - S p.2))]
+      match GlobalContextMap.lookup_projection Σ p with 
+      | Some (mdecl, idecl, cdecl, pdecl) => 
+        tCase p.1 (optimize c) [(unfold cdecl.(cstr_nargs) (fun n => nAnon), tRel (cdecl.(cstr_nargs) - S p.2))]
       | _ => tProj p (optimize c)
       end
     | tFix mfix idx =>
@@ -63,82 +100,89 @@ Section optimize.
     now rewrite mkApps_app /= IHl map_app /= mkApps_app /=.
   Qed.
 
-  Lemma map_repeat {A B} (f : A -> B) x n : map f (repeat x n) = repeat (f x) n.
-  Proof.
-    now induction n; simpl; auto; rewrite IHn.
-  Qed.
-  
   Lemma map_optimize_repeat_box n : map optimize (repeat tBox n) = repeat tBox n.
   Proof. by rewrite map_repeat. Qed.
 
-  Import ECSubst.
+  (* move to globalenv *)
 
-  Lemma closed_optimize t k : closedn k t -> closedn k (optimize t).
+
+  Lemma wf_optimize t k : 
+    wf_glob Σ ->
+    wellformed Σ k t -> wellformed Σ k (optimize t).
   Proof.
+    intros wfΣ.
     induction t in k |- * using EInduction.term_forall_list_ind; simpl; auto;
     intros; try easy;
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
-    unfold test_def in *;
+    unfold wf_fix_gen, test_def in *;
     simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
-    - move/andP: H => [] clt cll.
+    - move/andP: H => [] /andP[] -> clt cll /=.
       rewrite IHt //=. solve_all.
-    - destruct GlobalContextMap.lookup_constructor as [[[mdecl idecl] cdecl]|]; cbn; auto.
-      rewrite IHt //=; len. rewrite andb_true_r; apply Nat.ltb_lt. 
-      assert (cdecl.2 > 0). admit. lia.
+    - rewrite GlobalContextMap.lookup_projection_spec.
+      destruct lookup_projection as [[[[mdecl idecl] cdecl] pdecl]|] eqn:hl; auto => //.
+      simpl.
+      have arglen := wellformed_projection_args wfΣ hl.
+      apply lookup_projection_lookup_constructor, lookup_constructor_lookup_inductive in hl.
+      rewrite hl /= andb_true_r.
+      rewrite IHt //=; len. apply Nat.ltb_lt.
       lia.
+    - len. rtoProp; solve_all. rewrite forallb_map; solve_all.
+    - len. rtoProp; solve_all. rewrite forallb_map; solve_all.
   Qed.
  
-  Lemma optimize_csubst a k b : 
-    closed a ->
+  Lemma optimize_csubst {a k b} n : 
+    wf_glob Σ ->
+    wellformed Σ (k + n) b ->
     optimize (ECSubst.csubst a k b) = ECSubst.csubst (optimize a) k (optimize b).
   Proof.
+    intros wfΣ.
     induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto;
-    intros cl; try easy; 
+    intros wft; try easy; 
     rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
-    unfold test_def in *;
+    unfold wf_fix, test_def in *;
     simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
-    - destruct (k ?= n)%nat; auto.
-    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
-      destruct l as [|[br n] [|l']] eqn:eql; simpl.
-      all:unfold on_snd; cbn.
-      * f_equal; auto.
-      * depelim X. simpl in *.
-        rewrite e //.
-        assert (#|br| = #|repeat tBox #|br| |). now rewrite repeat_length.
-        rewrite {2}H.
-        rewrite substl_csubst_comm //.
-        solve_all. eapply All_repeat => //.
-        now eapply closed_optimize.
-      * depelim X. depelim X.
-        f_equal; eauto.
-        unfold on_snd; cbn. f_equal; eauto.
-        f_equal; eauto.
-        f_equal; eauto. f_equal; eauto.
-        rewrite map_map_compose; solve_all.
-      * rewrite ?map_map_compose; f_equal; eauto; solve_all.
-      * rewrite ?map_map_compose; f_equal; eauto; solve_all.
-    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|]=> //;
-      now rewrite IHb.
+    - destruct (k ?= n0)%nat; auto.
+    - move/andP: wft => [] /andP[] hi hb hl. rewrite IHb. f_equal. unfold on_snd; solve_all.
+      repeat toAll. f_equal. solve_all. unfold on_snd; cbn. f_equal.
+      rewrite a0 //. now rewrite -Nat.add_assoc.
+    - move/andP: wft => [] hp hb.
+      rewrite GlobalContextMap.lookup_projection_spec.
+      destruct lookup_projection as [[[[mdecl idecl] cdecl] pdecl]|] eqn:hl => /= //.
+      f_equal; eauto. f_equal. len. f_equal.
+      have arglen := wellformed_projection_args wfΣ hl.
+      case: Nat.compare_spec. lia. lia.
+      auto.
+    - f_equal. move/andP: wft => [hidx hb].
+      solve_all. unfold map_def. f_equal.
+      eapply a0. now rewrite -Nat.add_assoc.
+    - f_equal. move/andP: wft => [hidx hb].
+      solve_all. unfold map_def. f_equal.
+      eapply a0. now rewrite -Nat.add_assoc.
   Qed.
 
   Lemma optimize_substl s t : 
-    forallb (closedn 0) s ->
+    wf_glob Σ ->
+    forallb (wellformed Σ 0) s ->
+    wellformed Σ #|s| t ->
     optimize (substl s t) = substl (map optimize s) (optimize t).
   Proof.
-    induction s in t |- *; simpl; auto.
-    move/andP => [] cla cls.
-    rewrite IHs //. f_equal.
-    now rewrite optimize_csubst.
+    intros wfΣ. induction s in t |- *; simpl; auto.
+    move/andP => [] cla cls wft.
+    rewrite IHs //. eapply wellformed_csubst => //.
+    f_equal. rewrite (optimize_csubst (S #|s|)) //.
   Qed.
 
   Lemma optimize_iota_red pars args br :
-    forallb (closedn 0) args ->
+    wf_glob Σ ->
+    forallb (wellformed Σ 0) args ->
+    wellformed Σ #|skipn pars args| br.2 ->
     optimize (EGlobalEnv.iota_red pars args br) = EGlobalEnv.iota_red pars (map optimize args) (on_snd optimize br).
   Proof.
-    intros cl.
+    intros wfΣ wfa wfbr.
     unfold EGlobalEnv.iota_red.
     rewrite optimize_substl //.
     rewrite forallb_rev forallb_skipn //.
+    now rewrite List.rev_length.
     now rewrite map_rev map_skipn.
   Qed.
   
@@ -161,79 +205,42 @@ Section optimize.
   Qed.
 
   Lemma optimize_cunfold_fix mfix idx n f : 
-    forallb (closedn 0) (EGlobalEnv.fix_subst mfix) ->
+    wf_glob Σ ->
+    wellformed Σ 0 (tFix mfix idx) ->
     cunfold_fix mfix idx = Some (n, f) ->
     cunfold_fix (map (map_def optimize) mfix) idx = Some (n, optimize f).
   Proof.
-    intros hfix.
+    intros wfΣ hfix.
     unfold cunfold_fix.
     rewrite nth_error_map.
-    destruct nth_error.
+    cbn in hfix. move/andP: hfix => [] hidx hfix. 
+    destruct nth_error eqn:hnth => //.
     intros [= <- <-] => /=. f_equal.
-    now rewrite optimize_substl // optimize_fix_subst.
-    discriminate.
+    rewrite optimize_substl //. eapply wellformed_fix_subst => //.
+    rewrite fix_subst_length.
+    eapply nth_error_forallb in hfix; tea. now rewrite Nat.add_0_r in hfix.
+    now rewrite optimize_fix_subst.
   Qed.
 
   Lemma optimize_cunfold_cofix mfix idx n f : 
-    forallb (closedn 0) (EGlobalEnv.cofix_subst mfix) ->
+    wf_glob Σ ->
+    wellformed Σ 0 (tCoFix mfix idx) ->
     cunfold_cofix mfix idx = Some (n, f) ->
     cunfold_cofix (map (map_def optimize) mfix) idx = Some (n, optimize f).
   Proof.
-    intros hcofix.
+    intros wfΣ hfix.
     unfold cunfold_cofix.
     rewrite nth_error_map.
-    destruct nth_error.
+    cbn in hfix. move/andP: hfix => [] hidx hfix. 
+    destruct nth_error eqn:hnth => //.
     intros [= <- <-] => /=. f_equal.
-    now rewrite optimize_substl // optimize_cofix_subst.
-    discriminate.
-  Qed.
-
-  Lemma optimize_nth {n l d} : 
-    optimize (nth n l d) = nth n (map optimize l) (optimize d).
-  Proof.
-    induction l in n |- *; destruct n; simpl; auto.
+    rewrite optimize_substl //. eapply wellformed_cofix_subst => //.
+    rewrite cofix_subst_length.
+    eapply nth_error_forallb in hfix; tea. now rewrite Nat.add_0_r in hfix.
+    now rewrite optimize_cofix_subst.
   Qed.
 
 End optimize.
-
-Lemma is_box_inv b : is_box b -> ∑ args, b = mkApps tBox args.
-Proof.
-  unfold is_box, EAstUtils.head.
-  destruct decompose_app eqn:da.
-  simpl. destruct t => //.
-  eapply decompose_app_inv in da. subst.
-  eexists; eauto.
-Qed.
-
-Lemma eval_is_box {wfl:WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
-Proof.
-  intros ev; induction ev => //.
-  - rewrite is_box_tApp.
-    intros isb. intuition congruence.
-  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
-  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
-  - rewrite is_box_tApp. move/IHev1 => ?. subst => //.
-  - rewrite is_box_tApp. move/IHev1 => ?. subst. solve_discr.
-  - rewrite is_box_tApp. move/IHev1 => ?. subst. cbn in i.
-    destruct EWcbvEval.with_guarded_fix => //.
-  - destruct t => //.
-Qed. 
-
-Lemma isType_tSort {cf:checker_flags} {Σ : global_env_ext} {Γ l A} {wfΣ : wf Σ} : Σ ;;; Γ |- tSort (Universe.make l) : A -> isType Σ Γ (tSort (Universe.make l)).
-Proof.
-  intros HT.
-  eapply inversion_Sort in HT as [l' [wfΓ Hs]]; auto.
-  eexists; econstructor; eauto.
-Qed.
-
-Lemma isType_it_mkProd {cf:checker_flags} {Σ : global_env_ext} {Γ na dom codom A} {wfΣ : wf Σ} :   
-  Σ ;;; Γ |- tProd na dom codom : A -> 
-  isType Σ Γ (tProd na dom codom).
-Proof.
-  intros HT.
-  eapply inversion_Prod in HT as (? & ? & ? & ? & ?); auto.
-  eexists; econstructor; eauto.
-Qed.
 
 Definition optimize_constant_decl Σ cb := 
   {| cst_body := option_map (optimize Σ) cb.(cst_body) |}.
@@ -259,30 +266,15 @@ Program Fixpoint optimize_env' Σ : EnvMap.fresh_globals Σ -> global_context :=
 
 Import EGlobalEnv EExtends.
 
-(* Lemma extends_is_propositional {Σ Σ'} : 
-  wf_glob Σ' -> extends Σ Σ' ->
-  forall ind, 
-  match inductive_isprop_and_pars Σ ind with
-  | Some b => inductive_isprop_and_pars Σ' ind = Some b
-  | None => inductive_isprop_and_pars Σ' ind = None
-  end.
-Proof.
-  intros wf ex ind.
-  rewrite /inductive_isprop_and_pars.
-  destruct lookup_env eqn:lookup => //.
-  now rewrite (extends_lookup wf ex lookup).
-
-Qed. *)
-
-Lemma extends_inductive_isprop_and_pars {efl : EEnvFlags} {Σ Σ' ind} : extends Σ Σ' -> wf_glob Σ' ->
-  isSome (lookup_inductive Σ ind) -> 
-  inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars Σ' ind.
+Lemma extends_lookup_projection {efl : EEnvFlags} {Σ Σ' p} : extends Σ Σ' -> wf_glob Σ' ->
+  isSome (lookup_projection Σ p) -> 
+  lookup_projection Σ p = lookup_projection Σ' p.
 Proof.
   intros ext wf; cbn.
-  unfold inductive_isprop_and_pars.
-  destruct lookup_env as [[]|] eqn:hl => //.
-  rewrite (extends_lookup wf ext hl).
-  destruct nth_error => //.
+  unfold lookup_projection.
+  destruct lookup_constructor as [[[mdecl idecl] cdecl]|] eqn:hl => //.
+  simpl.
+  rewrite (extends_lookup_constructor wf ext _ _ _ hl) //.
 Qed.
 
 Lemma wellformed_optimize_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t : 
@@ -291,20 +283,13 @@ Lemma wellformed_optimize_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t :
   optimize Σ t = optimize Σ' t.
 Proof.
   induction t using EInduction.term_forall_list_ind; cbn -[lookup_constant lookup_inductive
-    GlobalContextMap.inductive_isprop_and_pars]; intros => //.
+    GlobalContextMap.lookup_projection]; intros => //.
   all:unfold wf_fix_gen in *; rtoProp; intuition auto.  
   all:f_equal; eauto; solve_all.
-  - rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
-    assert (map (on_snd (optimize Σ)) l = map (on_snd (optimize Σ')) l) as -> by solve_all.
-    rewrite (extends_inductive_isprop_and_pars H0 H1 H2).
-    destruct inductive_isprop_and_pars as [[[]]|].
-    destruct map => //. f_equal; eauto.
-    destruct l0 => //. destruct p0 => //. f_equal; eauto.
-    all:f_equal; eauto; solve_all.
-  - rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (extends_inductive_isprop_and_pars H0 H1 H3).
-    destruct inductive_isprop_and_pars as [[[]]|] => //.
-    all:f_equal; eauto.
+  - rewrite !GlobalContextMap.lookup_projection_spec.
+    rewrite -(extends_lookup_projection H0 H1 H3).
+    destruct lookup_projection as [[[[]]]|]. f_equal; eauto.
+    now cbn in H3.
 Qed.
 
 Lemma wellformed_optimize_decl_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t : 
@@ -439,6 +424,14 @@ Proof.
   destruct g => //.
 Qed.
 
+Lemma lookup_projection_optimize {efl : EEnvFlags} {Σ : GlobalContextMap.t} {p} :
+  wf_glob Σ ->
+  lookup_projection Σ p = lookup_projection (optimize_env Σ) p.
+Proof.
+  intros wfΣ. rewrite /lookup_projection.
+  rewrite -lookup_constructor_optimize //.
+Qed.
+
 Lemma constructor_isprop_pars_decl_inductive {Σ ind c} {prop pars cdecl} :
   constructor_isprop_pars_decl Σ ind c = Some (prop, pars, cdecl)  -> 
   inductive_isprop_and_pars Σ ind = Some (prop, pars).
@@ -448,152 +441,190 @@ Proof.
   destruct nth_error => //. congruence.
 Qed.
 
-Lemma optimize_correct {efl : EEnvFlags} {fl} {Σ : GlobalContextMap.t} t v :
-  wf_glob Σ ->
-  closed_env Σ ->
-  @Ee.eval fl Σ t v ->
-  closed t ->
-  @Ee.eval (disable_prop_cases fl) (optimize_env Σ) (optimize Σ t) (optimize Σ v).
+Lemma constructor_isprop_pars_decl_constructor {Σ ind c} {mdecl idecl cdecl} :
+  lookup_constructor Σ ind c = Some (mdecl, idecl, cdecl) ->
+  constructor_isprop_pars_decl Σ ind c = Some (ind_propositional idecl, ind_npars mdecl, cdecl).
 Proof.
-  intros wfΣ clΣ ev.
+  rewrite /constructor_isprop_pars_decl. intros -> => /= //.
+Qed.
+
+Lemma wf_mkApps Σ k f args : reflect (wellformed Σ k f /\ forallb (wellformed Σ k) args) (wellformed Σ k (mkApps f args)).
+Proof.
+  rewrite wellformed_mkApps //. eapply andP.
+Qed.
+
+Lemma substl_closed s t : closed t -> substl s t = t.
+Proof.
+  induction s in t |- *; cbn => //.
+  intros clt. rewrite csubst_closed //. now apply IHs.
+Qed.
+
+Lemma substl_rel s k a : 
+  closed a ->
+  nth_error s k = Some a ->
+  substl s (tRel k) = a.
+Proof.
+  intros cla.
+  induction s in k |- *.
+  - rewrite nth_error_nil //.
+  - destruct k => //=.
+    * intros [= ->]. rewrite substl_closed //.
+    * intros hnth. now apply IHs. 
+Qed.
+
+Lemma optimize_correct (efl := all_env_flags) {fl} {Σ : GlobalContextMap.t} t v :
+  wf_glob Σ ->
+  @eval fl Σ t v ->
+  wellformed Σ 0 t ->
+  @eval fl (optimize_env Σ) (optimize Σ t) (optimize Σ v).
+Proof.
+  intros wfΣ ev.
   induction ev; simpl in *.
 
   - move/andP => [] cla clt. econstructor; eauto.
   - move/andP => [] clf cla.
-    eapply eval_closed in ev2; tea.
-    eapply eval_closed in ev1; tea.
+    eapply eval_wellformed in ev2; tea => //.
+    eapply eval_wellformed in ev1; tea => //.
     econstructor; eauto.
-    rewrite optimize_csubst // in IHev3.
-    apply IHev3. eapply closed_csubst => //.
+    rewrite -(optimize_csubst _ 1) //.
+    apply IHev3. eapply wellformed_csubst => //.
 
-  - move/andP => [] clb0 clb1. rewrite optimize_csubst in IHev2.
-    now eapply eval_closed in ev1.
-    econstructor; eauto. eapply IHev2, closed_csubst => //.
-    now eapply eval_closed in ev1.
+  - move/andP => [] clb0 clb1.
+    intuition auto.
+    eapply eval_wellformed in ev1; tea => //.
+    forward IHev2 by eapply wellformed_csubst => //.
+    econstructor; eauto. rewrite -(optimize_csubst _ 1) //.
 
-  - move/andP => [] cld clbrs. rewrite optimize_mkApps in IHev1.
-    have := (eval_closed _ clΣ _ _ cld ev1); rewrite closedn_mkApps => /andP[] _ clargs.
-    rewrite optimize_iota_red in IHev2.
-    eapply eval_closed in ev1 => //.
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (constructor_isprop_pars_decl_inductive e).
-    eapply eval_iota; eauto. tea.
-    now rewrite -is_propositional_cstr_optimize.
-    rewrite nth_error_map e0 //. now len. cbn.
-    rewrite -e2. rewrite !skipn_length map_length //.
-    eapply IHev2.
-    eapply closed_iota_red => //; tea.
-    eapply nth_error_forallb in clbrs; tea. cbn in clbrs.
-    now rewrite Nat.add_0_r in clbrs.
+  - move/andP => [] /andP[] hl wfd wfbrs. rewrite optimize_mkApps in IHev1.
+    eapply eval_wellformed in ev1 => //.
+    move/wf_mkApps: ev1 => [] wfc' wfargs.
+    eapply nth_error_forallb in wfbrs; tea.
+    rewrite Nat.add_0_r in wfbrs.
+    forward IHev2. eapply wellformed_iota_red; tea => //.
+    rewrite optimize_iota_red in IHev2 => //. now rewrite e2.
+    econstructor; eauto.
+    rewrite -is_propositional_cstr_optimize //. tea.
+    rewrite nth_error_map e0 //. len. len.
   
-  - move/andP => [] cld clbrs.
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite e e0 /=.
-    subst brs. cbn in clbrs. rewrite Nat.add_0_r andb_true_r in clbrs.
-    rewrite optimize_substl in IHev2. 
-    eapply All_forallb, All_repeat => //.
-    rewrite map_optimize_repeat_box in IHev2.
-    apply IHev2.
-    eapply closed_substl.
-    eapply All_forallb, All_repeat => //.
-    now rewrite repeat_length Nat.add_0_r.
+  - move/andP => [] /andP[] hl wfd wfbrs.
+    forward IHev2. eapply wellformed_substl; tea => //.
+    rewrite forallb_repeat //. len.
+    rewrite e0 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
+    rewrite optimize_substl in IHev2 => //.
+    rewrite forallb_repeat //. len.
+    rewrite e0 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
+    eapply eval_iota_sing => //; eauto.
+    rewrite -is_propositional_optimize //.
+    rewrite e0 //. simpl.
+    rewrite map_repeat in IHev2 => //.
 
   - move/andP => [] clf cla. rewrite optimize_mkApps in IHev1.
     simpl in *.
-    eapply eval_closed in ev1 => //.
-    rewrite closedn_mkApps in ev1.
-    move: ev1 => /andP [] clfix clargs.
-    eapply Ee.eval_fix; eauto.
+    eapply eval_wellformed in ev1 => //.
+    move/wf_mkApps: ev1 => [] wff wfargs.
+    eapply eval_fix; eauto.
     rewrite map_length.
     eapply optimize_cunfold_fix; tea.
-    eapply closed_fix_subst. tea.
     rewrite optimize_mkApps in IHev3. apply IHev3.
-    rewrite closedn_mkApps clargs.
-    eapply eval_closed in ev2; tas. rewrite ev2 /= !andb_true_r.
-    eapply closed_cunfold_fix; tea.
+    rewrite wellformed_mkApps // wfargs.
+    eapply eval_wellformed in ev2; tas => //. rewrite ev2 /= !andb_true_r.
+    eapply wellformed_cunfold_fix; tea.
 
   - move/andP => [] clf cla.
-    eapply eval_closed in ev1 => //.
-    rewrite closedn_mkApps in ev1.
-    move: ev1 => /andP [] clfix clargs.
-    eapply eval_closed in ev2; tas.
+    eapply eval_wellformed in ev1 => //.
+    move/wf_mkApps: ev1 => [] clfix clargs.
+    eapply eval_wellformed in ev2; tas => //.
     rewrite optimize_mkApps in IHev1 |- *.
-    simpl in *. eapply Ee.eval_fix_value. auto. auto. auto.
+    simpl in *. eapply eval_fix_value. auto. auto. auto.
     eapply optimize_cunfold_fix; eauto.
-    eapply closed_fix_subst => //.
     now rewrite map_length. 
   
   - move/andP => [] clf cla.
-    eapply eval_closed in ev1 => //.
-    eapply eval_closed in ev2; tas.
-    simpl in *. eapply Ee.eval_fix'. auto. auto.
+    eapply eval_wellformed in ev1 => //.
+    eapply eval_wellformed in ev2; tas => //.
+    simpl in *. eapply eval_fix'. auto. auto.
     eapply optimize_cunfold_fix; eauto.
-    eapply closed_fix_subst => //.
     eapply IHev2; tea. eapply IHev3.
     apply/andP; split => //.
-    eapply closed_cunfold_fix; tea.
+    eapply wellformed_cunfold_fix; tea. now cbn.
 
-  - move/andP => [] cd clbrs. specialize (IHev1 cd).
-    rewrite closedn_mkApps in IHev2.
-    move: (eval_closed _ clΣ _ _ cd ev1).
-    rewrite closedn_mkApps.
-    move/andP => [] clfix clargs.
+  - move/andP => [] /andP[] hl cd clbrs. specialize (IHev1 cd).
+    eapply eval_wellformed in ev1; tea => //.
+    move/wf_mkApps: ev1 => [] wfcof wfargs.
     forward IHev2.
-    { rewrite clargs clbrs !andb_true_r.
-      eapply closed_cunfold_cofix; tea. }
-    rewrite -> optimize_mkApps in IHev1, IHev2. simpl.
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec in IHev2 |- *.
-    destruct EGlobalEnv.inductive_isprop_and_pars as [[[] pars]|] eqn:isp => //.
-    destruct brs as [|[a b] []]; simpl in *; auto.
-    simpl in IHev1.
-    eapply Ee.eval_cofix_case. tea.
-    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
-    apply IHev2.
-    eapply Ee.eval_cofix_case; tea.
-    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
-    simpl in *.
-    eapply Ee.eval_cofix_case; tea.
-    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
-    eapply Ee.eval_cofix_case; tea.
-    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    rewrite hl wellformed_mkApps // /= wfargs clbrs !andb_true_r.
+    eapply wellformed_cunfold_cofix; tea => //.
+    rewrite !optimize_mkApps /= in IHev1, IHev2.
+    eapply eval_cofix_case. tea.
+    eapply optimize_cunfold_cofix; tea.
+    exact IHev2.
+
+  - move/andP => [] hl hd.
+    rewrite GlobalContextMap.lookup_projection_spec in IHev2 |- *.
+    destruct lookup_projection as [[[[mdecl idecl] cdecl] pdecl]|] eqn:hl' => //.
+    eapply eval_wellformed in ev1 => //.
+    move/wf_mkApps: ev1 => [] wfcof wfargs.
+    forward IHev2.
+    { rewrite /= wellformed_mkApps // wfargs andb_true_r.
+      eapply wellformed_cunfold_cofix; tea. }
+    rewrite optimize_mkApps /= in IHev1.
+    eapply eval_cofix_case. eauto.
+    eapply optimize_cunfold_cofix; tea.
+    rewrite optimize_mkApps in IHev2 => //.
     
-  - intros cd. specialize (IHev1 cd).
-    move: (eval_closed _ clΣ _ _ cd ev1).
-    rewrite closedn_mkApps; move/andP => [] clfix clargs. forward IHev2.
-    { rewrite closedn_mkApps clargs andb_true_r. eapply closed_cunfold_cofix; tea. }
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec in IHev2 |- *.
-    destruct EGlobalEnv.inductive_isprop_and_pars as [[[] pars]|] eqn:isp; auto.
-    rewrite -> optimize_mkApps in IHev1, IHev2. simpl in *.
-    econstructor; eauto.
-    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
-    rewrite -> optimize_mkApps in IHev1, IHev2. simpl in *.
-    econstructor; eauto.
-    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
-  
   - rewrite /declared_constant in isdecl.
     move: (lookup_env_optimize c wfΣ).
     rewrite isdecl /= //.
     intros hl.
     econstructor; tea. cbn. rewrite e //.
     apply IHev.
-    eapply lookup_env_closed in clΣ; tea.
-    move: clΣ. rewrite /closed_decl e //.
+    eapply lookup_env_wellformed in wfΣ; tea.
+    move: wfΣ. rewrite /wf_global_decl /= e //.
   
-  - move=> cld.
-    eapply eval_closed in ev1; tea.
-    move: ev1; rewrite closedn_mkApps /= => clargs.
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (constructor_isprop_pars_decl_inductive e).
-    rewrite optimize_mkApps in IHev1.
-    specialize (IHev1 cld).
-    eapply Ee.eval_proj; tea.
-    now rewrite -is_propositional_cstr_optimize.
-    now len. rewrite nth_error_map e1 //.
-    eapply IHev2.
-    eapply nth_error_forallb in e1; tea.
+  - move=> /andP[] iss cld.
+    rewrite GlobalContextMap.lookup_projection_spec.
+    eapply eval_wellformed in ev1; tea => //.
+    move/wf_mkApps: ev1 => [] wfc wfargs.
+    destruct lookup_projection as [[[[mdecl idecl] cdecl'] pdecl]|] eqn:hl' => //.
+    pose proof (lookup_projection_lookup_constructor hl').
+    rewrite (constructor_isprop_pars_decl_constructor H) in e. noconf e.
+    forward IHev1 by auto.
+    forward IHev2. eapply nth_error_forallb in wfargs; tea.
+    rewrite optimize_mkApps /= in IHev1.
+    eapply eval_iota; tea.
+    rewrite /constructor_isprop_pars_decl -lookup_constructor_optimize // H //= //.
+    rewrite H0; reflexivity. cbn. reflexivity. len. len.
+    rewrite skipn_length. lia.
+    unfold iota_red. cbn.
+    rewrite (substl_rel _ _ (optimize Σ a)) => //.
+    { eapply nth_error_forallb in wfargs; tea.
+      eapply wf_optimize in wfargs => //.
+      now eapply wellformed_closed in wfargs. }
+    pose proof (wellformed_projection_args wfΣ hl'). cbn in H1.
+    rewrite nth_error_rev. len. rewrite skipn_length. lia. 
+    rewrite List.rev_involutive. len. rewrite skipn_length.
+    rewrite nth_error_skipn nth_error_map.
+    rewrite e0.
+    assert((ind_npars mdecl + cstr_nargs cdecl - ind_npars mdecl) = cstr_nargs cdecl) by lia.
+    rewrite H2. 
+    eapply (f_equal (option_map (optimize Σ))) in e1.
+    cbn in e1. rewrite -e1. f_equal. f_equal. lia.
 
-  - rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    now rewrite e.
+  - move=> /andP[] iss cld.
+    rewrite GlobalContextMap.lookup_projection_spec.
+    destruct lookup_projection as [[[[mdecl idecl] cdecl'] pdecl]|] eqn:hl' => //.
+    pose proof (lookup_projection_lookup_constructor hl').
+    simpl in H. 
+    move: e. rewrite /inductive_isprop_and_pars.
+    rewrite (lookup_constructor_lookup_inductive H) /=.
+    intros [= eq <-].
+    eapply eval_iota_sing => //; eauto.
+    rewrite -is_propositional_optimize // /inductive_isprop_and_pars
+      (lookup_constructor_lookup_inductive H) //=. congruence.
+    have lenarg := wellformed_projection_args wfΣ hl'.
+    rewrite (substl_rel _ _ tBox) => //.
+    { rewrite nth_error_repeat //. len. }
+    now constructor.
 
   - move/andP=> [] clf cla.
     rewrite optimize_mkApps.
@@ -605,8 +636,8 @@ Proof.
 
   - move/andP => [] clf cla.
     specialize (IHev1 clf). specialize (IHev2 cla).
-    eapply Ee.eval_app_cong; eauto.
-    eapply Ee.eval_to_value in ev1.
+    eapply eval_app_cong; eauto.
+    eapply eval_to_value in ev1.
     destruct ev1; simpl in *; eauto.
     * destruct t => //; rewrite optimize_mkApps /=.
     * destruct with_guarded_fix.
@@ -627,19 +658,6 @@ Proof.
     all:constructor; eauto.
 Qed.
 
-(* 
-Lemma optimize_extends Σ Σ' : 
-  wf_glob Σ' ->
-  extends Σ Σ' ->
-  forall t b, optimize Σ t = b -> optimize Σ' t = b.
-Proof.
-  intros wf ext.
-  induction t using EInduction.term_forall_list_ind; cbn => //.
-  all:try solve [f_equal; solve_all].
-  destruct inductive_isp
-  rewrite (extends_is_propositional wf ext).
- *)
-
 From MetaCoq.Erasure Require Import EEtaExpanded.
 
 Lemma isLambda_optimize Σ t : isLambda t -> isLambda (optimize Σ t).
@@ -654,24 +672,11 @@ Proof.
   all:rewrite ?optimize_mkApps.
   - eapply expanded_mkApps_expanded => //. solve_all.
   - cbn -[GlobalContextMap.inductive_isprop_and_pars].
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
-    2-3:constructor; eauto; solve_all.
-    destruct branches eqn:heq.
-    constructor; eauto; solve_all. cbn.
-    destruct l => /=.
-    eapply isEtaExp_expanded.
-    eapply isEtaExp_substl. eapply forallb_repeat => //.
-    destruct branches as [|[]]; cbn in heq; noconf heq.
-    cbn -[isEtaExp] in *. depelim H1. cbn in H1.
-    now eapply expanded_isEtaExp.
-    constructor; eauto; solve_all.
-    depelim H1. depelim H1. do 2 (constructor; intuition auto).
-    solve_all.
-  - cbn -[GlobalContextMap.inductive_isprop_and_pars].
-    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
-    constructor. all:constructor; auto.
+    rewrite GlobalContextMap.lookup_projection_spec.
+    destruct lookup_projection as [[[[mdecl idecl] cdecl] pdecl]|] => /= //.
+    2:constructor; eauto; solve_all.
+    destruct proj as [[ind npars] arg].
+    econstructor; eauto. repeat constructor.
   - cbn. eapply expanded_tFix. solve_all.
     rewrite isLambda_optimize //.
   - eapply expanded_tConstruct_app; tea.
@@ -760,31 +765,45 @@ Proof.
   now unshelve eapply (optimize_expanded_decl (Σ:=Σ')).
 Qed.
 
+Definition disable_projections_term_flags (et : ETermFlags) := 
+  {| has_tBox := has_tBox
+    ; has_tRel := has_tRel
+    ; has_tVar := has_tVar
+    ; has_tEvar := has_tEvar
+    ; has_tLambda := has_tLambda
+    ; has_tLetIn := has_tLetIn
+    ; has_tApp := has_tApp
+    ; has_tConst := has_tConst
+    ; has_tConstruct := has_tConstruct
+    ; has_tCase := true
+    ; has_tProj := false
+    ; has_tFix := has_tFix
+    ; has_tCoFix := has_tCoFix
+  |}.
+
+Definition disable_projections_env_flag (efl : EEnvFlags) := 
+  {| has_axioms := true;
+     term_switches := disable_projections_term_flags term_switches;
+     has_cstr_params := true |}.
+
 Lemma optimize_wellformed {efl : EEnvFlags} {Σ : GlobalContextMap.t} n t :
   has_tBox -> has_tRel ->
-  wf_glob Σ -> EWellformed.wellformed Σ n t -> EWellformed.wellformed Σ n (optimize Σ t).
+  wf_glob Σ -> EWellformed.wellformed Σ n t -> 
+  EWellformed.wellformed (efl := disable_projections_env_flag efl) Σ n (optimize Σ t).
 Proof.
-  intros wfΣ hbox hrel.
+  intros hbox hrel wfΣ.
   induction t in n |- * using EInduction.term_forall_list_ind => //.
   all:try solve [cbn; rtoProp; intuition auto; solve_all].
-  - cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/and3P => [] hasc /andP[]hs ht hbrs.
-    destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
-    destruct l as [|[br n'] [|l']] eqn:eql; simpl.
-    all:rewrite ?hasc ?hs /= ?andb_true_r.
-    rewrite IHt //.
-    depelim X. cbn in hbrs.
-    rewrite andb_true_r in hbrs.
-    specialize (i _ hbrs).
-    eapply wellformed_substl => //. solve_all. eapply All_repeat => //.
-    now rewrite repeat_length.
-    cbn in hbrs; rtoProp; solve_all. depelim X; depelim X. solve_all.
-    do 2 depelim X. solve_all.
-    do 2 depelim X. solve_all.
-    rtoProp; solve_all. solve_all.
-    rtoProp; solve_all. solve_all.
-  - cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/andP => [] /andP[]hasc hs ht.
-    destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
-    all:rewrite hasc hs /=; eauto.
+  - simpl. destruct lookup_constant => //.
+    move/andP => [] hasc _ => //. now rewrite hasc.
+  - cbn. move/andP => [] /andP[] hast hl wft.
+    rewrite GlobalContextMap.lookup_projection_spec.
+    destruct lookup_projection as [[[[mdecl idecl] cdecl] pdecl]|] eqn:hl'; auto => //.
+    simpl. 
+    rewrite (lookup_constructor_lookup_inductive (lookup_projection_lookup_constructor hl')) /=.
+    rewrite hrel IHt //= andb_true_r.
+    have hargs' := wellformed_projection_args wfΣ hl'.
+    apply Nat.ltb_lt. len.
   - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
     unfold test_def in *. len. eauto.
   - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
@@ -795,14 +814,14 @@ Import EWellformed.
 
 Lemma optimize_wellformed_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t :
   wf_glob Σ ->
-  forall n, wellformed Σ n t -> wellformed (optimize_env Σ) n t.
+  forall n, wellformed (efl := disable_projections_env_flag efl) Σ n t -> 
+  wellformed (efl := disable_projections_env_flag efl) (optimize_env Σ) n t.
 Proof.
   intros wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
   all:try solve [intros; unfold wf_fix_gen in *; rtoProp; intuition eauto; solve_all].
   - rewrite lookup_env_optimize //.
     destruct lookup_env eqn:hl => // /=.
-    destruct g eqn:hg => /= //. subst g.
-    destruct (cst_body c) => //.
+    destruct g eqn:hg => /= //.
   - rewrite lookup_env_optimize //.
     destruct lookup_env eqn:hl => // /=.
     destruct g eqn:hg => /= //. 
@@ -811,17 +830,12 @@ Proof.
     destruct g eqn:hg => /= //. subst g.
     destruct nth_error => /= //.
     intros; rtoProp; intuition auto; solve_all.
-  - rewrite lookup_env_optimize //.
-    destruct lookup_env eqn:hl => // /=.
-    destruct g eqn:hg => /= //.
-    rewrite andb_false_r => //.
-    destruct nth_error => /= //.
-    all:intros; rtoProp; intuition auto; solve_all.
 Qed.
 
 Lemma optimize_wellformed_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} d :
   wf_glob Σ ->
-  wf_global_decl Σ d -> wf_global_decl (optimize_env Σ) d.
+  wf_global_decl (efl:= disable_projections_env_flag efl) Σ d -> 
+  wf_global_decl (efl := disable_projections_env_flag efl) (optimize_env Σ) d.
 Proof.
   intros wf; destruct d => /= //.
   destruct (cst_body c) => /= //.
@@ -830,15 +844,18 @@ Qed.
 
 Lemma optimize_decl_wf {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
   has_tBox -> has_tRel -> wf_glob Σ -> 
-  forall d, wf_global_decl Σ d -> wf_global_decl (optimize_env Σ) (optimize_decl Σ d).
+  forall d, wf_global_decl Σ d -> 
+  wf_global_decl (efl := disable_projections_env_flag efl) (optimize_env Σ) (optimize_decl Σ d).
 Proof.
   intros hasb hasr wf d.
   intros hd.
-  eapply optimize_wellformed_decl_irrel; tea.
+  eapply optimize_wellformed_decl_irrel; tea; eauto.
   move: hd.
   destruct d => /= //.
   destruct (cst_body c) => /= //.
-  now eapply optimize_wellformed => //.
+  intros hwf. eapply optimize_wellformed => //. auto.
+  destruct efl => //. destruct m => //. cbn. unfold wf_minductive.
+  cbn. move/andP => [] hp //.
 Qed.
 
 Lemma fresh_global_optimize_env {Σ : GlobalContextMap.t} kn : 
@@ -852,7 +869,7 @@ Qed.
 
 Lemma optimize_env_wf {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
   has_tBox -> has_tRel -> 
-  wf_glob Σ -> wf_glob (optimize_env Σ).
+  wf_glob Σ -> wf_glob (efl := disable_projections_env_flag efl) (optimize_env Σ).
 Proof.
   intros hasb hasrel.
   intros wfg. rewrite optimize_env_eq //.
@@ -866,10 +883,10 @@ Proof.
 Qed.
 
 Definition optimize_program (p : eprogram_env) :=
-  (EOptimizePropDiscr.optimize_env p.1, EOptimizePropDiscr.optimize p.1 p.2).
+  (optimize_env p.1, optimize p.1 p.2).
 
-Definition optimize_program_wf {efl} (p : eprogram_env) {hastbox : has_tBox} {hastrel : has_tRel} :
-  wf_eprogram_env efl p -> wf_eprogram efl (optimize_program p).
+Definition optimize_program_wf {efl : EEnvFlags} (p : eprogram_env) {hastbox : has_tBox} {hastrel : has_tRel} :
+  wf_eprogram_env efl p -> wf_eprogram (disable_projections_env_flag efl) (optimize_program p).
 Proof.
   intros []; split.
   now eapply optimize_env_wf.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -1,0 +1,891 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import Utf8 Program.
+From MetaCoq.Template Require Import config utils Kernames.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+     PCUICReflect PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
+     PCUICTyping PCUICInversion
+     PCUICSafeLemmata. (* for welltyped *)
+From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
+From MetaCoq.Erasure Require Import EAst EAstUtils EDeps EExtends
+    ELiftSubst ECSubst EGlobalEnv EWellformed EWcbvEval Extract Prelim
+    EEnvMap EArities EProgram.
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Import MCMonadNotation.
+
+From Equations Require Import Equations.
+Set Equations Transparent.
+Local Set Keyed Unification.
+Require Import ssreflect ssrbool.
+
+(** We assumes [Prop </= Type] and universes are checked correctly in the following. *)
+Local Existing Instance extraction_checker_flags.
+
+Ltac introdep := let H := fresh in intros H; depelim H.
+
+#[global]
+Hint Constructors eval : core.
+
+Section optimize.
+  Context (Σ : GlobalContextMap.t).
+
+  Fixpoint optimize (t : term) : term :=
+    match t with
+    | tRel i => tRel i
+    | tEvar ev args => tEvar ev (List.map optimize args)
+    | tLambda na M => tLambda na (optimize M)
+    | tApp u v => tApp (optimize u) (optimize v)
+    | tLetIn na b b' => tLetIn na (optimize b) (optimize b')
+    | tCase ind c brs => tCase ind (optimize c) (map (on_snd optimize) brs)
+    | tProj p c =>
+      match GlobalContextMap.lookup_constructor Σ p.1.1 0 with 
+      | Some (mdecl, idecl, cdecl) => 
+        tCase p.1 (optimize c) [(unfold cdecl.2 (fun n => nAnon), tRel (cdecl.2 - S p.2))]
+      | _ => tProj p (optimize c)
+      end
+    | tFix mfix idx =>
+      let mfix' := List.map (map_def optimize) mfix in
+      tFix mfix' idx
+    | tCoFix mfix idx =>
+      let mfix' := List.map (map_def optimize) mfix in
+      tCoFix mfix' idx
+    | tBox => t
+    | tVar _ => t
+    | tConst _ => t
+    | tConstruct _ _ => t
+    (* | tPrim _ => t *)
+    end.
+
+  Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).
+  Proof.
+    induction l using rev_ind; simpl; auto.
+    now rewrite mkApps_app /= IHl map_app /= mkApps_app /=.
+  Qed.
+
+  Lemma map_repeat {A B} (f : A -> B) x n : map f (repeat x n) = repeat (f x) n.
+  Proof.
+    now induction n; simpl; auto; rewrite IHn.
+  Qed.
+  
+  Lemma map_optimize_repeat_box n : map optimize (repeat tBox n) = repeat tBox n.
+  Proof. by rewrite map_repeat. Qed.
+
+  Import ECSubst.
+
+  Lemma closed_optimize t k : closedn k t -> closedn k (optimize t).
+  Proof.
+    induction t in k |- * using EInduction.term_forall_list_ind; simpl; auto;
+    intros; try easy;
+    rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
+    unfold test_def in *;
+    simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
+    - move/andP: H => [] clt cll.
+      rewrite IHt //=. solve_all.
+    - destruct GlobalContextMap.lookup_constructor as [[[mdecl idecl] cdecl]|]; cbn; auto.
+      rewrite IHt //=; len. rewrite andb_true_r; apply Nat.ltb_lt. 
+      assert (cdecl.2 > 0). admit. lia.
+      lia.
+  Qed.
+ 
+  Lemma optimize_csubst a k b : 
+    closed a ->
+    optimize (ECSubst.csubst a k b) = ECSubst.csubst (optimize a) k (optimize b).
+  Proof.
+    induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto;
+    intros cl; try easy; 
+    rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
+    unfold test_def in *;
+    simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
+    - destruct (k ?= n)%nat; auto.
+    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+      destruct l as [|[br n] [|l']] eqn:eql; simpl.
+      all:unfold on_snd; cbn.
+      * f_equal; auto.
+      * depelim X. simpl in *.
+        rewrite e //.
+        assert (#|br| = #|repeat tBox #|br| |). now rewrite repeat_length.
+        rewrite {2}H.
+        rewrite substl_csubst_comm //.
+        solve_all. eapply All_repeat => //.
+        now eapply closed_optimize.
+      * depelim X. depelim X.
+        f_equal; eauto.
+        unfold on_snd; cbn. f_equal; eauto.
+        f_equal; eauto.
+        f_equal; eauto. f_equal; eauto.
+        rewrite map_map_compose; solve_all.
+      * rewrite ?map_map_compose; f_equal; eauto; solve_all.
+      * rewrite ?map_map_compose; f_equal; eauto; solve_all.
+    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|]=> //;
+      now rewrite IHb.
+  Qed.
+
+  Lemma optimize_substl s t : 
+    forallb (closedn 0) s ->
+    optimize (substl s t) = substl (map optimize s) (optimize t).
+  Proof.
+    induction s in t |- *; simpl; auto.
+    move/andP => [] cla cls.
+    rewrite IHs //. f_equal.
+    now rewrite optimize_csubst.
+  Qed.
+
+  Lemma optimize_iota_red pars args br :
+    forallb (closedn 0) args ->
+    optimize (EGlobalEnv.iota_red pars args br) = EGlobalEnv.iota_red pars (map optimize args) (on_snd optimize br).
+  Proof.
+    intros cl.
+    unfold EGlobalEnv.iota_red.
+    rewrite optimize_substl //.
+    rewrite forallb_rev forallb_skipn //.
+    now rewrite map_rev map_skipn.
+  Qed.
+  
+  Lemma optimize_fix_subst mfix : EGlobalEnv.fix_subst (map (map_def optimize) mfix) = map optimize (EGlobalEnv.fix_subst mfix).
+  Proof.
+    unfold EGlobalEnv.fix_subst.
+    rewrite map_length.
+    generalize #|mfix|.
+    induction n; simpl; auto.
+    f_equal; auto.
+  Qed.
+
+  Lemma optimize_cofix_subst mfix : EGlobalEnv.cofix_subst (map (map_def optimize) mfix) = map optimize (EGlobalEnv.cofix_subst mfix).
+  Proof.
+    unfold EGlobalEnv.cofix_subst.
+    rewrite map_length.
+    generalize #|mfix|.
+    induction n; simpl; auto.
+    f_equal; auto.
+  Qed.
+
+  Lemma optimize_cunfold_fix mfix idx n f : 
+    forallb (closedn 0) (EGlobalEnv.fix_subst mfix) ->
+    cunfold_fix mfix idx = Some (n, f) ->
+    cunfold_fix (map (map_def optimize) mfix) idx = Some (n, optimize f).
+  Proof.
+    intros hfix.
+    unfold cunfold_fix.
+    rewrite nth_error_map.
+    destruct nth_error.
+    intros [= <- <-] => /=. f_equal.
+    now rewrite optimize_substl // optimize_fix_subst.
+    discriminate.
+  Qed.
+
+  Lemma optimize_cunfold_cofix mfix idx n f : 
+    forallb (closedn 0) (EGlobalEnv.cofix_subst mfix) ->
+    cunfold_cofix mfix idx = Some (n, f) ->
+    cunfold_cofix (map (map_def optimize) mfix) idx = Some (n, optimize f).
+  Proof.
+    intros hcofix.
+    unfold cunfold_cofix.
+    rewrite nth_error_map.
+    destruct nth_error.
+    intros [= <- <-] => /=. f_equal.
+    now rewrite optimize_substl // optimize_cofix_subst.
+    discriminate.
+  Qed.
+
+  Lemma optimize_nth {n l d} : 
+    optimize (nth n l d) = nth n (map optimize l) (optimize d).
+  Proof.
+    induction l in n |- *; destruct n; simpl; auto.
+  Qed.
+
+End optimize.
+
+Lemma is_box_inv b : is_box b -> ∑ args, b = mkApps tBox args.
+Proof.
+  unfold is_box, EAstUtils.head.
+  destruct decompose_app eqn:da.
+  simpl. destruct t => //.
+  eapply decompose_app_inv in da. subst.
+  eexists; eauto.
+Qed.
+
+Lemma eval_is_box {wfl:WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
+Proof.
+  intros ev; induction ev => //.
+  - rewrite is_box_tApp.
+    intros isb. intuition congruence.
+  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst => //.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst. solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst. cbn in i.
+    destruct EWcbvEval.with_guarded_fix => //.
+  - destruct t => //.
+Qed. 
+
+Lemma isType_tSort {cf:checker_flags} {Σ : global_env_ext} {Γ l A} {wfΣ : wf Σ} : Σ ;;; Γ |- tSort (Universe.make l) : A -> isType Σ Γ (tSort (Universe.make l)).
+Proof.
+  intros HT.
+  eapply inversion_Sort in HT as [l' [wfΓ Hs]]; auto.
+  eexists; econstructor; eauto.
+Qed.
+
+Lemma isType_it_mkProd {cf:checker_flags} {Σ : global_env_ext} {Γ na dom codom A} {wfΣ : wf Σ} :   
+  Σ ;;; Γ |- tProd na dom codom : A -> 
+  isType Σ Γ (tProd na dom codom).
+Proof.
+  intros HT.
+  eapply inversion_Prod in HT as (? & ? & ? & ? & ?); auto.
+  eexists; econstructor; eauto.
+Qed.
+
+Definition optimize_constant_decl Σ cb := 
+  {| cst_body := option_map (optimize Σ) cb.(cst_body) |}.
+  
+Definition optimize_decl Σ d :=
+  match d with
+  | ConstantDecl cb => ConstantDecl (optimize_constant_decl Σ cb)
+  | InductiveDecl idecl => d
+  end.
+
+Definition optimize_env Σ := 
+  map (on_snd (optimize_decl Σ)) Σ.(GlobalContextMap.global_decls).
+  
+Import EnvMap.
+
+Program Fixpoint optimize_env' Σ : EnvMap.fresh_globals Σ -> global_context :=
+  match Σ with
+  | [] => fun _ => []
+  | hd :: tl => fun HΣ =>
+    let Σg := GlobalContextMap.make tl (fresh_globals_cons_inv HΣ) in 
+    on_snd (optimize_decl Σg) hd :: optimize_env' tl (fresh_globals_cons_inv HΣ) 
+  end.
+
+Import EGlobalEnv EExtends.
+
+(* Lemma extends_is_propositional {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind, 
+  match inductive_isprop_and_pars Σ ind with
+  | Some b => inductive_isprop_and_pars Σ' ind = Some b
+  | None => inductive_isprop_and_pars Σ' ind = None
+  end.
+Proof.
+  intros wf ex ind.
+  rewrite /inductive_isprop_and_pars.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+
+Qed. *)
+
+Lemma extends_inductive_isprop_and_pars {efl : EEnvFlags} {Σ Σ' ind} : extends Σ Σ' -> wf_glob Σ' ->
+  isSome (lookup_inductive Σ ind) -> 
+  inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars Σ' ind.
+Proof.
+  intros ext wf; cbn.
+  unfold inductive_isprop_and_pars.
+  destruct lookup_env as [[]|] eqn:hl => //.
+  rewrite (extends_lookup wf ext hl).
+  destruct nth_error => //.
+Qed.
+
+Lemma wellformed_optimize_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t : 
+  forall n, EWellformed.wellformed Σ n t ->
+  forall {Σ' : GlobalContextMap.t}, extends Σ Σ' -> wf_glob Σ' ->
+  optimize Σ t = optimize Σ' t.
+Proof.
+  induction t using EInduction.term_forall_list_ind; cbn -[lookup_constant lookup_inductive
+    GlobalContextMap.inductive_isprop_and_pars]; intros => //.
+  all:unfold wf_fix_gen in *; rtoProp; intuition auto.  
+  all:f_equal; eauto; solve_all.
+  - rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
+    assert (map (on_snd (optimize Σ)) l = map (on_snd (optimize Σ')) l) as -> by solve_all.
+    rewrite (extends_inductive_isprop_and_pars H0 H1 H2).
+    destruct inductive_isprop_and_pars as [[[]]|].
+    destruct map => //. f_equal; eauto.
+    destruct l0 => //. destruct p0 => //. f_equal; eauto.
+    all:f_equal; eauto; solve_all.
+  - rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite (extends_inductive_isprop_and_pars H0 H1 H3).
+    destruct inductive_isprop_and_pars as [[[]]|] => //.
+    all:f_equal; eauto.
+Qed.
+
+Lemma wellformed_optimize_decl_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t : 
+  wf_global_decl Σ t ->
+  forall {Σ' : GlobalContextMap.t}, extends Σ Σ' -> wf_glob Σ' ->
+  optimize_decl Σ t = optimize_decl Σ' t.
+Proof.
+  destruct t => /= //.
+  intros wf Σ' ext wf'. f_equal. unfold optimize_constant_decl. f_equal.
+  destruct (cst_body c) => /= //. f_equal.
+  now eapply wellformed_optimize_extends.
+Qed.
+
+Lemma lookup_env_optimize_env_Some {efl : EEnvFlags} {Σ : GlobalContextMap.t} kn d : 
+  wf_glob Σ ->
+  GlobalContextMap.lookup_env Σ kn = Some d ->
+  ∑ Σ' : GlobalContextMap.t, 
+    [× extends Σ' Σ, wf_global_decl Σ' d &
+      lookup_env (optimize_env Σ) kn = Some (optimize_decl Σ' d)].
+Proof.
+  rewrite GlobalContextMap.lookup_env_spec.
+  destruct Σ as [Σ map repr wf].
+  induction Σ in map, repr, wf |- *; simpl; auto => //.
+  intros wfg.
+  case: eqb_specT => //.
+  - intros ->. cbn. intros [= <-].
+    exists (GlobalContextMap.make Σ (fresh_globals_cons_inv wf)). split.
+    now eexists [_].
+    cbn. now depelim wfg.
+    f_equal. symmetry. eapply wellformed_optimize_decl_extends. cbn. now depelim wfg.
+    cbn. now exists [a]. now cbn.
+  - intros _. 
+    set (Σ' := GlobalContextMap.make Σ (fresh_globals_cons_inv wf)).
+    specialize (IHΣ (GlobalContextMap.map Σ') (GlobalContextMap.repr Σ') (GlobalContextMap.wf Σ')).
+    cbn in IHΣ. forward IHΣ. now depelim wfg.
+    intros hl. specialize (IHΣ hl) as [Σ'' [ext wfgd hl']].
+    exists Σ''. split => //.
+    * destruct ext as [? ->].
+      now exists (a :: x).
+    * rewrite -hl'. f_equal.
+      clear -wfg.
+      eapply map_ext_in => kn hin. unfold on_snd. f_equal.
+      symmetry. eapply wellformed_optimize_decl_extends => //. cbn.
+      eapply lookup_env_In in hin. 2:now depelim wfg.
+      depelim wfg. eapply lookup_env_wellformed; tea.
+      cbn. now exists [a].
+Qed.
+
+Lemma lookup_env_map_snd Σ f kn : lookup_env (List.map (on_snd f) Σ) kn = option_map f (lookup_env Σ kn).
+Proof.
+  induction Σ; cbn; auto.
+  case: eqb_spec => //.
+Qed.
+
+Lemma lookup_env_optimize_env_None {efl : EEnvFlags} {Σ : GlobalContextMap.t} kn : 
+  GlobalContextMap.lookup_env Σ kn = None ->
+  lookup_env (optimize_env Σ) kn = None.
+Proof.
+  rewrite GlobalContextMap.lookup_env_spec.
+  destruct Σ as [Σ map repr wf].
+  cbn. intros hl. rewrite lookup_env_map_snd hl //.
+Qed.
+
+Lemma lookup_env_optimize {efl : EEnvFlags} {Σ : GlobalContextMap.t} kn : 
+  wf_glob Σ ->
+  lookup_env (optimize_env Σ) kn = option_map (optimize_decl Σ) (lookup_env Σ kn).
+Proof.
+  intros wf.
+  rewrite -GlobalContextMap.lookup_env_spec.
+  destruct (GlobalContextMap.lookup_env Σ kn) eqn:hl.
+  - eapply lookup_env_optimize_env_Some in hl as [Σ' [ext wf' hl']] => /=.
+    rewrite hl'. f_equal.
+    eapply wellformed_optimize_decl_extends; eauto. auto.
+    
+  - cbn. now eapply lookup_env_optimize_env_None in hl. 
+Qed.
+
+Lemma is_propositional_optimize {efl : EEnvFlags} {Σ : GlobalContextMap.t} ind : 
+  wf_glob Σ ->
+  inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars (optimize_env Σ) ind.
+Proof.
+  rewrite /inductive_isprop_and_pars => wf.
+  rewrite /lookup_inductive /lookup_minductive.
+  rewrite (lookup_env_optimize (inductive_mind ind) wf).
+  rewrite /GlobalContextMap.inductive_isprop_and_pars /GlobalContextMap.lookup_inductive
+    /GlobalContextMap.lookup_minductive.  
+  destruct lookup_env as [[decl|]|] => //.
+Qed.
+
+Lemma is_propositional_cstr_optimize {efl : EEnvFlags} {Σ : GlobalContextMap.t} ind c : 
+  wf_glob Σ ->
+  constructor_isprop_pars_decl Σ ind c = constructor_isprop_pars_decl (optimize_env Σ) ind c.
+Proof.
+  rewrite /constructor_isprop_pars_decl => wf.
+  rewrite /lookup_constructor /lookup_inductive /lookup_minductive.
+  rewrite (lookup_env_optimize (inductive_mind ind) wf).
+  rewrite /GlobalContextMap.inductive_isprop_and_pars /GlobalContextMap.lookup_inductive
+    /GlobalContextMap.lookup_minductive.  
+  destruct lookup_env as [[decl|]|] => //.
+Qed.
+
+
+Lemma closed_iota_red pars c args brs br :
+  forallb (closedn 0) args ->
+  nth_error brs c = Some br ->
+  #|skipn pars args| = #|br.1| ->
+  closedn #|br.1| br.2 ->
+  closed (iota_red pars args br).
+Proof.
+  intros clargs hnth hskip clbr.
+  rewrite /iota_red.
+  eapply ECSubst.closed_substl => //.
+  now rewrite forallb_rev forallb_skipn.
+  now rewrite List.rev_length hskip Nat.add_0_r.
+Qed.
+
+Definition disable_prop_cases fl := {| with_prop_case := false; with_guarded_fix := fl.(@with_guarded_fix) |}.
+
+Lemma isFix_mkApps t l : isFix (mkApps t l) = isFix t && match l with [] => true | _ => false end.
+Proof.
+  induction l using rev_ind; cbn.
+  - now rewrite andb_true_r.
+  - rewrite mkApps_app /=. now destruct l => /= //; rewrite andb_false_r.
+Qed.
+
+Lemma lookup_constructor_optimize {efl : EEnvFlags} {Σ : GlobalContextMap.t} {ind c} :
+  wf_glob Σ ->
+  lookup_constructor Σ ind c = lookup_constructor (optimize_env Σ) ind c.
+Proof.
+  intros wfΣ. rewrite /lookup_constructor /lookup_inductive /lookup_minductive.
+  rewrite lookup_env_optimize // /=. destruct lookup_env => // /=.
+  destruct g => //.
+Qed.
+
+Lemma constructor_isprop_pars_decl_inductive {Σ ind c} {prop pars cdecl} :
+  constructor_isprop_pars_decl Σ ind c = Some (prop, pars, cdecl)  -> 
+  inductive_isprop_and_pars Σ ind = Some (prop, pars).
+Proof.
+  rewrite /constructor_isprop_pars_decl /inductive_isprop_and_pars /lookup_constructor.
+  destruct lookup_inductive as [[mdecl idecl]|]=> /= //.
+  destruct nth_error => //. congruence.
+Qed.
+
+Lemma optimize_correct {efl : EEnvFlags} {fl} {Σ : GlobalContextMap.t} t v :
+  wf_glob Σ ->
+  closed_env Σ ->
+  @Ee.eval fl Σ t v ->
+  closed t ->
+  @Ee.eval (disable_prop_cases fl) (optimize_env Σ) (optimize Σ t) (optimize Σ v).
+Proof.
+  intros wfΣ clΣ ev.
+  induction ev; simpl in *.
+
+  - move/andP => [] cla clt. econstructor; eauto.
+  - move/andP => [] clf cla.
+    eapply eval_closed in ev2; tea.
+    eapply eval_closed in ev1; tea.
+    econstructor; eauto.
+    rewrite optimize_csubst // in IHev3.
+    apply IHev3. eapply closed_csubst => //.
+
+  - move/andP => [] clb0 clb1. rewrite optimize_csubst in IHev2.
+    now eapply eval_closed in ev1.
+    econstructor; eauto. eapply IHev2, closed_csubst => //.
+    now eapply eval_closed in ev1.
+
+  - move/andP => [] cld clbrs. rewrite optimize_mkApps in IHev1.
+    have := (eval_closed _ clΣ _ _ cld ev1); rewrite closedn_mkApps => /andP[] _ clargs.
+    rewrite optimize_iota_red in IHev2.
+    eapply eval_closed in ev1 => //.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite (constructor_isprop_pars_decl_inductive e).
+    eapply eval_iota; eauto. tea.
+    now rewrite -is_propositional_cstr_optimize.
+    rewrite nth_error_map e0 //. now len. cbn.
+    rewrite -e2. rewrite !skipn_length map_length //.
+    eapply IHev2.
+    eapply closed_iota_red => //; tea.
+    eapply nth_error_forallb in clbrs; tea. cbn in clbrs.
+    now rewrite Nat.add_0_r in clbrs.
+  
+  - move/andP => [] cld clbrs.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite e e0 /=.
+    subst brs. cbn in clbrs. rewrite Nat.add_0_r andb_true_r in clbrs.
+    rewrite optimize_substl in IHev2. 
+    eapply All_forallb, All_repeat => //.
+    rewrite map_optimize_repeat_box in IHev2.
+    apply IHev2.
+    eapply closed_substl.
+    eapply All_forallb, All_repeat => //.
+    now rewrite repeat_length Nat.add_0_r.
+
+  - move/andP => [] clf cla. rewrite optimize_mkApps in IHev1.
+    simpl in *.
+    eapply eval_closed in ev1 => //.
+    rewrite closedn_mkApps in ev1.
+    move: ev1 => /andP [] clfix clargs.
+    eapply Ee.eval_fix; eauto.
+    rewrite map_length.
+    eapply optimize_cunfold_fix; tea.
+    eapply closed_fix_subst. tea.
+    rewrite optimize_mkApps in IHev3. apply IHev3.
+    rewrite closedn_mkApps clargs.
+    eapply eval_closed in ev2; tas. rewrite ev2 /= !andb_true_r.
+    eapply closed_cunfold_fix; tea.
+
+  - move/andP => [] clf cla.
+    eapply eval_closed in ev1 => //.
+    rewrite closedn_mkApps in ev1.
+    move: ev1 => /andP [] clfix clargs.
+    eapply eval_closed in ev2; tas.
+    rewrite optimize_mkApps in IHev1 |- *.
+    simpl in *. eapply Ee.eval_fix_value. auto. auto. auto.
+    eapply optimize_cunfold_fix; eauto.
+    eapply closed_fix_subst => //.
+    now rewrite map_length. 
+  
+  - move/andP => [] clf cla.
+    eapply eval_closed in ev1 => //.
+    eapply eval_closed in ev2; tas.
+    simpl in *. eapply Ee.eval_fix'. auto. auto.
+    eapply optimize_cunfold_fix; eauto.
+    eapply closed_fix_subst => //.
+    eapply IHev2; tea. eapply IHev3.
+    apply/andP; split => //.
+    eapply closed_cunfold_fix; tea.
+
+  - move/andP => [] cd clbrs. specialize (IHev1 cd).
+    rewrite closedn_mkApps in IHev2.
+    move: (eval_closed _ clΣ _ _ cd ev1).
+    rewrite closedn_mkApps.
+    move/andP => [] clfix clargs.
+    forward IHev2.
+    { rewrite clargs clbrs !andb_true_r.
+      eapply closed_cunfold_cofix; tea. }
+    rewrite -> optimize_mkApps in IHev1, IHev2. simpl.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec in IHev2 |- *.
+    destruct EGlobalEnv.inductive_isprop_and_pars as [[[] pars]|] eqn:isp => //.
+    destruct brs as [|[a b] []]; simpl in *; auto.
+    simpl in IHev1.
+    eapply Ee.eval_cofix_case. tea.
+    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    apply IHev2.
+    eapply Ee.eval_cofix_case; tea.
+    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    simpl in *.
+    eapply Ee.eval_cofix_case; tea.
+    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    eapply Ee.eval_cofix_case; tea.
+    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    
+  - intros cd. specialize (IHev1 cd).
+    move: (eval_closed _ clΣ _ _ cd ev1).
+    rewrite closedn_mkApps; move/andP => [] clfix clargs. forward IHev2.
+    { rewrite closedn_mkApps clargs andb_true_r. eapply closed_cunfold_cofix; tea. }
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec in IHev2 |- *.
+    destruct EGlobalEnv.inductive_isprop_and_pars as [[[] pars]|] eqn:isp; auto.
+    rewrite -> optimize_mkApps in IHev1, IHev2. simpl in *.
+    econstructor; eauto.
+    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    rewrite -> optimize_mkApps in IHev1, IHev2. simpl in *.
+    econstructor; eauto.
+    apply optimize_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+  
+  - rewrite /declared_constant in isdecl.
+    move: (lookup_env_optimize c wfΣ).
+    rewrite isdecl /= //.
+    intros hl.
+    econstructor; tea. cbn. rewrite e //.
+    apply IHev.
+    eapply lookup_env_closed in clΣ; tea.
+    move: clΣ. rewrite /closed_decl e //.
+  
+  - move=> cld.
+    eapply eval_closed in ev1; tea.
+    move: ev1; rewrite closedn_mkApps /= => clargs.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite (constructor_isprop_pars_decl_inductive e).
+    rewrite optimize_mkApps in IHev1.
+    specialize (IHev1 cld).
+    eapply Ee.eval_proj; tea.
+    now rewrite -is_propositional_cstr_optimize.
+    now len. rewrite nth_error_map e1 //.
+    eapply IHev2.
+    eapply nth_error_forallb in e1; tea.
+
+  - rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    now rewrite e.
+
+  - move/andP=> [] clf cla.
+    rewrite optimize_mkApps.
+    eapply eval_construct; tea.
+    rewrite -lookup_constructor_optimize //. exact e.
+    rewrite optimize_mkApps in IHev1. now eapply IHev1.
+    now len.
+    now eapply IHev2.
+
+  - move/andP => [] clf cla.
+    specialize (IHev1 clf). specialize (IHev2 cla).
+    eapply Ee.eval_app_cong; eauto.
+    eapply Ee.eval_to_value in ev1.
+    destruct ev1; simpl in *; eauto.
+    * destruct t => //; rewrite optimize_mkApps /=.
+    * destruct with_guarded_fix.
+      + move: i. 
+        rewrite !negb_or.
+        rewrite optimize_mkApps !isFixApp_mkApps !isConstructApp_mkApps.
+        destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
+        rewrite !andb_true_r.
+        rtoProp; intuition auto.
+        destruct v => /= //. 
+        destruct v => /= //.
+      + move: i. 
+        rewrite !negb_or.
+        rewrite optimize_mkApps !isConstructApp_mkApps.
+        destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
+        destruct v => /= //. 
+  - destruct t => //.
+    all:constructor; eauto.
+Qed.
+
+(* 
+Lemma optimize_extends Σ Σ' : 
+  wf_glob Σ' ->
+  extends Σ Σ' ->
+  forall t b, optimize Σ t = b -> optimize Σ' t = b.
+Proof.
+  intros wf ext.
+  induction t using EInduction.term_forall_list_ind; cbn => //.
+  all:try solve [f_equal; solve_all].
+  destruct inductive_isp
+  rewrite (extends_is_propositional wf ext).
+ *)
+
+From MetaCoq.Erasure Require Import EEtaExpanded.
+
+Lemma isLambda_optimize Σ t : isLambda t -> isLambda (optimize Σ t).
+Proof. destruct t => //. Qed.
+Lemma isBox_optimize Σ t : isBox t -> isBox (optimize Σ t).
+Proof. destruct t => //. Qed.
+
+Lemma optimize_expanded {Σ : GlobalContextMap.t} t : expanded Σ t -> expanded Σ (optimize Σ t).
+Proof.
+  induction 1 using expanded_ind.
+  all:try solve[constructor; eauto; solve_all].
+  all:rewrite ?optimize_mkApps.
+  - eapply expanded_mkApps_expanded => //. solve_all.
+  - cbn -[GlobalContextMap.inductive_isprop_and_pars].
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    2-3:constructor; eauto; solve_all.
+    destruct branches eqn:heq.
+    constructor; eauto; solve_all. cbn.
+    destruct l => /=.
+    eapply isEtaExp_expanded.
+    eapply isEtaExp_substl. eapply forallb_repeat => //.
+    destruct branches as [|[]]; cbn in heq; noconf heq.
+    cbn -[isEtaExp] in *. depelim H1. cbn in H1.
+    now eapply expanded_isEtaExp.
+    constructor; eauto; solve_all.
+    depelim H1. depelim H1. do 2 (constructor; intuition auto).
+    solve_all.
+  - cbn -[GlobalContextMap.inductive_isprop_and_pars].
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    constructor. all:constructor; auto.
+  - cbn. eapply expanded_tFix. solve_all.
+    rewrite isLambda_optimize //.
+  - eapply expanded_tConstruct_app; tea.
+    now len. solve_all.
+Qed.
+
+Lemma optimize_expanded_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t : wf_glob Σ -> expanded Σ t -> expanded (optimize_env Σ) t.
+Proof.
+  intros wf; induction 1 using expanded_ind.
+  all:try solve[constructor; eauto; solve_all].
+  eapply expanded_tConstruct_app.
+  destruct H as [[H ?] ?].
+  split => //. split => //. red.
+  red in H. rewrite lookup_env_optimize // /= H //. 1-2:eauto. auto. solve_all. 
+Qed.
+
+Lemma optimize_expanded_decl {Σ : GlobalContextMap.t} t : expanded_decl Σ t -> expanded_decl Σ (optimize_decl Σ t).
+Proof.
+  destruct t as [[[]]|] => /= //.
+  unfold expanded_constant_decl => /=.
+  apply optimize_expanded.
+Qed.
+
+Lemma optimize_expanded_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t : wf_glob Σ -> expanded_decl Σ t -> expanded_decl (optimize_env Σ) t.
+Proof.
+  destruct t as [[[]]|] => /= //.
+  unfold expanded_constant_decl => /=.
+  apply optimize_expanded_irrel.
+Qed.
+
+Lemma optimize_env_extends' {efl : EEnvFlags} {Σ Σ' : GlobalContextMap.t} : 
+  extends Σ Σ' ->
+  wf_glob Σ' -> 
+  List.map (on_snd (optimize_decl Σ)) Σ.(GlobalContextMap.global_decls) =
+  List.map (on_snd (optimize_decl Σ')) Σ.(GlobalContextMap.global_decls).
+Proof.
+  intros ext.
+  destruct Σ as [Σ map repr wf]; cbn in *.
+  move=> wfΣ.
+  assert (extends Σ Σ); auto. now exists [].
+  assert (wf_glob Σ).
+  { eapply extends_wf_glob. exact ext. tea. }
+  revert H H0.
+  generalize Σ at 1 3 5 6. intros Σ''.
+  induction Σ'' => //. cbn.
+  intros hin wfg. depelim wfg.
+  f_equal.
+  2:{ eapply IHΣ'' => //. destruct hin. exists (x ++ [(kn, d)]). rewrite -app_assoc /= //. }
+  unfold on_snd. cbn. f_equal.
+  eapply wellformed_optimize_decl_extends => //. cbn.
+  eapply extends_wf_global_decl. 3:tea.
+  eapply extends_wf_glob; tea.
+  destruct hin. exists (x ++ [(kn, d)]). rewrite -app_assoc /= //.
+Qed.
+
+Lemma optimize_env_eq {efl : EEnvFlags} (Σ : GlobalContextMap.t) : wf_glob Σ -> optimize_env Σ = optimize_env' Σ.(GlobalContextMap.global_decls) Σ.(GlobalContextMap.wf).
+Proof.
+  intros wf.
+  unfold optimize_env.
+  destruct Σ; cbn. cbn in wf.
+  induction global_decls in map, repr, wf0, wf |- * => //.
+  cbn. f_equal.
+  destruct a as [kn d]; unfold on_snd; cbn. f_equal. symmetry.
+  eapply wellformed_optimize_decl_extends => //. cbn. now depelim wf. cbn. now exists [(kn, d)]. cbn.
+  set (Σg' := GlobalContextMap.make global_decls (fresh_globals_cons_inv wf0)).
+  erewrite <- (IHglobal_decls (GlobalContextMap.map Σg') (GlobalContextMap.repr Σg')).
+  2:now depelim wf.
+  set (Σg := {| GlobalContextMap.global_decls := _ :: _ |}).
+  symmetry. eapply (optimize_env_extends' (Σ := Σg') (Σ' := Σg)) => //.
+  cbn. now exists [a].
+Qed.
+
+Lemma optimize_env_expanded {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
+  wf_glob Σ -> expanded_global_env Σ -> expanded_global_env (optimize_env Σ).
+Proof.
+  unfold expanded_global_env; move=> wfg.
+  rewrite optimize_env_eq //.
+  destruct Σ as [Σ map repr wf]. cbn in *.
+  clear map repr.
+  induction 1; cbn; constructor; auto.
+  cbn in IHexpanded_global_declarations.
+  unshelve eapply IHexpanded_global_declarations. now depelim wfg. cbn. 
+  set (Σ' := GlobalContextMap.make _ _).
+  rewrite -(optimize_env_eq Σ'). cbn. now depelim wfg.
+  eapply (optimize_expanded_decl_irrel (Σ := Σ')). now depelim wfg.
+  now unshelve eapply (optimize_expanded_decl (Σ:=Σ')).
+Qed.
+
+Lemma optimize_wellformed {efl : EEnvFlags} {Σ : GlobalContextMap.t} n t :
+  has_tBox -> has_tRel ->
+  wf_glob Σ -> EWellformed.wellformed Σ n t -> EWellformed.wellformed Σ n (optimize Σ t).
+Proof.
+  intros wfΣ hbox hrel.
+  induction t in n |- * using EInduction.term_forall_list_ind => //.
+  all:try solve [cbn; rtoProp; intuition auto; solve_all].
+  - cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/and3P => [] hasc /andP[]hs ht hbrs.
+    destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    destruct l as [|[br n'] [|l']] eqn:eql; simpl.
+    all:rewrite ?hasc ?hs /= ?andb_true_r.
+    rewrite IHt //.
+    depelim X. cbn in hbrs.
+    rewrite andb_true_r in hbrs.
+    specialize (i _ hbrs).
+    eapply wellformed_substl => //. solve_all. eapply All_repeat => //.
+    now rewrite repeat_length.
+    cbn in hbrs; rtoProp; solve_all. depelim X; depelim X. solve_all.
+    do 2 depelim X. solve_all.
+    do 2 depelim X. solve_all.
+    rtoProp; solve_all. solve_all.
+    rtoProp; solve_all. solve_all.
+  - cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/andP => [] /andP[]hasc hs ht.
+    destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    all:rewrite hasc hs /=; eauto.
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
+    unfold test_def in *. len. eauto.
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
+    unfold test_def in *. len. eauto.
+Qed.
+
+Import EWellformed.
+
+Lemma optimize_wellformed_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t :
+  wf_glob Σ ->
+  forall n, wellformed Σ n t -> wellformed (optimize_env Σ) n t.
+Proof.
+  intros wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
+  all:try solve [intros; unfold wf_fix_gen in *; rtoProp; intuition eauto; solve_all].
+  - rewrite lookup_env_optimize //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //. subst g.
+    destruct (cst_body c) => //.
+  - rewrite lookup_env_optimize //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //. 
+  - rewrite lookup_env_optimize //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //. subst g.
+    destruct nth_error => /= //.
+    intros; rtoProp; intuition auto; solve_all.
+  - rewrite lookup_env_optimize //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //.
+    rewrite andb_false_r => //.
+    destruct nth_error => /= //.
+    all:intros; rtoProp; intuition auto; solve_all.
+Qed.
+
+Lemma optimize_wellformed_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} d :
+  wf_glob Σ ->
+  wf_global_decl Σ d -> wf_global_decl (optimize_env Σ) d.
+Proof.
+  intros wf; destruct d => /= //.
+  destruct (cst_body c) => /= //.
+  now eapply optimize_wellformed_irrel.
+Qed.
+
+Lemma optimize_decl_wf {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
+  has_tBox -> has_tRel -> wf_glob Σ -> 
+  forall d, wf_global_decl Σ d -> wf_global_decl (optimize_env Σ) (optimize_decl Σ d).
+Proof.
+  intros hasb hasr wf d.
+  intros hd.
+  eapply optimize_wellformed_decl_irrel; tea.
+  move: hd.
+  destruct d => /= //.
+  destruct (cst_body c) => /= //.
+  now eapply optimize_wellformed => //.
+Qed.
+
+Lemma fresh_global_optimize_env {Σ : GlobalContextMap.t} kn : 
+  fresh_global kn Σ ->
+  fresh_global kn (optimize_env Σ).
+Proof.
+  destruct Σ as [Σ map repr wf]; cbn in *.
+  induction 1; cbn; constructor; auto.
+  now eapply Forall_map; cbn.
+Qed.
+
+Lemma optimize_env_wf {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
+  has_tBox -> has_tRel -> 
+  wf_glob Σ -> wf_glob (optimize_env Σ).
+Proof.
+  intros hasb hasrel.
+  intros wfg. rewrite optimize_env_eq //.
+  destruct Σ as [Σ map repr wf]; cbn in *.
+  clear map repr.
+  induction wfg; cbn; constructor; auto.
+  - rewrite /= -(optimize_env_eq (GlobalContextMap.make Σ (fresh_globals_cons_inv wf))) //.
+    eapply optimize_decl_wf => //.
+  - rewrite /= -(optimize_env_eq (GlobalContextMap.make Σ (fresh_globals_cons_inv wf))) //.
+    now eapply fresh_global_optimize_env.
+Qed.
+
+Definition optimize_program (p : eprogram_env) :=
+  (EOptimizePropDiscr.optimize_env p.1, EOptimizePropDiscr.optimize p.1 p.2).
+
+Definition optimize_program_wf {efl} (p : eprogram_env) {hastbox : has_tBox} {hastrel : has_tRel} :
+  wf_eprogram_env efl p -> wf_eprogram efl (optimize_program p).
+Proof.
+  intros []; split.
+  now eapply optimize_env_wf.
+  cbn. eapply optimize_wellformed_irrel => //. now eapply optimize_wellformed.
+Qed.
+
+Definition optimize_program_expanded {efl} (p : eprogram_env) :
+  wf_eprogram_env efl p ->
+  expanded_eprogram_env_cstrs p -> expanded_eprogram_cstrs (optimize_program p).
+Proof.
+  unfold expanded_eprogram_env_cstrs.
+  move=> [wfe wft] /andP[] etae etat.
+  apply/andP; split.
+  cbn. eapply expanded_global_env_isEtaExp_env, optimize_env_expanded => //.
+  now eapply isEtaExp_env_expanded_global_env.
+  eapply expanded_isEtaExp.
+  eapply optimize_expanded_irrel => //.
+  now apply optimize_expanded, isEtaExp_expanded.
+Qed.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -363,6 +363,7 @@ Lemma wellformed_optimize_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t :
   optimize Σ t = optimize Σ' t.
 Proof.
   induction t using EInduction.term_forall_list_ind; cbn -[lookup_constant lookup_inductive
+    lookup_projection
     GlobalContextMap.inductive_isprop_and_pars]; intros => //.
   all:unfold wf_fix_gen in *; rtoProp; intuition auto.  
   all:f_equal; eauto; solve_all.
@@ -374,7 +375,10 @@ Proof.
     destruct l0 => //. destruct p0 => //. f_equal; eauto.
     all:f_equal; eauto; solve_all.
   - rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (extends_inductive_isprop_and_pars H0 H1 H3).
+    rewrite (extends_inductive_isprop_and_pars H0 H1).
+    destruct (lookup_projection) as [[[[mdecl idecl] cdecl] pdecl]|] eqn:hl => //.
+    eapply lookup_projection_lookup_constructor in hl.
+    eapply lookup_constructor_lookup_inductive in hl. now rewrite hl.
     destruct inductive_isprop_and_pars as [[[]]|] => //.
     all:f_equal; eauto.
 Qed.
@@ -492,8 +496,6 @@ Proof.
   now rewrite forallb_rev forallb_skipn.
   now rewrite List.rev_length hskip Nat.add_0_r.
 Qed.
-
-Definition disable_prop_cases fl := {| with_prop_case := false; with_guarded_fix := fl.(@with_guarded_fix) |}.
 
 Lemma isFix_mkApps t l : isFix (mkApps t l) = isFix t && match l with [] => true | _ => false end.
 Proof.

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -115,7 +115,7 @@ Module PrintTermTree.
       match lookup_ind_decl Σ i k with
       | Some oib =>
         match nth_error oib.(ind_ctors) l with
-        | Some (na, _) => na
+        | Some cstr => cstr.(cstr_name)
         | None =>
           "UnboundConstruct(" ^ string_of_inductive ind ^ "," ^ string_of_nat l ^ ")"
         end
@@ -136,7 +136,7 @@ Module PrintTermTree.
         let brs := combine brs oib.(ind_ctors) in
         parens top ("match " ^ print_term Γ true false t ^
                     " with " ^ nl ^
-                    print_list (fun '(b, (na, _)) => (na : String.t) ^ " " ^ b)
+                    print_list (fun '(b, cstr) => (cstr.(cstr_name) : String.t) ^ " " ^ b)
                     (nl ^ " | ") brs ^ nl ^ "end" ^ nl)
       | None =>
         "Case(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_term t ^ ","
@@ -188,7 +188,8 @@ Module PrintTermTree.
     let params := string_of_nat npars ^ " parameters" in
     let prop := if body.(ind_propositional) then "propositional" else "computational" in
     let kelim := pr_allowed_elim body.(ind_kelim) in
-    let ctors := print_list (fun idn => "| " ^ (idn.1 : ident) ^ " " ^ string_of_nat idn.2 ^ " arguments") nl body.(ind_ctors) in
+    let ctors := print_list (fun cstr => "| " ^ (cstr.(cstr_name) : ident) ^ " " ^ 
+      string_of_nat cstr.(cstr_nargs) ^ " arguments") nl body.(ind_ctors) in
     let projs :=
     match body.(ind_projs) return Tree.t with
     | [] => ""

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -1,3 +1,4 @@
+From Coq Require Import ssreflect ssrbool.
 From MetaCoq.Template Require Import utils BasicAst Reflect.
 From MetaCoq.Erasure Require Import EAst EInduction.
 From Equations Require Import Equations.
@@ -109,15 +110,29 @@ Instance ReflectEq_term : ReflectEq.ReflectEq _ :=
 Definition eqb_constant_body (x y : constant_body) :=
   eqb (cst_body x) (cst_body y).
 
-#[global]
-Instance reflect_constant_body : ReflectEq constant_body.
+#[global, program]
+Instance reflect_constant_body : ReflectEq constant_body := 
+  {| eqb := eqb_constant_body |}.
+Next Obligation.
 Proof.
-  refine {| eqb := eqb_constant_body |}.
-  intros [] [].
+  revert x y; intros [] [].
   unfold eqb_constant_body.
   cbn -[eqb].
   finish_reflect.
-Defined.
+Qed.
+
+Definition eqb_constructor_body (x y : constructor_body) :=
+  (x.(cstr_name), x.(cstr_nargs)) == (y.(cstr_name), y.(cstr_nargs)).
+
+#[global, program]
+Instance reflect_constructor_body : ReflectEq constructor_body := 
+  {| eqb := eqb_constructor_body |}.
+Next Obligation.
+Proof.
+  unfold eqb_constructor_body.
+  destruct x, y; cbn.
+  case: eqb_spec; intros H; constructor; congruence.
+Qed.
 
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
   let (n, i, k, c, p) := x in
@@ -137,11 +152,12 @@ Definition eqb_mutual_inductive_body (x y : mutual_inductive_body) :=
   let (n', b') := y in
   eqb n n' && eqb b b'.
 
-#[global]
-Instance reflect_mutual_inductive_body : ReflectEq mutual_inductive_body.
+#[global, program]
+Instance reflect_mutual_inductive_body : ReflectEq mutual_inductive_body := 
+  {| eqb := eqb_mutual_inductive_body |}.
+Next Obligation.  
 Proof.
-  refine {| eqb := eqb_mutual_inductive_body |}.
-  intros [] [].
+  revert x y; intros [] [].
   unfold eqb_mutual_inductive_body; finish_reflect.
 Defined.
 
@@ -152,10 +168,12 @@ Definition eqb_global_decl x y :=
   | _, _ => false
   end.
 
-#[global]
-Instance reflect_global_decl : ReflectEq global_decl.
+#[global, program]
+Instance reflect_global_decl : ReflectEq global_decl :=
+  {| eqb := eqb_global_decl |}.
+Next Obligation.
 Proof.
-  refine {| eqb := eqb_global_decl |}.
+  revert x y.
   unfold eqb_global_decl.
   intros [] []; finish_reflect.
 Defined.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -61,8 +61,8 @@ Proof.
   simpl. intros. now rewrite mkApps_app in H.
 Qed.
 
-Definition cstr_arity (mdecl : mutual_inductive_body) (cdecl : Kernames.ident × nat) := 
-  (mdecl.(ind_npars) + cdecl.2)%nat.
+Definition cstr_arity (mdecl : mutual_inductive_body) cdecl := 
+  (mdecl.(ind_npars) + cdecl.(cstr_nargs))%nat.
 
 (* Tells if the evaluation relation should include match-prop and proj-prop reduction rules. *)
 Class WcbvFlags := { with_prop_case : bool ; with_guarded_fix : bool }.
@@ -101,7 +101,7 @@ Section Wcbv.
       eval discr (mkApps (tConstruct ind c) args) ->
       constructor_isprop_pars_decl Σ ind c = Some (false, pars, cdecl) ->
       nth_error brs c = Some br ->
-      #|args| = pars + cdecl.2 ->
+      #|args| = pars + cdecl.(cstr_nargs) ->
       #|skipn pars args| = #|br.1| ->
       eval (iota_red pars args br) res ->
       eval (tCase (ind, pars) discr brs) res
@@ -166,7 +166,7 @@ Section Wcbv.
   | eval_proj i pars cdecl arg discr args a res :
       eval discr (mkApps (tConstruct i 0) args) ->
       constructor_isprop_pars_decl Σ i 0 = Some (false, pars, cdecl) ->
-      #|args| = pars + cdecl.2 ->
+      #|args| = pars + cdecl.(cstr_nargs) ->
       nth_error args (pars + arg) = Some a ->
       eval a res ->
       eval (tProj (i, pars, arg) discr) res

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -179,7 +179,7 @@ Lemma eval_preserve_mkApps_ind :
            → P discr (mkApps (tConstruct ind c) args)
            → constructor_isprop_pars_decl Σ ind c = Some (false, pars, cdecl)
                → nth_error brs c = Some br
-               → #|args| = pars + cdecl.2 
+               → #|args| = pars + cdecl.(cstr_nargs) 
                  → #|skipn pars args| = #|br.1|
                  -> Q #|br.1| br.2
                    → eval Σ (iota_red pars args br) res
@@ -285,7 +285,7 @@ Lemma eval_preserve_mkApps_ind :
                            (mkApps (tConstruct i 0) args)
                          → P discr (mkApps (tConstruct i 0) args)
                          → constructor_isprop_pars_decl Σ i 0 = Some (false, pars, cdecl) 
-                         → #|args| = pars + cdecl.2
+                         → #|args| = pars + cdecl.(cstr_nargs)
                          -> nth_error args (pars + arg) = Some a
                          -> eval Σ a res
                          → P a res

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -50,7 +50,7 @@ Section eval_mkApps_rect.
           → P discr (mkApps (tConstruct ind c) args)
           → constructor_isprop_pars_decl Σ ind c = Some (false, pars, cdecl)
           → nth_error brs c = Some br
-          → #|args| = pars + cdecl.2 
+          → #|args| = pars + cdecl.(cstr_nargs) 
           → #|skipn pars args| = #|br.1|
           → eval Σ (iota_red pars args br) res
           → P (iota_red pars args br) res
@@ -133,7 +133,7 @@ Section eval_mkApps_rect.
           eval Σ discr (mkApps (tConstruct i 0) args)
           → P discr (mkApps (tConstruct i 0) args)
           → constructor_isprop_pars_decl Σ i 0 = Some (false, pars, cdecl) 
-          → #|args| = pars + cdecl.2 
+          → #|args| = pars + cdecl.(cstr_nargs) 
           -> nth_error args (pars + arg) = Some a
           -> eval Σ a res
           → P a res

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -117,10 +117,26 @@ Proof.
   now eapply Nat.ltb_nlt in lt.
 Qed.
 
-Definition wf_global_decl {sw : EEnvFlags} Σ d : bool :=
+Definition wf_projections idecl :=
+  match idecl.(ind_projs) with
+  | [] => true
+  | _ =>
+    match idecl.(ind_ctors) with
+    | [cstr] => #|idecl.(ind_projs)| == cstr.(cstr_nargs)
+    | _ => false
+    end
+  end.
+
+Definition wf_inductive (idecl : one_inductive_body) :=
+  wf_projections idecl.
+
+Definition wf_minductive {efl : EEnvFlags} (mdecl : mutual_inductive_body) :=
+  (has_cstr_params || (mdecl.(ind_npars) == 0)) && forallb wf_inductive mdecl.(ind_bodies).
+
+Definition wf_global_decl {efl : EEnvFlags} Σ d : bool :=
   match d with
   | ConstantDecl cb => option_default (fun b => wellformed Σ 0 b) cb.(cst_body) has_axioms
-  | InductiveDecl idecl => has_cstr_params || (idecl.(ind_npars) == 0)
+  | InductiveDecl idecl => wf_minductive idecl
   end.
 
 Inductive wf_glob {efl : EEnvFlags} : global_declarations -> Prop :=

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -91,7 +91,7 @@ Section wf.
     | tCase ind c brs => has_tCase && 
       let brs' := List.forallb (fun br => wellformed (#|br.1| + k) br.2) brs in
       isSome (lookup_inductive Σ ind.1) && wellformed k c && brs'
-    | tProj p c => has_tProj && isSome (lookup_inductive Σ p.1.1) && wellformed k c
+    | tProj p c => has_tProj && isSome (lookup_projection Σ p) && wellformed k c
     | tFix mfix idx => has_tFix && wf_fix_gen wellformed k mfix idx
     | tCoFix mfix idx => has_tCoFix && wf_fix_gen wellformed k mfix idx
     | tBox => has_tBox

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -48,15 +48,44 @@ Program Definition erasure_pipeline (efl := EWellformed.all_env_flags) :
   (* Rebuild the efficient lookup table *)
   rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
   (* Remove all cases / projections on propositional content *)
-  optimize_prop_discr_optimization (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) (hastrel := eq_refl) (hastbox := eq_refl).
+  optimize_prop_discr_optimization (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) (hastrel := eq_refl) (hastbox := eq_refl) ▷
+  (* Rebuild the efficient lookup table *)
+  rebuild_wf_env_transform (efl := EWellformed.all_env_flags) ▷
+  (* Inline projections to cases *)
+  inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (hastrel := eq_refl) (hastbox := eq_refl).
 (* At the end of erasure we get a well-formed program (well-scoped globally and localy), without 
    parameters in inductive declarations. The constructor applications are also expanded, and
    the evaluation relation does not need to consider guarded fixpoints or case analyses on propositional
    content. All fixpoint bodies start with a lambda as well. *)
 
+Import EGlobalEnv EWellformed.
+
+Lemma wf_global_switch_no_params (efl : EWellformed.EEnvFlags) Σ :
+  wf_glob (efl := ERemoveParams.switch_no_params efl) Σ ->
+  wf_glob (efl := efl) Σ.
+Proof.
+  induction 1; constructor; auto.
+  destruct d; cbn in *. auto.
+  move/andP: H0 => [] hasp. unfold wf_minductive.
+  cbn in hasp. rewrite hasp. rewrite orb_true_r //.
+Qed.
+
+Lemma wf_eprogram_switch_no_params (p : EProgram.eprogram) : 
+  EProgram.wf_eprogram (ERemoveParams.switch_no_params all_env_flags) p ->
+  EProgram.wf_eprogram all_env_flags p.
+Proof.
+  destruct p as [Σ p].
+  intros []; split; cbn in * => //.
+  now eapply wf_global_switch_no_params.
+Qed.
+
 Next Obligation.
   destruct H. split => //. sq.
   now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs. 
+Qed.
+Next Obligation.
+  split => //.
+  now apply wf_eprogram_switch_no_params.
 Qed.
 
 Definition run_erase_program := run erasure_pipeline.

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -211,7 +211,7 @@ Definition erases_constant_body (Σ : global_env_ext) (cb : constant_body) (cb' 
   end.
 
 Definition erases_one_inductive_body (oib : one_inductive_body) (oib' : E.one_inductive_body) :=
-  Forall2 (fun cdecl '(i', n') => cdecl.(PCUICEnvironment.cstr_arity) = n' /\ cdecl.(cstr_name) = i') oib.(ind_ctors) oib'.(E.ind_ctors) /\
+  Forall2 (fun cdecl cstr => cdecl.(PCUICEnvironment.cstr_arity) = cstr.(E.cstr_nargs) /\ cdecl.(cstr_name) = cstr.(E.cstr_name)) oib.(ind_ctors) oib'.(E.ind_ctors) /\
   Forall2 (fun '(i,t) i' => i = i') oib.(ind_projs) oib'.(E.ind_projs) /\
   oib'.(E.ind_name) = oib.(ind_name) /\
   oib'.(E.ind_kelim) = oib.(ind_kelim) /\ 

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -283,9 +283,9 @@ Inductive erases_deps (Σ : global_env) (Σ' : E.global_declarations) : E.term -
     erases_deps Σ Σ' discr ->
     Forall (fun br => erases_deps Σ Σ' br.2) brs ->
     erases_deps Σ Σ' (E.tCase p discr brs)
-| erases_deps_tProj p mdecl idecl mdecl' idecl' t :
-    declared_inductive Σ p.1.1 mdecl idecl ->
-    EGlobalEnv.declared_inductive Σ' p.1.1 mdecl' idecl' ->
+| erases_deps_tProj p mdecl idecl cdecl pdecl mdecl' idecl' cdecl' pdecl' t :
+    declared_projection Σ p mdecl idecl cdecl pdecl ->
+    EGlobalEnv.declared_projection Σ' p mdecl' idecl' cdecl' pdecl' ->
     erases_mutual_inductive_body mdecl mdecl' ->
     erases_one_inductive_body idecl idecl' ->
     erases_deps Σ Σ' t ->


### PR DESCRIPTION
This adds a pass to erasure that simply inlines projections to cases, preserving evaluation. This allows e.g. CertiCoq to not have to consider this construct at all.