### PR TITLE
Fix admitted proof in SafeConversion due to Acc_intro_generator.

### DIFF
--- a/pcuic/theories/PCUICConfluence.v
+++ b/pcuic/theories/PCUICConfluence.v
@@ -253,16 +253,16 @@ Notation eq_one_decl Σ Re Rle :=
       (fun _ (x0 y0 : term) => 
         eq_term_upto_univ Σ Re Rle x0 y0))).
 
-Lemma red1_eq_context_upto_l {Σ Rle Re Γ Δ u v} :
+Lemma red1_eq_context_upto_l {Σ Σ' Rle Re Γ Δ u v} :
   RelationClasses.Reflexive Rle ->
   SubstUnivPreserving Rle ->
   RelationClasses.Reflexive Re ->
   SubstUnivPreserving Re ->
   RelationClasses.subrelation Re Rle ->
   red1 Σ Γ u v ->
-  eq_context_upto Σ Re Rle Γ Δ ->
+  eq_context_upto Σ' Re Rle Γ Δ ->
   ∑ v', red1 Σ Δ u v' *
-        eq_term_upto_univ Σ Re Re v v'.
+        eq_term_upto_univ Σ' Re Re v v'.
 Proof.
   intros hle hle' he he' hlee h e.
   induction h in Δ, e |- * using red1_ind_all.
@@ -283,7 +283,7 @@ Proof.
   all: try solve [
     match goal with
     | r : red1 _ (?Γ ,, ?d) _ _ |- _ =>
-      assert (e' : eq_context_upto Σ Re Rle (Γ,, d) (Δ,, d))
+      assert (e' : eq_context_upto Σ' Re Rle (Γ,, d) (Δ,, d))
       ; [
         constructor ; [ eauto | constructor; eauto ] ;
         eapply eq_term_upto_univ_refl ; eauto
@@ -299,7 +299,7 @@ Proof.
   ].
   - assert (h : ∑ b',
                 (option_map decl_body (nth_error Δ i) = Some (Some b')) *
-                eq_term_upto_univ Σ Re Re body b').
+                eq_term_upto_univ Σ' Re Re body b').
     { induction i in Γ, Δ, H, e |- *.
       - destruct e.
         + cbn in *. discriminate.
@@ -341,7 +341,7 @@ Proof.
         specialize (IH (Δ ,,, inst_case_branch_context p x)).
         forward IH by now apply eq_context_upto_cat. exact IH. }
     eapply (OnOne2_exist' _ (fun x y => on_Trel_eq (red1 Σ (Δ ,,, inst_case_branch_context p x)) bbody bcontext x y)
-      (fun x y => on_Trel_eq (eq_term_upto_univ Σ Re Re) bbody bcontext x y)) in X as [brr [Hred Heq]]; tea.
+      (fun x y => on_Trel_eq (eq_term_upto_univ Σ' Re Re) bbody bcontext x y)) in X as [brr [Hred Heq]]; tea.
     2:{ intros x y [[v' [redv' eq]] eqctx].
         exists {| bcontext := bcontext x; bbody := v' |}.
         intuition auto. }
@@ -359,7 +359,7 @@ Proof.
     reflexivity.
   - assert (h : ∑ ll,
       OnOne2 (red1 Σ Δ) l ll *
-      All2 (eq_term_upto_univ Σ Re Re) l' ll
+      All2 (eq_term_upto_univ Σ' Re Re) l' ll
     ).
     { induction X.
       - destruct p as [p1 p2].
@@ -389,8 +389,8 @@ Proof.
         ) mfix0 mfix'
       *
       All2 (fun x y =>
-        eq_term_upto_univ Σ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Σ Re Re (dbody x) (dbody y) *
+        eq_term_upto_univ Σ' Re Re (dtype x) (dtype y) *
+        eq_term_upto_univ Σ' Re Re (dbody x) (dbody y) *
         (rarg x = rarg y) *
         (eq_binder_annot (dname x) (dname y)))%type mfix1 mfix').
     { induction X.
@@ -424,8 +424,8 @@ Proof.
           (d'.(dname), d'.(dtype), d'.(rarg))
         ) mfix0 mfix' *
       All2 (fun x y =>
-        eq_term_upto_univ Σ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Σ Re Re (dbody x) (dbody y) *
+        eq_term_upto_univ Σ' Re Re (dtype x) (dtype y) *
+        eq_term_upto_univ Σ' Re Re (dbody x) (dbody y) *
         (rarg x = rarg y) * 
         eq_binder_annot (dname x) (dname y))%type mfix1 mfix').
     { (* Maybe we should use a lemma using firstn or skipn to keep
@@ -440,9 +440,9 @@ Proof.
       ((fun L (x y : def term) =>
        (red1 Σ (Γ ,,, fix_context L) (dbody x) (dbody y)
         × (forall Δ : context,
-           eq_context_upto Σ Re Rle (Γ ,,, fix_context L) Δ ->
+           eq_context_upto Σ' Re Rle (Γ ,,, fix_context L) Δ ->
            ∑ v' : term,
-             red1 Σ Δ (dbody x) v' × eq_term_upto_univ Σ Re Re (dbody y) v'))
+             red1 Σ Δ (dbody x) v' × eq_term_upto_univ Σ' Re Re (dbody y) v'))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix0) mfix0 mfix1
       ) in X.
       Fail induction X using OnOne2_ind_l.
@@ -450,9 +450,9 @@ Proof.
       refine (OnOne2_ind_l _ (fun (L : mfixpoint term) (x y : def term) =>
     ((red1 Σ (Γ ,,, fix_context L) (dbody x) (dbody y)
      × (forall Δ0 : context,
-        eq_context_upto Σ Re Rle (Γ ,,, fix_context L) Δ0 ->
+        eq_context_upto Σ' Re Rle (Γ ,,, fix_context L) Δ0 ->
         ∑ v' : term,
-          red1 Σ Δ0 (dbody x) v' × eq_term_upto_univ Σ Re Re (dbody y) v'))
+          red1 Σ Δ0 (dbody x) v' × eq_term_upto_univ Σ' Re Re (dbody y) v'))
     × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)))
   (fun L mfix0 mfix1 o => ∑ mfix' : list (def term),
   OnOne2
@@ -461,13 +461,13 @@ Proof.
        × (dname d, dtype d, rarg d) = (dname d', dtype d', rarg d')) mfix0 mfix'
     × All2
         (fun x y : def term =>
-         ((eq_term_upto_univ Σ Re Re (dtype x) (dtype y)
-          × eq_term_upto_univ Σ Re Re (dbody x) (dbody y)) ×
+         ((eq_term_upto_univ Σ' Re Re (dtype x) (dtype y)
+          × eq_term_upto_univ Σ' Re Re (dbody x) (dbody y)) ×
          (rarg x = rarg y)) *
          eq_binder_annot (dname x) (dname y)) mfix1 mfix') _ _).
       - intros L x y l [[p1 p2] p3].
         assert (
-           e' : eq_context_upto Σ Re Rle (Γ ,,, fix_context L) (Δ ,,, fix_context L)
+           e' : eq_context_upto Σ' Re Rle (Γ ,,, fix_context L) (Δ ,,, fix_context L)
         ).
         { eapply eq_context_upto_cat ; eauto. reflexivity. }
         eapply p2 in e' as hh. destruct hh as [? [? ?]].
@@ -499,8 +499,8 @@ Proof.
           (d'.(dname), d'.(dbody), d'.(rarg))
         ) mfix0 mfix' *
       All2 (fun x y =>
-        eq_term_upto_univ Σ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Σ Re Re (dbody x) (dbody y) *
+        eq_term_upto_univ Σ' Re Re (dtype x) (dtype y) *
+        eq_term_upto_univ Σ' Re Re (dbody x) (dbody y) *
         (rarg x = rarg y) *
         eq_binder_annot (dname x) (dname y))%type mfix1 mfix'
     ).
@@ -535,8 +535,8 @@ Proof.
           (d'.(dname), d'.(dtype), d'.(rarg))
         ) mfix0 mfix' *
       All2 (fun x y =>
-        eq_term_upto_univ Σ Re Re (dtype x) (dtype y) *
-        eq_term_upto_univ Σ Re Re (dbody x) (dbody y) *
+        eq_term_upto_univ Σ' Re Re (dtype x) (dtype y) *
+        eq_term_upto_univ Σ' Re Re (dbody x) (dbody y) *
         (rarg x = rarg y) * 
         eq_binder_annot (dname x) (dname y))%type mfix1 mfix').
     { (* Maybe we should use a lemma using firstn or skipn to keep
@@ -551,9 +551,9 @@ Proof.
       ((fun L (x y : def term) =>
        (red1 Σ (Γ ,,, fix_context L) (dbody x) (dbody y)
         × (forall Δ : context,
-           eq_context_upto Σ Re Rle (Γ ,,, fix_context L) Δ ->
+           eq_context_upto Σ' Re Rle (Γ ,,, fix_context L) Δ ->
            ∑ v' : term,
-             red1 Σ Δ (dbody x) v' × eq_term_upto_univ Σ Re Re (dbody y) v' ))
+             red1 Σ Δ (dbody x) v' × eq_term_upto_univ Σ' Re Re (dbody y) v' ))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix0) mfix0 mfix1
       ) in X.
       Fail induction X using OnOne2_ind_l.
@@ -561,9 +561,9 @@ Proof.
       refine (OnOne2_ind_l _ (fun (L : mfixpoint term) (x y : def term) =>
     (red1 Σ (Γ ,,, fix_context L) (dbody x) (dbody y)
      × (forall Δ0 : context,
-        eq_context_upto Σ Re Rle (Γ ,,, fix_context L) Δ0 ->
+        eq_context_upto Σ' Re Rle (Γ ,,, fix_context L) Δ0 ->
         ∑ v' : term,
-           red1 Σ Δ0 (dbody x) v' × eq_term_upto_univ Σ Re Re (dbody y) v' ))
+           red1 Σ Δ0 (dbody x) v' × eq_term_upto_univ Σ' Re Re (dbody y) v' ))
     × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) (fun L mfix0 mfix1 o => ∑ mfix' : list (def term),
   (OnOne2
       (fun d d' : def term =>
@@ -571,13 +571,13 @@ Proof.
        × (dname d, dtype d, rarg d) = (dname d', dtype d', rarg d')) mfix0 mfix'
     × All2
         (fun x y : def term =>
-         ((eq_term_upto_univ Σ Re Re (dtype x) (dtype y)
-          × eq_term_upto_univ Σ Re Re (dbody x) (dbody y)) ×
+         ((eq_term_upto_univ Σ' Re Re (dtype x) (dtype y)
+          × eq_term_upto_univ Σ' Re Re (dbody x) (dbody y)) ×
          rarg x = rarg y) *
          eq_binder_annot (dname x) (dname y)) mfix1 mfix')) _ _).
       - intros L x y l [[p1 p2] p3].
         assert (
-           e' : eq_context_upto Σ Re Rle (Γ ,,, fix_context L) (Δ ,,, fix_context L)
+           e' : eq_context_upto Σ' Re Rle (Γ ,,, fix_context L) (Δ ,,, fix_context L)
         ).
         { eapply eq_context_upto_cat ; eauto. reflexivity. }
         eapply p2 in e' as hh. destruct hh as [? [? ?]].
@@ -640,7 +640,7 @@ Proof.
   cbn; intros ????. move => []; constructor; subst; auto; reflexivity.
 Qed.
 
-Lemma red1_eq_context_upto_univ_l Σ Re Rle Γ ctx ctx' ctx'' :
+Lemma red1_eq_context_upto_univ_l {Σ Σ' Re Rle Γ ctx ctx' ctx''} :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
   RelationClasses.Transitive Re ->
@@ -648,8 +648,8 @@ Lemma red1_eq_context_upto_univ_l Σ Re Rle Γ ctx ctx' ctx'' :
   SubstUnivPreserving Re ->
   SubstUnivPreserving Rle ->
   RelationClasses.subrelation Re Rle ->
-  eq_context_gen (eq_term_upto_univ Σ Re Re)
-   (eq_term_upto_univ Σ Re Re) ctx ctx' ->
+  eq_context_gen (eq_term_upto_univ Σ' Re Re)
+   (eq_term_upto_univ Σ' Re Re) ctx ctx' ->
   OnOne2_local_env (on_one_decl
     (fun (Γ' : context) (u v : term) =>
     forall (Rle : Relation_Definitions.relation Universe.t)
@@ -661,13 +661,13 @@ Lemma red1_eq_context_upto_univ_l Σ Re Rle Γ ctx ctx' ctx'' :
     SubstUnivPreserving Re ->
     SubstUnivPreserving Rle ->
     (forall x y : Universe.t, Re x y -> Rle x y) ->
-    eq_term_upto_univ_napp Σ Re Rle napp u u' ->
+    eq_term_upto_univ_napp Σ' Re Rle napp u u' ->
     ∑ v' : term,
       red1 Σ (Γ,,, Γ') u' v'
-      × eq_term_upto_univ_napp Σ Re Rle napp v v')) ctx ctx'' ->
+      × eq_term_upto_univ_napp Σ' Re Rle napp v v')) ctx ctx'' ->
   ∑ pctx,
     red1_ctx_rel Σ Γ ctx' pctx *
-    eq_context_gen (eq_term_upto_univ Σ Re Re) (eq_term_upto_univ Σ Re Re) ctx'' pctx.
+    eq_context_gen (eq_term_upto_univ Σ' Re Re) (eq_term_upto_univ Σ' Re Re) ctx'' pctx.
 Proof.
   intros. 
   rename X into e, X0 into X.
@@ -835,7 +835,7 @@ Proof.
   eapply eq_context_upto_univ_subst_instance; tc. tea.
 Qed.*)
 
-Lemma red1_eq_term_upto_univ_l {Σ : global_env_ext} Re Rle napp Γ u v u' :
+Lemma red1_eq_term_upto_univ_l {Σ Σ' : global_env} Re Rle napp Γ u v u' :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
   RelationClasses.Transitive Re ->
@@ -843,10 +843,10 @@ Lemma red1_eq_term_upto_univ_l {Σ : global_env_ext} Re Rle napp Γ u v u' :
   SubstUnivPreserving Re ->
   SubstUnivPreserving Rle ->
   RelationClasses.subrelation Re Rle ->
-  eq_term_upto_univ_napp Σ Re Rle napp u u' ->
+  eq_term_upto_univ_napp Σ' Re Rle napp u u' ->
   red1 Σ Γ u v ->
   ∑ v', red1 Σ Γ u' v' *
-         eq_term_upto_univ_napp Σ Re Rle napp v v'.
+         eq_term_upto_univ_napp Σ' Re Rle napp v v'.
 Proof.
   intros he he' tRe tRle hle hle' hR e h.
   induction h in napp, u', e, he, he', tRe, tRle, Rle, hle, hle', hR |- * using red1_ind_all.
@@ -1053,7 +1053,7 @@ Proof.
     eapply OnOne2_prod_inv in X as [_ X].
     assert (h : ∑ args,
                OnOne2 (red1 Σ Γ) (pparams p') args *
-               All2 (eq_term_upto_univ Σ Re Re) params' args
+               All2 (eq_term_upto_univ Σ' Re Re) params' args
            ).
     { destruct p, p' as []; cbn in *.
       induction X in a0, pparams, pparams0, X |- *.
@@ -1103,7 +1103,7 @@ Proof.
             on_Trel_eq (red1 Σ (Γ ,,, inst_case_branch_context p' br)) bbody bcontext br br') brs' brs0 *
           All2 (fun x y =>
             eq_context_gen eq eq (bcontext x) (bcontext y) *
-            (eq_term_upto_univ Σ Re Re (bbody x) (bbody y))
+            (eq_term_upto_univ Σ' Re Re (bbody x) (bbody y))
             )%type brs'0 brs0
         ).
       { induction X in a, brs' |- *.
@@ -1139,7 +1139,7 @@ Proof.
   - dependent destruction e.
     assert (h : ∑ args,
                OnOne2 (red1 Σ Γ) args' args *
-               All2 (eq_term_upto_univ Σ Re Re) l' args
+               All2 (eq_term_upto_univ Σ' Re Re) l' args
            ).
     { induction X in a, args' |- *.
       - destruct p as [p1 p2].
@@ -1168,8 +1168,8 @@ Proof.
                    (d1.(dname), d1.(dbody), d1.(rarg))
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Σ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Σ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto_univ Σ' Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto_univ Σ' Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg)) * 
                  eq_binder_annot (dname x) (dname y))%type mfix1 mfix
            ).
@@ -1204,8 +1204,8 @@ Proof.
                    (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Σ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Σ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto_univ Σ' Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto_univ Σ' Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg)) * 
                  eq_binder_annot (dname x) (dname y)) mfix1 mfix
            ).
@@ -1219,14 +1219,14 @@ Proof.
            SubstUnivPreserving Re ->
            SubstUnivPreserving Rle ->
            (forall u u'0 : Universe.t, Re u u'0 -> Rle u u'0) ->
-           eq_term_upto_univ_napp Σ Re Rle napp (dbody x) u' ->
+           eq_term_upto_univ_napp Σ' Re Rle napp (dbody x) u' ->
            ∑ v' : term,
              red1 Σ (Γ ,,, fix_context L) u' v'
-                  × eq_term_upto_univ_napp Σ Re Rle napp (dbody y) v' ))
+                  × eq_term_upto_univ_napp Σ' Re Rle napp (dbody y) v' ))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) (fun L mfix0 mfix1 o => forall mfix', All2
       (fun x y : def term =>
-       ((eq_term_upto_univ Σ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Σ Re Re (dbody x) (dbody y)) ×
+       ((eq_term_upto_univ Σ' Re Re (dtype x) (dtype y)
+        × eq_term_upto_univ Σ' Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) * eq_binder_annot (dname x) (dname y)) mfix0 mfix' -> ∑ mfix : list (def term),
   ( OnOne2
       (fun x y : def term =>
@@ -1234,8 +1234,8 @@ Proof.
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix' mfix ) *
   ( All2
       (fun x y : def term =>
-       ((eq_term_upto_univ Σ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Σ Re Re (dbody x) (dbody y)) ×
+       ((eq_term_upto_univ Σ' Re Re (dtype x) (dtype y)
+        × eq_term_upto_univ Σ' Re Re (dbody x) (dbody y)) ×
        (rarg x = rarg y)) * eq_binder_annot (dname x) (dname y)) mfix1 mfix )) _ _ _ _ X).
       - clear X. intros L x y l [[p1 p2] p3] mfix' h.
         dependent destruction h. destruct p as [[[h1 h2] h3] h4].
@@ -1263,14 +1263,14 @@ Proof.
                   (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                ) mfix' mfix ×
         All2 (fun x y =>
-                eq_term_upto_univ Σ Re Re x.(dtype) y.(dtype) *
-                eq_term_upto_univ Σ Re Re x.(dbody) y.(dbody) *
+                eq_term_upto_univ Σ' Re Re x.(dtype) y.(dtype) *
+                eq_term_upto_univ Σ' Re Re x.(dbody) y.(dbody) *
                 (x.(rarg) = y.(rarg)) *
                 eq_binder_annot (dname x) (dname y)
              ) mfix1 mfix %type
     ).
     { clear X.
-      assert (hc : eq_context_upto Σ
+      assert (hc : eq_context_upto Σ'
                      Re Rle
                      (Γ ,,, fix_context mfix0)
                      (Γ ,,, fix_context mfix')
@@ -1326,8 +1326,8 @@ Proof.
                    (d1.(dname), d1.(dbody), d1.(rarg))
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Σ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Σ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto_univ Σ' Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto_univ Σ' Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg)) *
                  eq_binder_annot (dname x) (dname y))%type mfix1 mfix
            ).
@@ -1362,8 +1362,8 @@ Proof.
                    (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                  ) mfix' mfix *
                All2 (fun x y =>
-                 eq_term_upto_univ Σ Re Re x.(dtype) y.(dtype) *
-                 eq_term_upto_univ Σ Re Re x.(dbody) y.(dbody) *
+                 eq_term_upto_univ Σ' Re Re x.(dtype) y.(dtype) *
+                 eq_term_upto_univ Σ' Re Re x.(dbody) y.(dbody) *
                  (x.(rarg) = y.(rarg)) * 
                  eq_binder_annot (dname x) (dname y)
                ) mfix1 mfix
@@ -1378,14 +1378,14 @@ Proof.
             SubstUnivPreserving Re ->
             SubstUnivPreserving Rle ->
            (forall u u'0 : Universe.t, Re u u'0 -> Rle u u'0) ->
-           eq_term_upto_univ_napp Σ Re Rle napp (dbody x) u' ->
+           eq_term_upto_univ_napp Σ' Re Rle napp (dbody x) u' ->
            ∑ v' : term,
              red1 Σ (Γ ,,, fix_context L) u' v'
-               × eq_term_upto_univ_napp Σ Re Rle napp (dbody y) v'))
+               × eq_term_upto_univ_napp Σ' Re Rle napp (dbody y) v'))
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) (fun L mfix0 mfix1 o => forall mfix', All2
       (fun x y : def term =>
-       ((eq_term_upto_univ Σ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Σ Re Re (dbody x) (dbody y)) ×
+       ((eq_term_upto_univ Σ' Re Re (dtype x) (dtype y)
+        × eq_term_upto_univ Σ' Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) * eq_binder_annot (dname x) (dname y)) mfix0 mfix' -> ∑ mfix : list (def term),
   ( OnOne2
       (fun x y : def term =>
@@ -1393,8 +1393,8 @@ Proof.
        × (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)) mfix' mfix ) *
   ( All2
       (fun x y : def term =>
-       ((eq_term_upto_univ Σ Re Re (dtype x) (dtype y)
-        × eq_term_upto_univ Σ Re Re (dbody x) (dbody y)) ×
+       ((eq_term_upto_univ Σ' Re Re (dtype x) (dtype y)
+        × eq_term_upto_univ Σ' Re Re (dbody x) (dbody y)) ×
        rarg x = rarg y) * eq_binder_annot (dname x) (dname y)) mfix1 mfix )) _ _ _ _ X).
       - clear X. intros L x y l [[p1 p2] p3] mfix' h.
         dependent destruction h. destruct p as [[[h1 h2] h3] h4].
@@ -1421,14 +1421,14 @@ Proof.
                   (dname x, dtype x, rarg x) = (dname y, dtype y, rarg y)
                ) mfix' mfix ×
         All2 (fun x y =>
-                eq_term_upto_univ Σ Re Re x.(dtype) y.(dtype) *
-                eq_term_upto_univ Σ Re Re x.(dbody) y.(dbody) *
+                eq_term_upto_univ Σ' Re Re x.(dtype) y.(dtype) *
+                eq_term_upto_univ Σ' Re Re x.(dbody) y.(dbody) *
                 (x.(rarg) = y.(rarg)) *
                 eq_binder_annot (dname x) (dname y)
              ) mfix1 mfix
     ).
     { clear X.
-      assert (hc : eq_context_upto Σ
+      assert (hc : eq_context_upto Σ'
                      Re Rle
                      (Γ ,,, fix_context mfix0)
                      (Γ ,,, fix_context mfix')
@@ -1510,19 +1510,19 @@ Proof.
   - now eapply eq_term_upto_univ_napp_flip; try typeclasses eauto.
 Qed.
 
-Lemma red1_eq_context_upto_r Σ Re Rle Γ Δ u v :
+Lemma red1_eq_context_upto_r {Σ Σ' Re Rle Γ Δ u v} :
   RelationClasses.Equivalence Re ->
   RelationClasses.PreOrder Rle ->
   SubstUnivPreserving Re ->
   SubstUnivPreserving Rle ->
   RelationClasses.subrelation Re Rle ->
   red1 Σ Γ u v ->
-  eq_context_upto Σ Re Rle Δ Γ ->
+  eq_context_upto Σ' Re Rle Δ Γ ->
   ∑ v', red1 Σ Δ u v' *
-        eq_term_upto_univ Σ Re Re v' v.
+        eq_term_upto_univ Σ' Re Re v' v.
 Proof.
   intros.
-  destruct (@red1_eq_context_upto_l Σ (flip Rle) Re Γ Δ u v); auto; try typeclasses eauto.
+  destruct (@red1_eq_context_upto_l Σ Σ' (flip Rle) Re Γ Δ u v); auto; try typeclasses eauto.
   - intros x; red; reflexivity.
   - intros s u1 u2 Ru. red. apply R_universe_instance_flip in Ru. now apply H2.
   - intros x y rxy; red. now symmetry in rxy.
@@ -1531,7 +1531,7 @@ Proof.
     now eapply eq_term_upto_univ_sym.
 Qed.
 
-Lemma red1_eq_term_upto_univ_r (Σ : global_env_ext) Re Rle napp Γ u v u' :
+Lemma red1_eq_term_upto_univ_r {Σ Σ' Re Rle napp Γ u v u'} :
   RelationClasses.Reflexive Re ->
   RelationClasses.Reflexive Rle ->
   RelationClasses.Symmetric Re ->
@@ -1540,13 +1540,13 @@ Lemma red1_eq_term_upto_univ_r (Σ : global_env_ext) Re Rle napp Γ u v u' :
   SubstUnivPreserving Re ->
   SubstUnivPreserving Rle ->
   RelationClasses.subrelation Re Rle ->
-  eq_term_upto_univ_napp Σ Re Rle napp u' u ->
+  eq_term_upto_univ_napp Σ' Re Rle napp u' u ->
   red1 Σ Γ u v ->
   ∑ v', red1 Σ Γ u' v' ×
-        eq_term_upto_univ_napp Σ Re Rle napp v' v.
+        eq_term_upto_univ_napp Σ' Re Rle napp v' v.
 Proof.
   intros he he' hse hte htle sre srle hR h uv.
-  destruct (@red1_eq_term_upto_univ_l Σ Re (flip Rle) napp Γ u v u'); auto.
+  destruct (@red1_eq_term_upto_univ_l Σ Σ' Re (flip Rle) napp Γ u v u'); auto.
   - now eapply flip_Transitive.
   - red. intros s u1 u2 ru.
     apply R_universe_instance_flip in ru.
@@ -1554,7 +1554,7 @@ Proof.
   - intros x y X. symmetry in X. apply hR in X. apply X.
   - eapply eq_term_upto_univ_napp_flip; eauto.
   - exists x. intuition auto.
-    eapply (eq_term_upto_univ_napp_flip Σ Re (flip Rle) Rle); eauto.
+    eapply (@eq_term_upto_univ_napp_flip Σ' Re (flip Rle) Rle); eauto.
     + now eapply flip_Transitive.
     + unfold flip. intros ? ? H. symmetry in H. eauto.
 Qed.

--- a/pcuic/theories/PCUICContextConversion.v
+++ b/pcuic/theories/PCUICContextConversion.v
@@ -610,7 +610,7 @@ Section ContextConversion.
   Proof.
     intros r HΓ.
     induction r.
-    - eapply (red1_eq_context_upto_r _ Re R) in r; eauto.
+    - eapply (@red1_eq_context_upto_r Σ Σ Re R) in r; eauto.
       destruct r as [v [? ?]]. exists v. intuition pcuic.
       now symmetry.
     - exists x. split; auto. reflexivity.

--- a/pcuic/theories/utils/PCUICUtils.v
+++ b/pcuic/theories/utils/PCUICUtils.v
@@ -40,6 +40,7 @@ Inductive dlexmod {A} {B : A -> Type}
     forall x x' y y' (e : eA x x'),
       leB x' (coe _ _ e y) y' ->
       dlexmod leA eA coe leB (x;y) (x';y').
+Derive Signature for dlexmod.
 
 Notation "x ⊩ R1 ⨶ R2" :=
   (dlexprod R1 (fun x => R2)) (at level 20, right associativity).
@@ -98,8 +99,6 @@ Proof.
     + left. assumption.
     + right. eapply hB ; eassumption.
 Qed.
-
-Derive Signature for dlexmod.
 
 Lemma acc_dlexmod A B
       (leA : A -> A -> Prop) (eA : A -> A -> Prop)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -157,8 +157,20 @@ Section Conversion.
     eapply H0. eapply r; eauto. 
   Qed.
 
-  Definition eqt u v :=
-    forall Σ (wfΣ : abstract_env_ext_rel X Σ), ∥ eq_term Σ Σ u v ∥.
+  Import PCUICAlpha.
+
+  Definition eqt u v := ∥ u ≡α v ∥.
+
+  Lemma eqt_eqterm {Σ} {wfΣ : abstract_env_ext_rel X Σ} {u v} :
+    u ≡α v -> eq_term Σ Σ u v.
+  Proof.
+    intros eq.
+    eapply upto_names_eq_term_refl; tc.
+    exact eq.
+  Qed.
+
+  Local Instance eqt_refl : RelationClasses.Reflexive eqt.
+  Proof. red. intros x; constructor. reflexivity. Qed.
 
   Lemma eq_term_valid_pos :
     forall {u v p},
@@ -168,13 +180,14 @@ Section Conversion.
   Proof.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     intros u v p vp e.
-    destruct (e _ wfΣ) as [e']. 
-    eapply eq_term_valid_pos. all: eauto.
+    destruct e as [e']. 
+    eapply eq_term_valid_pos. all: eauto. now eapply eqt_eqterm.
+    Unshelve. all:eauto.
   Qed.
 
   Definition weqt {Γ} (u v : wterm Γ) :=
     eqt (` u) (` v).
-
+  
   Equations R_aux (Γ : context) :
     (∑ t : term, pos t × (∑ w : wterm Γ, pos (` w) × state)) ->
     (∑ t : term, pos t × (∑ w : wterm Γ, pos (` w) × state)) -> Prop :=
@@ -210,32 +223,31 @@ Section Conversion.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     rewrite R_aux_equation_1.
     unshelve eapply dlexmod_Acc.
-    - intros x y [e]; eauto.  constructor. eapply compare_term_sym.
-      erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
-    - intros x y z [e1] [e2]; eauto. constructor. 
-      erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.  eapply compare_term_trans. all: eauto.
+    - intros x y [e]; eauto.  constructor. now symmetry.
+    - intros x y z [e1] [e2]; eauto. constructor. now etransitivity; tea.
     - intro u. eapply Subterm.wf_lexprod.
       + intro. eapply posR_Acc.
       + intros [w' q'].
         unshelve eapply dlexmod_Acc.
-        * intros x y [e]; eauto. constructor.
-        erewrite (abstract_env_ext_irr _ _ wfΣ); eauto. eapply compare_term_sym. assumption.
-        * intros x y z [e1] [e2]; eauto. constructor. 
-        erewrite (abstract_env_ext_irr _ _ wfΣ); eauto. eapply compare_term_trans. all: eauto.
+        * intros x y [e]; eauto. constructor. now symmetry.
+        * intros x y z [e1] [e2]; eauto. constructor.
+          now etransitivity; tea. 
         * intros [t' h']. eapply Subterm.wf_lexprod.
           -- intro. eapply posR_Acc.
           -- intro. eapply stateR_Acc.
         * intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]]; eauto. 
           eexists _,_. erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
           intuition eauto using sq.
-          constructor. eapply compare_term_trans. all: eauto.
-        * intros x. exists (fun  _ _ => sq (compare_term_refl _ _ _)).
+          constructor. etransitivity; tea.
+        * intros x.
+          exists (@eqt_refl _).
+          unfold weqt, eqt.
           intros [[q'' h] ?].
           unfold R_aux_obligations_obligation_2.
           simpl. f_equal. f_equal.
           eapply uip.
         * cbn. intros x x' [[q'' h] ?] e.
-          destruct (e _ wfΣ) as [e'].
+          destruct e as [e'].
           unfold R_aux_obligations_obligation_2.
           simpl. f_equal. f_equal.
           eapply uip.
@@ -244,7 +256,7 @@ Section Conversion.
           simpl. f_equal. f_equal.
           eapply uip.
         * intros [t1 ht1] [t2 ht2] e [[q1 hq1] s1] [[q2 hq2] s2] h.
-          destruct (e _ wfΣ) as [e'].
+          destruct e as [e'].
           simpl in *.
           dependent destruction h. 
           -- left. unfold posR in *. simpl in *. assumption.
@@ -257,13 +269,13 @@ Section Conversion.
     - intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]]; eauto.
       intros. erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
       eexists _,_. intuition eauto using sq.
-      constructor. eapply compare_term_trans. all: eauto.
-    - intros x. exists (fun  _ _ => sq (compare_term_refl _ _ _)). intros [[q' h] [? [? ?]]].
+      constructor. etransitivity; eauto.
+    - intros x. exists (@eqt_refl _). intros [[q' h] [? [? ?]]].
       unfold R_aux_obligations_obligation_1.
       simpl. f_equal. f_equal.
       eapply uip.
     - intros x x' [[q' h] [? [? ?]]] e.
-      destruct (e _ _) as [e']; eauto. 
+      destruct e as [e']; eauto. 
       unfold R_aux_obligations_obligation_1.
       simpl. f_equal. f_equal.
       eapply uip.
@@ -274,7 +286,7 @@ Section Conversion.
     - intros x x' e
              [[p1 hp1] [[u hu] [[q1 hq1] s1]]]
              [[p2 hp2] [[v hv] [[q2 hq2] s2]]] hl.
-      destruct (e _ _) as [e']; eauto. 
+      destruct e as [e']; eauto. 
       simpl in *.
       dependent destruction hl.
       + left. unfold posR in *.
@@ -322,6 +334,42 @@ Section Conversion.
   Qed.
 
   Notation eq_term Σ t u := (eq_term Σ Σ t u).
+  
+  Lemma R_aux_irrelevance Γ x y z : 
+    ((x.π1; x.π2.1), (existT (fun x => pos x × state) (` x.π2.2.π1) x.π2.2.π2)) = 
+    ((y.π1; y.π2.1), (existT (fun x => pos x × state) (` y.π2.2.π1) y.π2.2.π2)) ->
+    R_aux Γ z x -> R_aux Γ z y.
+  Proof.
+    destruct x as [t [pt [w [pw s]]]], y as [t' [pt' [w' [pw' s']]]].
+    destruct z as [tz [ptz [wz [pwz sz]]]].
+    cbn. intros [=]. subst. noconf H1. destruct w as [w wt], w' as [w' wt'].
+    cbn in *. subst w'. noconf H3.
+    unfold R_aux.
+    intros hr. depelim hr.
+    - now constructor.
+    - cbn in H.
+      eapply right_dlexmod with e. cbn.
+      depelim H.
+      * constructor. exact H.
+      * constructor 2.
+        depelim H.
+        + now constructor.
+        + eapply right_dlexmod with e0. cbn in H.
+          depelim H.
+          { constructor 1. cbn. exact H. }
+          { constructor 2. exact H. }
+  Qed.
+
+  Lemma R_irrelevance Γ x y z : 
+    (x.(st), x.(tm1), x.(stk1), x.(tm2), x.(stk2)) = 
+    (y.(st), y.(tm1), y.(stk1), y.(tm2), y.(stk2)) ->
+    R Γ z x -> R Γ z y.
+  Proof.
+    destruct x, y; cbn.
+    intros [=]; subst.
+    unfold R. eapply R_aux_irrelevance; cbn.
+    reflexivity.
+  Qed.
 
   Lemma R_cored :
     forall Γ p1 p2,
@@ -334,19 +382,19 @@ Section Conversion.
 
   Lemma R_aux_positionR :
     forall Γ t1 t2 (p1 : pos t1) (p2 : pos t2) s1 s2,
-      (forall Σ (wfΣ : abstract_env_ext_rel X Σ), eq_term Σ t1 t2) ->
+      eqt t1 t2 ->
       positionR (` p1) (` p2) ->
       R_aux Γ (t1 ; (p1, s1)) (t2 ; (p2, s2)).
   Proof.
     intros Γ t1 t2 p1 p2 [? [? ?]] s2 e h.
     unshelve eright.
-    - constructor. eauto.
+    - eauto.
     - left. unfold posR. simpl. assumption.
   Qed.
 
   Lemma R_positionR :
     forall Γ p1 p2,
-      (forall Σ (wfΣ : abstract_env_ext_rel X Σ), eq_term Σ (pzt p1) (pzt p2)) ->
+      (eqt (pzt p1) (pzt p2)) ->
       positionR (` (pps1 p1)) (` (pps1 p2)) ->
       R Γ p1 p2.
   Proof.
@@ -358,7 +406,7 @@ Section Conversion.
 
   Lemma R_aux_cored2 :
     forall Γ t1 t2 (p1 : pos t1) (p2 : pos t2) w1 w2 q1 q2 s1 s2,
-      (forall Σ (wfΣ : abstract_env_ext_rel X Σ), eq_term Σ t1 t2) ->
+      (eqt t1 t2) ->
       ` p1 = ` p2 ->
       (forall Σ (wfΣ : abstract_env_ext_rel X Σ), cored' Σ Γ (` w1) (` w2)) ->
       R_aux Γ (t1 ; (p1, (w1 ; (q1, s1)))) (t2 ; (p2, (w2 ; (q2, s2)))).
@@ -366,7 +414,7 @@ Section Conversion.
     intros Γ t1 t2 [p1 hp1] [p2 hp2] [t1' h1'] [t2' h2'] q1 q2 s1 s2 e1 e2 h.
     cbn in e2. cbn in h. subst.
     unshelve eright.
-    - constructor. eauto. 
+    - auto.
     - unfold R_aux_obligations_obligation_1. simpl.
       match goal with
       | |- context [ exist p2 ?hp1 ] =>
@@ -379,7 +427,7 @@ Section Conversion.
 
   Lemma R_cored2 :
     forall Γ p1 p2,
-      (forall Σ (wfΣ : abstract_env_ext_rel X Σ), eq_term Σ (pzt p1) (pzt p2)) ->
+      (eqt (pzt p1) (pzt p2)) ->
       ` (pps1 p1) = ` (pps1 p2) ->
       (forall Σ (wfΣ : abstract_env_ext_rel X Σ), 
           cored Σ Γ (` (pwt p1)) (` (pwt p2))) ->
@@ -394,16 +442,16 @@ Section Conversion.
 
   Lemma R_aux_positionR2 :
     forall Γ t1 t2 (p1 : pos t1) (p2 : pos t2) w1 w2 q1 q2 s1 s2,
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ t1 t2) ->
+      (eqt t1 t2) ->
       ` p1 = ` p2 ->
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ (` w1) (` w2)) ->
+      (eqt (` w1) (` w2)) ->
       positionR (` q1) (` q2) ->
       R_aux Γ (t1 ; (p1, (w1 ; (q1, s1)))) (t2 ; (p2, (w2 ; (q2, s2)))).
   Proof.
     intros Γ t1 t2 [p1 hp1] [p2 hp2] [t1' h1'] [t2' h2'] q1 q2 s1 s2 e1 e2 e3 h.
     cbn in e2. cbn in e3. subst.
     unshelve eright.
-    - constructor. eauto.
+    - auto.
     - unfold R_aux_obligations_obligation_1. simpl.
       match goal with
       | |- context [ exist p2 ?hp1 ] =>
@@ -412,15 +460,15 @@ Section Conversion.
       rewrite e.
       right.
       unshelve eright.
-      + constructor. eauto.
+      + auto.
       + left. unfold posR. simpl. assumption.
   Qed.
 
   Lemma R_positionR2 :
     forall Γ p1 p2,
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ (pzt p1) (pzt p2)) ->
+      (eqt (pzt p1) (pzt p2)) ->
       ` (pps1 p1) = ` (pps1 p2) ->
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ (` (pwt p1)) (` (pwt p2))) ->
+      (eqt (` (pwt p1)) (` (pwt p2))) ->
       positionR (` (pps2 p1)) (` (pps2 p2)) ->
       R Γ p1 p2.
   Proof.
@@ -431,9 +479,9 @@ Section Conversion.
 
   Lemma R_aux_stateR :
     forall Γ t1 t2 (p1 : pos t1) (p2 : pos t2) w1 w2 q1 q2 s1 s2 ,
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ t1 t2) ->
+      (eqt t1 t2) ->
       ` p1 = ` p2 ->
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ (` w1) (` w2)) ->
+      (eqt (` w1) (` w2)) ->
       ` q1 = ` q2 ->
       stateR s1 s2 ->
       R_aux Γ (t1 ; (p1, (w1 ; (q1, s1)))) (t2 ; (p2, (w2 ; (q2, s2)))).
@@ -442,7 +490,7 @@ Section Conversion.
            e1 e2 e3 e4 h.
     cbn in e2. cbn in e3. cbn in e4. subst.
     unshelve eright.
-    - constructor. eauto.
+    - auto.
     - unfold R_aux_obligations_obligation_1. simpl.
       match goal with
       | |- context [ exist p2 ?hp1 ] =>
@@ -451,7 +499,7 @@ Section Conversion.
       rewrite e.
       right.
       unshelve eright.
-      + constructor. eauto.
+      + auto.
       + unfold R_aux_obligations_obligation_2. simpl.
         match goal with
         | |- context [ exist q2 ?hq1 ] =>
@@ -463,9 +511,9 @@ Section Conversion.
 
   Lemma R_stateR :
     forall Γ p1 p2,
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ (pzt p1) (pzt p2)) ->
+      (eqt (pzt p1) (pzt p2)) ->
       ` (pps1 p1) = ` (pps1 p2) ->
-      (forall Σ, abstract_env_ext_rel X Σ -> eq_term Σ (` (pwt p1)) (` (pwt p2))) ->
+      (eqt (` (pwt p1)) (` (pwt p2))) ->
       ` (pps2 p1) = ` (pps2 p2) ->
       stateR (st p1) (st p2) ->
       R Γ p1 p2.
@@ -739,7 +787,7 @@ Section Conversion.
     (repack (isconv_args_raw leq t1 π1 t2 π2 aux)) (only parsing).
   Notation isconv_fallback leq t1 π1 t2 π2 aux :=
     (repack (isconv_fallback_raw leq t1 π1 t2 π2 aux)) (only parsing).
-
+  
   Equations(noeqns) _isconv_red (Γ : context) (leq : conv_pb)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)
             (t2 : term) (π2 : stack) (h2 : wtp Γ t2 π2)
@@ -819,7 +867,7 @@ Section Conversion.
       end.
       + assert (ee2 := eq2). rewrite ee in ee2. inversion ee2. subst.
         unshelve eapply R_stateR.
-        * simpl. rewrite stack_cat_appstack. reflexivity.
+        * simpl. rewrite stack_cat_appstack. red. reflexivity.
         * simpl. rewrite stack_cat_appstack. reflexivity.
         * simpl. rewrite stack_cat_appstack. reflexivity.
         * simpl. rewrite stack_cat_appstack. reflexivity.
@@ -1927,6 +1975,7 @@ Qed.
       Unshelve. all: eauto. 
   Qed.
 
+
   Equations isconv_branches (Γ : context)
     (ci : case_info)
     (p : predicate term) (c : term) (brs1 brs2 : list (branch term))
@@ -2042,22 +2091,10 @@ Qed.
       now unfold app_context; rewrite app_assoc.
   Qed.
   Next Obligation.
-    clear aux.
-    lazymatch goal with
-    | h : R _ _ ?r1 |- R _ _ ?r2 =>
-      assert (er : r1 = r2)
-    end.
-    { clear i.
-      match goal with
-      | |- {| wth := ?x |} = _ =>
-        generalize x
-      end.
-      rewrite <- !app_assoc. simpl.
-      intro w.
-      f_equal.
-      eapply proof_irrelevance.
-    }
-    rewrite <- er. assumption.
+    clear aux. unfold isconv_branches_obligations_obligation_13.
+    eapply R_irrelevance. 2:tea. cbn.
+    f_equal. f_equal. 2:{ f_equal. now rewrite <-app_assoc. } 
+    f_equal. f_equal. f_equal. now rewrite <- app_assoc.
   Qed. 
   Next Obligation.
     destruct (case_conv_brs_inv h p' c' brs1' brs2' _ h') as [[mdecl [idecl [decli eqp eqp' eqm clm clm']]]]; tea.
@@ -2249,22 +2286,8 @@ Qed.
   Qed.
   Next Obligation.
     clear aux.
-    lazymatch goal with
-    | h : R _ _ ?r1 |- R _ _ ?r2 =>
-      rename h into hr ;
-      assert (e0 : r1 = r2)
-    end.
-    { clear hr.
-      match goal with
-      | |- {| wth := ?x |} = _ =>
-        generalize x
-      end.
-      rewrite <- !app_assoc. simpl.
-      intro w.
-      f_equal.
-      eapply proof_irrelevance.
-    }
-    rewrite <- e0. assumption.
+    eapply R_irrelevance; tea; cbn.
+    now rewrite <- !app_assoc.
   Qed.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
@@ -2528,22 +2551,8 @@ Qed.
   Qed.
   Next Obligation.
     clear aux.
-    lazymatch goal with
-    | h : R _ _ ?r1 |- R _ _ ?r2 =>
-      rename h into hr ;
-      assert (e0 : r1 = r2)
-    end.
-    { clear hr.
-      match goal with
-      | |- {| wth := ?x |} = _ =>
-        generalize x
-      end.
-      rewrite <- !app_assoc. simpl.
-      intro w.
-      f_equal.
-      eapply proof_irrelevance.
-    }
-    rewrite <- e0. assumption.
+    eapply R_irrelevance; tea; cbn.
+    now rewrite <- !app_assoc.
   Qed.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
@@ -5704,20 +5713,23 @@ Qed.
     _isconv Fallback Γ t1 π1 h1 t2 π2 h2 aux :=
       λ { | leq | hx | r1 | r2 | hd := _isconv_fallback Γ leq t1 π1 h1 t2 π2 h2 r1 r2 hd hx aux }.
 
-    Lemma welltyped_R_zipc Σ (wfΣ : abstract_env_ext_rel X Σ) Γ :
-      forall x y : pack Γ, welltyped Σ Γ (zipc (tm1 x) (stk1 x)) -> R Γ y x -> welltyped Σ Γ (zipc (tm1 y) (stk1 y)).
-    Proof.
-      intros x y H HR.
-      pose proof (heΣ := heΣ _ wfΣ).
-      pose proof (hΣ := hΣ _ wfΣ). cbn.
-      sq. 
-      destruct x, y; cbn in *.
-      (* dependent induction HR.
-      - eapply cored_welltyped. all: eauto.
-        cbn in *. specialize_Σ wfΣ. destruct H.
-      - simpl in H1. revert H1; intros [= H2 _].
-        now rewrite <- H2. *)
-    Admitted.
+  Lemma welltyped_R_zipc Σ (wfΣ : abstract_env_ext_rel X Σ) Γ :
+    forall x y : pack Γ, welltyped Σ Γ (zipc (tm1 x) (stk1 x)) -> R Γ y x -> welltyped Σ Γ (zipc (tm1 y) (stk1 y)).
+  Proof.
+    intros x y H HR.
+    pose proof (heΣ := heΣ _ wfΣ).
+    pose proof (hΣ := hΣ _ wfΣ). cbn.
+    sq. 
+    destruct x, y; cbn in *.
+    depind HR.
+    - cbn in *. specialize_Σ wfΣ.
+      eapply cored'_postpone in H as [u' [cor eq]].
+      eapply cored_welltyped in cor; tea.
+      destruct eq as [eq].
+      eapply welltyped_alpha; tea. symmetry. exact eq.
+    - simpl in *. destruct e. eapply welltyped_alpha; tea.
+      now symmetry.
+  Qed.
 
   Equations(noeqns) isconv_full (s : state) (Γ : context)
             (t1 : term) (π1 : stack) (h1 : wtp Γ t1 π1)
@@ -5738,8 +5750,7 @@ Qed.
     unshelve eapply _isconv. all: try assumption.
     intros s' t1' π1' t2' π2' h1' h2' hx' hR.
     eapply (f (mkpack Γ s' t1' π1' t2' π2' h2')); tea.
-    destruct pp.
-    assert (wth0 = H0) by apply proof_irrelevance. simpl in hR. subst. exact hR.
+    destruct pp. eapply R_irrelevance; tea; cbn. reflexivity.
   Defined.
   Next Obligation.
   match goal with | |- Acc _ ?X => set (u := X) end.
@@ -5754,7 +5765,6 @@ Qed.
   - destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     destruct (hΣ _ wfΣ) as [hΣ]. eapply R_Acc; eassumption.
   Defined.
-
   
   Inductive ConversionResultSummary :=
   | ConvSuccess : ConversionResultSummary


### PR DESCRIPTION
When using the Acc_intro_generator, we have to show that the wellfounded order preserves welltypedness. This was not possible as the order was including `eq_term \Sigma t u`, i.e. allowing to change universes before doing a recursive call. While this is wellfounded, typing is not obviously preserved by `eq_term`. The intention was to use only alpha-equivalence in the order, which preseves typing directly. This required generalizing the commutation lemma between reduction and `eq_term_upto_univ_napp` to also apply to alpha equivalence, i.e. `eq_term empty_global_env t u`.
As a bonus we show that the relation `R` does not care about the welltypedness witnesses passed as arguments, avoiding some uses of the proof-irrelevance axiom. SafeConversion is again admit and axiom-free.