### PR TITLE
Constructors as blocks improvement: they always have the right arity

### DIFF
--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -281,7 +281,7 @@ Proof.
     + intuition auto.
       apply erases_deps_mkApps_inv in H4.
       now apply Forall_rev, Forall_skipn.
-    + eapply nth_error_forall in e1; [|now eauto].
+    + eapply nth_error_forall in e2; [|now eauto].
       assumption.
   - congruence.
   - depelim er.
@@ -333,7 +333,7 @@ Proof.
     intuition auto.
     apply erases_deps_mkApps_inv in H3 as (? & ?).
     apply IHev2.
-    now eapply nth_error_forall in e2.
+    now eapply nth_error_forall in e3.
   - congruence.
   - constructor.
   - depelim er.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -1392,7 +1392,7 @@ Proof.
     destruct s.
     * destruct p; solve_discr. noconf H3.
       right. len.
-      move: e; unfold isEtaExp_fixapp.
+      move: e1; unfold isEtaExp_fixapp.
       unfold EGlobalEnv.cunfold_fix. destruct nth_error eqn:hnth => //.
       intros [=]. rewrite H3. rewrite -(All2_length a0). eapply Nat.ltb_lt; lia.
     * right. len. eapply isEtaExp_fixapp_mon; tea. lia.
@@ -1404,7 +1404,7 @@ Proof.
     destruct s.
     * destruct p; solve_discr. noconf H2.
       left. split. 
-      unfold isStuckFix'; rewrite e. len. eapply Nat.leb_le. lia.
+      unfold isStuckFix'; rewrite e1. len. eapply Nat.leb_le. lia.
       now rewrite -[tApp _ _](mkApps_app _ _ [av]).
     * right. len. eapply isEtaExp_fixapp_mon; tea. lia.
   + eapply mkApps_eq in H1 as [? []] => //; subst.
