### PR TITLE
Use explicit records for projection names and declarations

### DIFF
--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -180,13 +180,18 @@ Record constructor_body :=
     cstr_nargs : nat (* arity, w/o lets, w/o parameters *)
   }.
 
+Record projection_body :=
+  mkProjection {
+    proj_name : ident;
+  }.
+  
 (** See [one_inductive_body] from [declarations.ml]. *)
 Record one_inductive_body : Set := {
   ind_name : ident;
   ind_propositional : bool; (* True iff the inductive lives in Prop *)
   ind_kelim : allowed_eliminations; (* Allowed eliminations *)
   ind_ctors : list constructor_body;
-  ind_projs : list ident (* names of projections, if any. *) }.
+  ind_projs : list projection_body (* names of projections, if any. *) }.
 
 (** See [mutual_inductive_body] from [declarations.ml]. *)
 Record mutual_inductive_body := {

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -335,8 +335,8 @@ Fixpoint string_of_term (t : term) : string :=
   | tCase (ind, i) t brs =>
     "Case(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_term t ^ ","
             ^ string_of_list (fun b => string_of_term (snd b)) brs ^ ")"
-  | tProj (ind, i, k) c =>
-    "Proj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
+  | tProj p c =>
+    "Proj(" ^ string_of_inductive p.(proj_ind) ^ "," ^ string_of_nat p.(proj_npars) ^ "," ^ string_of_nat p.(proj_arg) ^ ","
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
@@ -360,7 +360,7 @@ Fixpoint term_global_deps (t : EAst.term) :=
      List.fold_left (fun acc x => KernameSet.union (term_global_deps (EAst.dbody x)) acc) mfix
       KernameSet.empty
   | EAst.tProj p c => 
-    KernameSet.union (KernameSet.singleton (inductive_mind (fst (fst p))))
+    KernameSet.union (KernameSet.singleton (inductive_mind p.(proj_ind)))
       (term_global_deps c)
   | _ => KernameSet.empty
   end.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -525,15 +525,13 @@ Proof.
     inv wfΣ. unfold PCUICAst.declared_minductive in *.
     unfold PCUICEnvironment.lookup_env.
     simpl in *.
-    change (eq_kername (inductive_mind p.1.1) kn) with (ReflectEq.eqb (inductive_mind p.1.1) kn); auto.
-    destruct (ReflectEq.eqb_spec (inductive_mind p.1.1) kn). subst.
+    destruct (ReflectEq.eqb_spec (inductive_mind p.(proj_ind)) kn). subst.
     eapply PCUICWeakeningEnvConv.lookup_env_Some_fresh in declm; eauto. contradiction.
     apply declm.
     destruct H0 as [[[]]]. destruct a.
     repeat split; eauto.
     inv wfΣ. simpl. unfold declared_minductive. cbn.
-    change (eq_kername (inductive_mind p.1.1) kn) with (ReflectEq.eqb (inductive_mind p.1.1) kn); auto.
-    destruct (ReflectEq.eqb_spec (inductive_mind p.1.1) kn); auto. subst.
+    destruct (ReflectEq.eqb_spec (inductive_mind p.(proj_ind)) kn); auto. subst.
     destruct H as [[[]]].
     eapply PCUICWeakeningEnvConv.lookup_env_Some_fresh in H. eauto. contradiction.
 Qed.

--- a/erasure/theories/EEnvMap.v
+++ b/erasure/theories/EEnvMap.v
@@ -57,9 +57,10 @@ Module GlobalContextMap.
     rewrite lookup_inductive_spec //.
   Qed.
 
-  Definition lookup_projection Σ (p : projection) : option (mutual_inductive_body * one_inductive_body * constructor_body * ident) :=
-    '(mdecl, idecl, cdecl) <- lookup_constructor Σ p.1.1 0 ;;
-    pdecl <- nth_error idecl.(ind_projs) p.2 ;;
+  Definition lookup_projection Σ (p : projection) :
+    option (mutual_inductive_body * one_inductive_body * constructor_body * projection_body) :=
+    '(mdecl, idecl, cdecl) <- lookup_constructor Σ p.(proj_ind) 0 ;;
+    pdecl <- nth_error idecl.(ind_projs) p.(proj_arg) ;;
     ret (mdecl, idecl, cdecl, pdecl).
 
   Lemma lookup_projection_spec Σ kn : lookup_projection Σ kn = EGlobalEnv.lookup_projection Σ kn.

--- a/erasure/theories/EGlobalEnv.v
+++ b/erasure/theories/EGlobalEnv.v
@@ -35,9 +35,9 @@ Definition declared_constructor Σ cstr mdecl idecl cdecl : Prop :=
   List.nth_error idecl.(ind_ctors) (snd cstr) = Some cdecl.
 
 Definition declared_projection Σ (proj : projection) mdecl idecl cdecl pdecl : Prop :=
-  declared_constructor Σ (fst (fst proj), 0) mdecl idecl cdecl /\
-  List.nth_error idecl.(ind_projs) (snd proj) = Some pdecl /\
-  proj.1.2 = ind_npars mdecl.
+  declared_constructor Σ (proj.(proj_ind), 0) mdecl idecl cdecl /\
+  List.nth_error idecl.(ind_projs) proj.(proj_arg) = Some pdecl /\
+  proj.(proj_npars) = ind_npars mdecl.
 
 Lemma elookup_env_cons_fresh {kn d Σ kn'} : 
   kn <> kn' ->
@@ -82,9 +82,10 @@ Section Lookups.
     '(mdecl, idecl, cdecl) <- lookup_constructor kn c ;;
     ret (mdecl.(ind_npars), cdecl.(cstr_nargs)).
 
-  Definition lookup_projection (p : projection) : option (mutual_inductive_body * one_inductive_body * constructor_body * ident) :=
-    '(mdecl, idecl, cdecl) <- lookup_constructor p.1.1 0 ;;
-    pdecl <- nth_error idecl.(ind_projs) p.2 ;;
+  Definition lookup_projection (p : projection) : 
+    option (mutual_inductive_body * one_inductive_body * constructor_body * projection_body) :=
+    '(mdecl, idecl, cdecl) <- lookup_constructor p.(proj_ind) 0 ;;
+    pdecl <- nth_error idecl.(ind_projs) p.(proj_arg) ;;
     ret (mdecl, idecl, cdecl, pdecl).
   
 End Lookups.
@@ -125,7 +126,7 @@ Qed.
 
 Lemma lookup_projection_lookup_constructor {Σ p mdecl idecl cdecl pdecl} :
   lookup_projection Σ p = Some (mdecl, idecl, cdecl, pdecl) ->
-  lookup_constructor Σ p.1.1 0 = Some (mdecl, idecl, cdecl).
+  lookup_constructor Σ p.(proj_ind) 0 = Some (mdecl, idecl, cdecl).
 Proof.
   rewrite /lookup_projection; destruct lookup_constructor as [[[? ?] ?]|]=> //=.
   now destruct nth_error => //.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -41,7 +41,7 @@ Qed.
 Lemma wellformed_projection_args {efl : EEnvFlags} {Σ p mdecl idecl cdecl pdecl} : 
   wf_glob Σ ->
   lookup_projection Σ p = Some (mdecl, idecl, cdecl, pdecl) ->
-  p.2 < cdecl.(cstr_nargs).
+  p.(proj_arg) < cdecl.(cstr_nargs).
 Proof.
   intros wfΣ.
   rewrite /lookup_projection /lookup_constructor /lookup_inductive.
@@ -78,7 +78,7 @@ Section optimize.
     | tProj p c =>
       match GlobalContextMap.lookup_projection Σ p with 
       | Some (mdecl, idecl, cdecl, pdecl) => 
-        tCase p.1 (optimize c) [(unfold cdecl.(cstr_nargs) (fun n => nAnon), tRel (cdecl.(cstr_nargs) - S p.2))]
+        tCase (p.(proj_ind), p.(proj_npars)) (optimize c) [(unfold cdecl.(cstr_nargs) (fun n => nAnon), tRel (cdecl.(cstr_nargs) - S p.(proj_arg)))]
       | _ => tProj p (optimize c)
       end
     | tFix mfix idx =>
@@ -593,7 +593,7 @@ Proof.
     rewrite optimize_mkApps /= in IHev1.
     eapply eval_iota; tea.
     rewrite /constructor_isprop_pars_decl -lookup_constructor_optimize // H //= //.
-    rewrite H0; reflexivity. cbn. reflexivity. len. len.
+    rewrite H0 H1; reflexivity. cbn. reflexivity. len. len.
     rewrite skipn_length. lia.
     unfold iota_red. cbn.
     rewrite (substl_rel _ _ (optimize Σ a)) => //.
@@ -604,9 +604,9 @@ Proof.
     rewrite nth_error_rev. len. rewrite skipn_length. lia. 
     rewrite List.rev_involutive. len. rewrite skipn_length.
     rewrite nth_error_skipn nth_error_map.
-    rewrite e0.
+    rewrite e0 -H1.
     assert((ind_npars mdecl + cstr_nargs cdecl - ind_npars mdecl) = cstr_nargs cdecl) by lia.
-    rewrite H2. 
+    rewrite H3.
     eapply (f_equal (option_map (optimize Σ))) in e1.
     cbn in e1. rewrite -e1. f_equal. f_equal. lia.
 

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -48,7 +48,7 @@ Section optimize.
       | _ => tCase ind (optimize c) brs'
       end
     | tProj p c =>
-      match GlobalContextMap.inductive_isprop_and_pars Σ p.1.1 with 
+      match GlobalContextMap.inductive_isprop_and_pars Σ p.(proj_ind) with 
       | Some (true, _) => tBox
       | _ => tProj p (optimize c)
       end

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -142,18 +142,14 @@ Module PrintTermTree.
         "Case(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_term t ^ ","
                 ^ string_of_list (fun b => string_of_term (snd b)) brs ^ ")"
       end
-    | tProj (mkInd mind i as ind, pars, k) c =>
-      match lookup_ind_decl Σ mind i with
-      | Some oib =>
-        match nth_error oib.(ind_projs) k with
-        | Some na => print_term Γ false false c ^ ".(" ^ na ^ ")"
-        | None =>
-          "UnboundProj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
-                        ^ print_term Γ true false c ^ ")"
-        end
+    | tProj p c =>
+      match lookup_projection Σ p with
+      | Some (mdecl, idecl, cdecl, pdecl) =>
+        print_term Γ false false c ^ ".(" ^ pdecl.(proj_name) ^ ")"
       | None =>
-        "UnboundProj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
-                      ^ print_term Γ true false c ^ ")"
+        "UnboundProj(" ^ string_of_inductive p.(proj_ind) ^ "," ^ string_of_nat p.(proj_npars) 
+          ^ "," ^ string_of_nat p.(proj_arg) ^ ","
+          ^ print_term Γ true false c ^ ")"
       end
 
 
@@ -193,7 +189,7 @@ Module PrintTermTree.
     let projs :=
     match body.(ind_projs) return Tree.t with
     | [] => ""
-    | _ => nl ^ "projections: " ^ print_list (fun x => x : ident) ", " body.(ind_projs) 
+    | _ => nl ^ "projections: " ^ print_list (fun x => x.(proj_name)) ", " body.(ind_projs) 
     end
     in
     "Inductive " ^ body.(ind_name) ^ "(" ^ params ^ "," ^ prop ^ ", elimination " ^ kelim ^ ") := " ^ nl ^ ctors ^ projs.

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -133,6 +133,18 @@ Proof.
   destruct x, y; cbn.
   case: eqb_spec; intros H; constructor; congruence.
 Qed.
+Definition eqb_projection_body (x y : projection_body) :=
+  x.(proj_name) == y.(proj_name).
+
+#[global, program]
+Instance reflect_projection_body : ReflectEq projection_body := 
+  {| eqb := eqb_projection_body |}.
+Next Obligation.
+Proof.
+  unfold eqb_projection_body.
+  destruct x, y; cbn.
+  case: eqb_spec; intros H; constructor; congruence.
+Qed.
 
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
   let (n, i, k, c, p) := x in

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -47,7 +47,7 @@ Section strip.
     | tCase ind c brs =>
       let brs' := map_InP brs (fun x H => (x.1, strip x.2)) in
       EAst.tCase (ind.1, 0) (strip c) brs'
-    | tProj (ind, pars, args) c => EAst.tProj (ind, 0, args) (strip c)
+    | tProj p c => EAst.tProj {| proj_ind := p.(proj_ind); proj_npars := 0; proj_arg := p.(proj_arg) |} (strip c)
     | tFix mfix idx =>
       let mfix' := map_InP mfix (fun d H => {| dname := dname d; dbody := strip d.(dbody); rarg := d.(rarg) |}) in
       EAst.tFix mfix' idx
@@ -524,7 +524,7 @@ Module Fast.
     | app, tCase ind c brs =>
         let brs' := strip_brs brs in
         mkApps (EAst.tCase (ind.1, 0) (strip [] c) brs') app
-    | app, tProj (ind, pars, args) c => mkApps (EAst.tProj (ind, 0, args) (strip [] c)) app
+    | app, tProj p c => mkApps (EAst.tProj {| proj_ind := p.(proj_ind); proj_npars := 0; proj_arg := p.(proj_arg) |} (strip [] c)) app
     | app, tFix mfix idx =>
         let mfix' := strip_defs mfix in
         mkApps (EAst.tFix mfix' idx) app
@@ -947,12 +947,12 @@ Proof.
     rewrite strip_mkApps // /= in e0.
     rewrite (constructor_isprop_pars_decl_lookup H2) in e0.
     eapply eval_proj; eauto.
-    move: (@is_propositional_cstr_strip Σ i 0). now rewrite H2. simpl.
+    move: (@is_propositional_cstr_strip Σ p.(proj_ind) 0). now rewrite H2. simpl.
     len. rewrite skipn_length. cbn in H3. lia.
     rewrite nth_error_skipn nth_error_map /= H4 //.
 
   - simp_strip. eapply eval_proj_prop => //.
-    move: (is_propositional_strip Σ i); now rewrite H3.
+    move: (is_propositional_strip Σ p.(proj_ind)); now rewrite H3.
 
   - rewrite !strip_tApp //.
     eapply eval_app_cong; tea.
@@ -1267,7 +1267,6 @@ Proof.
   all:try solve[simp_strip; constructor; eauto; solve_all].
   - rewrite strip_mkApps_etaexp. now eapply expanded_isEtaExp.
     eapply expanded_mkApps_expanded => //. solve_all.
-  - destruct proj as [[] ?]; simp_strip. constructor; eauto.
   - simp_strip; constructor; eauto. solve_all.
     rewrite -strip_isLambda //.
   - rewrite strip_mkApps // /=.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -166,20 +166,20 @@ Section Wcbv.
       eval (tConst c) res
 
   (** Proj *)
-  | eval_proj i pars cdecl arg discr args a res :
-      eval discr (mkApps (tConstruct i 0) args) ->
-      constructor_isprop_pars_decl Σ i 0 = Some (false, pars, cdecl) ->
-      #|args| = pars + cdecl.(cstr_nargs) ->
-      nth_error args (pars + arg) = Some a ->
+  | eval_proj p cdecl discr args a res :
+      eval discr (mkApps (tConstruct p.(proj_ind) 0) args) ->
+      constructor_isprop_pars_decl Σ p.(proj_ind) 0 = Some (false, p.(proj_npars), cdecl) ->
+      #|args| = p.(proj_npars) + cdecl.(cstr_nargs) ->
+      nth_error args (p.(proj_npars) + p.(proj_arg)) = Some a ->
       eval a res ->
-      eval (tProj (i, pars, arg) discr) res
+      eval (tProj p discr) res
 
   (** Proj *)
-  | eval_proj_prop i pars arg discr :
+  | eval_proj_prop p discr :
       with_prop_case ->
       eval discr tBox ->
-      inductive_isprop_and_pars Σ i = Some (true, pars) ->
-      eval (tProj (i, pars, arg) discr) tBox
+      inductive_isprop_and_pars Σ p.(proj_ind) = Some (true, p.(proj_npars)) ->
+      eval (tProj p discr) tBox
 
   (** Constructor congruence: we do not allow over-applications *)
   | eval_construct ind c mdecl idecl cdecl f args a a' : 
@@ -776,7 +776,7 @@ Section Wcbv.
     - depelim ev'; try go.
       specialize (IHev _ ev'). noconf IHev.
       rewrite (uip e e0).
-      now rewrite (uip i0 i2).
+      now rewrite (uip i i0).
     - depelim ev'; try go.
       + move: (IHev1 _ ev'1).
         eapply DepElim.simplification_sigma1 => heq IHev1'.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -277,28 +277,24 @@ Lemma eval_preserve_mkApps_ind :
                            cst_body decl = Some body
                            → eval Σ body res
                              → P body res → P' (tConst c) res)
-                    → (∀ (i : inductive) cdecl (pars arg : nat) 
-                         (discr : term) (args : list term)  a
-                         (res : term),
+                    → (∀ p cdecl (discr : term) (args : list term) a (res : term),
                          has_tProj ->
                          eval Σ discr
-                           (mkApps (tConstruct i 0) args)
-                         → P discr (mkApps (tConstruct i 0) args)
-                         → constructor_isprop_pars_decl Σ i 0 = Some (false, pars, cdecl) 
-                         → #|args| = pars + cdecl.(cstr_nargs)
-                         -> nth_error args (pars + arg) = Some a
+                           (mkApps (tConstruct p.(proj_ind) 0) args)
+                         → P discr (mkApps (tConstruct p.(proj_ind) 0) args)
+                         → constructor_isprop_pars_decl Σ p.(proj_ind) 0 = Some (false, p.(proj_npars), cdecl) 
+                         → #|args| = p.(proj_npars) + cdecl.(cstr_nargs)
+                         -> nth_error args (p.(proj_npars) + p.(proj_arg)) = Some a
                          -> eval Σ a res
                          → P a res
-                         → P' (tProj (i, pars, arg) discr) res)
-                      → (∀ (i : inductive) (pars arg : nat) 
-                           (discr : term),
+                         → P' (tProj p discr) res)
+                      → (∀ p (discr : term),
                            has_tProj ->
                            with_prop_case
                            → eval Σ discr tBox
                              → P discr tBox
-                               → inductive_isprop_and_pars Σ i = Some (true, pars)
-                                 → P' (tProj (i, pars, arg) discr)
-                                     tBox) →
+                               → inductive_isprop_and_pars Σ p.(proj_ind) = Some (true, p.(proj_npars))
+                                 → P' (tProj p discr) tBox) →
   (∀ (f11 f' : term) a a',
      forall (ev : eval Σ f11 f'), 
      P f11 f' ->  
@@ -575,7 +571,7 @@ Proof.
       { eapply nth_error_all in qargs; tea. }
       clear ev1'; ih. }
     assert (isEtaExp Σ a).
-    { assert (isEtaExp Σ (mkApps (tConstruct i 0) args)) by iheta q.
+    { assert (isEtaExp Σ (mkApps (tConstruct p.(proj_ind) 0) args)) by iheta q.
       move: H; simp_eta.
       rewrite isEtaExp_mkApps_napp // /=.
       move=> /andP[] etaapp etaargs.

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -127,24 +127,23 @@ Section eval_mkApps_rect.
           cst_body decl = Some body
           → eval Σ body res
           → P body res → P (tConst c) res)
-    → (∀ (i : inductive) (pars arg : nat) 
-         (discr : term) (args : list term) 
+    → (∀ p (discr : term) (args : list term) 
          (res : term) cdecl a,
-          eval Σ discr (mkApps (tConstruct i 0) args)
-          → P discr (mkApps (tConstruct i 0) args)
-          → constructor_isprop_pars_decl Σ i 0 = Some (false, pars, cdecl) 
-          → #|args| = pars + cdecl.(cstr_nargs) 
-          -> nth_error args (pars + arg) = Some a
+          eval Σ discr (mkApps (tConstruct p.(proj_ind) 0) args)
+          → P discr (mkApps (tConstruct p.(proj_ind) 0) args)
+          → constructor_isprop_pars_decl Σ p.(proj_ind) 0 = Some (false, p.(proj_npars), cdecl) 
+          → #|args| = p.(proj_npars) + cdecl.(cstr_nargs) 
+          -> nth_error args (p.(proj_npars) + p.(proj_arg)) = Some a
           -> eval Σ a res
           → P a res
-          → P (tProj (i, pars, arg) discr) res)
+          → P (tProj p discr) res)
 
-    → (∀ (i : inductive) (pars arg : nat) (discr : term),
+    → (∀ p (discr : term),
           with_prop_case
           → eval Σ discr tBox
           → P discr tBox
-          → inductive_isprop_and_pars Σ i = Some (true, pars)
-          → P (tProj (i, pars, arg) discr) tBox)
+          → inductive_isprop_and_pars Σ p.(proj_ind) = Some (true, p.(proj_npars))
+          → P (tProj p discr) tBox)
 
     → (∀ ind c mdecl idecl cdecl f args a a',
       lookup_constructor Σ ind c = Some (mdecl, idecl, cdecl) ->

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -923,7 +923,7 @@ Qed.
 Definition erase_one_inductive_body (oib : one_inductive_body) : E.one_inductive_body :=
   (* Projection and constructor types are types, hence always erased *)
   let ctors := map (fun cdecl => EAst.mkConstructor cdecl.(cstr_name) cdecl.(cstr_arity)) oib.(ind_ctors) in
-  let projs := map (fun '(x, y) => x) oib.(ind_projs) in
+  let projs := map (fun pdecl => EAst.mkProjection pdecl.(proj_name)) oib.(ind_projs) in
   let is_propositional := 
     match destArity [] oib.(ind_type) with
     | Some (_, u) => is_propositional u
@@ -1228,7 +1228,7 @@ Proof.
     
   - apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?&?); eauto.
     destruct (proj1 d).
-    specialize (H0 (inductive_mind p.1.1)). forward H0.
+    specialize (H0 (inductive_mind p.(proj_ind))). forward H0.
     now rewrite KernameSet.singleton_spec. red in H0. destruct H0.
     elimtype False. destruct H0 as [cst [declc _]].
     { red in declc. destruct d as [[[d _] _] _]. red in d. rewrite d in declc. noconf declc. }
@@ -1317,7 +1317,7 @@ Proof.
     destruct d0; split; eauto.
     inv wfΣ. inv X.
     red in H |- *.
-    rewrite -H. simpl. unfold lookup_env; simpl; destruct (eqb_spec (inductive_mind p.1.1) kn); try congruence.
+    rewrite -H. simpl. unfold lookup_env; simpl; destruct (eqb_spec (inductive_mind p.(proj_ind)) kn); try congruence.
     eapply lookup_env_Some_fresh in H. subst kn. contradiction.
 Qed.
 
@@ -1467,7 +1467,6 @@ Proof.
   cbn in *.
   intuition auto.
   induction ind_projs0; constructor; auto.
-  destruct a; auto.
   unfold isPropositionalArity.
   destruct destArity as [[? ?]|] eqn:da; auto.
 Qed.
@@ -3063,7 +3062,7 @@ Proof.
     specialize (Hind X_type' X' hl).
     unfold PCUICSafeRetyping.principal_type_type in *.
     eapply elim_inspect => y eq.
-    assert (abstract_env_lookup X (inductive_mind ind) = abstract_env_lookup X' (inductive_mind ind)).
+    assert (abstract_env_lookup X (inductive_mind p.(proj_ind)) = abstract_env_lookup X' (inductive_mind p.(proj_ind))).
     { epose proof (abstract_env_ext_exists X) as [[Σ wfΣ]].
       epose proof (abstract_env_ext_wf X wfΣ) as [hwfΣ].
       epose proof (abstract_env_ext_exists X') as [[Σ' wfΣ']].
@@ -3081,10 +3080,10 @@ Proof.
     eapply elim_inspect => nth eq'.
     cbn in eq', e0. destruct nth as [[]|] => //.
     simp infer.
-    set (obl4 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_33 X_type _ _ _ _ _ _ _ _ _ Σ wfΣ)) in *.
-    set (obl3 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_33 X_type' _ _ _ _ _ _ _ _ _ Σ wfΣ)).
-    set (obl1 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_32 X_type _ _ _ _ _ _ _ Σ wfΣ)) in *; cbn in obl1.
-    set (obl2 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_32 X_type' _ _ _ _ _ _ _ Σ wfΣ)) in *; cbn in obl2.
+    set (obl4 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_33 X_type _ _ _ _ _ _ _ Σ wfΣ)) in *.
+    set (obl3 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_33 X_type' _ _ _ _ _ _ _ Σ wfΣ)).
+    set (obl1 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_32 X_type _ _ _ _ _ Σ wfΣ)) in *; cbn in obl1.
+    set (obl2 := (fun Σ wfΣ => PCUICSafeRetyping.infer_obligations_obligation_32 X_type' _ _ _ _ _ Σ wfΣ)) in *; cbn in obl2.
     specialize (Hind wf' obl2).
     set (t'' := (infer X_type' _ _ _ _ _)) in *.
     cbn in obl3. unfold PCUICSafeRetyping.principal_type_type in obl3 |- *.

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -73,8 +73,8 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
           (fun (x : branch term) (x' : list name × E.term) =>
           Σ;;; Γ ,,, inst_case_branch_context p x |- bbody x ⇝ℇ snd x' × erase_context (bcontext x) = fst x') brs brs' ->
         Σ;;; Γ |- tCase ci p c brs ⇝ℇ E.tCase (ci.(ci_ind), ci.(ci_npar)) c' brs'
-  | erases_tProj : forall (p : (inductive × nat) × nat) (c : term) (c' : E.term),
-                   let ind := fst (fst p) in
+  | erases_tProj : forall p (c : term) (c' : E.term),
+                   let ind := p.(proj_ind) in
                    Informative Σ ind ->
                    Σ;;; Γ |- c ⇝ℇ c' -> Σ;;; Γ |- tProj p c ⇝ℇ E.tProj p c'
   | erases_tFix : forall (mfix : mfixpoint term) (n : nat) (mfix' : list (E.def E.term)),
@@ -131,7 +131,7 @@ Lemma erases_forall_list_ind
           Forall2 (fun br br' => P (Γ ,,, inst_case_branch_context p br) (bbody br) br'.2) brs brs' ->
           P Γ (tCase ci p c brs) (E.tCase (ci.(ci_ind), ci.(ci_npar)) c' brs'))
       (Hproj : forall Γ p c c',
-          let ind := p.1.1 in
+          let ind := p.(proj_ind) in
           PCUICElimination.Informative Σ ind ->
           Σ;;; Γ |- c ⇝ℇ c' ->
           P Γ c c' ->
@@ -212,7 +212,7 @@ Definition erases_constant_body (Σ : global_env_ext) (cb : constant_body) (cb' 
 
 Definition erases_one_inductive_body (oib : one_inductive_body) (oib' : E.one_inductive_body) :=
   Forall2 (fun cdecl cstr => cdecl.(PCUICEnvironment.cstr_arity) = cstr.(E.cstr_nargs) /\ cdecl.(cstr_name) = cstr.(E.cstr_name)) oib.(ind_ctors) oib'.(E.ind_ctors) /\
-  Forall2 (fun '(i,t) i' => i = i') oib.(ind_projs) oib'.(E.ind_projs) /\
+  Forall2 (fun 'i i' => i.(PCUICEnvironment.proj_name) = i'.(E.proj_name)) oib.(ind_projs) oib'.(E.ind_projs) /\
   oib'.(E.ind_name) = oib.(ind_name) /\
   oib'.(E.ind_kelim) = oib.(ind_kelim) /\ 
   isPropositionalArity oib.(ind_type) oib'.(E.ind_propositional).

--- a/pcuic/theories/Bidirectional/BDFromPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDFromPCUIC.v
@@ -291,7 +291,7 @@ Proof.
            1: apply wf_local_closed_context ; tea.
            eapply subject_is_open_term ; tea.
 
-  - intros ? c u mdecl idecl cdecl [] isdecl args ? ? ? Cumc ? ty.
+  - intros ? c u mdecl idecl cdecl pdecl isdecl args ? ? ? Cumc ?.
     apply conv_infer_ind in Cumc as (ui'&args'&[]) ; auto.
     eexists.
     split.
@@ -302,8 +302,8 @@ Proof.
       eapply All2_length.
       eassumption.
 
-    + assert (Σ ;;; Γ |- c : mkApps (tInd p.1.1 ui') args')
-        by (apply infering_ind_typing in i0 ; auto).
+    + assert (Σ ;;; Γ |- c : mkApps (tInd p.(proj_ind) ui') args')
+        by (apply infering_ind_typing in i ; auto).
       assert (consistent_instance_ext Σ (ind_universes mdecl) u).
         { destruct isdecl.
           apply validity in X1 as [].
@@ -334,7 +334,6 @@ Proof.
       * cbn -[projection_context].
         apply weaken_ws_cumul_pb ; auto.
         1: apply wf_local_closed_context ; auto.
-        change t with (i,t).2.
         eapply projection_cumulative_indices ; eauto.
         2: now easy.
         eapply (weaken_lookup_on_global_env' _ _ (InductiveDecl _)) => //.

--- a/pcuic/theories/Bidirectional/BDStrengthening.v
+++ b/pcuic/theories/Bidirectional/BDStrengthening.v
@@ -442,7 +442,7 @@ Section OnFreeVars.
         auto.
     
     - intros until args.
-      move => ? _ ? largs ? ? ? ?.
+      move => ? _ ? largs ? ? ?.
       apply on_free_vars_subst0.
       + cbn ; apply /andP ; split ; auto.
         rewrite forallb_rev.

--- a/pcuic/theories/Bidirectional/BDTyping.v
+++ b/pcuic/theories/Bidirectional/BDTyping.v
@@ -102,10 +102,9 @@ Inductive infering `{checker_flags} (Σ : global_env_ext) (Γ : context) : term 
 
 | infer_Proj p c u mdecl idecl cdecl pdecl args :
   declared_projection Σ.1 p mdecl idecl cdecl pdecl ->
-  Σ ;;; Γ |- c ▹{fst (fst p)} (u,args) ->
+  Σ ;;; Γ |- c ▹{p.(proj_ind)} (u,args) ->
   #|args| = ind_npars mdecl ->
-  let ty := snd pdecl in
-  Σ ;;; Γ |- tProj p c ▹ subst0 (c :: List.rev args) (subst_instance u ty)
+  Σ ;;; Γ |- tProj p c ▹ subst0 (c :: List.rev args) (subst_instance u pdecl.(proj_type))
 
 | infer_Fix mfix n decl :
   fix_guard Σ Γ mfix ->
@@ -418,11 +417,10 @@ Section BidirectionalInduction.
     (forall (Γ : context) (p : projection) (c : term) u
       mdecl idecl cdecl pdecl args,
       declared_projection Σ.1 p mdecl idecl cdecl pdecl ->
-      Σ ;;; Γ |- c ▹{fst (fst p)} (u,args) ->
-      Pind Γ (fst (fst p)) c u args ->
+      Σ ;;; Γ |- c ▹{p.(proj_ind)} (u,args) ->
+      Pind Γ p.(proj_ind) c u args ->
       #|args| = ind_npars mdecl ->
-      let ty := snd pdecl in
-      Pinfer Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance u ty))) ->
+      Pinfer Γ (tProj p c) (subst0 (c :: List.rev args) pdecl.(proj_type)@[u])) ->
 
     (forall (Γ : context) (mfix : mfixpoint term) (n : nat) decl,
       fix_guard Σ Γ mfix ->

--- a/pcuic/theories/Bidirectional/BDUnique.v
+++ b/pcuic/theories/Bidirectional/BDUnique.v
@@ -136,7 +136,7 @@ Proof.
     eapply infering_ind_typing in X ; tea.
     eapply infering_ind_typing in tyc' ; tea.
     subst.
-    exists (subst0 (c :: List.rev args'') ty@[u0]).
+    exists (subst0 (c :: List.rev args'') (proj_type pdecl)@[u0]).
     split.
     + eapply closed_red_red_subst0 ; tea.
       3: eapply subslet_untyped_subslet, projection_subslet ; tea.

--- a/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
+++ b/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
@@ -1080,7 +1080,7 @@ Definition map_one_inductive_body' fu f oib :=
     ind_type := f oib.(ind_type);
     ind_kelim := oib.(ind_kelim);
     ind_ctors := List.map (map_constructor_body' f) oib.(ind_ctors);
-    ind_projs := List.map (on_snd f) oib.(ind_projs);
+    ind_projs := List.map (map_projection_body 0 (fun _ => f)) oib.(ind_projs);
     ind_relevance := oib.(ind_relevance) |}.
 
 Global Instance subst_instance_inductive_body : UnivSubst one_inductive_body

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -826,7 +826,7 @@ Section Alpha.
         eapply All2_app. apply All2_refl; reflexivity.
         repeat constructor. now apply upto_names_impl_eq_term.
 
-    - intros p c u mdecl idecl cdecl pdecl isdecl args X X0 hc ihc H ty Δ v e e'; invs e.
+    - intros p c u mdecl idecl cdecl pdecl isdecl args X X0 hc ihc H Δ v e e'; invs e.
       eapply type_Cumul'.
       + econstructor. all: try eassumption.
         eapply ihc; tea.

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -556,32 +556,6 @@ Hint Rewrite context_assumptions_mapi_context : len.
 Module PCUICEnvTyping := EnvironmentTyping.EnvTyping PCUICTerm PCUICEnvironment.
 (** Included in PCUICTyping only *)
 
-Definition lookup_minductive Σ mind :=
-  match lookup_env Σ mind with
-  | Some (InductiveDecl decl) => Some decl
-  | _ => None
-  end.
-
-Definition lookup_inductive Σ ind :=
-  match lookup_minductive Σ (inductive_mind ind) with
-  | Some mdecl => 
-    match nth_error mdecl.(ind_bodies) (inductive_ind ind) with
-    | Some idecl => Some (mdecl, idecl)
-    | None => None
-    end
-  | None => None
-  end.
-
-Definition lookup_constructor Σ ind k :=
-  match lookup_inductive Σ ind with
-  | Some (mdecl, idecl) => 
-    match nth_error idecl.(ind_ctors) k with
-    | Some cdecl => Some (mdecl, idecl, cdecl)
-    | None => None
-    end
-  | _ => None
-  end.
-  
 Global Instance context_reflect`(ReflectEq term) : 
   ReflectEq (list (BasicAst.context_decl term)) := _.
 

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -1139,7 +1139,7 @@ Section WeakNormalization.
     - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
       apply inversion_Proj in Ht; auto; destruct_sigma Ht.
       specialize (IHHe1 _ t).
-      assert (red Σ [] (tProj (i, pars, arg) discr) a).
+      assert (red Σ [] (tProj p discr) a).
       { redt _.
         eapply red_proj_c; eauto.
         eapply red1_red; constructor; auto. }

--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -2200,7 +2200,7 @@ Section PredRed.
       eapply (All2_impl X3); unfold on_Trel; intuition auto; repeat inv_on_free_vars_xpredT; eauto with fvs.
       eapply red_step. econstructor; eauto. eauto.
 
-    - transitivity (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args1)).
+    - transitivity (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args1)).
       eapply red_proj_c; eauto.
       cbn in H1. repeat inv_on_free_vars_xpredT.
       eapply red_mkApps; [|solve_all]. auto.

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -1270,13 +1270,12 @@ Proof.
     eapply cumul_prop_trans; eauto.
     eapply cumul_prop_mkApps_Ind_inv in X2 => //.
     destruct (declared_projection_inj a isdecl) as [<- [<- [<- <-]]].
-    subst ty. 
     destruct (isType_mkApps_Ind_inv _ isdecl X0 (validity X1)) as [ps [argss [_ cu]]]; eauto.
     destruct (isType_mkApps_Ind_inv _ isdecl X0 (validity a0)) as [? [? [_ cu']]]; eauto.
     epose proof (wf_projection_context _ _ isdecl c1).
     epose proof (wf_projection_context _ _ isdecl c2).
-    transitivity (subst0 (c0 :: List.rev args') (subst_instance u pdecl'.2)).
-    eapply (@substitution_untyped_cumul_prop_cumul Σ Γ (projection_context p.1.1 mdecl' idecl' u)) => //.
+    transitivity (subst0 (c0 :: List.rev args') (subst_instance u pdecl'.(proj_type))).
+    eapply (@substitution_untyped_cumul_prop_cumul Σ Γ (projection_context p.(proj_ind) mdecl' idecl' u)) => //.
     * cbn -[projection_context on_free_vars_ctx].
       eapply is_closed_context_weaken; tas. fvs. now eapply wf_local_closed_context in X3.
     * cbn -[projection_context on_free_vars_ctx].
@@ -1292,7 +1291,7 @@ Proof.
     * constructor => //. symmetry; constructor => //; fvs.
       { now eapply leq_term_eq_term_prop_impl. }
       { now eapply All2_rev. }
-    * eapply (@substitution_cumul_prop Σ Γ (projection_context p.1.1 mdecl' idecl' u') []) => //.
+    * eapply (@substitution_cumul_prop Σ Γ (projection_context p.(proj_ind) mdecl' idecl' u') []) => //.
       { apply (projection_subslet Σ _ _ _ _ _ _ _ _ _ a wfΣ a0 (validity a0)). }
       eapply cumul_prop_subst_instance; eauto.
       cbn -[projection_context on_free_vars_ctx]; eapply is_closed_context_weaken => //; fvs.

--- a/pcuic/theories/PCUICCumulativitySpec.v
+++ b/pcuic/theories/PCUICCumulativitySpec.v
@@ -170,9 +170,9 @@ Inductive cumulSpec0 {cf : checker_flags} (Σ : global_env_ext) Γ (pb : conv_pb
     Σ ;;; Γ ⊢ tConst c u ≤s[pb] body@[u]
 
 (** Proj *)
-| cumul_proj : forall i pars narg args u arg,
-    nth_error args (pars + narg) = Some arg ->
-    Σ ;;; Γ ⊢ tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args) ≤s[pb] arg
+| cumul_proj : forall p args u arg,
+    nth_error args (p.(proj_npars) + p.(proj_arg)) = Some arg ->
+    Σ ;;; Γ ⊢ tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args) ≤s[pb] arg
 
 where " Σ ;;; Γ ⊢ t ≤s[ pb ] u " := (@cumulSpec0 _ Σ Γ pb t u) : type_scope.
 
@@ -281,10 +281,10 @@ Lemma cumulSpec0_ind_all :
         forall u : Instance.t, cst_body decl = Some body -> P pb Γ (tConst c u) (subst_instance u body)) ->
 
         (* Proj *)
-       (forall (pb : conv_pb) (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
+       (forall (pb : conv_pb) (Γ : context)p (args : list term) (u : Instance.t)
          (arg : term),
-           nth_error args (pars + narg) = Some arg ->
-           P pb Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
+           nth_error args (p.(proj_npars) + p.(proj_arg)) = Some arg ->
+           P pb Γ (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args)) arg) ->
 
         (* transitivity *)
        (forall (pb : conv_pb) (Γ : context) (t u v : term),
@@ -372,7 +372,7 @@ Lemma cumulSpec0_ind_all :
               eq_binder_annot (dname x) (dname y)) mfix mfix' ->
             P pb Γ (tCoFix mfix idx) (tCoFix mfix' idx)) ->
  
-      (* cumulativiity rules *)
+      (* cumulativity rules *)
       
       (forall (pb : conv_pb) 
             (Γ : context) (i : inductive) (u u' : list Level.t)
@@ -499,10 +499,10 @@ Lemma convSpec0_ind_all :
         forall u : Instance.t, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance u body)) ->
 
         (* Proj *)
-       (forall  (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
+       (forall  (Γ : context) p (args : list term) (u : Instance.t)
          (arg : term),
-           nth_error args (pars + narg) = Some arg ->
-           P  Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
+           nth_error args (p.(proj_npars) + p.(proj_arg)) = Some arg ->
+           P  Γ (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args)) arg) ->
 
         (* transitivity *)
        (forall  (Γ : context) (t u v : term),

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -637,12 +637,12 @@ Lemma declared_projection_projs_nonempty `{cf : checker_flags} {Σ : global_env_
 Proof.
   intros. destruct H. destruct H0.
   destruct (ind_projs idecl); try congruence. destruct p.
-  cbn in *. destruct n; inv H0.
+  cbn in *. destruct proj_arg; inv H0.
 Qed.
 
 Lemma elim_restriction_works_proj_kelim1 `{cf : checker_flags} (Σ : global_env_ext) Γ T p c mind idecl :
   wf Σ ->
-  declared_inductive (fst Σ) (fst (fst p)) mind idecl ->
+  declared_inductive (fst Σ) p.(proj_ind) mind idecl ->
   Σ ;;; Γ |- tProj p c : T ->
   (Is_proof Σ Γ (tProj p c) -> False) -> ind_kelim idecl = IntoAny.
 Proof.
@@ -660,9 +660,9 @@ Qed.
 
 Lemma elim_restriction_works_proj `{cf : checker_flags} (Σ : global_env_ext) Γ  p c mind idecl T :
   check_univs -> wf_ext Σ ->
-  declared_inductive (fst Σ) (fst (fst p)) mind idecl ->
+  declared_inductive (fst Σ) p.(proj_ind) mind idecl ->
   Σ ;;; Γ |- tProj p c : T ->
-  (Is_proof Σ Γ (tProj p c) -> False) -> Informative Σ (fst (fst p)).
+  (Is_proof Σ Γ (tProj p c) -> False) -> Informative Σ p.(proj_ind).
 Proof.
   intros cu; intros. eapply elim_restriction_works_kelim; eauto.
   eapply elim_restriction_works_proj_kelim1 in H0; eauto.

--- a/pcuic/theories/PCUICEquiv.v
+++ b/pcuic/theories/PCUICEquiv.v
@@ -1,0 +1,487 @@
+From Coq Require Import Utf8 ssreflect.
+From MetaCoq.Template Require Import utils config.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICReduction PCUICTyping PCUICValidity PCUICSN PCUICSR.
+
+Local Existing Instance default_checker_flags.
+
+Record car {Σ} := mkCar {
+  context : context;
+  subject : term;
+  type : term;
+  typing : Σ ;;; context |- subject : type
+}.
+Arguments car : clear implicits.
+Derive NoConfusion for car.
+Import PCUICSafeLemmata.
+
+Definition rel Σ (x y : car Σ) :=
+  (* typing_size (typing x) < typing_size (typing y) \/ *)
+  (cored Σ (context x) (subject x) (subject y) /\ context x = context y /\ type x = type y) \/
+  (cored Σ (context x) (type x) (type y)  /\ context x = context y /\ subject x = subject y).
+
+Import Relation_Definitions Relation_Operators.
+
+Definition compose {A} (R R' : relation A) := fun x z => exists y, R x y /\ R' y z.
+
+Section Acc_equiv.
+  Context {A} (R R' : relation A).
+
+  Lemma Acc_equiv : (forall x y, R x y <-> R' x y) -> forall x, Acc R x -> Acc R' x.
+  Proof.
+    intros heq x.
+    induction 1. constructor; intros y hr.
+    eapply heq in hr. now apply H0.
+  Qed.
+End Acc_equiv.
+
+Section Acc_union.
+  Context {A} (R R' : relation A).
+  Context (wfr : well_founded R) (wfr' : well_founded R').
+
+  Context (comp : forall x y, compose R R' x y <-> compose R' R x y).
+
+  (* Lemma comp_union x y : union _ R R' x y <-> compose R R' x y. *)
+  
+  Inductive AccR (x : A) : Prop :=
+	  | Acc_introR : (∀ y : A, R y x → AccR y) → AccR x
+    | Acc2 : Acc R' x -> AccR x.
+
+  (* Context (trans : forall x y z, union _ R R' x y -> union _ R R' y z -> union _ R R' x z). *)
+
+  Lemma accu_accr x : Acc (union _ R R') x -> AccR x.
+  Proof.
+    induction 1.
+    constructor.
+    intros y hr. now specialize (H0 _ (or_introl hr)).
+  Qed.
+
+  Lemma accr_accu x : AccR x -> Acc (union _ R R') x.
+  Proof.
+    induction 1. clear H.
+    induction (wfr' x). clear H.
+    - constructor.
+      intros y hr. destruct hr. eauto.
+      eapply H1; tea. intros.
+      destruct (comp y0 x). forward H3. red. exists y; split => //.
+      destruct H3 as [z [Hz Hz']].
+      specialize (H0 _ Hz'). 
+      apply (Acc_inv H0 (or_intror Hz)).
+    - induction H. clear H.
+      induction (wfr x). clear H.
+      constructor.
+      intros y hr. destruct hr; eauto.
+      eapply H1; tea. intros.
+      destruct (comp y0 x). forward H4. red. exists y; split => //.
+      destruct H4 as [z [Hz Hz']].
+      specialize (H0 _ Hz'). 
+      apply (Acc_inv H0 (or_introl Hz)).
+  Qed.
+
+  Lemma acc_union x : Acc (union _ R R') x.
+  Proof.
+    eapply accr_accu.
+    induction (wfr x). clear H.
+    constructor. apply H0.
+  Qed.
+
+End Acc_union.
+
+Require Import Wf.
+From Equations Require Import Equations.
+
+Lemma Acc_image {A B} (R : relation A) (f : B -> A) : forall x : B, Acc R (f x) -> Acc (fun x y => R (f x) (f y)) x.
+Proof.
+  intros x.
+  intros H; depind H.
+  constructor. 
+  intros y hr.
+  eapply H0. exact hr. reflexivity.
+Qed.
+
+Lemma wf_subject_red Σ {wfΣ : wf_ext Σ} : forall x : car Σ,
+  Acc (fun x y => cored Σ (context x) (subject x) (subject y) /\ 
+    (context x) = (context y) /\ (type x) = (type y)) x.
+Proof.
+  intros x.
+  pose proof (normalisation _ wfΣ).
+  specialize (H _ _ (iswelltyped (typing x))).
+  destruct x as [Γ t T Ht].
+  cbn in *.
+  revert T Ht. induction H.
+  intros.
+  constructor. cbn.
+  intros [Γ' t' T' Ht']; cbn; intros [hred []].
+  subst Γ' T'.
+  eapply H0. exact hred.
+Qed.
+
+Lemma wf_type_red Σ {wfΣ : wf_ext Σ} : forall x : car Σ,
+  Acc (fun x y => cored Σ (context x) (type x) (type y) /\ (context x) = (context y) /\ (subject x) = (subject y)) x.
+Proof.
+  intros x.
+  pose proof (normalisation _ wfΣ).
+  pose proof (validity (typing x)).
+  destruct X as [s Hs].
+  specialize (H _ _ (iswelltyped Hs)). clear s Hs.
+  destruct x as [Γ t T Ht]. cbn in *.
+  cbn in *.
+  revert t Ht. induction H.
+  intros.
+  constructor. cbn.
+  intros [Γ' t' T' Ht']; cbn; intros [hred []].
+  subst Γ' t'.
+  eapply H0. exact hred.
+Qed.
+
+Import PCUICOnFreeVars PCUICCumulativity PCUICConversion.
+
+Lemma wf_rel Σ : wf_ext Σ -> forall x : car Σ, Acc (rel Σ) x.
+Proof.
+  intros wfΣ car.
+  apply acc_union; auto.
+  red. eapply (wf_subject_red Σ).
+  red; now eapply wf_type_red. 
+  unfold compose. 
+  intros [Γ t T Ht] [Γ' t' T' Ht']; cbn in *.
+  split.
+  - intros [[Γ'' t'' T'' Ht''] [hred' []]]. cbn in *.
+    destruct H0; subst.
+    destruct hred'. destruct H1; subst.
+    destruct (cored_alt _ _ _ _ H) as [hr].
+    unshelve eexists (mkCar Σ Γ' t T' _).
+    { eapply validity in Ht' as [s HT']. eapply type_Cumul; tea.
+      eapply PCUICConversion.cumulAlgo_cumulSpec.
+      eapply PCUICWellScopedCumulativity.into_ws_cumul_pb; fvs.
+      eapply red_cumul_inv. red.
+      now eapply clos_t_rt. }
+    cbn. intuition auto.
+  - intros [[Γ'' t'' T'' Ht''] [hred' []]]. cbn in *.
+    destruct H0; subst.
+    destruct hred'. destruct H1; subst.
+    destruct (cored_alt _ _ _ _ H0) as [hr].
+    destruct (cored_alt _ _ _ _ H) as [hr'].
+    unshelve eexists (mkCar Σ Γ' t' T _).
+    { eapply validity in Ht as [s HT']. eapply type_Cumul; tea.
+      eapply PCUICConversion.cumulAlgo_cumulSpec.
+      eapply PCUICWellScopedCumulativity.into_ws_cumul_pb; fvs.
+      eapply red_cumul. red.
+      now eapply clos_t_rt. }
+    cbn. intuition auto.
+Qed.
+
+Definition inj_car {Σ Γ t T} (d : Σ ;;; Γ |- t : T) := mkCar _ _ _ _ d.
+
+Definition subderiv Σ (d d' : car Σ) : Prop := 
+  match d'.(typing) with
+  | type_Cumul t A B s ta bs cum => (d = inj_car ta \/ d = inj_car bs)
+  | _ => False
+  end.
+
+Definition is_subderiv {Σ} (d d' : car Σ) : Prop := 
+  match d'.(typing) with
+  | type_Cumul t A B s ta bs cum => d = inj_car bs
+  | _ => False
+  end.
+
+Definition on_subderiv Σ (P : car Σ -> car Σ -> Prop) (d d' : car Σ) : Prop := 
+  match d'.(typing) with
+  | type_Cumul t A B s ta bs cum => P d (inj_car ta)
+    (* d = inj_car bs \/  *)
+    (* P d (inj_car bs) *)
+  | _ => False
+  end.
+
+Set Equations With UIP.
+Import PCUICReflect PCUICWellScopedCumulativity.
+
+Definition rel' Σ P (x y : car Σ) :=
+  on_subderiv _ P x y.
+
+
+Definition on_subderivty Σ (P : car Σ -> car Σ -> Prop) (d d' : car Σ) : Prop := 
+  match d'.(typing) with
+  | type_Cumul t A B s ta bs cum => P d (inj_car bs)
+    (* d = inj_car bs \/  *)
+    (* P d (inj_car bs) *)
+  | _ => False
+  end.
+
+Definition rel'' Σ P (x y : car Σ) :=
+  on_subderivty _ P x y.
+
+Definition on_subderivs Σ (P : car Σ -> Prop) (d : car Σ) : Prop := 
+  match d.(typing) with
+  | type_Cumul t A B s ta bs cum => P (inj_car ta)
+  | _ => True
+  end.
+(* 
+Lemma ons Σ (P : car Σ -> Prop) (R : car Σ -> car Σ -> Prop) 
+  (HRP : forall x y, R x y -> P x) d : Acc R d -> on_subderivs Σ P d.
+Proof.
+  induction 1.
+  destruct x.
+  destruct typing0; cbn => //.
+  specialize (H0 (inj_car typing0_2)).
+  forward H0. cbn. *)
+
+Definition red_subject Σ (x y : car Σ) := 
+  cored Σ (context x) (subject x) (subject y) /\ 
+  (context x) = (context y) /\ (type x) = (type y).
+
+Definition red_type Σ (x y : car Σ) := 
+  cored Σ (context x) (type x) (type y) /\ 
+  (context x) = (context y) /\ (subject x) = (subject y).
+
+Lemma wf_rel' Σ : wf_ext Σ -> 
+  forall x : car Σ, Acc (rel' Σ (red_subject Σ)) x.
+Proof.
+  intros wfΣ car.
+  pose proof (normalisation _ wfΣ _ _ (iswelltyped (typing car))).
+  destruct car as [Γ t T Ht]; cbn in *.
+  revert T Ht.
+  induction H.
+  intros T Ht.
+  destruct Ht.
+  1-13:constructor;
+  intros [Γ' t' T' Ht']; unfold rel'; cbn => //.
+  set (tc := {| typing := type_Cumul _ _ _ _ _ _ _ _ _ |}).
+  constructor. intros.
+  unfold rel' in H1.
+  cbn in H1. destruct y as [].
+  unfold red_subject in H1. cbn in H1. destruct H1 as [cor [eqctx eqty]].
+  subst context0 type0.
+  now eapply (H0).
+Qed.
+
+Lemma subject_reduction_cored {Σ} {wfΣ : wf_ext Σ} {Γ t t' T} : 
+  Σ ;;; Γ |- t : T ->
+  cored Σ Γ t' t ->
+  ∥ Σ ;;; Γ |- t' : T ∥.
+Proof.
+  intros ht.
+  move/cored_alt => [] hr.
+  sq. eapply subject_reduction; tea. apply wfΣ.
+  now eapply clos_t_rt.
+Qed.
+
+Lemma type_reduction_cored {Σ} {wfΣ : wf_ext Σ} {Γ t T T'} : 
+  Σ ;;; Γ |- t : T ->
+  cored Σ Γ T' T ->
+  ∥ Σ ;;; Γ |- t : T' ∥.
+Proof.
+  intros ht.
+  move/cored_alt => [] hr.
+  sq. eapply type_reduction; tea.
+  now eapply clos_t_rt.
+Qed.
+
+Lemma wf_rel'' Σ : wf_ext Σ -> 
+  forall x : car Σ, Acc (rel'' Σ (rel Σ)) x.
+Proof.
+  intros wfΣ car.
+  pose proof (wf_rel _ wfΣ car).
+  induction H.
+  destruct x as [Γ t T Ht]; cbn in *.
+  destruct Ht. 1-13:admit.
+  constructor; intros [].
+  unfold rel''. cbn. intros hrel.
+  unfold inj_car in hrel. red in hrel. cbn in hrel.
+  destruct hrel.
+  - destruct H1 as [? []]. subst Γ type0.
+    assert (∥ ∑ H2 : Σ ;;; context0 |- t : subject0 , on_subderivty Σ (rel Σ) {|
+      context := context0;
+      subject := subject0;
+      type := tSort s;
+      typing := typing0
+    |} (inj_car H2) ∥).
+    { move/cored_alt: H1 => [hr]. sq.
+      exists (type_reduction (type_Cumul Σ context0 t A B s Ht1 Ht2 c) (clos_t_rt _ _ hr)).
+      admit. }
+    destruct H2 as [[H2 H2P]].
+    specialize (H0 {| context := context0; subject := _; type := _; typing := H2 |}). apply H0.
+    unfold rel. cbn. right; auto.
+    red. apply H2P.
+  -
+    red. cbn.
+
+  intros 
+
+
+  destruct (validity (typing car)).
+  pose proof (normalisation _ wfΣ _ _ (iswelltyped t)). clear x t.
+  destruct car as [Γ t T Ht]; cbn in *.
+  revert t Ht.
+  induction H.
+  intros t Ht.
+  destruct Ht.
+  1-13:constructor;
+  intros [Γ' t' T' Ht']; unfold rel''; cbn => //.
+  set (tc := {| typing := type_Cumul _ _ _ _ _ _ _ _ _ |}).
+  constructor. intros.
+  unfold rel'' in H1.
+  cbn in H1. destruct y as [].
+  unfold red_type in H1. cbn in H1. destruct H1 as [cor [eqctx eqty]].
+  subst context0 subject0. specialize (H0 _ cor).
+  eapply H0.
+Qed.
+
+(*Lemma wf_rel' Σ P : wf_ext Σ -> 
+  (forall x : car Σ, Acc P x) ->
+  forall x : car Σ, Acc (rel' Σ P) x.
+Proof.
+  intros wfΣ HP car.
+  induction car. induction typing0.
+  1-13:constructor;
+  intros [Γ' t' T' Ht']; unfold rel'; cbn => //.
+  set (tc := {| typing := type_Cumul _ _ _ _ _ _ _ _ _ |}).
+  pose proof (HP (inj_car typing0_2)). unfold tc in *.
+  clear -H.
+  unfold inj_car in *.
+  constructor. intros.
+  unfold rel' in H0.
+
+  depind H.
+  constructor.
+  intros y. set (yr := y).
+  destruct y as [Γ0 t0 T0 Ht0].
+  intros hrel.
+  cbn in hrel.
+  (* - unfold inj_car in eq. cbn in eq. noconf eq. cbn in *.
+    eapply IHtyping0_2. *)
+  - specialize ()
+  
+    epose proof (Acc_inv IHtyping0_2).
+    apply H1. red.
+    unfold rel'.
+    constructor. 
+    intros y'.
+    set (yr' := y').
+    destruct y' as [Γ0' t0' T0' H0'].
+    destruct H0; cbn. 1-13:move=> //.
+    intros []. subst yr'. unfold inj_car in H0; cbn in H0. noconf H0.
+    cbn in *.
+    { eapply H1.
+    [].
+Qed.
+
+Definition rel' Σ (x y : car Σ) :=
+  on_subderiv _ (rel Σ) x y.
+
+Lemma wf_rel' Σ : wf_ext Σ -> forall x : car Σ, Acc (rel' Σ) x.
+Proof.
+  intros wfΣ car.
+  induction car. induction typing0.
+  1-13:constructor;
+  intros [Γ' t' T' Ht']; unfold rel'; cbn => //.
+  set (tc := {| typing := type_Cumul _ _ _ _ _ _ _ _ _ |}).
+  pose proof (wf_rel _ wfΣ tc). unfold tc in *.
+  depind H.
+  constructor.
+  intros y. set (yr := y).
+  destruct y as [Γ0 t0 T0 Ht0].
+  intros [eq|hrel].
+  - unfold inj_car in eq. cbn in eq. noconf eq. cbn in *.
+    eapply IHtyping0_2.
+  - epose proof (Acc_inv IHtyping0_2).
+    apply H1. red.
+    unfold rel'.
+    constructor. 
+    intros y'.
+    set (yr' := y').
+    destruct y' as [Γ0' t0' T0' H0'].
+    destruct H0; cbn. 1-13:move=> //.
+    intros []. subst yr'. unfold inj_car in H0; cbn in H0. noconf H0.
+    cbn in *.
+    { eapply H1.
+    [].
+Qed.*)
+(* destruct H as [? []]. subst Γ.
+  
+  unfold on_subderiv. cbn.
+  simpl.
+  unfold on_subderiv.
+  intros 
+
+  apply acc_union; auto.
+  { red. intros [Γ t T Ht].
+    induction Ht.
+    all:constructor; intros []; cbn; intros H.
+    all:destruct H as [H].
+    all:try solve [destruct H].
+    unfold inj_car in H. destruct H.
+    * noconf H. now cbn in IHHt1.
+    * noconf H. now cbn in IHHt2. }
+  { red. now eapply wf_rel. }
+  red. 
+  unfold compose. 
+  intros [Γ t T Ht] [Γ' t' T' Ht']; cbn -[typing_size] in *.
+  split.
+  - intros [[Γ'' t'' T'' Ht''] [hred' []]]. cbn -[typing_size] in *.
+    destruct H; subst. destruct H0; subst.
+    destruct (cored_alt _ _ _ _ H) as [hr].
+    unfold rel. cbn -[typing_size].
+    destruct hred'.
+    destruct Ht''; cbn in H0 => //.
+    destruct H0; unfold inj_car in *.
+    * noconf H0.
+      eexists (inj_car Ht'). cbn.
+    { cbn -[typing_size]. 
+      inv X.
+      depelim X.
+    eapply validity in Ht' as [s HT']. eapply type_Cumul; tea.
+      eapply PCUICConversion.cumulAlgo_cumulSpec.
+      eapply PCUICWellScopedCumulativity.into_ws_cumul_pb; fvs.
+      eapply red_cumul_inv. red.
+      now eapply clos_t_rt. }
+    cbn. intuition auto.
+  - intros [[Γ'' t'' T'' Ht''] [hred' []]]. cbn in *.
+    destruct H0; subst.
+    destruct hred'. destruct H1; subst.
+    destruct (cored_alt _ _ _ _ H0) as [hr].
+    destruct (cored_alt _ _ _ _ H) as [hr'].
+    unshelve eexists (mkCar Σ Γ' t' T _).
+    { eapply validity in Ht as [s HT']. eapply type_Cumul; tea.
+      eapply PCUICConversion.cumulAlgo_cumulSpec.
+      eapply PCUICWellScopedCumulativity.into_ws_cumul_pb; fvs.
+      eapply red_cumul. red.
+      now eapply clos_t_rt. }
+    cbn. intuition auto.
+Qed. *)
+
+Local Instance wf Σ {wfΣ : wf_ext Σ} : WellFounded (rel' Σ (red_subject Σ)).
+Proof. red. red. now apply wf_rel'. Qed.
+ (* now apply wf_rel. Qed. *)
+
+Lemma test {Σ : global_env_ext} {wfΣ : wf_ext Σ} {Γ t T} : 
+  Σ ;;; Γ |- t : T -> Σ ;;; Γ |- t : T.
+Proof.
+  intros d.
+  epose proof (FixWf (WF:=wf Σ)).
+  set (c := mkCar _ Γ t T d).
+  change Γ with (context c).
+  change t with (subject c).
+  change T with (type c).
+  clearbody c. revert c. clear -wfΣ X.
+  refine (X _ _).
+  intros [Γ t T d]; cbn. unfold rel. cbn.
+  intros IH.
+  set (IH' := fun Γ' t' T' (d' : Σ ;;; Γ' |- t' : T') => IH (mkCar _ Γ' t' T' d')).
+  clearbody IH'. cbn in IH'. clear IH. rename IH' into IH.
+  destruct d.
+  14:{
+    clear X. unfold rel' in IH.
+    eapply type_Cumul.
+    eapply IH. cbn. unfold inj_car, rel. cbn.
+    split. cbn. reflexivity.
+    assert (Σ ;;; Γ ⊢ B ⇝1 A). admit.
+    clear IH. eapply subject_reduction1 in d2; tea. 2:exact X.
+    exists (inj_car d2). cbn. left. intuition auto.
+    eapply cored_alt. sq. eapply clrel_rel in X. now constructor.
+
+
+
+    specialize (y ) 
+
+   }
+  
+  rec_wf_rel IH d (rel Σ).

--- a/pcuic/theories/PCUICExpandLets.v
+++ b/pcuic/theories/PCUICExpandLets.v
@@ -66,7 +66,12 @@ Definition trans_constructor_body i (mdecl : mutual_inductive_body) (d : PCUICEn
         (it_mkProd_or_LetIn args
           (trans_cstr_concl mdecl i args indices));
      cstr_arity := d.(PCUICEnvironment.cstr_arity) |}.
-      
+
+Definition trans_projection_body (d : PCUICEnvironment.projection_body) :=
+ {| proj_name := d.(PCUICEnvironment.proj_name); 
+    proj_type := trans d.(PCUICEnvironment.proj_type);
+    proj_relevance := d.(PCUICEnvironment.proj_relevance) |}.
+
 Definition trans_one_ind_body mdecl i (d : PCUICEnvironment.one_inductive_body) :=
   {| ind_name := d.(PCUICEnvironment.ind_name);
      ind_relevance := d.(PCUICEnvironment.ind_relevance);
@@ -75,7 +80,7 @@ Definition trans_one_ind_body mdecl i (d : PCUICEnvironment.one_inductive_body) 
      ind_sort := d.(PCUICEnvironment.ind_sort);
      ind_kelim := d.(PCUICEnvironment.ind_kelim);
      ind_ctors := List.map (trans_constructor_body i mdecl) d.(PCUICEnvironment.ind_ctors);
-     ind_projs := List.map (fun '(x, y) => (x, trans y)) d.(PCUICEnvironment.ind_projs) |}.
+     ind_projs := List.map trans_projection_body d.(PCUICEnvironment.ind_projs) |}.
 
 Definition trans_minductive_body md :=
   {| ind_finite := md.(PCUICEnvironment.ind_finite);

--- a/pcuic/theories/PCUICGlobalEnv.v
+++ b/pcuic/theories/PCUICGlobalEnv.v
@@ -61,7 +61,7 @@ Coercion declared_constructor_inductive : declared_constructor >-> declared_indu
 
 Lemma declared_projection_constructor {Σ ind mdecl idecl cdecl pdecl} :
   declared_projection Σ ind mdecl idecl cdecl pdecl ->
-  declared_constructor Σ (ind.1.1, 0) mdecl idecl cdecl.
+  declared_constructor Σ (ind.(proj_ind), 0) mdecl idecl cdecl.
 Proof. now intros []. Qed.
 Coercion declared_projection_constructor : declared_projection >-> declared_constructor.
 

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -295,10 +295,9 @@ Section Inversion.
       Σ ;;; Γ |- tProj p c : T ->
       ∑ u mdecl idecl cdecl pdecl args,
         declared_projection Σ p mdecl idecl cdecl pdecl ×
-        Σ ;;; Γ |- c : mkApps (tInd (fst (fst p)) u) args ×
+        Σ ;;; Γ |- c : mkApps (tInd p.(proj_ind) u) args ×
         #|args| = ind_npars mdecl ×
-        let ty := snd pdecl in
-        Σ ;;; Γ ⊢ (subst0 (c :: List.rev args)) (subst_instance u ty) ≤ T.
+        Σ ;;; Γ ⊢ (subst0 (c :: List.rev args)) pdecl.(proj_type)@[u] ≤ T.
   Proof.
     intros Γ p c T h. invtac h.
   Qed.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -758,10 +758,10 @@ Lemma whne_red1_ind
           RedFlags.iota flags = false ->
           unfold_cofix mfix idx = Some (narg, fn) ->
           P (tProj p (mkApps (tCoFix mfix idx) args)) (tProj p (mkApps fn args)))
-      (Hproj_noiota : forall i pars narg args u arg,
+      (Hproj_noiota : forall p args u arg,
           RedFlags.iota flags = false ->
-          nth_error args (pars + narg) = Some arg ->
-          P (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg)
+          nth_error args (p.(proj_npars) + p.(proj_arg)) = Some arg ->
+          P (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args)) arg)
       (Hproj_discr_noiota : forall p c c',
           RedFlags.iota flags = false ->
           red1 Σ Γ c c' ->

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -335,11 +335,11 @@ Section ParallelReduction.
     pred1 Γ Γ' (tConst c u) (tConst c u)
 
   (** Proj *)
-  | pred_proj i pars narg u args0 args1 arg1 :
+  | pred_proj p u args0 args1 arg1 :
     pred1_ctx Γ Γ' ->
     All2 (pred1 Γ Γ') args0 args1 ->
-    nth_error args1 (pars + narg) = Some arg1 ->
-    pred1 Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args0)) arg1
+    nth_error args1 (p.(proj_npars) + p.(proj_arg)) = Some arg1 ->
+    pred1 Γ Γ' (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args0)) arg1
 
   (** Congruences *)
   | pred_abs na M M' N N' : 
@@ -538,14 +538,14 @@ Section ParallelReduction.
           pred1_ctx Γ Γ' ->
           Pctx Γ Γ' ->
           P Γ Γ' (tConst c u) (tConst c u)) ->
-      (forall (Γ Γ' : context) (i : inductive) (pars narg : nat) (u : Instance.t)
+      (forall (Γ Γ' : context) p (u : Instance.t)
               (args0 args1 : list term) (arg1 : term),
           pred1_ctx Γ Γ' ->
           Pctx Γ Γ' ->
           All2 (pred1 Γ Γ') args0 args1 ->
           All2 (P Γ Γ') args0 args1 ->
-          nth_error args1 (pars + narg) = Some arg1 ->
-          P Γ Γ' (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args0)) arg1) ->
+          nth_error args1 (p.(proj_npars) + p.(proj_arg)) = Some arg1 ->
+          P Γ Γ' (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args0)) arg1) ->
       (forall (Γ Γ' : context) (na : aname) (M M' N N' : term),
           pred1 Γ Γ' M M' ->
           P Γ Γ' M M' -> pred1 (Γ,, vass na M) (Γ' ,, vass na M') N N' ->

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -245,20 +245,20 @@ Section Principality.
       * split; eauto.
       * split; eauto.
 
-    - destruct s as [[ind k] pars]; simpl in *.
+    - destruct s as [ind k pars]; simpl in *.
       eapply inversion_Proj in hA=>//; auto.
       repeat outsum. repeat outtimes.
       simpl in *.
       specialize (IHu _ _ t) as [C HP].
       destruct (HP _ t).
       eapply ws_cumul_pb_Ind_r_inv in w0 as [u' [x0' [redr redu ?]]]; auto.
-      exists (subst0 (u :: List.rev x0') (subst_instance u' t0)).
+      exists (subst0 (u :: List.rev x0') (subst_instance u' (proj_type x3))).
       intros B hB.
       eapply inversion_Proj in hB=>//; auto.
       repeat outsum. repeat outtimes.
       simpl in *.
-      destruct (declared_projection_inj d d0) as [-> [-> [-> [= -> ->]]]].
-      destruct (HP _ t2).
+      destruct (declared_projection_inj d d0) as [-> [-> [-> ?]]]. subst x9.
+      destruct (HP _ t1).
       eapply ws_cumul_pb_Ind_r_inv in w1 as [u'' [x0'' [redr' redu' ?]]]; auto.
       split; cycle 1.
       eapply type_reduction in t0. 2:exact redr.
@@ -269,43 +269,44 @@ Section Principality.
       eapply invert_red_mkApps_tInd in redr'' as [? [[=] conv']]; auto.
       solve_discr.
       etransitivity; eauto.
-      assert (consistent_instance_ext Σ (ind_universes x5) u').
-      { eapply type_reduction in t1. 2:eapply redr.
-        eapply validity in t1; eauto.
-        destruct t1 as [s Hs].
+      assert (consistent_instance_ext Σ (ind_universes x6) u').
+      { eapply type_reduction in t2. 2:eapply redr.
+        eapply validity in t2; eauto.
+        destruct t2 as [s Hs].
         eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto. eapply d. }
-      assert (consistent_instance_ext Σ (ind_universes x5) x3).
-        { eapply validity in t2; eauto.
-          destruct t2 as [s Hs].
+      assert (consistent_instance_ext Σ (ind_universes x6) x5).
+        { eapply validity in t1; eauto.
+          destruct t1 as [s Hs].
           eapply invert_type_mkApps_ind in Hs. intuition eauto. all:auto. eapply d. }
-        transitivity (subst0 (u :: List.rev x0') (subst_instance x3 t3)); cycle 1.
+      set (p := {| proj_ind := ind; proj_npars := k; proj_arg := pars |}).
+      transitivity (subst0 (u :: List.rev x0') (subst_instance x5 (proj_type x3))); cycle 1.
       eapply ws_cumul_pb_eq_le.
-      assert (ws_cumul_pb_terms Σ Γ x0' x9).
+      assert (ws_cumul_pb_terms Σ Γ x0' x10).
       { transitivity x0'' => //.
         transitivity x0. auto using red_terms_ws_cumul_pb_terms.
         symmetry. auto using red_terms_ws_cumul_pb_terms. }
-      eapply (substitution_ws_cumul_pb_subst_conv (Γ0 := projection_context ind x5 x6 u')
-      (Γ1 := projection_context ind x5 x6 x3) (Δ := [])); auto.
-      * eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
+      eapply (substitution_ws_cumul_pb_subst_conv (Γ0 := projection_context ind x6 x7 u')
+      (Γ1 := projection_context ind x6 x7 x5) (Δ := [])); auto.
+      * eapply (projection_subslet _ _ _ _ _ _ p); eauto.
         simpl. eapply type_reduction; eauto. eapply redr. simpl.
         eapply type_reduction in t0. 2:eapply redr. eapply validity; eauto.
       * split.
         { eapply PCUICWeakeningTyp.weaken_wf_local; tea. pcuic. pcuic. 
-          eapply (wf_projection_context _ (p:=(ind, k, pars))); tea. pcuic. }
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
+          eapply (wf_projection_context _ (p:=p)); tea. pcuic. }
+        eapply (projection_subslet _ _ _ _ _ _ p); eauto.
         simpl. eapply validity; eauto.
       * constructor; auto. now eapply wt_cumul_pb_refl. now apply All2_rev.
       * eapply ws_cumul_pb_refl.
         { eapply wf_local_closed_context. cbn -[projection_context].
           eapply PCUICWeakeningTyp.weaken_wf_local; pcuic.
-          eapply (wf_projection_context _ (p:= (ind, k, pars))); pcuic. }
+          eapply (wf_projection_context _ (p:=p)); pcuic. }
         eapply declared_projection_closed in d0; eauto.
         cbn in d0. len. rewrite (declared_minductive_ind_npars d) in d0.
         len. rewrite on_free_vars_subst_instance.
         rewrite closedn_on_free_vars //.
         eapply closed_upwards; tea. lia.
-      * eapply (substitution_ws_cumul_pb (Γ:=Γ) (Γ' := projection_context ind x5 x6 u') (Γ'' := [])); auto.
-        eapply (projection_subslet _ _ _ _ _ _ (ind, k, pars)); eauto.
+      * eapply (substitution_ws_cumul_pb (Γ:=Γ) (Γ' := projection_context ind x6 x7 u') (Γ'' := [])); auto.
+        eapply (projection_subslet _ _ _ _ _ _ p); eauto.
         simpl. eapply type_reduction; eauto. eapply redr. simpl.
         eapply type_reduction in t0. 2:eapply redr.
         eapply validity; eauto. simpl in redu'.
@@ -660,9 +661,8 @@ Proof.
       now rewrite (All2_length X3').
     * eapply PCUICValidity.validity; eauto.
       eapply type_Proj; eauto.
-    * rewrite /ty.
-      destruct (declared_projection_inj a isdecl) as [-> [-> [-> ->]]].
-      set (ctx := PCUICInductives.projection_context p.1.1 mdecl idecl u).
+    * destruct (declared_projection_inj a isdecl) as [-> [-> [-> ->]]].
+      set (ctx := PCUICInductives.projection_context p.(proj_ind) mdecl idecl u).
       have clctx : is_closed_context (Γ,,, ctx).
       { rewrite /ctx.
         eapply validity in X1.
@@ -717,6 +717,7 @@ Proof.
     constructor. apply eq_term_empty_leq_term in eqty.
     now eapply leq_term_empty_leq_term.
 Qed.
+
 
 Lemma typing_eq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' : 
   wf_ext Σ ->

--- a/pcuic/theories/PCUICReduction.v
+++ b/pcuic/theories/PCUICReduction.v
@@ -59,9 +59,9 @@ Inductive red1 (Σ : global_env) (Γ : context) : term -> term -> Type :=
     Σ ;;; Γ |- tConst c u ⇝ subst_instance u body
 
 (** Proj *)
-| red_proj i pars narg args u arg:
-    nth_error args (pars + narg) = Some arg ->
-    Σ ;;; Γ |- tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args) ⇝ arg
+| red_proj p args u arg:
+    nth_error args (p.(proj_npars) + p.(proj_arg)) = Some arg ->
+    Σ ;;; Γ |- tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args) ⇝ arg
 
 
 | abs_red_l na M M' N : Σ ;;; Γ |- M ⇝ M' -> Σ ;;; Γ |- tLambda na M N ⇝ tLambda na M' N
@@ -155,10 +155,10 @@ Lemma red1_ind_all :
         declared_constant Σ c decl ->
         forall u : Instance.t, cst_body decl = Some body -> P Γ (tConst c u) (subst_instance u body)) ->
 
-       (forall (Γ : context) (i : inductive) (pars narg : nat) (args : list term) (u : Instance.t)
+       (forall (Γ : context) p (args : list term) (u : Instance.t)
          (arg : term),
-           nth_error args (pars + narg) = Some arg ->
-           P Γ (tProj (i, pars, narg) (mkApps (tConstruct i 0 u) args)) arg) ->
+           nth_error args (p.(proj_npars) + p.(proj_arg)) = Some arg ->
+           P Γ (tProj p (mkApps (tConstruct p.(proj_ind) 0 u) args)) arg) ->
 
        (forall (Γ : context) (na : aname) (M M' N : term),
         red1 Σ Γ M M' -> P Γ M M' -> P Γ (tLambda na M N) (tLambda na M' N)) ->

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -940,11 +940,11 @@ Section Lemmata.
   Qed.
 
   Lemma Proj_red_cond :
-    forall Γ i pars narg i' c u l,
-      welltyped Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i' c u) l)) ->
-      nth_error l (pars + narg) <> None.
+    forall Γ p i' c u l,
+      welltyped Σ Γ (tProj p (mkApps (tConstruct i' c u) l)) ->
+      nth_error l (p.(proj_npars) + p.(proj_arg)) <> None.
   Proof.
-    intros Γ i pars narg i' c u l [T h].
+    intros Γ p i' c u l [T h].
     apply PCUICInductiveInversion.invert_Proj_Construct in h as (<-&->&?).
     2: now sq.
     now apply nth_error_Some.
@@ -1057,11 +1057,11 @@ Section Lemmata.
   Qed.
 
   Lemma Proj_Construct_ind_eq :
-    forall Γ i i' pars narg c u l,
-      welltyped Σ Γ (tProj (i, pars, narg) (mkApps (tConstruct i' c u) l)) ->
-      i = i'.
+    forall Γ p i' c u l,
+      welltyped Σ Γ (tProj p (mkApps (tConstruct i' c u) l)) ->
+      p.(proj_ind) = i'.
   Proof.
-    intros Γ i i' pars narg c u l [T h].
+    intros Γ p i' c u l [T h].
     now apply PCUICInductiveInversion.invert_Proj_Construct in h.
   Qed.
 

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -64,7 +64,12 @@ Definition trans_constructor_body (d : PCUICEnvironment.constructor_body) :=
      cstr_indices := map trans d.(PCUICEnvironment.cstr_indices); 
      cstr_type := trans d.(PCUICEnvironment.cstr_type);
      cstr_arity := d.(PCUICEnvironment.cstr_arity) |}.
-      
+
+Definition trans_projection_body (d : PCUICEnvironment.projection_body) :=
+ {| proj_name := d.(PCUICEnvironment.proj_name); 
+    proj_type := trans d.(PCUICEnvironment.proj_type);
+    proj_relevance := d.(PCUICEnvironment.proj_relevance) |}.
+          
 Definition trans_one_ind_body (d : PCUICEnvironment.one_inductive_body) :=
   {| ind_name := d.(PCUICEnvironment.ind_name);
      ind_relevance := d.(PCUICEnvironment.ind_relevance);
@@ -73,7 +78,7 @@ Definition trans_one_ind_body (d : PCUICEnvironment.one_inductive_body) :=
      ind_sort := d.(PCUICEnvironment.ind_sort);
      ind_kelim := d.(PCUICEnvironment.ind_kelim);
      ind_ctors := List.map trans_constructor_body d.(PCUICEnvironment.ind_ctors);
-     ind_projs := List.map (fun '(x, y) => (x, trans y)) d.(PCUICEnvironment.ind_projs) |}.
+     ind_projs := List.map trans_projection_body d.(PCUICEnvironment.ind_projs) |}.
 
 Definition trans_constant_body bd :=
   {| cst_type := trans bd.(PCUICEnvironment.cst_type); cst_body := option_map trans bd.(PCUICEnvironment.cst_body);

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -402,7 +402,7 @@ Qed.
 Lemma trans_declared_projection Σ p mdecl idecl cdecl pdecl :
   S.declared_projection Σ.1 p mdecl idecl cdecl pdecl ->
   T.declared_projection (trans_global Σ).1 p (trans_minductive_body mdecl) (trans_one_ind_body idecl) 
-    (trans_constructor_body cdecl) (on_snd trans pdecl).
+    (trans_constructor_body cdecl) (trans_projection_body pdecl).
 Proof.
   intros []. split; [|split].
   - now apply trans_declared_constructor.
@@ -410,8 +410,6 @@ Proof.
     destruct H0.
     destruct pdecl, p.
     cbn in *.
-    change (Some (i, trans t)) with
-      (Some((fun '(x, y) => (x, trans y)) (i,t))).
     now apply map_nth_error.
   - now destruct mdecl;cbn in *.
 Qed.
@@ -2308,19 +2306,13 @@ Proof.
         rewrite -/brctxty -/ptm in H5. cbn in H5. clearbody brctxty.
         subst brctxty. rewrite -trans_local_app. cbn. apply IHbty.
 
-  - rewrite trans_subst.
-    rewrite trans_subst_instance.
-    cbn.
-    rewrite map_rev.
-    change (trans ty) with ((on_snd trans pdecl).2).
+  - rewrite trans_subst trans_subst_instance /= map_rev.
+    change (trans (proj_type pdecl)) with (trans_projection_body pdecl).(Ast.Env.proj_type).
     eapply TT.type_Proj.
     + now apply trans_declared_projection.
     + rewrite trans_mkApps in X2.
       assumption.
-    + rewrite map_length.
-      rewrite H.
-      destruct mdecl.
-      reflexivity.
+    + rewrite map_length H. now destruct mdecl.  
   - rewrite trans_dtype. simpl.
     eapply TT.type_Fix; auto.
     + now rewrite fix_guard_trans.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -252,9 +252,9 @@ Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term ->
 
 | type_Proj : forall p c u mdecl idecl cdecl pdecl args,
     declared_projection Σ p mdecl idecl cdecl pdecl ->
-    Σ ;;; Γ |- c : mkApps (tInd (fst (fst p)) u) args ->
+    Σ ;;; Γ |- c : mkApps (tInd p.(proj_ind) u) args ->
     #|args| = ind_npars mdecl ->
-    Σ ;;; Γ |- tProj p c : subst0 (c :: List.rev args) (snd pdecl)@[u]
+    Σ ;;; Γ |- tProj p c : subst0 (c :: List.rev args) pdecl.(proj_type)@[u]
 
 | type_Fix : forall mfix n decl,
     wf_local Σ Γ ->
@@ -706,10 +706,10 @@ Lemma typing_ind_env_app_size `{cf : checker_flags} :
    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : projection) (c : term) u
          mdecl idecl cdecl pdecl (isdecl : declared_projection Σ.1 p mdecl idecl cdecl pdecl) args,
        Forall_decls_typing P Σ.1 -> PΓ Σ Γ ->
-       Σ ;;; Γ |- c : mkApps (tInd (fst (fst p)) u) args ->
-       P Σ Γ c (mkApps (tInd (fst (fst p)) u) args) ->
+       Σ ;;; Γ |- c : mkApps (tInd p.(proj_ind) u) args ->
+       P Σ Γ c (mkApps (tInd p.(proj_ind) u) args) ->
        #|args| = ind_npars mdecl ->
-       let ty := snd pdecl in P Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance u ty))) ->
+       P Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance u pdecl.(proj_type)))) ->
 
    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : list (def term)) (n : nat) decl,
        let types := fix_context mfix in
@@ -1178,10 +1178,10 @@ Lemma typing_ind_env `{cf : checker_flags} :
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : projection) (c : term) u
           mdecl idecl cdecl pdecl (isdecl : declared_projection Σ.1 p mdecl idecl cdecl pdecl) args,
         Forall_decls_typing P Σ.1 -> PΓ Σ Γ ->
-        Σ ;;; Γ |- c : mkApps (tInd (fst (fst p)) u) args ->
-        P Σ Γ c (mkApps (tInd (fst (fst p)) u) args) ->
+        Σ ;;; Γ |- c : mkApps (tInd p.(proj_ind) u) args ->
+        P Σ Γ c (mkApps (tInd p.(proj_ind) u) args) ->
         #|args| = ind_npars mdecl ->
-        let ty := snd pdecl in P Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance u ty))) ->
+        P Σ Γ (tProj p c) (subst0 (c :: List.rev args) (subst_instance u pdecl.(proj_type)))) ->
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (mfix : list (def term)) (n : nat) decl,
         let types := fix_context mfix in

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -411,7 +411,6 @@ Section Validity.
     - (* Proj *)
       pose proof isdecl as isdecl'.
       eapply declared_projection_type in isdecl'; eauto.
-      subst ty.
       destruct isdecl' as [s Hs].
       unshelve eapply isType_mkApps_Ind_inv in X2 as [parsubst [argsubst [sppar sparg 
         lenpars lenargs cu]]]; eauto.

--- a/pcuic/theories/PCUICWfUniverses.v
+++ b/pcuic/theories/PCUICWfUniverses.v
@@ -1159,7 +1159,7 @@ Qed.
       destruct X1 as [[[? ?] ?] ?] => //.
       red in o0.
       destruct nth_error eqn:heq => //. 
-      subst ty. destruct o0  as [_ ->].
+      destruct o0  as [_ ->].
       rewrite wf_universes_mkApps {1}/wf_universes /= -!/(wf_universes _ _)
         wf_universeb_instance_forall in H1.
       move/andP: H1 => [/wf_universe_instanceP wfu wfargs].

--- a/pcuic/theories/Syntax/PCUICClosed.v
+++ b/pcuic/theories/Syntax/PCUICClosed.v
@@ -479,7 +479,7 @@ Definition closed_inductive_body mdecl idecl :=
   closedn 0 idecl.(ind_type) &&
   closedn_ctx #|mdecl.(ind_params)| idecl.(ind_indices) &&
   forallb (closed_constructor_body mdecl) idecl.(ind_ctors) &&
-  forallb (fun x => closedn (S (ind_npars mdecl)) x.2) idecl.(ind_projs).
+  forallb (fun x => closedn (S (ind_npars mdecl)) x.(proj_type)) idecl.(ind_projs).
 
 Definition closed_inductive_decl mdecl :=
   closed_ctx (ind_params mdecl) &&

--- a/pcuic/theories/Syntax/PCUICNamelessDef.v
+++ b/pcuic/theories/Syntax/PCUICNamelessDef.v
@@ -123,6 +123,11 @@ Definition nl_constructor_body c :=
      cstr_type := nl c.(cstr_type);
      cstr_arity := c.(cstr_arity) |}.
 
+Definition nl_projection_body p :=
+  {| proj_name := p.(proj_name) ;   
+     proj_type := nl p.(proj_type);
+     proj_relevance := p.(proj_relevance) |}.
+    
 Definition nl_one_inductive_body o :=
   Build_one_inductive_body
     o.(ind_name)
@@ -131,7 +136,7 @@ Definition nl_one_inductive_body o :=
     (nl o.(ind_type))
     o.(ind_kelim)
     (map nl_constructor_body o.(ind_ctors))
-    (map (fun '(x,y) => (x, nl y)) o.(ind_projs))
+    (map nl_projection_body o.(ind_projs))
     o.(ind_relevance).
 
 Definition nl_mutual_inductive_body m :=

--- a/pcuic/theories/Syntax/PCUICReflect.v
+++ b/pcuic/theories/Syntax/PCUICReflect.v
@@ -311,6 +311,21 @@ Proof.
   unfold eqb_constructor_body; cbn -[eqb]. finish_reflect.
 Qed.
   
+Definition eqb_projection_body (x y : projection_body) :=
+  (x.(proj_name), x.(proj_type), x.(proj_relevance)) == 
+  (y.(proj_name), y.(proj_type), y.(proj_relevance)).
+
+#[program, global]
+Instance reflect_projection_body : ReflectEq projection_body :=
+  {| eqb := eqb_projection_body |}.
+Next Obligation.
+Proof.
+  unfold eqb_projection_body.
+  case: eqb_spec.
+  destruct x, y; cbn in *. constructor; auto. congruence.
+  unfold eqb_constructor_body; cbn -[eqb]. finish_reflect.
+Qed.
+
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
   x.(ind_name) ==? y.(ind_name) &&
   x.(ind_indices) ==? y.(ind_indices) &&

--- a/pcuic/theories/TemplateToPCUIC.v
+++ b/pcuic/theories/TemplateToPCUIC.v
@@ -117,6 +117,10 @@ Section Trans.
       cstr_indices := map trans d.(Ast.Env.cstr_indices); 
       cstr_type := trans d.(Ast.Env.cstr_type);
       cstr_arity := d.(Ast.Env.cstr_arity) |}.
+  Definition trans_projection_body (d : Ast.Env.projection_body) :=
+    {| proj_name := d.(Ast.Env.proj_name); 
+        proj_type := trans d.(Ast.Env.proj_type);
+        proj_relevance := d.(Ast.Env.proj_relevance) |}.
 
   Definition trans_one_ind_body (d : Ast.Env.one_inductive_body) :=
     {| ind_name := d.(Ast.Env.ind_name);
@@ -126,7 +130,7 @@ Section Trans.
       ind_type := trans d.(Ast.Env.ind_type);
       ind_kelim := d.(Ast.Env.ind_kelim);
       ind_ctors := List.map trans_constructor_body d.(Ast.Env.ind_ctors);
-      ind_projs := List.map (fun '(x, y) => (x, trans y)) d.(Ast.Env.ind_projs) |}.
+      ind_projs := List.map trans_projection_body d.(Ast.Env.ind_projs) |}.
 
   Definition trans_constant_body bd :=
     {| cst_type := trans bd.(Ast.Env.cst_type); 

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -292,7 +292,7 @@ Proof.
     * rewrite [map _ _]trans_local_weakening //.
     * solve_all. rewrite trans_weakening //.
     * rewrite trans_weakening //.
-  - destruct x. f_equal.
+  - destruct x. unfold trans_projection_body; cbn. f_equal.
     rewrite trans_weakening //.
 Qed.
 
@@ -717,7 +717,7 @@ Section Trans_Global.
   Lemma forall_decls_declared_projection cst mdecl idecl cdecl pdecl :
     Ast.declared_projection Σ cst mdecl idecl cdecl pdecl ->
     declared_projection (trans_global_env Σ) cst (trans_minductive_body Σ' mdecl) (trans_one_ind_body Σ' idecl)
-      (trans_constructor_body Σ' cdecl)  ((fun '(x, y) => (x, trans Σ' y)) pdecl).
+      (trans_constructor_body Σ' cdecl)  (trans_projection_body Σ' pdecl).
   Proof.
     unfold declared_constructor, Ast.declared_constructor.
     move=> [decl' [Hnth Hnpar]].
@@ -2386,15 +2386,15 @@ Proof.
       rewrite trans_local_app in IHbod.
       rewrite trans_local_app in IHty => //.
 
-  - destruct pdecl as [arity ty']; simpl in *.
+  - destruct pdecl as [arity relevance ty']. simpl in *.
     assert (wfproj := TypingWf.declared_projection_wf _ _ _ _ _ isdecl).
     simpl in wfproj.
     eapply forall_decls_declared_projection in isdecl => //.
     destruct (typing_wf _ wfΣ _ _ _ X1) as [wfc wfind].
     eapply WfAst.wf_mkApps_inv in wfind; auto.
     rewrite trans_subst; auto with wf. 
-    simpl. rewrite map_rev. rewrite trans_subst_instance.
-    eapply (type_Proj _ _ _ _ _ _ _ _ (arity, trans Σ' ty)). eauto.
+    simpl. rewrite map_rev trans_subst_instance.
+    eapply (type_Proj _ _ _ _ _ _ _ _ (Build_projection_body arity relevance (trans Σ' ty'))). eauto.
     rewrite trans_mkApps in X2; auto. rewrite map_length.
     destruct mdecl; auto.
 
@@ -3201,8 +3201,9 @@ Proof.
             rewrite context_assumptions_map.
             rewrite -[trans_local _ _ ++ _]trans_local_app -(trans_smash_context _ []) nth_error_map.
             rewrite /Ast.Env.app_context. destruct nth_error => // /=.
-            intros [-> ->]. cbn -[Σg]. split => //.
-            rewrite trans_subst trans_inds. f_equal.
+            rewrite /trans_projection_body /=. 
+            move=> [] /= hb -> ->. cbn -[Σg]. split => //.
+            rewrite trans_subst trans_inds. cbn -[Σg]. f_equal.
             rewrite trans_subst trans_lift. f_equal. now rewrite trans_projs.
         --- have inds := oni.(ST.ind_sorts).
             eapply trans_check_ind_sorts in inds; tea.

--- a/pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -659,15 +659,12 @@ Proof.
     apply IHev2.
 
   - wf_inv wf hdiscr.
-    destruct proj as ((?&?)&?).
     cbn in *; eapply eval_proj; tea.
-    * destruct H. cbn in d. 
-      eapply forall_decls_declared_constructor in d; tea.
+    * eapply forall_decls_declared_projection in H; tea.
     * rewrite trans_mkApps in IHev1. 
       now eapply IHev1.
     * cbn. len. rewrite H0 /WcbvEval.cstr_arity. f_equal.
       now rewrite context_assumptions_map.
-    * cbn. symmetry; eapply H.
     * rewrite nth_error_map H1 //.
     * eapply IHev2.
       eapply eval_wf in ev1; tea.

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -14,7 +14,7 @@ Lemma declared_projection_closed_ind {cf:checker_flags} {Σ : global_env} {wfΣ 
   Forall_decls_typing
   (fun _ (Γ : context) (t T : term) =>
   closedn #|Γ| t && closedn #|Γ| T) Σ ->
-  closedn (S (ind_npars mdecl)) pdecl.2.
+  closedn (S (ind_npars mdecl)) pdecl.(proj_type).
 Proof.
   intros isdecl X0.
   pose proof (declared_projection_inv weaken_env_prop_closed wfΣ X0 isdecl) as onp.
@@ -38,9 +38,9 @@ Proof.
     induction l; simpl; auto. }
   rewrite inds_length.
   eapply closedn_subst0.
-  { clear. unfold projs. induction p.2; simpl; auto. }
+  { clear. unfold projs. induction p.(proj_arg); simpl; auto. }
   rewrite projs_length /=.
-  eapply (@closed_upwards (ind_npars mdecl + #|ind_bodies mdecl| + p.2 + 1)).
+  eapply (@closed_upwards (ind_npars mdecl + #|ind_bodies mdecl| + p.(proj_arg) + 1)).
   2:lia.
   eapply closedn_lift.
   clear -parslen isdecl Heq' onpars X.
@@ -142,7 +142,7 @@ Proof.
     destruct (ind_ctors x) as [|cdecl []] eqn:hcdecl; try contradiction.
     apply on_projs in X.
     assert (Alli (fun i pdecl => declared_projection Σ 
-     (({| inductive_mind := mind; inductive_ind := n |}, mdecl.(ind_npars)), i) mdecl x cdecl pdecl)
+      (mkProjection {| inductive_mind := mind; inductive_ind := n |} mdecl.(ind_npars) i) mdecl x cdecl pdecl)
       0 (ind_projs x)).
     { eapply forall_nth_error_Alli.
       intros. split; auto. split; auto. cbn. now rewrite hcdecl. }
@@ -310,11 +310,9 @@ Proof.
   now simpl in cli.
 Qed.
 
-
-
 Lemma declared_projection_closed {cf:checker_flags} {Σ : global_env} {wfΣ : wf Σ}{mdecl idecl p cdecl pdecl} : 
   declared_projection Σ p mdecl idecl cdecl pdecl ->
-  closedn (S (ind_npars mdecl)) pdecl.2.
+  closedn (S (ind_npars mdecl)) pdecl.(proj_type).
 Proof.
   intros; eapply declared_projection_closed_ind; eauto.
   eapply (env_prop_sigma typecheck_closed); eauto.
@@ -677,7 +675,7 @@ Qed.
 Lemma declared_projection_closed_type {cf:checker_flags} 
   {Σ mdecl idecl p cdecl pdecl} {wfΣ : wf Σ} :
   declared_projection Σ p mdecl idecl cdecl pdecl ->
-  closedn (S (ind_npars mdecl)) pdecl.2.
+  closedn (S (ind_npars mdecl)) pdecl.(proj_type).
 Proof.
   intros decl.
   now eapply declared_projection_closed in decl.

--- a/pcuic/theories/Typing/PCUICInstTyp.v
+++ b/pcuic/theories/Typing/PCUICInstTyp.v
@@ -511,7 +511,7 @@ Proof.
           { eapply well_subst_app_up => //. }
           rewrite /brctxty /= case_branch_context_length //.
     * rewrite /predctx case_predicate_context_length //.
-  - intros Σ wfΣ Γ wfΓ p c u mdecl idecl cdecl pdecl isdecl args X X0 hc ihc e ty
+  - intros Σ wfΣ Γ wfΓ p c u mdecl idecl cdecl pdecl isdecl args X X0 hc ihc e
            Δ σ hΔ hσ.
     simpl.
     eapply meta_conv; [econstructor|].
@@ -523,7 +523,6 @@ Proof.
       eapply declared_projection_closed in isdecl; auto.
       move: isdecl.
       rewrite -(closedn_subst_instance _ _ u).
-      rewrite /ty.
       eapply inst_ext_closed.
       intros x Hx.
       rewrite subst_consn_lt /=; len; try lia.

--- a/pcuic/theories/Typing/PCUICRenameTyp.v
+++ b/pcuic/theories/Typing/PCUICRenameTyp.v
@@ -977,7 +977,7 @@ Proof.
           relativize #|bcontext br|; [eapply urenaming_context, Hf|len].
           now rewrite case_branch_context_length. }
     * rewrite /predctx case_predicate_context_length //.
-  - intros Σ wfΣ Γ wfΓ p c u mdecl idecl cdecl pdecl isdecl args X X0 hc ihc e ty
+  - intros Σ wfΣ Γ wfΓ p c u mdecl idecl cdecl pdecl isdecl args X X0 hc ihc e
            P Δ f hf.
     simpl. eapply meta_conv.
     + econstructor.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -524,9 +524,9 @@ Lemma declared_projection_inv `{checker_flags} {Σ P mdecl idecl cdecl ref pdecl
      | [cs] => sorts_local_ctx (lift_typing P) (Σ, ind_universes mdecl) (arities_context (ind_bodies mdecl) ,,, ind_params mdecl) (cstr_args c) cs
      | _ => False
     end) *
-    on_projections mdecl (inductive_mind ref.1.1) (inductive_ind ref.1.1) idecl (idecl.(ind_indices)) c *
-    ((snd ref) < context_assumptions c.(cstr_args)) *
-    on_projection mdecl (inductive_mind ref.1.1) (inductive_ind ref.1.1) c (snd ref) pdecl
+    on_projections mdecl (inductive_mind ref.(proj_ind)) (inductive_ind ref.(proj_ind)) idecl (idecl.(ind_indices)) c *
+    (ref.(proj_arg) < context_assumptions c.(cstr_args)) *
+    on_projection mdecl (inductive_mind ref.(proj_ind)) (inductive_ind ref.(proj_ind)) c ref.(proj_arg) pdecl
   | _ => False
   end.
 Proof.
@@ -640,7 +640,7 @@ Defined.
 
 Lemma on_declared_projection `{checker_flags} {Σ ref mdecl idecl cdecl pdecl} {wfΣ : wf Σ}
   (Hdecl : declared_projection Σ ref mdecl idecl cdecl pdecl) :
-  on_inductive (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind (fst (fst ref))) mdecl *
+  on_inductive (lift_typing typing) (Σ, ind_universes mdecl) (inductive_mind ref.(proj_ind)) mdecl *
   (idecl.(ind_ctors) = [cdecl]) *
   let oib := declared_inductive_inv weaken_env_prop_typing wfΣ wfΣ (let (x, _) := Hdecl in let (x, _) := x in x) in
   (match oib.(ind_cunivs) with
@@ -648,9 +648,9 @@ Lemma on_declared_projection `{checker_flags} {Σ ref mdecl idecl cdecl pdecl} {
       (arities_context (ind_bodies mdecl) ,,, ind_params mdecl) (cstr_args cdecl) cs
     | _ => False
   end) *
-  on_projections mdecl (inductive_mind ref.1.1) (inductive_ind ref.1.1) idecl (idecl.(ind_indices)) cdecl *
-  ((snd ref) < context_assumptions cdecl.(cstr_args)) *
-  on_projection mdecl (inductive_mind ref.1.1) (inductive_ind ref.1.1) cdecl (snd ref) pdecl.
+  on_projections mdecl (inductive_mind ref.(proj_ind)) (inductive_ind ref.(proj_ind)) idecl (idecl.(ind_indices)) cdecl *
+  (ref.(proj_arg) < context_assumptions cdecl.(cstr_args)) *
+  on_projection mdecl (inductive_mind ref.(proj_ind)) (inductive_ind ref.(proj_ind)) cdecl ref.(proj_arg) pdecl.
 Proof.
   have hctors : idecl.(ind_ctors) = [cdecl].
   { pose proof (declared_projection_inv weaken_env_prop_typing wfΣ wfΣ Hdecl).

--- a/pcuic/theories/utils/PCUICAstUtils.v
+++ b/pcuic/theories/utils/PCUICAstUtils.v
@@ -35,8 +35,8 @@ Fixpoint string_of_term (t : term) :=
   | tCase ci p t brs =>
     "Case(" ^ string_of_case_info ci ^ "," ^ string_of_term t ^ ","
             ^ string_of_predicate string_of_term p ^ "," ^ string_of_list (string_of_branch string_of_term) brs ^ ")"
-  | tProj (ind, i, k) c =>
-    "Proj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
+  | tProj p c =>
+    "Proj(" ^ string_of_inductive p.(proj_ind) ^ "," ^ string_of_nat p.(proj_npars) ^ "," ^ string_of_nat p.(proj_arg) ^ ","
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -244,17 +244,12 @@ Module PrintTermTree.
               ^ string_of_predicate string_of_term p ^ "," ^ 
               string_of_list (pretty_string_of_branch string_of_term) brs ^ ")"
       end
-    | tProj (mkInd mind i as ind, pars, k) c =>
-      match lookup_ind_decl Σ mind i with
-      | Some (_, oib) =>
-        match nth_error oib.(ind_projs) k with
-        | Some (na, _) => print_term Γ false false c ^ ".(" ^ na ^ ")"
-        | None =>
-          "UnboundProj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
-                        ^ print_term Γ true false c ^ ")"
-        end
+    | tProj p c =>
+      match lookup_projection Σ p with
+      | Some (mdecl, idecl, cdecl, pdecl) =>
+        print_term Γ false false c ^ ".(" ^ pdecl.(proj_name) ^ ")"
       | None =>
-        "UnboundProj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
+        "UnboundProj(" ^ string_of_inductive p.(proj_ind) ^ "," ^ string_of_nat p.(proj_npars) ^ "," ^ string_of_nat p.(proj_arg) ^ ","
                       ^ print_term Γ true false c ^ ")"
       end
 

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1913,7 +1913,7 @@ Section CheckEnv.
     (i : nat) (idecl : one_inductive_body) (indices : context)
     (cdecl : constructor_body) (cs : constructor_univs)
     (oncs : forall Σ, abstract_env_ext_rel X_ext Σ ->  ∥ on_constructors (lift_typing typing) Σ mdecl i idecl indices [cdecl] [cs] ∥)
-    (k : nat) (p : ident × term) (hnth : nth_error idecl.(ind_projs) k = Some p)
+    (k : nat) p (hnth : nth_error idecl.(ind_projs) k = Some p)
     (heq : #|idecl.(ind_projs)| = context_assumptions cdecl.(cstr_args))
     : typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ on_projection mdecl mind i cdecl k p ∥) :=
     let Γ :=  smash_context [] (cdecl.(cstr_args) ++ ind_params mdecl) in
@@ -1921,9 +1921,11 @@ Section CheckEnv.
     | Some decl =>
       let u := abstract_instance (ind_universes mdecl) in
       let ind := {| inductive_mind := mind; inductive_ind := i |} in
-      check_na <- check_eq_true (eqb (binder_name (decl_name decl)) (nNamed p.1))
+      check_na <- check_eq_true (eqb (binder_name (decl_name decl)) (nNamed p.(proj_name)))
         (Msg "Projection name does not match argument binder name");;
-      check_eq <- check_eq_true (eqb p.2
+      check_rel <- check_eq_true (eqb (binder_relevance (decl_name decl)) p.(proj_relevance))
+        (Msg "Projection relevance does not match argument binder relevance");;
+      check_eq <- check_eq_true (eqb p.(proj_type)
           (subst (inds mind u (ind_bodies mdecl)) (S (ind_npars mdecl))
           (subst0 (projs ind (ind_npars mdecl) k) (lift 1 k (decl_type decl)))))
         (Msg "Projection type does not match argument type") ;;
@@ -1932,6 +1934,7 @@ Section CheckEnv.
     end.
   Next Obligation.
     eapply eqb_eq in check_na.
+    eapply eqb_eq in check_rel.
     eapply eqb_eq in check_eq.
     sq.
     red. rewrite -Heq_anonymous. simpl. split; auto.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -521,25 +521,25 @@ Corollary R_Acc_aux :
       | false := give (tCase ci p c brs) π
       } ;
 
-    | red_view_Proj (i, pars, narg) c π with RedFlags.iota flags := {
-      | true with inspect (reduce c (Proj (i, pars, narg) :: π) _) := {
+    | red_view_Proj p c π with RedFlags.iota flags := {
+      | true with inspect (reduce c (Proj p :: π) _) := {
         | @exist (@exist (t,π') prf) eq with inspect (decompose_stack π') := {
           | @exist (args, ρ) prf' with cc0_viewc t := {
             | cc0view_construct ind' _
-              with inspect (nth_error args (pars + narg)) := {
+              with inspect (nth_error args (p.(proj_npars) + p.(proj_arg))) := {
               | @exist (Some arg) eqa := rec reduce arg π ;
               | @exist None eqa := False_rect _ _
               } ;
             | cc0view_cofix mfix idx with inspect (unfold_cofix mfix idx) := {
               | @exist (Some (rarg, fn)) eq' :=
-                rec reduce (tProj (i, pars, narg) (mkApps fn args)) π ;
+                rec reduce (tProj p (mkApps fn args)) π ;
               | @exist None bot := False_rect _ _
               } ;
-            | cc0view_other t ht := give (tProj (i, pars, narg) (mkApps t args)) π
+            | cc0view_other t ht := give (tProj p (mkApps t args)) π
             }
           }
         } ;
-      | false := give (tProj (i, pars, narg) c) π
+      | false := give (tProj p c) π
       } ;
 
     | red_view_other t π discr := give t π
@@ -940,15 +940,15 @@ Corollary R_Acc_aux :
   Qed.
   Next Obligation.
     pose proof (hΣ := hΣ _ wfΣ).
-    destruct (prf Σ wfΣ)  as [r [p p0]].
+    destruct (prf Σ wfΣ)  as [r [p' p0]].
     sq.
     left.
     apply Req_red in r as hr.
     sq.
     pose proof (red_welltyped _ hΣ (h _ wfΣ) hr) as hh.
     eapply cored_red_cored ; try eassumption.
-    unfold Pr in p. simpl in p. pose proof p as p'.
-    rewrite <- prf' in p'. simpl in p'. subst.
+    unfold Pr in p'. simpl in p'. pose proof p' as p''.
+    rewrite <- prf' in p''. simpl in p''. subst.
     symmetry in prf'. apply decompose_stack_eq in prf' as ?.
     subst. cbn. rewrite zipc_appstack. cbn.
     do 2 zip fold. eapply cored_context.
@@ -960,10 +960,10 @@ Corollary R_Acc_aux :
   Qed.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
-    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [p p0]].
+    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [pr p0]].
     sq.
-    unfold Pr in p. simpl in p.
-    pose proof p as p'.
+    unfold Pr in pr. simpl in pr.
+    pose proof pr as p'.
     rewrite <- prf' in p'. simpl in p'. subst.
     symmetry in prf'. apply decompose_stack_eq in prf' as ?.
     subst.
@@ -977,9 +977,9 @@ Corollary R_Acc_aux :
     apply Proj_red_cond in hh. all: eauto.
   Qed.
   Next Obligation.
-    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [p p0]].
-    unfold Pr in p. simpl in p.
-    pose proof p as p'.
+    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [pr p0]].
+    unfold Pr in pr. simpl in pr.
+    pose proof pr as p'.
     rewrite <- prf' in p'. simpl in p'. subst.
     dependent destruction r.
     - inversion H. subst.
@@ -1005,12 +1005,12 @@ Corollary R_Acc_aux :
   Qed.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
-    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [p p0]].
+    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [pr p0]].
     sq.
-    unfold Pr in p. simpl in p.
-    pose proof p as p'.
+    unfold Pr in pr. simpl in pr.
+    pose proof pr as p'.
     rewrite <- prf' in p'. simpl in p'. subst.
-    assert (h' : welltyped Σ Γ (zip (tProj (i, pars, narg) (mkApps (tCoFix mfix idx) args), π))).
+    assert (h' : welltyped Σ Γ (zip (tProj p (mkApps (tCoFix mfix idx) args), π))).
     { dependent destruction r.
       - inversion H. subst.
         simpl in prf'. inversion prf'. subst. now apply h.
@@ -1025,8 +1025,8 @@ Corollary R_Acc_aux :
           rewrite zipc_appstack in H2. cbn in H2.
           cbn. rewrite <- H2. now apply h.
           }
-    replace (zip (tProj (i, pars, narg) (mkApps (tCoFix mfix idx) args), π))
-      with (zip (tCoFix mfix idx, appstack args (Proj (i, pars, narg) :: π)))
+    replace (zip (tProj p (mkApps (tCoFix mfix idx) args), π))
+      with (zip (tCoFix mfix idx, appstack args (Proj p :: π)))
       in h'.
     - sq.
       apply welltyped_context in h' ; auto. simpl in h'.
@@ -1039,12 +1039,12 @@ Corollary R_Acc_aux :
   Qed.
   Next Obligation.
     clear eq.
-    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [p p0]].
+    destruct (hΣ _ wfΣ) as [hΣ]. destruct (prf Σ wfΣ)  as [r [pr p0]].
     dependent destruction r.
     - inversion H. subst. cbn in prf'. inversion prf'. subst.
       cbn. reflexivity.
-    - unfold Pr in p. cbn in p.
-      rewrite <- prf' in p. cbn in p. subst.
+    - unfold Pr in pr. cbn in pr.
+      rewrite <- prf' in pr. cbn in pr. subst.
       dependent destruction H.
       + cbn in H. symmetry in prf'.
         pose proof (decompose_stack_eq _ _ _ prf'). subst.
@@ -1503,8 +1503,8 @@ Corollary R_Acc_aux :
       rewrite decompose_app_mkApps by (now destruct hd).
       cbn.
       destruct hd; try easy.
-      destruct p as ((?&?)&?).
-      eapply PCUICInductiveInversion.invert_Proj_Construct in typ' as (->&->&?); auto.
+      destruct p as [].
+      eapply PCUICInductiveInversion.invert_Proj_Construct in typ' as (?&?&?); auto.
       2: sq; eapply wf.
       congruence.
     - unfold isCoFix_app.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -341,11 +341,11 @@ Qed.
           ret (mkApps ptm (List.skipn ci.(ci_npar) indargs.π2.π2.π1 ++ [c]));
         | exist (TypeError_comp _ _) _ => ! };
 
-    infer Γ wfΓ (tProj (ind, n, k) c) wt with inspect (@lookup_ind_decl ind) :=
-      { | exist (Checked d) _ with inspect (nth_error d.π2.π1.(ind_projs) k) :=
+    infer Γ wfΓ (tProj p c) wt with inspect (@lookup_ind_decl p.(proj_ind)) :=
+      { | exist (Checked d) _ with inspect (nth_error d.π2.π1.(ind_projs) p.(proj_arg)) :=
         { | exist (Some pdecl) _ with inspect (reduce_to_ind Γ (infer Γ wfΓ c _) _) :=
           { | exist (Checked_comp indargs) _ => 
-              let ty := snd pdecl in
+              let ty := pdecl.(proj_type) in
               ret (subst0 (c :: List.rev (indargs.π2.π2.π1)) (subst_instance indargs.π2.π1 ty));
             | exist (TypeError_comp _ _) _ => ! };
          | exist None _ => ! };
@@ -652,10 +652,9 @@ Qed.
   Next Obligation.
   cbn in *. intros.
   set (H := λ (Σ0 : global_env_ext) (wfΣ0 : abstract_env_ext_rel X Σ0),
-  infer_obligations_obligation_32 Γ ind n k c
-                                   wt Σ0 wfΣ0) in indargs. cbn in *. 
+  infer_obligations_obligation_32 Γ p c wt Σ0 wfΣ0) in indargs. cbn in *. 
   set (infer _ wfΓ c H) in *. unfold H in *. clear H.
-  pose proof p.π2 as p02. 
+  pose proof p0.π2 as p02. 
   destruct indargs as (?&?&?&?).
     destruct d as (?&?&isdecl).
     clear e.
@@ -687,12 +686,11 @@ Qed.
     cbn in *. 
     set (H := (λ (Σ0 : global_env_ext) 
     (wfΣ0 : abstract_env_ext_rel X Σ0),
-    infer_obligations_obligation_32 Γ ind n k c wt
-      Σ0 wfΣ0)) in a0.
+    infer_obligations_obligation_32 Γ p c wt Σ0 wfΣ0)) in a0.
       cbn in *. 
       set (infer _ wfΓ c H) in *.
       unfold H in *. clear H e1. 
-       destruct p.
+    destruct p0.
     cbn -[lookup_ind_decl] in *.
     pose proof wt; pose proof wfΓ.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -186,7 +186,7 @@ struct
 
   (*val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
   let unquote_proj (q : quoted_proj) : (quoted_inductive * quoted_int * quoted_int) =
-    let (ind, ps), idx = q in
+    let { proj_ind = ind; proj_npars = ps; proj_arg = idx } = q in
     (ind, ps, idx)
 
   let unquote_level (trm : Universes0.Level.t) : Univ.Level.t =

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -135,7 +135,7 @@ struct
      quote_ident (Label.to_id (KerName.label kn)))
 
   let quote_inductive (kn, i) = { inductive_mind = kn ; inductive_ind = i }
-  let quote_proj ind p a = ((ind,p),a)
+  let quote_proj ind p a = { proj_ind = ind; proj_npars = p; proj_arg = a }
 
   let quote_constraint_type = function
     | Univ.Lt -> Universes0.ConstraintType.Le 1
@@ -288,19 +288,22 @@ struct
   let mkMonomorphic_ctx () = Universes0.Monomorphic_ctx
   let mkPolymorphic_ctx tm = Universes0.Polymorphic_ctx tm
 
-  let mk_one_inductive_body (id, indices, sort, ty, kel, ctr, proj, relevance) =
-    let ctr = List.map (fun (name, args, indices, ty, arity) -> 
+  let mk_one_inductive_body (id, indices, sort, ty, kel, ctrs, projs, relevance) =
+    let ctrs = List.map (fun (name, args, indices, ty, arity) -> 
       { cstr_name = name; 
         cstr_args = args;
         cstr_indices = indices;
         cstr_type = ty;
-        cstr_arity = arity }) ctr in
+        cstr_arity = arity }) ctrs in
+    let projs = List.map (fun (proj_name, proj_relevance, proj_type) -> 
+        { proj_name; proj_relevance; proj_type }) projs in
     { ind_name = id; ind_type = ty;
       ind_indices = indices;
       ind_sort = sort;
       ind_kelim = kel; 
-      ind_ctors = ctr;
-      ind_projs = proj; ind_relevance = relevance }
+      ind_ctors = ctrs;
+      ind_projs = projs; 
+      ind_relevance = relevance }
 
   let mk_mutual_inductive_body finite npars params inds uctx variance =
     {ind_finite = finite;

--- a/template-coq/src/constr_denoter.ml
+++ b/template-coq/src/constr_denoter.ml
@@ -301,13 +301,11 @@ struct
 
   let unquote_proj (qp : quoted_proj) : (quoted_inductive * quoted_int * quoted_int) =
     let (h,args) = app_full qp [] in
-    match args with
-    | tyin::tynat::indpars::idx::[] ->
-      let (h',args') = app_full indpars [] in
-      (match args' with
-       | tyind :: tynat :: ind :: n :: [] -> (ind, n, idx)
-       | _ -> bad_term_verb qp "unquote_proj")
-    | _ -> bad_term_verb qp "unquote_proj"
+    if constr_equall h tmkProjection then
+      match args with
+      | ind :: nm :: num :: [] -> (ind, nm, num)
+      | _ -> bad_term_verb qp "unquote_proj"
+    else not_supported_verb qp "unquote_proj"
 
   let unquote_inductive trm : inductive =
     let (h,args) = app_full trm [] in

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -361,9 +361,10 @@ struct
       constr_mkApp (tBuild_constructor_body, [| a ; b ; to_coq_listl tTerm c ; d ; e |])) ls in
     to_coq_listl tconstructor_body ctors
 
-  let mk_proj_list d =
-    to_coq_list (prodl tident tTerm)
-                (List.map (fun (a, b) -> pairl tident tTerm a b) d)
+  let mk_proj_list ps =
+    let projs = List.map (fun (a,b,c) -> 
+      constr_mkApp (tBuild_projection_body, [| a ; b ; c |])) ps in
+    to_coq_listl tprojection_body projs
 
   let quote_dirpath dp =
     let l = DirPath.repr dp in
@@ -380,10 +381,8 @@ struct
     pairl tmodpath tident (quote_modpath (KerName.modpath kn))
       (quote_ident (Label.to_id (KerName.label kn)))
 
-
-  (* useful? *)
   let quote_proj ind pars args =
-    pair (prodl tIndTy tnat) (Lazy.force tnat) (pairl tIndTy tnat ind pars) args
+    constr_mkApp (tmkProjection, [| ind; pars; args |])
 
   let mk_one_inductive_body (na, indices, sort, ty, sf, ctors, projs, relevance) =
     let ctors = mk_ctor_list ctors in

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -139,6 +139,7 @@ struct
   let tname = ast "name"
   let tIndTy = ast "inductive"
   let tmkInd = ast "mkInd"
+  let tmkProjection = ast "mkProjection"
   let tcase_info = ast "case_info"
   let mk_case_info = ast "mk_case_info"
 
@@ -210,6 +211,8 @@ struct
   let (cFinite,cCoFinite,cBiFinite) = (ast "Finite", ast "CoFinite", ast "BiFinite")
   let tconstructor_body = ast "constructor_body"
   let tBuild_constructor_body = ast "Build_constructor_body"
+  let tprojection_body = ast "projection_body" 
+  let tBuild_projection_body = ast "Build_projection_body"
   let tone_inductive_body = ast "one_inductive_body"
   let tBuild_one_inductive_body = ast "Build_one_inductive_body"
   let tBuild_mutual_inductive_body = ast "Build_mutual_inductive_body"

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -131,7 +131,7 @@ sig
       t list (* indices in the conclusion *) *
       t (* constr type *) * 
       quoted_int (* arity (w/o lets) *)) list *
-    (quoted_ident * t (* projection type *)) list *
+    (quoted_ident * quoted_relevance *  t (* projection type *)) list *
     quoted_relevance -> 
     quoted_one_inductive_body
 
@@ -407,10 +407,11 @@ struct
                                         Context.Rel.to_extended_vect Constr.mkRel 0 ctxwolet) in
                 let indbinder = Context.Rel.Declaration.LocalAssum (Context.annotR (Names.Name id),indty) in
                 let envpars = push_rel_context (indbinder :: ctxwolet) env in
-                let ps, acc = CArray.fold_right2 (fun cst pb (ls,acc) ->
+                let ps, acc = CArray.fold_right3 (fun cst pb rel (ls,acc) ->
                   let (ty, acc) = quote_term acc envpars pb in
                   let na = Q.quote_ident (Names.Label.to_id cst) in
-                  ((na, ty) :: ls, acc)) csts ps ([],acc)
+                  let rel = Q.quote_relevance rel in
+                  ((na, rel, ty) :: ls, acc)) csts ps relevance ([],acc)
                 in ps, acc
             | _ -> [], acc
           in

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -66,8 +66,8 @@ Module string_of_term_tree.
             ^ string_of_predicate string_of_term p ^ ","
             ^ string_of_term t ^ ","
             ^ string_of_list (string_of_branch string_of_term) brs ^ ")"
-  | tProj (ind, i, k) c =>
-    "Proj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
+  | tProj p c =>
+    "Proj(" ^ string_of_inductive p.(proj_ind) ^ "," ^ string_of_nat p.(proj_npars) ^ "," ^ string_of_nat p.(proj_arg) ^ ","
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -69,6 +69,7 @@ Register MetaCoq.Template.Kernames.MPbound as metacoq.ast.MPbound.
 Register MetaCoq.Template.Kernames.MPdot as metacoq.ast.MPdot.
 Register MetaCoq.Template.Kernames.inductive as metacoq.ast.inductive.
 Register MetaCoq.Template.Kernames.mkInd as metacoq.ast.mkInd.
+Register MetaCoq.Template.Kernames.mkProjection as metacoq.ast.mkProjection.
 Register MetaCoq.Template.Kernames.global_reference as metacoq.ast.global_reference.
 Register MetaCoq.Template.Kernames.VarRef as metacoq.ast.VarRef.
 Register MetaCoq.Template.Kernames.ConstRef as metacoq.ast.ConstRef.
@@ -204,6 +205,8 @@ Register MetaCoq.Template.Ast.Env.context as metacoq.ast.context.
 
 Register MetaCoq.Template.Ast.Env.constructor_body as metacoq.ast.constructor_body.
 Register MetaCoq.Template.Ast.Env.Build_constructor_body as metacoq.ast.Build_constructor_body.
+Register MetaCoq.Template.Ast.Env.Build_projection_body as metacoq.ast.Build_projection_body.
+Register MetaCoq.Template.Ast.Env.projection_body as metacoq.ast.projection_body.
 Register MetaCoq.Template.Ast.Env.one_inductive_body as metacoq.ast.one_inductive_body.
 Register MetaCoq.Template.Ast.Env.Build_one_inductive_body as metacoq.ast.Build_one_inductive_body.
 Register MetaCoq.Template.Ast.Env.mutual_inductive_body as metacoq.ast.mutual_inductive_body.

--- a/template-coq/theories/Environment.v
+++ b/template-coq/theories/Environment.v
@@ -214,6 +214,14 @@ Module Environment (T : Term).
     cstr_arity : nat; (* arity, w/o lets, w/o parameters *)
   }.
 
+  Record projection_body := {
+    proj_name : ident;
+    (* The arguments and indices are typeable under the context of 
+      arities of the mutual inductive + parameters *)
+    proj_relevance : relevance;
+    proj_type : term; (* Type under context of params and inductive object *)
+  }.
+
   Definition map_constructor_body npars arities f c :=
     {| cstr_name := c.(cstr_name);
        cstr_args := fold_context_k (fun x => f (x + npars + arities)) c.(cstr_args);
@@ -223,6 +231,13 @@ Module Environment (T : Term).
        cstr_type := f arities c.(cstr_type);
        cstr_arity := c.(cstr_arity) |}.
 
+  (* Here npars should be the [context_assumptions] of the parameters context. *)
+  Definition map_projection_body npars f c :=
+    {| proj_name := c.(proj_name); 
+       proj_relevance := c.(proj_relevance);
+       proj_type := f (S npars) c.(proj_type)
+    |}.
+
   (** See [one_inductive_body] from [declarations.ml]. *)
   Record one_inductive_body := {
     ind_name : ident;
@@ -231,8 +246,7 @@ Module Environment (T : Term).
     ind_type : term; (* Closed arity = forall mind_params, ind_indices, tSort ind_sort *)
     ind_kelim : allowed_eliminations; (* Allowed eliminations *)
     ind_ctors : list constructor_body;
-    ind_projs : list (ident * term); (* names and types of projections, if any.
-                                      Type under context of params and inductive object *)
+    ind_projs : list projection_body; (* names and types of projections, if any. *)                                     
     ind_relevance : relevance (* relevance of the inductive definition *) }.
 
   Definition map_one_inductive_body npars arities f m :=
@@ -242,7 +256,7 @@ Module Environment (T : Term).
       Build_one_inductive_body
          ind_name (fold_context_k (fun x => f (npars + x)) ind_indices) ind_sort
                   (f 0 ind_type) ind_kelim (map (map_constructor_body npars arities f) ind_ctors)
-                  (map (on_snd (f (S npars))) ind_projs) ind_relevance
+                  (map (map_projection_body npars f) ind_projs) ind_relevance
     end.
 
   (** See [mutual_inductive_body] from [declarations.ml]. *)
@@ -490,13 +504,13 @@ Module Environment (T : Term).
 
   Lemma ind_projs_map f npars_ass arities oib :
     ind_projs (map_one_inductive_body npars_ass arities f oib) =
-    map (on_snd (f (S npars_ass))) (ind_projs oib).
+    map (map_projection_body npars_ass f) (ind_projs oib).
   Proof. destruct oib; simpl. reflexivity. Qed.
 
   Fixpoint projs ind npars k :=
     match k with
     | 0 => []
-    | S k' => (tProj ((ind, npars), k') (tRel 0)) :: projs ind npars k'
+    | S k' => (tProj (mkProjection ind npars k') (tRel 0)) :: projs ind npars k'
     end.
 
   Lemma projs_length ind npars k : #|projs ind npars k| = k.

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -1,4 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
+From Coq Require Import ssreflect.
 From MetaCoq.Template Require Import config utils BasicAst Universes Environment.
 From Equations Require Import Equations.
 
@@ -24,9 +25,69 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
 
   Definition declared_projection Σ (proj : projection) mdecl idecl cdecl pdecl
   : Prop :=
-    declared_constructor Σ (fst (fst proj), 0) mdecl idecl cdecl /\
-    List.nth_error idecl.(ind_projs) (snd proj) = Some pdecl /\
-    mdecl.(ind_npars) = snd (fst proj).
+    declared_constructor Σ (proj.(proj_ind), 0) mdecl idecl cdecl /\
+    List.nth_error idecl.(ind_projs) proj.(proj_arg) = Some pdecl /\
+    mdecl.(ind_npars) = proj.(proj_npars).
+
+  Definition lookup_minductive Σ mind :=
+    match lookup_env Σ mind with
+    | Some (InductiveDecl decl) => Some decl
+    | _ => None
+    end.
+  
+  Definition lookup_inductive Σ ind :=
+    match lookup_minductive Σ (inductive_mind ind) with
+    | Some mdecl => 
+      match nth_error mdecl.(ind_bodies) (inductive_ind ind) with
+      | Some idecl => Some (mdecl, idecl)
+      | None => None
+      end
+    | None => None
+    end.
+  
+  Definition lookup_constructor Σ ind k :=
+    match lookup_inductive Σ ind with
+    | Some (mdecl, idecl) => 
+      match nth_error idecl.(ind_ctors) k with
+      | Some cdecl => Some (mdecl, idecl, cdecl)
+      | None => None
+      end
+    | _ => None
+    end.
+
+  Definition lookup_projection Σ p :=
+    match lookup_constructor Σ p.(proj_ind) 0 with
+    | Some (mdecl, idecl, cdecl) => 
+      match nth_error idecl.(ind_projs) p.(proj_arg) with
+      | Some pdecl => Some (mdecl, idecl, cdecl, pdecl)
+      | None => None
+      end
+    | _ => None
+    end.
+    
+  Lemma declared_inductive_lookup {Σ ind mdecl idecl} :
+    declared_inductive Σ ind mdecl idecl ->
+    lookup_inductive Σ ind = Some (mdecl, idecl).
+  Proof.
+    rewrite /declared_inductive /lookup_inductive.
+    intros []. red in H. now rewrite /lookup_minductive H H0.
+  Qed.
+
+  Lemma declared_constructor_lookup {Σ id mdecl idecl cdecl} :
+    declared_constructor Σ id mdecl idecl cdecl -> 
+    lookup_constructor Σ id.1 id.2 = Some (mdecl, idecl, cdecl).
+  Proof.
+    intros []. unfold lookup_constructor.
+    rewrite (declared_inductive_lookup (Σ := Σ) H) /= H0 //.
+  Qed.
+
+  Lemma declared_projection_lookup {Σ p mdecl idecl cdecl pdecl} :
+    declared_projection Σ p mdecl idecl cdecl pdecl -> 
+    lookup_projection Σ p = Some (mdecl, idecl, cdecl, pdecl).
+  Proof.
+    intros [? []]. unfold lookup_projection.
+    rewrite (declared_constructor_lookup (Σ := Σ) H) /= H0 //.
+  Qed.
 
   Definition on_udecl_decl {A} (F : universes_decl -> A) d : A :=
   match d with
@@ -610,21 +671,24 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
       the instances of parameters and the inductive value without considering the 
       presence of let bindings. *)
 
-    Definition on_projection mdecl mind i cdecl (k : nat) (p : ident * term) :=
+    Record on_proj mdecl mind i k (p : projection_body) decl :=
+      { on_proj_name : (* All projections are be named after a constructor argument. *)
+          binder_name (decl_name decl) = nNamed p.(proj_name);
+        on_proj_type : 
+          (** The stored projection type already has the references to the inductive
+              type substituted along with the previous arguments replaced by projections. *)
+          let u := abstract_instance mdecl.(ind_universes) in
+          let ind := {| inductive_mind := mind; inductive_ind := i |} in
+          p.(proj_type) = subst (inds mind u mdecl.(ind_bodies)) (S (ind_npars mdecl))
+            (subst (projs ind mdecl.(ind_npars) k) 0 
+              (lift 1 k (decl_type decl)));
+        on_proj_relevance : p.(proj_relevance) = decl.(decl_name).(binder_relevance) }.
+
+    Definition on_projection mdecl mind i cdecl (k : nat) (p : projection_body) :=
       let Γ := smash_context [] (cdecl.(cstr_args) ++ mdecl.(ind_params)) in
       match nth_error Γ (context_assumptions cdecl.(cstr_args) - S k) with
       | None => False
-      | Some decl => 
-        let u := abstract_instance mdecl.(ind_universes) in
-        let ind := {| inductive_mind := mind; inductive_ind := i |} in
-        (** The stored projection type already has the references to the inductive
-          type substituted along with the previous arguments replaced by projections.
-          All projections must also be named.
-          *)
-        (binder_name (decl_name decl) = nNamed (fst p)) /\
-        (snd p = subst (inds mind u mdecl.(ind_bodies)) (S (ind_npars mdecl))
-              (subst (projs ind mdecl.(ind_npars) k) 0 
-                (lift 1 k (decl_type decl))))
+      | Some decl => on_proj mdecl mind i k p decl
       end.
 
     Record on_projections mdecl mind i idecl (ind_indices : context) cdecl :=
@@ -676,12 +740,12 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T)
         (** The inductive is declared in the impredicative sort Prop *)
         (** No universe-checking to do: any size of constructor argument is allowed,
             however elimination restrictions apply. *)
-        allowed_eliminations_subset kelim (elim_sort_prop_ind cdecls)
+        (allowed_eliminations_subset kelim (elim_sort_prop_ind cdecls) : Type)
       else if Universe.is_sprop ind_sort then
         (** The inductive is declared in the impredicative sort SProp *)
         (** No universe-checking to do: any size of constructor argument is allowed,
             however elimination restrictions apply. *)
-        allowed_eliminations_subset kelim (elim_sort_sprop_ind cdecls)
+        (allowed_eliminations_subset kelim (elim_sort_sprop_ind cdecls) : Type)
       else
         (** The inductive is predicative: check that all constructors arguments are
             smaller than the declared universe. *)

--- a/template-coq/theories/Kernames.v
+++ b/template-coq/theories/Kernames.v
@@ -360,17 +360,21 @@ Proof.
   apply ReflectEq.eqb_refl.
 Qed.
 
-Definition projection : Set := inductive * nat (* params *) * nat (* argument *).
+Record projection := mkProjection
+  { proj_ind : inductive;
+    proj_npars : nat; (* Number of (non-let) parameters *)
+    proj_arg : nat (* Argument to project *) }.
 
-Definition eq_projection (p p' : projection) := eqb p p'.
+Definition eq_projection (p p' : projection) := 
+  (p.(proj_ind), p.(proj_npars), p.(proj_arg)) == (p'.(proj_ind), p'.(proj_npars), p'.(proj_arg)).
 
 #[global, program] Instance reflect_eq_projection : ReflectEq projection := {
   eqb := eq_projection
 }.
 Next Obligation.
   unfold eq_projection.
-  case: eqb_spec ; nodec.
-  cbn. now constructor.
+  case: eqb_spec ; nodec. destruct x, y; cbn.
+  now constructor.
 Qed.
 
 Lemma eq_projection_refl i : eq_projection i i.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -233,17 +233,11 @@ Module PrintTermTree.
               ^ string_of_predicate string_of_term p ^ "," ^ 
               string_of_list (pretty_string_of_branch string_of_term) brs ^ ")"
     end
-  | tProj (mkInd mind i as ind, pars, k) c =>
-    match lookup_ind_decl Σ mind i with
-    | Some oib =>
-      match nth_error oib.(ind_projs) k with
-      | Some (na, _) => print_term Γ false c ^ ".(" ^ na ^ ")"
-      | None =>
-        "UnboundProj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
-                       ^ print_term Γ true c ^ ")"
-      end
+  | tProj p c =>
+    match lookup_projection Σ p with
+    | Some (mdecl, idecl, cdecl, pdecl) => print_term Γ false c ^ ".(" ^ pdecl.(proj_name) ^ ")"
     | None =>
-      "UnboundProj(" ^ string_of_inductive ind ^ "," ^ string_of_nat i ^ "," ^ string_of_nat k ^ ","
+      "UnboundProj(" ^ string_of_inductive p.(proj_ind) ^ "," ^ string_of_nat p.(proj_npars) ^ "," ^ string_of_nat p.(proj_arg) ^ ","
                      ^ print_term Γ true c ^ ")"
     end
 

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -612,7 +612,7 @@ Record wf_inductive_body Σ idecl := {
   wf_ind_ctors : All (fun cdecl => WfAst.wf Σ (cstr_type cdecl)) (ind_ctors idecl);
   wf_ind_ctor_args : All (fun cs => All (wf_decl Σ) (cstr_args cs)) idecl.(ind_ctors);
   wf_ind_ctors_indices : All (fun cdecl => All (WfAst.wf Σ) (cstr_indices cdecl)) (ind_ctors idecl);
-  wf_ind_projs : All (fun pdecl => WfAst.wf Σ pdecl.2) (ind_projs idecl)
+  wf_ind_projs : All (fun pdecl => WfAst.wf Σ pdecl.(proj_type)) (ind_projs idecl)
 }.
 
 Section WfLookup.
@@ -829,10 +829,10 @@ Section WfRed.
   Qed.
 
   Lemma declared_projection_wf (p : projection)
-          (mdecl : mutual_inductive_body) (idecl : one_inductive_body) cdecl (pdecl : ident * term) :
+          (mdecl : mutual_inductive_body) (idecl : one_inductive_body) cdecl pdecl :
       declared_projection Σ p mdecl idecl cdecl pdecl ->
       on_global_env wf_decl_pred Σ ->
-      WfAst.wf Σ (snd pdecl).
+      WfAst.wf Σ pdecl.(proj_type).
   Proof.
     intros isdecl X.
     destruct isdecl as [[[Hmdecl Hidecl] Hcdecl] Hpdecl].
@@ -979,11 +979,10 @@ Section TypingWf.
       apply All_app_inv; auto.
     - split. wf. apply wf_subst. solve_all. constructor. wf.
       apply wf_mkApps_inv in b. apply All_rev. solve_all.
-      subst ty. eapply declared_projection_wf in isdecl; eauto.
+      eapply declared_projection_wf in isdecl; eauto.
       now eapply wf_subst_instance.
       now eapply Forall_decls_on_global_wf.
  
-
     - subst types.
       clear H.
       split.

--- a/template-coq/theories/WcbvEval.v
+++ b/template-coq/theories/WcbvEval.v
@@ -205,9 +205,9 @@ Section Wcbv.
   (** Proj *)
   | eval_proj proj discr args u a res mdecl idecl cdecl pdecl :
       declared_projection Σ proj mdecl idecl cdecl pdecl ->
-      eval discr (mkApps (tConstruct proj.1.1 0 u) args) ->
+      eval discr (mkApps (tConstruct proj.(proj_ind) 0 u) args) ->
       #|args| = cstr_arity mdecl cdecl ->
-      nth_error args (proj.1.2 + proj.2) = Some a ->
+      nth_error args (proj.(proj_npars) + proj.(proj_arg)) = Some a ->
       eval a res ->
       eval (tProj proj discr) res
            
@@ -303,13 +303,13 @@ Section Wcbv.
           #|args| = (ci.(ci_npar) + context_assumptions bctx)%nat ->
           eval (iota_red npar args bctx br) res -> P (iota_red npar args bctx br) res -> 
           P (tCase ci p discr brs) res) ->
-      (forall (proj : ((inductive × nat) × nat)) (discr : term) (args : list term) (u : Instance.t)
+      (forall proj (discr : term) (args : list term) (u : Instance.t)
               a mdecl idecl cdecl pdecl res,
           declared_projection Σ proj mdecl idecl cdecl pdecl ->
-          eval discr (mkApps (tConstruct proj.1.1 0 u) args) ->
-          P discr (mkApps (tConstruct proj.1.1 0 u) args) ->
+          eval discr (mkApps (tConstruct proj.(proj_ind) 0 u) args) ->
+          P discr (mkApps (tConstruct proj.(proj_ind) 0 u) args) ->
           #|args| = cstr_arity mdecl cdecl ->
-          nth_error args (proj.1.2 + proj.2) = Some a ->
+          nth_error args (proj.(proj_npars) + proj.(proj_arg)) = Some a ->
           eval a res ->
           P a res ->
           P (tProj proj discr) res) ->

--- a/test-suite/proj.v
+++ b/test-suite/proj.v
@@ -23,7 +23,7 @@ Proof.
    |- ?T => quote_term T (fun x => pose (qgoal:=x))
   end.
   match goal with
-    H:= context [Ast.tProj (Kernames.mkInd _ 0, 1, 0) _] |- _ => idtac
+    H:= context [Ast.tProj {| proj_ind := Kernames.mkInd _ 0; proj_npars := 1; proj_arg := 0 |} _] |- _ => idtac
   end.
   reflexivity.
 Qed.
@@ -45,7 +45,7 @@ Definition qprod' := mkInd (MPfile ["proj"; "TestSuite"; "MetaCoq"], "prod'") 0.
 Definition qnat := mkInd (MPfile ["Datatypes"; "Init"; "Coq"], "nat") 0.
 Definition qbool := mkInd (MPfile ["Datatypes"; "Init"; "Coq"], "bool") 0.
 
-MetaCoq Unquote Definition x := (tProj (qprod', 2, 1)
+MetaCoq Unquote Definition x := (tProj (mkProjection qprod' 2 1)
    (tApp (tConstruct qprod' 0 nil)
       [tInd qbool nil;
       tInd qnat nil;

--- a/translations/param_generous_packed.v
+++ b/translations/param_generous_packed.v
@@ -20,11 +20,11 @@ MetaCoq Run (t <- tmQuote (@sigT) ;;
             | _ => tmFail "bug"
             end).
 Definition proj1 (t : term) : term
-  := tProj (sigma_ind, 2, 0) t.
+  := tProj (mkProjection sigma_ind 2 0) t.
 Definition proj2 (t : term) : term
-  := tProj (sigma_ind, 2, S 0) t.
+  := tProj (mkProjection sigma_ind 2 (S 0)) t.
 Definition proj (b : bool) (t : term) : term
-  := tProj (sigma_ind, 2, if b then 0 else S 0) t.
+  := tProj (mkProjection sigma_ind 2 (if b then 0 else S 0)) t.
 
 
 Fixpoint refresh_universes (t : term) {struct t} :=

--- a/translations/sigma.v
+++ b/translations/sigma.v
@@ -40,8 +40,8 @@ MetaCoq Run (t <- tmQuote sigma ;;
             | _ => tmFail "bug"
             end).
 Definition proj1 (t : term) : term
-  := tProj (sigma_ind, 2, 0) t.
+  := tProj (mkProjection sigma_ind 2 0) t.
 Definition proj2 (t : term) : term
-  := tProj (sigma_ind, 2, 1) t.
+  := tProj (mkProjection sigma_ind 2 1) t.
 Definition proj (b : bool) (t : term) : term
-  := tProj (sigma_ind, 2, if b then 0 else 1) t.
+  := tProj (mkProjection sigma_ind 2 (if b then 0 else 1)) t.

--- a/translations/times_bool_fun.v
+++ b/translations/times_bool_fun.v
@@ -24,9 +24,9 @@ MetaCoq Run (t <- tmQuote prod ;;
             | _ => tmFail "bug"
             end).
 Definition proj1 (t : term) : term
-  := tProj (prod_ind, 2, 0) t.
+  := tProj (mkProjection prod_ind 2 0) t.
 Definition proj2 (t : term) : term
-  := tProj (prod_ind, 2, S 0) t.
+  := tProj (mkProjection prod_ind 2 (S 0)) t.
 
 MetaCoq Quote Definition tbool := bool.
 MetaCoq Quote Definition ttrue := true.


### PR DESCRIPTION
Also add a relevance field to projections declarations and verify that this relevance corresponds to the relevance of the corresponding constructor argument.