### PR TITLE
Constructor atoms declared in evaluation

### DIFF
--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -1841,7 +1841,7 @@ Proof.
       rewrite (remove_last_last l a hl).
       rewrite -[tApp _ _](mkApps_app _ _ [a']).
       eapply eval_mkApps_Construct; tea.  
-      { now constructor. }
+      { constructor. cbn [atom]; rewrite H //. }
       { len. rewrite (All2_length hargs). lia. }
       eapply All2_app.
       eapply forallb_remove_last, forallb_All in etal.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -656,6 +656,8 @@ Proof.
         destruct v => /= //. 
   - destruct t => //.
     all:constructor; eauto.
+    cbn [atom optimize] in i |- *.
+    rewrite -lookup_constructor_optimize //.
 Qed.
 
 From MetaCoq.Erasure Require Import EEtaExpanded.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -698,7 +698,8 @@ Proof.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         destruct v => /= //. 
   - destruct t => //.
-    all:constructor; eauto.
+    all:constructor; eauto. cbn [atom optimize] in i |- *.
+    rewrite -lookup_constructor_optimize //.
 Qed.
 
 (* 

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -965,7 +965,7 @@ Proof.
     rewrite (lookup_constructor_lookup_inductive_pars H).
     eapply eval_mkApps_Construct; tea.
     + rewrite lookup_constructor_strip H //.
-    + now constructor.
+    + constructor. cbn [atom]. rewrite lookup_constructor_strip H //.
     + rewrite /cstr_arity /=.
       move: H0; rewrite /cstr_arity /=.
       rewrite skipn_length map_length => ->. lia.
@@ -974,7 +974,10 @@ Proof.
       intros x y []; auto.
     
   - destruct t => //.
-    all:constructor; eauto.
+    all:constructor; eauto. simp strip.
+    cbn [atom strip] in H |- *.
+    rewrite lookup_constructor_strip.
+    destruct lookup_constructor eqn:hl => //. destruct p as [[] ?] => //.
 Qed.
 
 From MetaCoq.Erasure Require Import EEtaExpanded.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -313,7 +313,7 @@ Lemma eval_preserve_mkApps_ind :
     All2 P args args' ->
     P' (mkApps (tConstruct ind i) args) (mkApps (tConstruct ind i) args')) → 
 
-  (∀ t : term, atom t → Q 0 t -> isEtaExp Σ t -> P' t t) ->
+  (∀ t : term, atom Σ t → Q 0 t -> isEtaExp Σ t -> P' t t) ->
   ∀ (t t0 : term), Q 0 t -> isEtaExp Σ t -> eval Σ t t0 → P' t t0.
 Proof.
   intros * Qpres P P'Q etaΣ wfΣ hasapp.

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -159,7 +159,7 @@ Section eval_mkApps_rect.
           → eval Σ a a'
           → P a a'
           → P (tApp f11 a) (tApp f' a'))
-    → (∀ t : term, atom t → P t t)
+    → (∀ t : term, atom Σ t → P t t)
     → ∀ t t0 : term, eval Σ t t0 → P t t0.
 Proof using Type.
   intros ?????????????????? H.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1102,7 +1102,8 @@ Proof.
       * eexists. split. 2: now constructor; econstructor.
         econstructor; eauto.
     + invs He.
-      * eexists. split. 2: now constructor; econstructor.
+      * eexists. split. 2:{ constructor; econstructor. cbn [EWcbvEval.atom].
+        depelim Hed. eapply EGlobalEnv.declared_constructor_lookup in H0. now rewrite H0. }
         econstructor; eauto.
       * eexists. split. 2: now constructor; econstructor.
         eauto.
@@ -1114,7 +1115,7 @@ Proof.
       * eexists. split; eauto. now constructor; econstructor.
       * eexists. split. 2: now constructor; econstructor.
         econstructor; eauto.
-        Unshelve. all: repeat econstructor.      
+        Unshelve. all: repeat econstructor.
 Qed.
 
 (* Print Assumptions erases_correct. *)


### PR DESCRIPTION
We ensure atoms that are constructors are declared during evaluation, to be more uniform with the constructor application rule.