@@ -1571,7 +1571,7 @@ Proof.
   - pose proof (eval_trans' H H0_0). subst a'. econstructor; tea.
   - pose proof (eval_trans' H H0_0). subst av. eapply eval_fix; tea.
   - pose proof (eval_trans' H H0_0). subst av. eapply eval_fix_value; tea.
-  - eapply value_final in X. pose proof (eval_trans' X H0_). subst f.
+  - eapply value_final in X. pose proof (eval_trans' X H0_). subst f7.
     pose proof (eval_trans' H H0_0). subst av.
     eapply eval_fix'; tea.
   - eapply eval_construct; tea.
@@ -1854,7 +1854,7 @@ Proof.
       rewrite (remove_last_last l0 a hl).
       rewrite -[tApp _ _](mkApps_app _ _ [a']).
       eapply eval_mkApps_Construct; tea.  
-      { constructor. cbn [atom]; rewrite e0 //. }
+      { constructor. cbn [atom]; rewrite e e0 //. }
       { len. rewrite (All2_length hargs). lia. }
       eapply All2_app.
       eapply forallb_remove_last, forallb_All in etal.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -512,23 +512,23 @@ Proof.
     eapply nth_error_forallb in wfbrs; tea.
     rewrite Nat.add_0_r in wfbrs.
     forward IHev2. eapply wellformed_iota_red; tea => //.
-    rewrite optimize_iota_red in IHev2 => //. now rewrite e3.
+    rewrite optimize_iota_red in IHev2 => //. now rewrite e4.
     econstructor; eauto.
     rewrite -is_propositional_cstr_optimize //. tea.
-    rewrite nth_error_map e1 //. len. len.
+    rewrite nth_error_map e2 //. len. len.
 
   - congruence.
 
   - move/andP => [] /andP[] hl wfd wfbrs.
     forward IHev2. eapply wellformed_substl; tea => //.
     rewrite forallb_repeat //. len.
-    rewrite e0 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
+    rewrite e1 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
     rewrite optimize_substl in IHev2 => //.
     rewrite forallb_repeat //. len.
-    rewrite e0 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
+    rewrite e1 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
     eapply eval_iota_sing => //; eauto.
     rewrite -is_propositional_optimize //.
-    rewrite e0 //. simpl.
+    rewrite e1 //. simpl.
     rewrite map_repeat in IHev2 => //.
 
   - move/andP => [] clf cla. rewrite optimize_mkApps in IHev1.
@@ -600,7 +600,7 @@ Proof.
     move/wf_mkApps: ev1 => [] wfc wfargs.
     destruct lookup_projection as [[[[mdecl idecl] cdecl'] pdecl]|] eqn:hl' => //.
     pose proof (lookup_projection_lookup_constructor hl').
-    rewrite (constructor_isprop_pars_decl_constructor H) in e0. noconf e0.
+    rewrite (constructor_isprop_pars_decl_constructor H) in e1. noconf e1.
     forward IHev1 by auto.
     forward IHev2. eapply nth_error_forallb in wfargs; tea.
     rewrite optimize_mkApps /= in IHev1.
@@ -617,11 +617,11 @@ Proof.
     rewrite nth_error_rev. len. rewrite skipn_length. lia. 
     rewrite List.rev_involutive. len. rewrite skipn_length.
     rewrite nth_error_skipn nth_error_map.
-    rewrite e1 -H1.
+    rewrite e2 -H1.
     assert((ind_npars mdecl + cstr_nargs cdecl - ind_npars mdecl) = cstr_nargs cdecl) by lia.
     rewrite H3.
-    eapply (f_equal (option_map (optimize Σ))) in e2.
-    cbn in e2. rewrite -e2. f_equal. f_equal. lia.
+    eapply (f_equal (option_map (optimize Σ))) in e3.
+    cbn in e3. rewrite -e3. f_equal. f_equal. lia.
 
   - congruence.
 
@@ -630,7 +630,7 @@ Proof.
     destruct lookup_projection as [[[[mdecl idecl] cdecl'] pdecl]|] eqn:hl' => //.
     pose proof (lookup_projection_lookup_constructor hl').
     simpl in H. 
-    move: e. rewrite /inductive_isprop_and_pars.
+    move: e0. rewrite /inductive_isprop_and_pars.
     rewrite (lookup_constructor_lookup_inductive H) /=.
     intros [= eq <-].
     eapply eval_iota_sing => //; eauto.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -551,11 +551,11 @@ Proof.
     rewrite optimize_iota_red in IHev2.
     eapply eval_closed in ev1 => //.
     rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (constructor_isprop_pars_decl_inductive e0).
+    rewrite (constructor_isprop_pars_decl_inductive e1).
     eapply eval_iota; eauto.
     now rewrite -is_propositional_cstr_optimize.
-    rewrite nth_error_map e1 //. now len. cbn.
-    rewrite -e3. rewrite !skipn_length map_length //.
+    rewrite nth_error_map e2 //. now len. cbn.
+    rewrite -e4. rewrite !skipn_length map_length //.
     eapply IHev2.
     eapply closed_iota_red => //; tea.
     eapply nth_error_forallb in clbrs; tea. cbn in clbrs.
@@ -565,7 +565,7 @@ Proof.
   
   - move/andP => [] cld clbrs.
     rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite e e0 /=.
+    rewrite e0 e1 /=.
     subst brs. cbn in clbrs. rewrite Nat.add_0_r andb_true_r in clbrs.
     rewrite optimize_substl in IHev2. 
     eapply All_forallb, All_repeat => //.
@@ -660,19 +660,19 @@ Proof.
     eapply eval_closed in ev1; tea.
     move: ev1; rewrite closedn_mkApps /= => clargs.
     rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (constructor_isprop_pars_decl_inductive e0).
+    rewrite (constructor_isprop_pars_decl_inductive e1).
     rewrite optimize_mkApps in IHev1.
     specialize (IHev1 cld).
     eapply Ee.eval_proj; tea.
     now rewrite -is_propositional_cstr_optimize.
-    now len. rewrite nth_error_map e2 //.
+    now len. rewrite nth_error_map e3 //.
     eapply IHev2.
-    eapply nth_error_forallb in e2; tea.
+    eapply nth_error_forallb in e3; tea.
 
   - congruence.
 
   - rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    now rewrite e.
+    now rewrite e0.
 
   - move/andP=> [] clf cla.
     rewrite optimize_mkApps.

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -967,7 +967,7 @@ Proof.
     rewrite (lookup_constructor_lookup_inductive_pars H).
     eapply eval_mkApps_Construct; tea.
     + rewrite lookup_constructor_strip H //.
-    + constructor. cbn [atom]. rewrite lookup_constructor_strip H //.
+    + constructor. cbn [atom]. rewrite wcon lookup_constructor_strip H //.
     + rewrite /cstr_arity /=.
       move: H0; rewrite /cstr_arity /=.
       rewrite skipn_length map_length => ->. lia.
@@ -1050,10 +1050,11 @@ Proof.
 Qed.
 
 Lemma strip_wellformed_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t :
+  cstr_as_blocks = false ->
   wf_glob Σ ->
   forall n, wellformed Σ n t -> wellformed (strip_env Σ) n t.
 Proof.
-  intros wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
+  intros hcstrs wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
   all:try solve [intros; unfold wf_fix in *; rtoProp; intuition eauto; solve_all].
   - rewrite lookup_env_strip //.
     destruct lookup_env eqn:hl => // /=.
@@ -1062,13 +1063,7 @@ Proof.
   - rewrite lookup_env_strip //.
     destruct lookup_env eqn:hl => // /=; intros; rtoProp; eauto.
     destruct g eqn:hg => /= //; intros; rtoProp; eauto.
-    destruct cstr_as_blocks; repeat split; eauto.
-    destruct nth_error => /= //.
-    destruct nth_error => /= //.
-    destruct nth_error => /= //.
-    destruct nth_error => /= //. rtoProp. split. solve_all.
-    eapply Nat.leb_le in H0. eapply Nat.leb_le. lia.
-    solve_all.
+    destruct cstr_as_blocks => //; repeat split; eauto.
     destruct nth_error => /= //.
     destruct nth_error => /= //.
   - rewrite lookup_env_strip //.
@@ -1087,10 +1082,11 @@ Proof.
 Qed.
 
 Lemma strip_wellformed_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} d :
+  cstr_as_blocks = false ->
   wf_glob Σ ->
   wf_global_decl Σ d -> wf_global_decl (strip_env Σ) d.
 Proof.
-  intros wf; destruct d => /= //.
+  intros hcstrs wf; destruct d => /= //.
   destruct (cst_body c) => /= //.
   now eapply strip_wellformed_irrel.
 Qed.

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -219,22 +219,14 @@ Section eval_mkApps_rect.
                    (c : nat) (mdecl : mutual_inductive_body) 
                    (idecl : one_inductive_body) 
                    (cdecl : constructor_body) 
-                   (args args' : 
-                    list term) (a a' : term) 
+                   (args args' : list term)
                    (e : with_constructor_as_block = true) 
                    (e0 : lookup_constructor Σ ind c =
                          Some (mdecl, idecl, cdecl)) 
-                   (l : #|args| < cstr_arity mdecl cdecl) 
-                   (e1 : eval Σ 
-                           (tConstruct ind c args)
-                           (tConstruct ind c args')),
-                   P (tConstruct ind c args)
-                     (tConstruct ind c args') 
-                   → ∀ e2 : eval Σ a a',
-                       P a a' 
-                       → P (tConstruct ind c (args ++ [a]))
-                           (tConstruct ind c
-                              (args' ++ [a'])))
+                   (l : #|args| = cstr_arity mdecl cdecl) 
+                   (e1 : All2 (eval Σ) args args'),
+                   All2 P args args'
+            → P (tConstruct ind c args) (tConstruct ind c args'))
 
       → (∀ (f15 f' a a' : term) (e : eval Σ f15 f'),
       P f15 f' -> IH _ _ e
@@ -282,6 +274,10 @@ Proof using Type.
   | [ H : _ |- _ ] =>
     unshelve eapply H; try match goal with |- eval _ _ _ => tea end; tea; unfold IH; intros; unshelve eapply IH'; tea; cbn; try lia
   end].
+  eapply X15; tea; auto.
+  clear -a IH'. induction a; constructor.
+  eapply (IH' _ _ r). cbn. lia. apply IHa.
+  intros. eapply (IH' _ _ H). cbn. lia.
 Qed.
 
 End eval_mkApps_rect. 

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -109,7 +109,11 @@ Section wf.
       | Some d => has_axioms || isSome d.(cst_body)
       | _ => false 
       end
-    | tConstruct ind c block_args => has_tConstruct && isSome (lookup_constructor Σ ind c) && if cstr_as_blocks then match lookup_constructor_pars_args Σ ind c with Some (p, a) => p + a <=? #|block_args| | _ => true end && forallb (wellformed k) block_args else is_nil block_args
+    | tConstruct ind c block_args => has_tConstruct && isSome (lookup_constructor Σ ind c) && 
+      if cstr_as_blocks then match lookup_constructor_pars_args Σ ind c with 
+        | Some (p, a) => (p + a) == #|block_args| 
+        | _ => true end 
+        && forallb (wellformed k) block_args else is_nil block_args
     | tVar _ => has_tVar
     end.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1102,7 +1102,7 @@ Proof.
       * eexists. split. 2: now constructor; econstructor.
         econstructor; eauto.
     + invs He.
-      * eexists. split. 2:{ constructor; econstructor. cbn [EWcbvEval.atom].
+      * eexists. split. 2:{ constructor. eapply EWcbvEval.eval_atom. cbn [EWcbvEval.atom].
         depelim Hed. eapply EGlobalEnv.declared_constructor_lookup in H0. now rewrite H0. }
         econstructor; eauto.
       * eexists. split. 2: now constructor; econstructor.

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -677,8 +677,8 @@ Lemma eval_empty_brs {wfl : Ee.WcbvFlags} Σ ci p e : Σ ⊢ E.tCase ci p [] ▷
 Proof.
   intros He.
   depind He. 
-  - clear -e1. now rewrite nth_error_nil in e1.
-  - clear -e1. now rewrite nth_error_nil in e1.
+  - clear -e2. now rewrite nth_error_nil in e2.
+  - clear -e2. now rewrite nth_error_nil in e2.
   - discriminate.
   - eapply IHHe2.
   - cbn in i. discriminate.
@@ -695,7 +695,7 @@ Proof.
     destruct args using rev_case. discriminate.
     rewrite EAstUtils.mkApps_app in H. discriminate.
   - depelim He1. 
-  - exists n, f. intuition auto.
+  - exists n, f4. intuition auto.
   - depelim He1. clear -H. symmetry in H. elimtype False.
     destruct args using rev_case. discriminate.
     rewrite EAstUtils.mkApps_app in H. discriminate.


### PR DESCRIPTION
In the final evaluation relation with constructors_as_blocks = true, constant constructors are no longer considered atoms. All constructors go through the eval_construct_block rule which now has an `All2 (eval \Sigma) args args'` premise and we now that constructors are applied exactly to their arity. 
Necessitated fancy dependently-typed programming for the derivation of the nested induction principle, and using an `All2_Set` alias to avoid a flurry of generated hypothesis name changes (eval falls in Set naturally) (very very bad).
Otherwise, it's was a breeze to adapt the proofs.