### PR TITLE
Ewellformed islambda

### DIFF
--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -34,4 +34,5 @@ theories/ERemoveParams.v
 theories/EInlineProjections.v
 theories/ETransform.v
 theories/EConstructorsAsBlocks.v
+theories/EWcbvEvalCstrsAsBlocksInd.v
 theories/Erasure.v

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -281,7 +281,7 @@ Proof.
     + intuition auto.
       apply erases_deps_mkApps_inv in H4.
       now apply Forall_rev, Forall_skipn.
-    + eapply nth_error_forall in e1; [|now eauto].
+    + eapply nth_error_forall in e2; [|now eauto].
       assumption.
   - congruence.
   - depelim er.
@@ -333,7 +333,7 @@ Proof.
     intuition auto.
     apply erases_deps_mkApps_inv in H3 as (? & ?).
     apply IHev2.
-    now eapply nth_error_forall in e2.
+    now eapply nth_error_forall in e3.
   - congruence.
   - constructor.
   - depelim er.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -1391,7 +1391,7 @@ Proof.
     destruct s.
     * destruct p; solve_discr. noconf H3.
       right. len.
-      move: e; unfold isEtaExp_fixapp.
+      move: e1; unfold isEtaExp_fixapp.
       unfold EGlobalEnv.cunfold_fix. destruct nth_error eqn:hnth => //.
       intros [=]. rewrite H3. rewrite -(All2_length a0). eapply Nat.ltb_lt; lia.
     * right. len. eapply isEtaExp_fixapp_mon; tea. lia.
@@ -1403,7 +1403,7 @@ Proof.
     destruct s.
     * destruct p; solve_discr. noconf H2.
       left. split. 
-      unfold isStuckFix'; rewrite e. len. eapply Nat.leb_le. lia.
+      unfold isStuckFix'; rewrite e1. len. eapply Nat.leb_le. lia.
       now rewrite -[tApp _ _](mkApps_app _ _ [av]).
     * right. len. eapply isEtaExp_fixapp_mon; tea. lia.
   + eapply mkApps_eq in H1 as [? []] => //; subst.
