### PR TITLE
Implementation of a "Quote Module" action in the monad to get the glo…

### DIFF
--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -165,6 +165,35 @@ let tmQuoteUniverses : UGraph.t tm =
   fun ~st env evm success _fail ->
     success ~st env evm (Environ.universes env)
 
+let quote_module (qualid : qualid) : global_reference list =
+  let mp = Nametab.locate_module qualid in
+  let mb = Global.lookup_module mp in
+  let rec aux mb =
+    let open Declarations in
+    let me = mb.mod_expr in
+    let get_refs s =
+      let body = Modops.destr_nofunctor s in
+      let get_ref (label, field) =
+        let open Names in 
+        match field with
+        | SFBconst _ -> [GlobRef.ConstRef (Constant.make2 mp label)]
+        | SFBmind _ -> [GlobRef.IndRef (MutInd.make2 mp label, 0)]
+        | SFBmodule mb -> aux mb
+        | SFBmodtype mtb -> []
+      in
+      CList.map_append get_ref body
+    in
+    match me with
+    | Abstract -> []
+    | Algebraic _ -> []
+    | Struct s -> get_refs s
+    | FullStruct -> get_refs mb.Declarations.mod_type
+  in aux mb
+
+let tmQuoteModule (qualid : qualid) : global_reference list tm =
+  fun ~st env evd success _fail ->
+  success ~st env evd (quote_module qualid)
+
 (*let universes_entry_of_decl ?withctx d =
   let open Declarations in
   let open Entries in

--- a/template-coq/src/plugin_core.mli
+++ b/template-coq/src/plugin_core.mli
@@ -60,6 +60,7 @@ val tmCurrentModPath : Names.ModPath.t tm
 val tmQuoteInductive : kername -> (Names.MutInd.t * mutual_inductive_body) option tm
 val tmQuoteUniverses : UGraph.t tm
 val tmQuoteConstant : kername -> bool -> constant_body tm
+val tmQuoteModule : qualid -> global_reference list tm
 
 val tmInductive : bool -> mutual_inductive_entry -> unit tm
 

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -227,6 +227,8 @@ let rec interp_tm (t : 'a coq_TM) : 'a tm =
            | Some (mi, mib) -> Obj.magic (tmOfMib mi mib))
   | Coq_tmQuoteUniverses ->
     tmMap (fun x -> failwith "tmQuoteUniverses") tmQuoteUniverses
+  | Coq_tmQuoteModule id ->
+    tmMap (fun x -> Obj.magic (List.map quote_global_reference x)) (tmQuoteModule (to_qualid id))
   | Coq_tmQuoteConstant (kn, b) ->
     tmBind (tmQuoteConstant (unquote_kn kn) b)
            (fun x -> Obj.magic (tmOfConstantBody x))

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -431,6 +431,13 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
   | TmQuoteUnivs ->
     let univs = Environ.universes env in
     k ~st env evm (quote_ugraph univs)
+  | TmQuoteModule id ->
+    let id = unquote_string (reduce_all env evm id) in
+    Plugin_core.run ~st (Plugin_core.tmQuoteModule (Libnames.qualid_of_string id)) env evm
+      (fun ~st env evm l ->
+         let l = List.map quote_global_reference l in
+         let l = to_coq_listl tglobal_reference l in
+         k ~st env evm l)
   | TmPrint trm ->
     Feedback.msg_info (Printer.pr_constr_env env evm trm);
     k ~st env evm (Lazy.force unit_tt)

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -36,6 +36,7 @@ let (ptmReturn,
      ptmQuoteInductive,
      ptmQuoteConstant,
      ptmQuoteUniverses,
+     ptmQuoteModule,
 
      ptmUnquote,
      ptmUnquoteTyped,
@@ -74,6 +75,7 @@ let (ptmReturn,
    r_template_monad_prop_p "tmQuoteInductive",
    r_template_monad_prop_p "tmQuoteConstant",
    r_template_monad_prop_p "tmQuoteUniverses",
+   r_template_monad_prop_p "tmQuoteModule",
 
    r_template_monad_prop_p "tmUnquote",
    r_template_monad_prop_p "tmUnquoteTyped",
@@ -103,6 +105,7 @@ let (ttmReturn,
      ttmCurrentModPath,
      ttmQuoteInductive,
      ttmQuoteUniverses,
+     ttmQuoteModule,
      ttmQuoteConstant,
      ttmInductive,
      ttmInferInstance,
@@ -126,6 +129,7 @@ let (ttmReturn,
 
    r_template_monad_type_p "tmQuoteInductive",
    r_template_monad_type_p "tmQuoteUniverses",
+   r_template_monad_type_p "tmQuoteModule",
    r_template_monad_type_p "tmQuoteConstant",
 
    r_template_monad_type_p "tmInductive",
@@ -170,6 +174,7 @@ type template_monad =
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
+  | TmQuoteModule of Constr.t
 
   | TmUnquote of Constr.t                   (* only Prop *)
   | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
@@ -326,6 +331,11 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     | [] ->
        (TmQuoteUnivs, universes)
     | _ -> monad_failure "tmQuoteUniverses" 0
+  else if eq_gr ptmQuoteModule || eq_gr ttmQuoteModule then
+    match args with
+    | [id] ->
+       (TmQuoteModule id, universes)
+    | _ -> monad_failure "tmQuoteModule" 0
   else if eq_gr ptmQuoteConstant then
     match args with
     | name::bypass::[] ->

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -42,6 +42,7 @@ type template_monad =
   | TmQuoteInd of Constr.t * bool (* strict *)
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
+  | TmQuoteModule of Constr.t
 
   | TmUnquote of Constr.t                   (* only Prop *)
   | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -254,6 +254,7 @@ Register MetaCoq.Template.TemplateMonad.Core.tmQuoteRecTransp as metacoq.templat
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteInductive as metacoq.templatemonad.prop.tmQuoteInductive.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteConstant as metacoq.templatemonad.prop.tmQuoteConstant.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteUniverses as metacoq.templatemonad.prop.tmQuoteUniverses.
+Register MetaCoq.Template.TemplateMonad.Core.tmQuoteModule as metacoq.templatemonad.prop.tmQuoteModule.
 
 Register MetaCoq.Template.TemplateMonad.Core.tmUnquote as metacoq.templatemonad.prop.tmUnquote.
 Register MetaCoq.Template.TemplateMonad.Core.tmUnquoteTyped as metacoq.templatemonad.prop.tmUnquoteTyped.
@@ -284,6 +285,7 @@ Register MetaCoq.Template.TemplateMonad.Extractable.tmCurrentModPath as metacoq.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteInductive as metacoq.templatemonad.type.tmQuoteInductive.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteUniverses as metacoq.templatemonad.type.tmQuoteUniverses.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteConstant as metacoq.templatemonad.type.tmQuoteConstant.
+Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteModule as metacoq.templatemonad.type.tmQuoteModule.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmInductive as metacoq.templatemonad.type.tmInductive.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmInferInstance as metacoq.templatemonad.type.tmInferInstance.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmExistingInstance as metacoq.templatemonad.type.tmExistingInstance.

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -50,6 +50,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmQuoteInductive : kername -> TemplateMonad mutual_inductive_body
 | tmQuoteUniverses : TemplateMonad ConstraintSet.t
 | tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_body
+| tmQuoteModule : qualid -> TemplateMonad (list global_reference)
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)
 | tmMkInductive : bool -> mutual_inductive_entry -> TemplateMonad unit

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -48,8 +48,8 @@ Cumulative Inductive TM@{t} : Type@{t} -> Type :=
   : TM mutual_inductive_body
 | tmQuoteConstant (nm : kername) (bypass_opacity : bool)
   : TM constant_body
-
 | tmQuoteUniverses : TM ConstraintSet.t
+| tmQuoteModule : qualid -> TM (list global_reference)
 
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -40,6 +40,7 @@ safechecker_test.v
 tmExistingInstance.v
 tmFreshName.v
 tmInferInstance.v
+tmQuoteModule.v
 unfold.v
 univ.v
 tmVariable.v

--- a/test-suite/tmQuoteModule.v
+++ b/test-suite/tmQuoteModule.v
@@ -1,0 +1,9 @@
+From MetaCoq.Template Require Import bytestring Loader All.
+Import MCMonadNotation.
+Module Foo.
+    Inductive bar : Set := .
+  Definition t := nat.
+End Foo.
+
+MetaCoq Run (tmQuoteModule "Foo"%bs).
+MetaCoq Run (tmQuoteModule "Datatypes"%bs).


### PR DESCRIPTION
…bal references associated to a module.

This could be improved to get a more structured view of a module, right now we flatten the structure and ignore module types. We also only reference the first inductive in a block declared in the module, using `global_reference`. 