### PR TITLE
Slightly faster erasure of global environments

### DIFF
--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1109,14 +1109,11 @@ Corollary R_Acc_aux :
         * reflexivity.
   Defined.
 
-  Definition tyarg := 
-    ∑ t π, forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ (zip (t,π)).
-  
   Equations reduce_stack_full (t : term) (π : stack) (h : forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ (zip (t,π))) :
     { t' : term * stack | forall Σ (wfΣ : abstract_env_ext_rel X Σ), Req Σ Γ t' (t, π) /\ Pr t' π /\ Pr' t' }
-    by wf ((t; π; h) : tyarg) (fun (x y : tyarg) => forall Σ (wfΣ : abstract_env_ext_rel X Σ), R Σ Γ (x.π1, x.π2.π1) (y.π1, y.π2.π1))
-    :=
-    reduce_stack_full t π h := _reduce_stack Γ t π h (fun t' π' hr => reduce_stack_full t' π' (fun Σ wfΣ => welltyped_R_pres Σ wfΣ Γ _ _ (h Σ wfΣ) (hr Σ wfΣ))).
+    by wf (t, π) (fun (x y : term * stack) => forall Σ (wfΣ : abstract_env_ext_rel X Σ), R Σ Γ x y) :=
+    reduce_stack_full t π h := _reduce_stack Γ t π h (fun t' π' hr => reduce_stack_full t' π' (fun Σ wfΣ' => welltyped_R_pres Σ wfΣ' Γ _ _ (h Σ wfΣ') (hr Σ wfΣ'))).
+
   End reducewf.
 
   (* Equations reduce_stack_full (Γ : context) (t : term) (π : stack)

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1502,9 +1502,19 @@ Corollary R_Acc_aux :
         ∥whnf flags Σ (Γ ,,, stack_context ρ) (zipp u ρ)∥
       ).
     clear -wfΣ.
-    intros t π h aux haux.
-    funelim (_reduce_stack Γ t π h aux).
+    intros t π h aux.
+    apply_funelim (_reduce_stack Γ t π h aux); clear -wfΣ.
     all: simpl.
+    all: intros *.
+    all: repeat match goal with 
+      [ |- (forall (t' : term) (π' : stack)
+         (hR : forall Σ,
+               abstract_env_ext_rel X Σ -> R Σ _ _ _), { _ : _ | _ }) -> _ ] => intros reduce
+    | [ |- (forall (t' : term) (π' : stack)
+        (hR : forall Σ,
+          abstract_env_ext_rel X Σ -> R Σ _ _ _), _) -> _ ] => intros haux
+          | [ |- _ ] => intros ?
+    end.
     all: try match goal with
              | |- context[False_rect _ ?f] => destruct f
              end.
@@ -1518,7 +1528,8 @@ Corollary R_Acc_aux :
       assumption.
     - clear Heq.
       revert discr.
-      funelim (red_discr t π). all: intros [].
+      revert h reduce haux; apply_funelim (red_discr t π); clear -wfΣ.
+      all: intros; try destruct discr.
       all: try solve [ constructor ; constructor ].
       all: try solve [
         unfold zipp ; case_eq (decompose_stack π) ; intros ;
@@ -1574,7 +1585,7 @@ Corollary R_Acc_aux :
     - unfold zipp. case_eq (decompose_stack π). intros.
       constructor. constructor. eapply whne_mkApps. econstructor.
       rewrite <- eq. cbn.
-      cbn in H. inversion H. reflexivity.
+      cbn in H. inversion e. reflexivity.
     - match goal with
       | |- context [ reduce ?x ?y ?z ] =>
         case_eq (reduce x y z) ;

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -19,7 +19,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTactics PCUICAriti
 
 From MetaCoq.PCUIC Require Import BDTyping BDToPCUIC BDFromPCUIC BDUnique.
 
-From MetaCoq.SafeChecker Require Import PCUICErrors PCUICSafeReduce PCUICSafeConversion PCUICWfEnv.
+From MetaCoq.SafeChecker Require Import PCUICErrors PCUICSafeReduce PCUICWfEnv.
 
 (** Allow reduction to run inside Coq *)
 Transparent Acc_intro_generator.


### PR DESCRIPTION
Instead of removing each declaration we go through when erasing the global environment, we prove that we can keep the original global environment untouched while filtering the declarations to be extracted. This should also allow in the future to use the erasure function in a more modular way, e.g. to implement `Extraction Library`. To implement this we also show that  retyping is invariant in the environment passed, as long as the term is initially welltyped in it. There might be a shorter proof using bidirectional derivations (we need to show that if `welltyped Sigm Gamm t` and `welltyped Sigma' Gamma t` then we always infer the same type for T. However, as the `isErasable` definition is stated in terms of (undirected) typing, that would require also some work to adapt.