@@ -1570,7 +1570,7 @@ Proof.
   - pose proof (eval_trans' H H0_0). subst a'. econstructor; tea.
   - pose proof (eval_trans' H H0_0). subst av. eapply eval_fix; tea.
   - pose proof (eval_trans' H H0_0). subst av. eapply eval_fix_value; tea.
-  - eapply value_final in X. pose proof (eval_trans' X H0_). subst f.
+  - eapply value_final in X. pose proof (eval_trans' X H0_). subst f7.
     pose proof (eval_trans' H H0_0). subst av.
     eapply eval_fix'; tea.
   - eapply eval_construct; tea.
@@ -1853,7 +1853,7 @@ Proof.
       rewrite (remove_last_last l0 a hl).
       rewrite -[tApp _ _](mkApps_app _ _ [a']).
       eapply eval_mkApps_Construct; tea.  
-      { constructor. cbn [atom]; rewrite e0 //. }
+      { constructor. cbn [atom]; rewrite e e0 //. }
       { len. rewrite (All2_length hargs). lia. }
       eapply All2_app.
       eapply forallb_remove_last, forallb_All in etal.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -112,7 +112,11 @@ Section optimize.
 
   (* move to globalenv *)
 
-
+  Lemma isLambda_optimize t : isLambda t -> isLambda (optimize t).
+  Proof. destruct t => //. Qed.
+  Lemma isBox_optimize t : isBox t -> isBox (optimize t).
+  Proof. destruct t => //. Qed.
+  
   Lemma wf_optimize t k : 
     wf_glob Σ ->
     wellformed Σ k t -> wellformed Σ k (optimize t).
@@ -135,6 +139,7 @@ Section optimize.
       rewrite IHt //=; len. apply Nat.ltb_lt.
       lia.
     - len. rtoProp; solve_all. rewrite forallb_map; solve_all.
+      now eapply isLambda_optimize. solve_all.
     - len. rtoProp; solve_all. rewrite forallb_map; solve_all.
   Qed.
  
@@ -161,7 +166,7 @@ Section optimize.
       have arglen := wellformed_projection_args wfΣ hl.
       case: Nat.compare_spec. lia. lia.
       auto.
-    - f_equal. move/andP: wft => [hidx hb].
+    - f_equal. move/andP: wft => [hlam /andP[] hidx hb].
       solve_all. unfold map_def. f_equal.
       eapply a0. now rewrite -Nat.add_assoc.
     - f_equal. move/andP: wft => [hidx hb].
@@ -222,7 +227,7 @@ Section optimize.
     intros wfΣ hfix.
     unfold cunfold_fix.
     rewrite nth_error_map.
-    cbn in hfix. move/andP: hfix => [] hidx hfix. 
+    cbn in hfix. move/andP: hfix => [] hlam /andP[] hidx hfix. 
     destruct nth_error eqn:hnth => //.
     intros [= <- <-] => /=. f_equal.
     rewrite optimize_substl //. eapply wellformed_fix_subst => //.
@@ -680,11 +685,6 @@ Qed.
 
 From MetaCoq.Erasure Require Import EEtaExpanded.
 
-Lemma isLambda_optimize Σ t : isLambda t -> isLambda (optimize Σ t).
-Proof. destruct t => //. Qed.
-Lemma isBox_optimize Σ t : isBox t -> isBox (optimize Σ t).
-Proof. destruct t => //. Qed.
-
 Lemma optimize_expanded {Σ : GlobalContextMap.t} t : expanded Σ t -> expanded Σ (optimize Σ t).
 Proof.
   induction 1 using expanded_ind.
@@ -829,7 +829,7 @@ Proof.
     rewrite hrel IHt //= andb_true_r.
     have hargs' := wellformed_projection_args wfΣ hl'.
     apply Nat.ltb_lt. len.
-  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now eapply isLambda_optimize. now len.
     unfold test_def in *. len. eauto.
   - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
     unfold test_def in *. len. eauto.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -512,23 +512,23 @@ Proof.
     eapply nth_error_forallb in wfbrs; tea.
     rewrite Nat.add_0_r in wfbrs.
     forward IHev2. eapply wellformed_iota_red; tea => //.
-    rewrite optimize_iota_red in IHev2 => //. now rewrite e3.
+    rewrite optimize_iota_red in IHev2 => //. now rewrite e4.
     econstructor; eauto.
     rewrite -is_propositional_cstr_optimize //. tea.
-    rewrite nth_error_map e1 //. len. len.
+    rewrite nth_error_map e2 //. len. len.
 
   - congruence.
 
   - move/andP => [] /andP[] hl wfd wfbrs.
     forward IHev2. eapply wellformed_substl; tea => //.
     rewrite forallb_repeat //. len.
-    rewrite e0 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
+    rewrite e1 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
     rewrite optimize_substl in IHev2 => //.
     rewrite forallb_repeat //. len.
-    rewrite e0 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
+    rewrite e1 /= Nat.add_0_r in wfbrs. now move/andP: wfbrs.
     eapply eval_iota_sing => //; eauto.
     rewrite -is_propositional_optimize //.
-    rewrite e0 //. simpl.
+    rewrite e1 //. simpl.
     rewrite map_repeat in IHev2 => //.
 
   - move/andP => [] clf cla. rewrite optimize_mkApps in IHev1.
@@ -600,7 +600,7 @@ Proof.
     move/wf_mkApps: ev1 => [] wfc wfargs.
     destruct lookup_projection as [[[[mdecl idecl] cdecl'] pdecl]|] eqn:hl' => //.
     pose proof (lookup_projection_lookup_constructor hl').
-    rewrite (constructor_isprop_pars_decl_constructor H) in e0. noconf e0.
+    rewrite (constructor_isprop_pars_decl_constructor H) in e1. noconf e1.
     forward IHev1 by auto.
     forward IHev2. eapply nth_error_forallb in wfargs; tea.
     rewrite optimize_mkApps /= in IHev1.
@@ -617,11 +617,11 @@ Proof.
     rewrite nth_error_rev. len. rewrite skipn_length. lia. 
     rewrite List.rev_involutive. len. rewrite skipn_length.
     rewrite nth_error_skipn nth_error_map.
-    rewrite e1 -H1.
+    rewrite e2 -H1.
     assert((ind_npars mdecl + cstr_nargs cdecl - ind_npars mdecl) = cstr_nargs cdecl) by lia.
     rewrite H3.
-    eapply (f_equal (option_map (optimize Σ))) in e2.
-    cbn in e2. rewrite -e2. f_equal. f_equal. lia.
+    eapply (f_equal (option_map (optimize Σ))) in e3.
+    cbn in e3. rewrite -e3. f_equal. f_equal. lia.
 
   - congruence.
 
@@ -630,7 +630,7 @@ Proof.
     destruct lookup_projection as [[[[mdecl idecl] cdecl'] pdecl]|] eqn:hl' => //.
     pose proof (lookup_projection_lookup_constructor hl').
     simpl in H. 
-    move: e. rewrite /inductive_isprop_and_pars.
+    move: e0. rewrite /inductive_isprop_and_pars.
     rewrite (lookup_constructor_lookup_inductive H) /=.
     intros [= eq <-].
     eapply eval_iota_sing => //; eauto.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -856,7 +856,7 @@ Proof.
   - cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/andP => [] /andP[]hasc hs ht.
     destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
     all:rewrite hasc hs /=; eauto.
-  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now eapply isLambda_optimize. now len.
     unfold test_def in *. len. eauto.
   - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len.
     unfold test_def in *. len. eauto.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -551,11 +551,11 @@ Proof.
     rewrite optimize_iota_red in IHev2.
     eapply eval_closed in ev1 => //.
     rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (constructor_isprop_pars_decl_inductive e0).
+    rewrite (constructor_isprop_pars_decl_inductive e1).
     eapply eval_iota; eauto.
     now rewrite -is_propositional_cstr_optimize.
-    rewrite nth_error_map e1 //. now len. cbn.
-    rewrite -e3. rewrite !skipn_length map_length //.
+    rewrite nth_error_map e2 //. now len. cbn.
+    rewrite -e4. rewrite !skipn_length map_length //.
     eapply IHev2.
     eapply closed_iota_red => //; tea.
     eapply nth_error_forallb in clbrs; tea. cbn in clbrs.
@@ -565,7 +565,7 @@ Proof.
   
   - move/andP => [] cld clbrs.
     rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite e e0 /=.
+    rewrite e0 e1 /=.
     subst brs. cbn in clbrs. rewrite Nat.add_0_r andb_true_r in clbrs.
     rewrite optimize_substl in IHev2. 
     eapply All_forallb, All_repeat => //.
@@ -660,19 +660,19 @@ Proof.
     eapply eval_closed in ev1; tea.
     move: ev1; rewrite closedn_mkApps /= => clargs.
     rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    rewrite (constructor_isprop_pars_decl_inductive e0).
+    rewrite (constructor_isprop_pars_decl_inductive e1).
     rewrite optimize_mkApps in IHev1.
     specialize (IHev1 cld).
     eapply Ee.eval_proj; tea.
     now rewrite -is_propositional_cstr_optimize.
-    now len. rewrite nth_error_map e2 //.
+    now len. rewrite nth_error_map e3 //.
     eapply IHev2.
-    eapply nth_error_forallb in e2; tea.
+    eapply nth_error_forallb in e3; tea.
 
   - congruence.
 
   - rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
-    now rewrite e.
+    now rewrite e0.
 
   - move/andP=> [] clf cla.
     rewrite optimize_mkApps.

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -791,7 +791,7 @@ Proof.
     rewrite vc. rewrite -mkApps_app !map_app //. 
 Qed.
 
-#[export] Instance Qpreserves_closedn (efl := all_env_flags) Σ : closed_env Σ ->
+ #[export] Instance Qpreserves_closedn (efl := all_env_flags) Σ : closed_env Σ ->
   Qpreserves (fun n x => closedn n x) Σ.
 Proof.
   intros clΣ.
@@ -816,22 +816,22 @@ Proof.
   - red. move=> t args clt cll.
     eapply closed_substl. solve_all. now rewrite Nat.add_0_r.
   - red. move=> n mfix idx. cbn.
-    split; intros; rtoProp; intuition auto; solve_all.
+    intros; rtoProp; intuition auto; solve_all.
   - red. move=> n mfix idx. cbn.
     split; intros; rtoProp; intuition auto; solve_all.
 Qed.
 
 Lemma strip_eval (efl := all_env_flags) {wfl:WcbvFlags} {wcon : with_constructor_as_block = false} {Σ : GlobalContextMap.t} t v :
-  closed_env Σ ->
   isEtaExp_env Σ ->
+  closed_env Σ ->
   wf_glob Σ ->
-  eval Σ t v ->
-  closed t ->
+  closedn 0 t ->
   isEtaExp Σ t ->
+  eval Σ t v ->
   eval (strip_env Σ) (strip Σ t) (strip Σ v).
 Proof.
-  intros clΣ etaΣ wfΣ ev clt etat.
-  revert t v clt etat ev.
+  intros etaΣ clΣ wfΣ.
+  revert t v.
   unshelve eapply (eval_preserve_mkApps_ind wfl wcon Σ (fun x y => eval (strip_env Σ) (strip Σ x) (strip Σ y))
     (fun n x => closedn n x) (Qpres := Qpreserves_closedn Σ clΣ)) => //.
   { intros. eapply eval_closed; tea. }
@@ -1030,6 +1030,7 @@ Proof.
     destruct EAst.ind_ctors => //.
     destruct nth_error => //.
   - unfold wf_fix_gen in *. rewrite map_length. rtoProp; intuition auto. toAll; solve_all.
+    now rewrite -strip_isLambda. toAll; solve_all.
   - unfold wf_fix in *. rewrite map_length; rtoProp; intuition auto. toAll; solve_all.
   - move:H1; rewrite !wellformed_mkApps //. rtoProp; intuition auto.
     toAll; solve_all.

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -965,7 +965,7 @@ Proof.
     rewrite (lookup_constructor_lookup_inductive_pars H).
     eapply eval_mkApps_Construct; tea.
     + rewrite lookup_constructor_strip H //.
-    + constructor. cbn [atom]. rewrite lookup_constructor_strip H //.
+    + constructor. cbn [atom]. rewrite wcon lookup_constructor_strip H //.
     + rewrite /cstr_arity /=.
       move: H0; rewrite /cstr_arity /=.
       rewrite skipn_length map_length => ->. lia.
@@ -1048,10 +1048,11 @@ Proof.
 Qed.
 
 Lemma strip_wellformed_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t :
+  cstr_as_blocks = false ->
   wf_glob Σ ->
   forall n, wellformed Σ n t -> wellformed (strip_env Σ) n t.
 Proof.
-  intros wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
+  intros hcstrs wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
   all:try solve [intros; unfold wf_fix in *; rtoProp; intuition eauto; solve_all].
   - rewrite lookup_env_strip //.
     destruct lookup_env eqn:hl => // /=.
@@ -1060,13 +1061,7 @@ Proof.
   - rewrite lookup_env_strip //.
     destruct lookup_env eqn:hl => // /=; intros; rtoProp; eauto.
     destruct g eqn:hg => /= //; intros; rtoProp; eauto.
-    destruct cstr_as_blocks; repeat split; eauto.
-    destruct nth_error => /= //.
-    destruct nth_error => /= //.
-    destruct nth_error => /= //.
-    destruct nth_error => /= //. rtoProp. split. solve_all.
-    eapply Nat.leb_le in H0. eapply Nat.leb_le. lia.
-    solve_all.
+    destruct cstr_as_blocks => //; repeat split; eauto.
     destruct nth_error => /= //.
     destruct nth_error => /= //.
   - rewrite lookup_env_strip //.
@@ -1085,10 +1080,11 @@ Proof.
 Qed.
 
 Lemma strip_wellformed_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} d :
+  cstr_as_blocks = false ->
   wf_glob Σ ->
   wf_global_decl Σ d -> wf_global_decl (strip_env Σ) d.
 Proof.
-  intros wf; destruct d => /= //.
+  intros hcstrs wf; destruct d => /= //.
   destruct (cst_body c) => /= //.
   now eapply strip_wellformed_irrel.
 Qed.

--- a/erasure/theories/ETransform.v
+++ b/erasure/theories/ETransform.v
@@ -165,13 +165,12 @@ Qed.
 
 Next Obligation.
   red. move=> ? wcon [Σ t] /= v [[wfe wft] etap] [ev].
-  eapply ERemoveParams.strip_eval in ev; eauto.
+  unshelve eapply ERemoveParams.strip_eval in ev; eauto.
   eexists; split => /= //. now sq. cbn in *.
-  now eapply wellformed_closed_env.
   now move/andP: etap.
+  now eapply wellformed_closed_env.
   now eapply wellformed_closed.
   now move/andP: etap.
-  Unshelve. auto.
 Qed.
 
 Program Definition remove_params_fast_optimization (fl : EWcbvEval.WcbvFlags) {wcon : EWcbvEval.with_constructor_as_block = false}
@@ -195,14 +194,13 @@ Qed.
 Next Obligation.
   red. move=> ? wcon [Σ t] /= v [[wfe wft] etap] [ev].
   rewrite -ERemoveParams.Fast.strip_fast -ERemoveParams.Fast.strip_env_fast.
-  eapply ERemoveParams.strip_eval in ev; eauto.
+  unshelve eapply ERemoveParams.strip_eval in ev; eauto.
   eexists; split => /= //.
   now sq. cbn in *.
-  now eapply wellformed_closed_env.
   now move/andP: etap.
+  now eapply wellformed_closed_env.
   now eapply wellformed_closed.
   now move/andP: etap.
-  Unshelve. auto.
 Qed.
 
 Import EOptimizePropDiscr EWcbvEval.
@@ -263,7 +261,7 @@ Program Definition constructors_as_blocks_transformation (efl := env_flags)
     transform p _ := EConstructorsAsBlocks.transform_blocks_program p ; 
     pre p := wf_eprogram_env efl p /\ EEtaExpanded.expanded_eprogram_env_cstrs p;
     post p := wf_eprogram env_flags_blocks p ;
-    obseq g g' v v' := True |}.
+    obseq g g' v v' := v' = EConstructorsAsBlocks.transform_blocks g.1 v |}.
 
 Next Obligation.
   move=> efl hastrel hastbox [Σ t] [] [wftp wft] /andP [etap etat]. 
@@ -275,6 +273,8 @@ Next Obligation.
   red. move=> hastrel hastbox [Σ t] /= v [[wfe1 wfe2] wft] [ev].
   eexists. split; [ | eauto].
   unfold EEtaExpanded.expanded_eprogram_env_cstrs in *.
-  revert wft. move => /andP // [e1 e2]. cbn in *.
-  econstructor. eapply transform_blocks_eval; cbn; eauto.
+  revert wft. move => /andP // [e1 e2]. 
+  econstructor. 
+  cbn -[transform_blocks].
+  eapply transform_blocks_eval; cbn; eauto.
 Qed.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1639,7 +1639,7 @@ Proof.
     rewrite wellformed_mkApps // clargs andb_true_r.
     eapply wellformed_cunfold_fix; tea => //.
   - eapply IHev3 => //. rtoProp; intuition auto.
-    eapply wellformed_cunfold_fix => //; tea. cbn. rewrite H H1 //.
+    eapply wellformed_cunfold_fix => //; tea. cbn. rewrite H H1 H2 //.
   - eapply IHev2. rewrite wellformed_mkApps //.
     rewrite wellformed_mkApps // in H2. 
     move/andP: H2 => [Hfix Hargs].

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1613,11 +1613,10 @@ Ltac sim := repeat (cbn ; autorewrite with simplifications).
 
 Lemma eval_wellformed {efl : EEnvFlags} {wfl : WcbvFlags} Σ : 
   forall (has_app : has_tApp), (* necessary due to mkApps *)
-  efl.(@cstr_as_blocks) = false ->
   wf_glob Σ ->
   forall t u, wellformed Σ 0 t -> eval Σ t u -> wellformed Σ 0 u.
 Proof.
-  move=> has_app blcks clΣ t u Hc ev. move: Hc.
+  move=> has_app clΣ t u Hc ev. move: Hc.
   induction ev; simpl in *; auto;
     (move/andP=> [/andP[Hc Hc'] Hc''] || move/andP=> [Hc Hc'] || move=>Hc); auto.
   all:intros; intuition auto; rtoProp; intuition auto; rtoProp; eauto using wellformed_csubst.
@@ -1662,7 +1661,13 @@ Proof.
     destruct lookup_constructor_pars_args as [ [] | ]; rtoProp; repeat solve_all.   
     destruct args; cbn in H0; eauto.
   - destruct cstr_as_blocks; try congruence.
-    destruct args; invs Hc''. now depelim a.
+    destruct lookup_constructor_pars_args as [ [] | ]; rtoProp; repeat solve_all.
+    now rewrite (All2_length a) in H.
+    eapply All2_over_impl in iha; tea.
+    intuition auto.
+    eapply All2_over_impl in iha; tea.
+    intuition auto.
+    depelim a => //.
 Qed.
 
 Lemma remove_last_length {X} {l : list X} : 

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
@@ -1,0 +1,487 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import Utf8 Program ssreflect ssrbool.
+From MetaCoq.Template Require Import config utils Kernames BasicAst EnvMap.
+From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst EWcbvEval EGlobalEnv
+  EWellformed ECSubst EInduction EWcbvEvalInd EEtaExpanded.
+
+Set Asymmetric Patterns.
+From Equations Require Import Equations.
+Set Equations Transparent.
+Local Set Keyed Unification.
+
+#[export]
+Hint Constructors eval : core.
+
+Definition atomic_term (t : term) :=
+  match t with
+  | tBox | tConst _ | tRel _ | tVar _ => true
+  | _ => false
+  end.
+
+Definition has_atom {etfl : ETermFlags} (t : term) :=
+  match t with
+  | tBox => has_tBox
+  | tConst _ => has_tConst
+  | tRel _ => has_tRel
+  | tVar _ => has_tVar
+  | _ => false
+  end.
+
+Section OnSubterm.
+  Context {etfl : ETermFlags}.
+  Inductive on_subterms (Q : nat -> term -> Type) (n : nat) : term -> Type :=
+  | on_atom t : has_atom t -> atomic_term t -> on_subterms Q n t
+  | on_evar k l : has_tEvar -> All (Q n) l -> on_subterms Q n (tEvar k l)
+  | on_lambda na t : has_tLambda -> Q (S n) t -> on_subterms Q n (tLambda na t)
+  | on_letin na t u : has_tLetIn -> Q n t -> Q (S n) u -> on_subterms Q n (tLetIn na t u)
+  | on_app f u : has_tApp -> Q n f -> Q n u -> on_subterms Q n (tApp f u)
+  | on_cstr i k args : has_tConstruct -> All (Q n) args -> on_subterms Q n (tConstruct i k args) 
+  | on_case ci discr brs : has_tCase -> Q n discr -> 
+    All (fun br => Q (#|br.1| + n) br.2) brs -> on_subterms Q n (tCase ci discr brs)
+  | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
+  | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
+  | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx).
+  Derive Signature for on_subterms.
+End OnSubterm.
+
+Class Qpres {etfl : ETermFlags} (Q : nat -> term -> Type) := qpres : forall n t, Q n t -> on_subterms Q n t.
+#[export] Hint Mode Qpres - ! : typeclass_instances.
+
+Class Qapp {etfl : ETermFlags} (Q : nat -> term -> Type) := qapp : has_tApp -> forall n f args, Q n (mkApps f args) <~> Q n f × All (Q n) args.
+#[export] Hint Mode Qapp - ! : typeclass_instances.
+
+Class Qcase {etfl : ETermFlags} (Q : nat -> term -> Type) := qcase : has_tCase -> 
+  forall n ci discr brs, Q n (tCase ci discr brs) -> forall discr', Q n discr' -> Q n (tCase ci discr' brs).
+#[export] Hint Mode Qcase - ! : typeclass_instances.
+
+(* Class Qcstr {etfl : ETermFlags} (Q : nat -> term -> Type) := *)
+  (* qcstr : has_tConstruct -> forall i n args, Q n (tConstruct i n args)   Q n discr × All (fun br => Q (#|br.1| + n) br.2) brs. *)
+(* #[export] Hint Mode Qcase - ! : typeclass_instances. *)
+
+Class Qproj {etfl : ETermFlags} (Q : nat -> term -> Type) := qproj : has_tProj -> forall n p discr, Q n (tProj p discr) -> forall discr', Q n discr' -> Q n (tProj p discr').
+#[export] Hint Mode Qproj - ! : typeclass_instances.
+
+Class Qfix {etfl : ETermFlags} (Q : nat -> term -> Type) := qfix : has_tFix -> forall n mfix idx, idx < #|mfix| -> Q n (tFix mfix idx) -> forall idx', idx' < #|mfix| -> Q n (tFix mfix idx').
+#[export] Hint Mode Qfix - ! : typeclass_instances.
+Class Qcofix {etfl : ETermFlags} (Q : nat -> term -> Type) := qcofix : has_tCoFix -> forall n mfix idx, idx < #|mfix| -> Q n (tCoFix mfix idx) -> forall idx', idx' < #|mfix| -> Q n (tCoFix mfix idx').
+#[export] Hint Mode Qcofix - ! : typeclass_instances.
+Class Qsubst (Q : nat -> term -> Type) := qsubst : forall t l, Q (#|l|) t -> All (Q 0) l -> Q 0 (substl l t).
+#[export] Hint Mode Qsubst ! : typeclass_instances.
+Class Qfixs (Q : nat -> term -> Type) := qfixs : forall mfix idx, Q 0 (tFix mfix idx) -> 
+    forall args fn, cunfold_fix mfix idx = Some (args, fn) ->
+    Q 0 fn.
+#[export] Hint Mode Qfixs ! : typeclass_instances.
+Class Qcofixs (Q : nat -> term -> Type) := qcofixs : forall mfix idx, Q 0 (tCoFix mfix idx) -> 
+  forall args fn, cunfold_cofix mfix idx = Some (args, fn) ->
+  Q 0 fn.
+#[export] Hint Mode Qcofixs ! : typeclass_instances.
+      
+Lemma Qfix_subst {etfl : ETermFlags} mfix Q : has_tFix -> Qfix Q -> Qpres Q -> forall idx, idx < #|mfix| -> Q 0 (tFix mfix idx) -> All (Q 0) (fix_subst mfix).
+Proof.
+  intros hasfix qfix qpre; unfold fix_subst.
+  generalize (Nat.le_refl #|mfix|).
+  generalize #|mfix| at 1 4.
+  induction n. intros. constructor; auto.
+  intros. constructor. eapply qfix => //. 2:tea. tea. 
+  eapply IHn. lia. 2:tea. assumption.
+Qed.
+
+Lemma Qcofix_subst {etfl : ETermFlags} mfix Q : has_tCoFix -> Qcofix Q -> Qpres Q -> forall idx, idx < #|mfix| -> Q 0 (tCoFix mfix idx) -> All (Q 0) (cofix_subst mfix).
+Proof.
+  intros hascofix qcofix qpre; unfold cofix_subst.
+  generalize (Nat.le_refl #|mfix|).
+  generalize #|mfix| at 1 4.
+  induction n. intros. constructor; auto.
+  intros. constructor. eapply qcofix => //. 2:tea. tea. 
+  eapply IHn. lia. 2:tea. assumption.
+Qed.
+
+#[export] Instance Qsubst_Qfixs {etfl : ETermFlags} Q : Qpres Q -> Qfix Q -> Qsubst Q -> Qfixs Q.
+Proof.
+  move=> qpres qfix; rewrite /Qsubst /Qfixs.
+  intros Hs mfix idx hfix args fn.
+  assert (hasfix : has_tFix).
+  { eapply qpres in hfix. now depelim hfix. }
+  rewrite /cunfold_fix.
+  destruct nth_error eqn:hnth => //.
+  pose proof (nth_error_Some_length hnth).
+  epose proof (Qfix_subst _ _ hasfix qfix qpres idx H hfix).
+  intros [= <-]. subst fn.
+  eapply Hs. rewrite fix_subst_length //.
+  eapply qpres in hfix. depelim hfix. depelim i0. eapply nth_error_all in a; tea. now rewrite Nat.add_0_r in a.
+  assumption.
+Qed.
+  
+#[export] Instance Qsubst_Qcofixs {etfl : ETermFlags} Q : Qpres Q -> Qcofix Q -> Qsubst Q -> Qcofixs Q.
+Proof.
+  move=> qpres qfix; rewrite /Qsubst /Qfixs.
+  intros Hs mfix idx hfix args fn.
+  assert (hasfix : has_tCoFix).
+  { eapply qpres in hfix. now depelim hfix. }
+  rewrite /cunfold_cofix.
+  destruct nth_error eqn:hnth => //.
+  pose proof (nth_error_Some_length hnth).
+  epose proof (Qcofix_subst _ _ hasfix qfix qpres idx H hfix).
+  intros [= <-]. subst fn.
+  eapply Hs. rewrite cofix_subst_length //.
+  eapply qpres in hfix. depelim hfix. depelim i0. eapply nth_error_all in a; tea. now rewrite Nat.add_0_r in a.
+  assumption.
+Qed.
+  
+Class Qconst Σ (Q : nat -> term -> Type) := qconst :
+  ∀ kn decl, declared_constant Σ kn decl → 
+    match cst_body decl with
+    | None => unit
+    | Some b => Q 0 b
+    end.
+#[export] Hint Mode Qconst - ! : typeclass_instances.
+
+Set Warnings "-future-coercion-class-field".
+Class Qpreserves {etfl : ETermFlags} (Q : nat -> term -> Type) Σ :=
+  { qpres_qpres :> Qpres Q;
+    qpres_qcons :> Qconst Σ Q;
+    qpres_qapp :> Qapp Q;
+    qpres_qcase :> Qcase Q;
+    qpres_qproj :> Qproj Q;
+    qpres_qsubst :> Qsubst Q;
+    qpres_qfix :> Qfix Q;
+    qpres_qcofix :> Qcofix Q }.
+Set Warnings "+future-coercion-class-field".
+
+Lemma eval_preserve_mkApps_ind :
+∀ (wfl : WcbvFlags), with_constructor_as_block = true -> forall  {efl : EEnvFlags} (Σ : global_declarations) 
+  (P' : term → term → Type)
+  (Q : nat -> term -> Type)
+  {Qpres : Qpreserves Q Σ}
+  (P := (fun x y => [× P' x y, Q 0 x & Q 0 y])%type)
+  (HPQ : ∀ t u, eval Σ t u -> Q 0 t -> P' t u -> Q 0 u),
+  wf_glob Σ ->
+  has_tApp ->
+  (∀ (a t t' : term),
+	 eval Σ a tBox ->
+     P a tBox →
+     eval Σ t t' → P t t' → P' (tApp a t) tBox) → 
+  (∀ (f0 : term) (na : name) (b a a' res : term),
+      eval Σ f0 (tLambda na b) → 
+      P f0 (tLambda na b)
+         → eval Σ a a'
+           → P a a'
+             → eval Σ (ECSubst.csubst a' 0 b) res
+          → P (ECSubst.csubst a' 0 b) res → P' (tApp f0 a) res)
+    → (∀ (na : name) (b0 b0' b1 res : term),
+         eval Σ b0 b0'
+         → P b0 b0'
+         -> Q 1 b1
+           → eval Σ (ECSubst.csubst b0' 0 b1) res
+             → P (ECSubst.csubst b0' 0 b1) res → 
+             P' (tLetIn na b0 b1) res)
+      → (∀ (ind : inductive) (pars : nat) cdecl (discr : term) 
+           (c : nat) (args : list term) (brs : 
+                                              list 
+                                                (list name × term)) 
+           (br : list name × term) (res : term),
+           eval Σ discr (tConstruct ind c args)
+           → P discr (tConstruct ind c args)
+           → constructor_isprop_pars_decl Σ ind c = Some (false, pars, cdecl)
+               → nth_error brs c = Some br
+               → #|args| = pars + cdecl.(cstr_nargs) 
+                 → #|skipn pars args| = #|br.1|
+                 -> Q #|br.1| br.2
+                   → eval Σ (iota_red pars args br) res
+                     → P (iota_red pars args br) res
+                       → P' (tCase (ind, pars) discr brs) res)
+        → (∀ (ind : inductive) (pars : nat) (discr : term) 
+             (brs : list (list name × term)) 
+             (n : list name) (f3 res : term),
+             with_prop_case
+             → eval Σ discr tBox
+               → P discr tBox
+                 → inductive_isprop_and_pars Σ ind = Some (true, pars)
+                   → brs = [(n, f3)]
+                   -> Q #|n| f3
+                     → eval Σ (ECSubst.substl (repeat tBox #|n|) f3)
+                         res
+                       → P (ECSubst.substl (repeat tBox #|n|) f3) res
+                         → P' (tCase (ind, pars) discr brs) res)
+          → (∀ (f4 : term) (mfix : mfixpoint term) 
+               (idx : nat) (argsv : list term) 
+               (a av fn res : term),
+               with_guarded_fix ->
+               eval Σ f4 (mkApps (tFix mfix idx) argsv)
+               → P f4 (mkApps (tFix mfix idx) argsv)
+                 → eval Σ a av
+                   → P a av
+                     → cunfold_fix mfix idx = Some (#|argsv|, fn)
+                     -> Q 0 fn
+                      → eval Σ (tApp (mkApps fn argsv) av) res
+                         → P (tApp (mkApps fn argsv) av) res
+                           → P' (tApp f4 a) res)
+            → (∀ (f5 : term) (mfix : mfixpoint term) 
+                 (idx : nat) (argsv : list term) 
+                 (a av : term) (narg : nat) (fn : term),
+                 with_guarded_fix ->
+                 eval Σ f5 (mkApps (tFix mfix idx) argsv)
+                 → P f5 (mkApps (tFix mfix idx) argsv)
+                   → eval Σ a av
+                     → P a av
+                       → cunfold_fix mfix idx = Some (narg, fn)
+                         → #|argsv| < narg
+                           → P' (tApp f5 a)
+                               (tApp
+                                  (mkApps (tFix mfix idx) argsv) av))
+            → (∀ (f5 : term) (mfix : mfixpoint term) 
+            (idx : nat) (a av : term) (narg : nat) (fn : term) res,
+            with_guarded_fix = false ->
+            eval Σ f5 (tFix mfix idx)
+            → P f5 (tFix mfix idx)
+              → cunfold_fix mfix idx = Some (narg, fn)
+              -> eval Σ a av -> P a av
+              → eval Σ (tApp fn av) res
+              → P (tApp fn av) res
+              → P' (tApp f5 a) res) → 
+              
+              (∀ (ip : inductive × nat) (mfix : mfixpoint term) 
+                   (idx : nat) (args : list term) 
+                   (narg : nat) discr (fn : term) (brs : 
+                                                 list 
+                                                 (list name × term)) 
+                   (res : term),
+                   cunfold_cofix mfix idx = Some (narg, fn)
+                   -> eval Σ discr (mkApps (tCoFix mfix idx) args)
+                   -> P discr (mkApps (tCoFix mfix idx) args)
+                   → eval Σ (tCase ip (mkApps fn args) brs) res
+                     → P (tCase ip (mkApps fn args) brs) res
+                       → P'
+                           (tCase ip discr brs)
+                           res)
+                → (∀ (p : projection) (mfix : mfixpoint term) 
+                     (idx : nat) (args : list term) 
+                     (narg : nat) discr (fn res : term),
+                     has_tProj ->
+                     cunfold_cofix mfix idx = Some (narg, fn)
+                     -> eval Σ discr (mkApps (tCoFix mfix idx) args)
+                     -> P discr (mkApps (tCoFix mfix idx) args)
+                     → eval Σ (tProj p (mkApps fn args)) res
+                       → P (tProj p (mkApps fn args)) res
+                         → P'
+                             (tProj p discr) res)
+                  → (∀ (c : kername) (decl : constant_body) 
+                       (body : term),
+                       declared_constant Σ c decl
+                       → ∀ res : term,
+                           cst_body decl = Some body
+                           → eval Σ body res
+                             → P body res → P' (tConst c) res)
+                    → (∀ p cdecl (discr : term) (args : list term) a (res : term),
+                         has_tProj ->
+                         eval Σ discr (tConstruct p.(proj_ind) 0 args)
+                         → P discr (tConstruct p.(proj_ind) 0 args)
+                         → constructor_isprop_pars_decl Σ p.(proj_ind) 0 = Some (false, p.(proj_npars), cdecl) 
+                         → #|args| = p.(proj_npars) + cdecl.(cstr_nargs)
+                         -> nth_error args (p.(proj_npars) + p.(proj_arg)) = Some a
+                         -> eval Σ a res
+                         → P a res
+                         → P' (tProj p discr) res)
+                      → (∀ p (discr : term),
+                           has_tProj ->
+                           with_prop_case
+                           → eval Σ discr tBox
+                             → P discr tBox
+                               → inductive_isprop_and_pars Σ p.(proj_ind) = Some (true, p.(proj_npars))
+                                 → P' (tProj p discr) tBox) →
+  (∀ (f11 f' : term) a a',
+     forall (ev : eval Σ f11 f'), 
+     P f11 f' ->  
+     (forall t u (ev' : eval Σ t u), eval_depth ev' <= eval_depth ev -> Q 0 t -> P t u) →
+     ~~ (isLambda f' || (if with_guarded_fix then isFixApp f' else isFix f') || isBox f' || isConstructApp f') → 
+     eval Σ a a' → P a a' → 
+     P' (tApp f11 a) (tApp f' a')) → 
+  (∀ ind i mdecl idecl cdecl args args',
+    lookup_constructor Σ ind i = Some (mdecl, idecl, cdecl) ->
+    #|args| = cstr_arity mdecl cdecl ->
+    All2 (eval Σ) args args' ->
+    All2 P args args' ->
+    P' (tConstruct ind i args) (tConstruct ind i args')) → 
+
+  (∀ t : term, atom Σ t → Q 0 t -> P' t t) ->
+  ∀ (t t0 : term), Q 0 t -> eval Σ t t0 → P' t t0.
+Proof.
+  intros wfl hcon. intros * Qpres P P'Q wfΣ hasapp.
+  assert (qfixs: Qfixs Q) by tc.
+  assert (qcofixs: Qcofixs Q) by tc.
+  intros.
+  pose proof (p := @Fix_F { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
+  specialize (p (MR lt (fun x => eval_depth x.π2.π2.π2))).
+  set(foo := existT _ t (existT _ t0 (existT _ X15 H)) :  { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
+  change t with (projT1 foo).
+  change t0 with (projT1 (projT2 foo)).
+  revert foo.
+  match goal with
+    |- let foo := _ in @?P foo => specialize (p (fun x => P x))
+  end.
+  forward p.
+  2:{ apply p. apply measure_wf, lt_wf. }
+  clear p.
+  rename X15 into qt. rename X13 into Xcappexp.
+  rename X14 into Qatom.
+  clear t t0 qt H.
+  intros (t & t0 & qt & ev). 
+  intros IH.
+  set (IH' t t0 q H := IH (t; t0; q; H)). clearbody IH'; clear IH; rename IH' into IH.
+  cbn in IH. unfold MR in IH; cbn in IH. cbn.
+  Ltac ih := 
+    match goal with 
+    [ IH : forall x y, ?Q 0 x -> _ |- _ ] => unshelve eapply IH; tea; cbn; try lia
+    end.
+  Ltac hp' P'Q := intros ?; repeat split => //; try eapply P'Q; tea.
+  assert (and_assum : forall x y, P' x y ->
+    ((P' x y) -> Q 0 x × Q 0 y) ->
+    P x y).    
+  { intuition auto. red. intuition auto. }
+  Ltac ih' P'Q :=
+    match goal with
+    | [ H : _, IH : forall x y, ?Q 0 x -> _ |- _ ] =>
+      eapply H; tea; (apply and_assum; [ih|hp' P'Q])
+    end.
+  Ltac myt hyp anda P'Q := eapply hyp; tea; (apply and_assum; [ih|hp' P'Q]).
+  
+  destruct ev.
+  1-18:eapply qpres in qt as qt'; depelim qt' => //. 
+  all:try congruence.
+  - eapply X; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (ql : Q 0 (tLambda na b)).
+    { eapply P'Q; tea. ih. }
+    assert (qs: Q 0 (csubst a' 0 b)).
+    { eapply qpres in ql. depelim ql => //.
+      eapply (qsubst b [a']) in q1. now cbn in q1.
+      repeat constructor.
+      eapply P'Q; tea; ih. }
+    eapply X0; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (qs : Q 0 (csubst b0' 0 b1)).
+    { eapply (qsubst b1 [b0']) in q0. now cbn in q0.
+      repeat constructor.
+      eapply P'Q; tea; ih. }
+    eapply X1; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (Q 0 (iota_red pars args br)).
+    { unfold iota_red.
+      eapply nth_error_all in a; tea. cbn in a.
+      rewrite -e3 in a.
+      rewrite -(List.rev_length (skipn pars args)) in a.
+      rewrite Nat.add_0_r in a.
+      eapply (qsubst _ (List.rev (skipn pars args))) in a.
+      2:{ eapply All_rev, All_skipn. 
+        assert (Q 0 (tConstruct ind c args)).
+        eapply P'Q; tea; ih. eapply qpres in X13.
+        depelim X13 => //. }
+      exact a. }
+    eapply nth_error_all in a; tea; cbn. rewrite Nat.add_0_r in a.
+    eapply X2; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (Q 0 (substl (repeat tBox #|n|) f)).
+    { subst brs. eapply All_tip in a. cbn in a.
+      rewrite -(repeat_length tBox #|n|) Nat.add_0_r in a.
+      eapply (qsubst _ (repeat tBox #|n|)) in a => //.
+      eapply All_repeat. eapply P'Q; tea; ih. }
+   eapply X3; tea. 1,3:(apply and_assum; [ih|hp' P'Q]).
+   subst brs. depelim a. now rewrite Nat.add_0_r in q0.
+  - pose proof (ev1' := ev1). eapply P'Q in ev1' => //. 2:{ clear ev1'; ih. }
+    eapply qapp in ev1' as [hfix qargs] => //.
+    assert (hastfix : has_tFix).
+    { eapply qpres in hfix. now depelim hfix. }
+    assert (qf : Q 0 fn).
+    { eapply (qfixs mfix idx) in hfix; tea. }
+    assert (qa : Q 0 (tApp (mkApps fn argsv) av)).
+    { rewrite -[tApp _ _](mkApps_app _ _ [av]).
+      unshelve eapply (qapp _ _ _ _).2; auto.
+      split => //.
+      eapply (qfixs mfix idx) in hfix; tea. 
+      eapply All_app_inv => //. eapply All_tip.1.
+      eapply P'Q; tea; ih. }
+    eapply X4; tea. 1-3:(apply and_assum; [ih|hp' P'Q]).
+  - eapply X5; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (qav : Q 0 av).
+    { eapply P'Q; tea; ih. }
+    assert (qa : Q 0 (tApp fn av)).
+    { pose proof (ev1' := ev1). eapply P'Q in ev1' => //. 2:clear ev1'; ih.
+      eapply qfixs in ev1'. cbn in IH. eapply ev1' in e.
+      unshelve eapply (qapp _ _ _ [av]); tea; split => //. now eapply All_tip.1. }
+    eapply X6; tea. 1-3:(apply and_assum; [ih|hp' P'Q]).
+  - assert (qa : Q 0 (tCase ip (mkApps fn args) brs)).
+    { eapply qcase; tea => //.
+      pose proof (ev1' := ev1). eapply P'Q in ev1' => //.
+      eapply qapp in ev1' as [hfix qargs] => //.
+      eapply qapp => //. split => //.
+      eapply (qcofixs mfix idx) in hfix; tea. 
+      clear ev1'; ih. }
+    eapply X7; tea; (apply and_assum; [ih|hp' P'Q]).
+  - cbn in IH.
+    assert (qa : Q 0 (tProj p (mkApps fn args))).
+    { pose proof (ev1' := ev1). eapply P'Q in ev1' => //.
+      eapply qapp in ev1' as [hfix ?] => //.
+      eapply qproj; tea => //. eapply qapp => //. split => //.
+      eapply (qcofixs mfix idx) in hfix; tea.
+      clear ev1'; ih. }
+    eapply X8; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (Q 0 body).
+    { cbn in IH; eapply (qconst (Q:=Q)) in isdecl. now rewrite e in isdecl. }
+    eapply X9; tea; (apply and_assum; [ih|hp' P'Q]).
+  - assert (Q 0 a).
+    { pose proof (ev1' := ev1). eapply P'Q in ev1' => //.
+      eapply qpres in ev1'; depelim ev1' => //.
+      { eapply nth_error_all in a0; tea. }
+      clear ev1'; ih. }
+    eapply X10; tea; (apply and_assum; [ih|hp' P'Q]).
+  - unshelve eapply X11; tea; try (intros; apply and_assum; [ih|hp' P'Q]).
+  - rename args into cargs.
+    eapply Xcappexp; tea. eauto.
+    cbn in IH.
+    clear -P'Q IH a a0 and_assum.
+    revert a0; induction a; constructor; auto. depelim a0.
+    apply and_assum; [ih|hp' P'Q].
+    eapply IHa. cbn. intros. eapply (IH _ _ q H). cbn. lia.
+    now depelim a0.
+  - eapply (X12 _ _ _ _ ev1); tea. 
+    1,3:(apply and_assum; [ih|hp' P'Q]).
+    intros. apply and_assum; [ih|hp' P'Q].
+  - eapply Qatom; tea.
+Qed.
+
+Lemma Qpreserves_wellformed (efl : EEnvFlags) Σ : wf_glob Σ -> Qpreserves (fun n x => wellformed Σ n x) Σ.
+Proof.
+  intros clΣ.
+  split.
+  - red. move=> n t.
+    destruct t; cbn -[lookup_constructor lookup_constructor_pars_args]; intuition auto; try solve [constructor; auto].
+    rtoProp; intuition auto.
+    constructor => //.
+    eapply on_evar; rtoProp; intuition auto. solve_all.
+    eapply on_lambda;rtoProp;  intuition auto. 
+    eapply on_letin; rtoProp; intuition auto.
+    eapply on_app; rtoProp; intuition auto.
+    constructor => //; rtoProp; intuition auto.
+    move/andP: H => [] /andP[] has isl hf => //.
+    eapply on_cstr => //. destruct cstr_as_blocks.
+    rtoProp; intuition auto. solve_all. destruct l => //.
+    eapply on_case; rtoProp; intuition auto. solve_all.
+    eapply on_proj; rtoProp; intuition auto.
+    rtoProp; intuition auto.
+    eapply on_fix => //. move/andP: H0 => [] _ ha. solve_all.
+    rtoProp; intuition auto.
+    eapply on_cofix => //. move/andP: H0 => [] _ ha. solve_all.
+  - red. intros kn decl.
+    move/(lookup_env_wellformed clΣ).
+    unfold wf_global_decl. destruct cst_body => //.
+  - red. move=> hasapp n t args. rewrite wellformed_mkApps //. 
+    split; intros; rtoProp; intuition auto; solve_all.
+  - red.
+    move=> hascase n ci discr brs. simpl.
+    destruct lookup_inductive eqn:hl => /= //.
+    intros; rtoProp; intuition auto; solve_all.
+  - red. simpl. move=> hasproj n p discr wf discr' wf'.
+    simpl. rtoProp; intuition auto.
+  - red. move=> t args clt cll.
+    eapply wellformed_substl. solve_all. now rewrite Nat.add_0_r.
+  - red. move=> n mfix idx. cbn. unfold EWellformed.wf_fix.
+    intros; rtoProp; intuition auto; solve_all. now apply Nat.ltb_lt.
+  - red. move=> n mfix idx. cbn. unfold EWellformed.wf_fix.
+    intros; rtoProp; intuition auto; solve_all. now apply Nat.ltb_lt.
+Qed.

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -219,22 +219,14 @@ Section eval_mkApps_rect.
                    (c : nat) (mdecl : mutual_inductive_body) 
                    (idecl : one_inductive_body) 
                    (cdecl : constructor_body) 
-                   (args args' : 
-                    list term) (a a' : term) 
+                   (args args' : list term)
                    (e : with_constructor_as_block = true) 
                    (e0 : lookup_constructor Σ ind c =
                          Some (mdecl, idecl, cdecl)) 
-                   (l : #|args| < cstr_arity mdecl cdecl) 
-                   (e1 : eval Σ 
-                           (tConstruct ind c args)
-                           (tConstruct ind c args')),
-                   P (tConstruct ind c args)
-                     (tConstruct ind c args') 
-                   → ∀ e2 : eval Σ a a',
-                       P a a' 
-                       → P (tConstruct ind c (args ++ [a]))
-                           (tConstruct ind c
-                              (args' ++ [a'])))
+                   (l : #|args| = cstr_arity mdecl cdecl) 
+                   (e1 : All2 (eval Σ) args args'),
+                   All2 P args args'
+            → P (tConstruct ind c args) (tConstruct ind c args'))
 
       → (∀ (f15 f' a a' : term) (e : eval Σ f15 f'),
       P f15 f' -> IH _ _ e
@@ -282,6 +274,10 @@ Proof using Type.
   | [ H : _ |- _ ] =>
     unshelve eapply H; try match goal with |- eval _ _ _ => tea end; tea; unfold IH; intros; unshelve eapply IH'; tea; cbn; try lia
   end].
+  eapply X15; tea; auto.
+  clear -a IH'. induction a; constructor.
+  eapply (IH' _ _ r). cbn. lia. apply IHa.
+  intros. eapply (IH' _ _ H). cbn. lia.
 Qed.
 
 End eval_mkApps_rect. 

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -109,7 +109,11 @@ Section wf.
       | Some d => has_axioms || isSome d.(cst_body)
       | _ => false 
       end
-    | tConstruct ind c block_args => has_tConstruct && isSome (lookup_constructor Σ ind c) && if cstr_as_blocks then match lookup_constructor_pars_args Σ ind c with Some (p, a) => p + a <=? #|block_args| | _ => true end && forallb (wellformed k) block_args else is_nil block_args
+    | tConstruct ind c block_args => has_tConstruct && isSome (lookup_constructor Σ ind c) && 
+      if cstr_as_blocks then match lookup_constructor_pars_args Σ ind c with 
+        | Some (p, a) => (p + a) == #|block_args| 
+        | _ => true end 
+        && forallb (wellformed k) block_args else is_nil block_args
     | tVar _ => has_tVar
     end.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1102,7 +1102,7 @@ Proof.
       * eexists. split. 2: now constructor; econstructor.
         econstructor; eauto.
     + invs He.
-      * eexists. split. 2:{ constructor; econstructor. cbn [EWcbvEval.atom].
+      * eexists. split. 2:{ constructor. eapply EWcbvEval.eval_atom. cbn [EWcbvEval.atom].
         depelim Hed. eapply EGlobalEnv.declared_constructor_lookup in H0. now rewrite H0. }
         econstructor; eauto.
       * eexists. split. 2: now constructor; econstructor.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -1938,7 +1938,7 @@ Section wffix.
       wf_fixpoints c && brs'
     | tProj p c => wf_fixpoints c
     | tFix mfix idx => 
-      (idx <? #|mfix|) && List.forallb (fun d => (isLambda d.(dbody) || isBox d.(dbody)) && wf_fixpoints d.(dbody)) mfix
+      (idx <? #|mfix|) && List.forallb (fun d => isLambda d.(dbody) && wf_fixpoints d.(dbody)) mfix
     | tCoFix mfix idx =>
       (idx <? #|mfix|) && List.forallb (wf_fixpoints ∘ dbody) mfix
     | tConst kn => true

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -677,8 +677,8 @@ Lemma eval_empty_brs {wfl : Ee.WcbvFlags} Σ ci p e : Σ ⊢ E.tCase ci p [] ▷
 Proof.
   intros He.
   depind He. 
-  - clear -e1. now rewrite nth_error_nil in e1.
-  - clear -e1. now rewrite nth_error_nil in e1.
+  - clear -e2. now rewrite nth_error_nil in e2.
+  - clear -e2. now rewrite nth_error_nil in e2.
   - discriminate.
   - eapply IHHe2.
   - cbn in i. discriminate.
@@ -695,7 +695,7 @@ Proof.
     destruct args using rev_case. discriminate.
     rewrite EAstUtils.mkApps_app in H. discriminate.
   - depelim He1. 
-  - exists n, f. intuition auto.
+  - exists n, f4. intuition auto.
   - depelim He1. clear -H. symmetry in H. elimtype False.
     destruct args using rev_case. discriminate.
     rewrite EAstUtils.mkApps_app in H. discriminate.

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -660,7 +660,7 @@ Proof.
     unfold EAst.test_def; simpl; eauto.
     rewrite fix_context_length in b1.
     move/andP: b0 => //; eauto. move=> [] wft /andP[] isl wf; eauto.
-    eapply b1; tea. now rewrite app_length fix_context_length.
+    eapply b1; tea. eapply b. now rewrite app_length fix_context_length.
   - epose proof (All2_length X0).
     unfold EWellformed.wf_fix_gen.
     rewrite -H0. move/andP: wfa => [] ->.


### PR DESCRIPTION
This includes the invariant that fixpoint bodies start with a lambda in the well-formedness predicate on lambda-box terms. This is ensured by typing and maintained by erasure by adding a dummy lambda if the body naturally erases to `tBox`. Both malfunction and certicoq need this (recursive bindings must be values). 