### PR TITLE
Constructors as blocks in the erasure pipeline

### DIFF
--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -145,6 +145,8 @@ src/eProgram.ml
 # src/eEtaExpandedFix.ml
 src/eInlineProjections.mli
 src/eInlineProjections.ml
+src/eConstructorsAsBlocks.mli
+src/eConstructorsAsBlocks.ml
 src/eTransform.mli
 src/eTransform.ml
 src/erasure.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -58,6 +58,7 @@ ERemoveParams
 ErasureFunction
 EOptimizePropDiscr
 EInlineProjections
+EConstructorsAsBlocks
 EProgram
 ETransform
 Erasure

--- a/erasure/theories/EEnvMap.v
+++ b/erasure/theories/EEnvMap.v
@@ -101,6 +101,17 @@ Module GlobalContextMap.
     rewrite lookup_constructor_spec //.
   Qed.
 
+  Definition lookup_constructor_pars_args Σ (ind : inductive) (c : nat) :=
+    '(mdecl, idecl, cdecl) <- lookup_constructor Σ ind c ;;
+    ret (ind_npars mdecl, cstr_nargs cdecl).
+  
+  Lemma lookup_constructor_pars_args_spec Σ kn : 
+    lookup_constructor_pars_args Σ kn = EGlobalEnv.lookup_constructor_pars_args Σ kn.
+  Proof.
+    rewrite /lookup_constructor_pars_args /EGlobalEnv.lookup_constructor_pars_args.
+    rewrite lookup_constructor_spec //.
+  Qed.
+
   Program Definition make (g : global_declarations) (Hg : EnvMap.fresh_globals g): t :=
     {| global_decls := g;
        map := EnvMap.of_global_env g |}.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -802,9 +802,9 @@ Definition disable_projections_term_flags (et : ETermFlags) :=
   |}.
 
 Definition disable_projections_env_flag (efl : EEnvFlags) := 
-  {| has_axioms := true;
+  {| has_axioms := efl.(@has_axioms);
      term_switches := disable_projections_term_flags term_switches;
-     has_cstr_params := true ;
+     has_cstr_params := efl.(@has_cstr_params) ;
      cstr_as_blocks := efl.(@cstr_as_blocks) |}.
 
 Lemma optimize_wellformed {efl : EEnvFlags} {Σ : GlobalContextMap.t} n t :
@@ -815,8 +815,6 @@ Proof.
   intros hbox hrel wfΣ.
   induction t in n |- * using EInduction.term_forall_list_ind => //.
   all:try solve [cbn; rtoProp; intuition auto; solve_all].
-  - simpl. destruct lookup_constant => //.
-    move/andP => [] hasc _ => //. now rewrite hasc.
   - cbn -[lookup_constructor_pars_args]. intros. rtoProp. repeat split; eauto.
     destruct cstr_as_blocks; rtoProp; eauto.
     destruct lookup_constructor_pars_args as [ [] | ]; eauto. split; len.  solve_all. split; eauto. 
@@ -847,6 +845,9 @@ Proof.
   - rewrite lookup_env_optimize //.
     destruct lookup_env eqn:hl => // /=.
     destruct g eqn:hg => /= //.
+    repeat (rtoProp; intuition auto).
+    destruct has_axioms => //. cbn in *.
+    destruct (cst_body c) => //.
   - rewrite lookup_env_optimize //.
     destruct lookup_env eqn:hl => // /=; intros; rtoProp; eauto.
     destruct g eqn:hg => /= //; intros; rtoProp; eauto.
@@ -879,9 +880,7 @@ Proof.
   move: hd.
   destruct d => /= //.
   destruct (cst_body c) => /= //.
-  intros hwf. eapply optimize_wellformed => //. auto.
-  destruct efl => //. destruct m => //. cbn. unfold wf_minductive.
-  cbn. move/andP => [] hp //.
+  intros hwf. eapply optimize_wellformed => //.
 Qed.
 
 Lemma fresh_global_optimize_env {Σ : GlobalContextMap.t} kn : 

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -115,7 +115,11 @@ Module PrintTermTree.
       match lookup_ind_decl Σ i k with
       | Some oib =>
         match nth_error oib.(ind_ctors) l with
-        | Some cstr => cstr.(cstr_name) ^ maybe_string_of_list string_of_term args
+        | Some cstr => 
+          match args with
+          | [] => cstr.(cstr_name)
+          | args => parens (top || inapp) (cstr.(cstr_name) ^ "[" ^ print_list (print_term Γ false false) " " args ^ "]")
+          end
         | None =>
           "UnboundConstruct(" ^ string_of_inductive ind ^ "," ^ string_of_nat l ^ ")"
         end

--- a/erasure/theories/EProgram.v
+++ b/erasure/theories/EProgram.v
@@ -4,7 +4,7 @@ From Equations Require Import Equations.
 From MetaCoq.Template Require Import Transform bytestring config utils BasicAst.
 From MetaCoq.PCUIC Require PCUICAst PCUICAstUtils PCUICProgram.
 (* From MetaCoq.SafeChecker Require Import PCUICErrors PCUICWfEnvImpl. *)
-From MetaCoq.Erasure Require EAstUtils EPretty EWellformed EEnvMap EWcbvEval.
+From MetaCoq.Erasure Require EAstUtils EWellformed EEnvMap EWcbvEval.
 
 Import bytestring.
 Local Open Scope bs.

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -810,15 +810,15 @@ Proof.
   - red. move=> hasapp n t args. rewrite closedn_mkApps. 
     split; intros; rtoProp; intuition auto; solve_all.
   - red. move=> hascase n ci discr brs. simpl.
-    split; intros; rtoProp; intuition auto; solve_all.
+    intros; rtoProp; intuition auto; solve_all.
   - red. move=> hasproj n p discr. simpl.
-    split; intros; rtoProp; intuition auto; solve_all.
+    intros; rtoProp; intuition auto; solve_all.
   - red. move=> t args clt cll.
     eapply closed_substl. solve_all. now rewrite Nat.add_0_r.
   - red. move=> n mfix idx. cbn.
     intros; rtoProp; intuition auto; solve_all.
   - red. move=> n mfix idx. cbn.
-    split; intros; rtoProp; intuition auto; solve_all.
+    intros; rtoProp; intuition auto; solve_all.
 Qed.
 
 Lemma strip_eval (efl := all_env_flags) {wfl:WcbvFlags} {wcon : with_constructor_as_block = false} {Σ : GlobalContextMap.t} t v :

--- a/erasure/theories/ETransform.v
+++ b/erasure/theories/ETransform.v
@@ -254,23 +254,23 @@ Qed.
 
 From MetaCoq.Erasure Require Import EConstructorsAsBlocks.
 
-Program Definition constructors_as_blocks_transformation (efl := env_flags)
-  {hastrel : has_tRel} {hastbox : has_tBox} :
+Program Definition constructors_as_blocks_transformation (efl : EEnvFlags)
+  {has_app : has_tApp} {has_pars : has_cstr_params = false} {has_cstrblocks : cstr_as_blocks = false} :
   Transform.t eprogram_env eprogram EAst.term EAst.term (eval_eprogram_env target_wcbv_flags) (eval_eprogram block_wcbv_flags) := 
   {| name := "transforming to constuctors as blocks"; 
     transform p _ := EConstructorsAsBlocks.transform_blocks_program p ; 
     pre p := wf_eprogram_env efl p /\ EEtaExpanded.expanded_eprogram_env_cstrs p;
-    post p := wf_eprogram env_flags_blocks p ;
+    post p := wf_eprogram (switch_cstr_as_blocks efl) p ;
     obseq g g' v v' := v' = EConstructorsAsBlocks.transform_blocks g.1 v |}.
 
 Next Obligation.
-  move=> efl hastrel hastbox [Σ t] [] [wftp wft] /andP [etap etat]. 
+  move=> efl hasapp haspars hascstrs [Σ t] [] [wftp wft] /andP [etap etat]. 
   cbn in *. split.
   - eapply transform_wf_global; eauto.
-  - subst efl. eapply transform_wellformed; eauto.
+  - eapply transform_wellformed; eauto.
 Qed.
 Next Obligation.
-  red. move=> hastrel hastbox [Σ t] /= v [[wfe1 wfe2] wft] [ev].
+  red. move=> efl hasapp haspars hascstrs [Σ t] /= v [[wfe1 wfe2] wft] [ev].
   eexists. split; [ | eauto].
   unfold EEtaExpanded.expanded_eprogram_env_cstrs in *.
   revert wft. move => /andP // [e1 e2]. 

--- a/erasure/theories/ETransform.v
+++ b/erasure/theories/ETransform.v
@@ -7,7 +7,7 @@ Set Warnings "-notation-overridden".
 From MetaCoq.PCUIC Require PCUICAst PCUICAstUtils PCUICProgram PCUICTransform.
 Set Warnings "+notation-overridden".
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICWfEnvImpl.
-From MetaCoq.Erasure Require EAstUtils ErasureFunction ErasureCorrectness EPretty Extract EOptimizePropDiscr ERemoveParams EProgram.
+From MetaCoq.Erasure Require EAstUtils ErasureFunction ErasureCorrectness Extract EOptimizePropDiscr ERemoveParams EProgram.
 
 Import PCUICAst (term) PCUICProgram PCUICTransform (eval_pcuic_program) Extract EProgram
     EAst Transform ERemoveParams.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1661,7 +1661,13 @@ Proof.
     destruct lookup_constructor_pars_args as [ [] | ]; rtoProp; repeat solve_all.   
     destruct args; cbn in H0; eauto.
   - destruct cstr_as_blocks; try congruence.
-    destruct args; invs Hc''. now depelim a.
+    destruct lookup_constructor_pars_args as [ [] | ]; rtoProp; repeat solve_all.
+    now rewrite (All2_length a) in H.
+    eapply All2_over_impl in iha; tea.
+    intuition auto.
+    eapply All2_over_impl in iha; tea.
+    intuition auto.
+    depelim a => //.
 Qed.
 
 Lemma remove_last_length {X} {l : list X} : 

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1661,13 +1661,7 @@ Proof.
     destruct lookup_constructor_pars_args as [ [] | ]; rtoProp; repeat solve_all.   
     destruct args; cbn in H0; eauto.
   - destruct cstr_as_blocks; try congruence.
-    destruct lookup_constructor_pars_args as [ [] | ]; rtoProp; repeat solve_all.
-    now rewrite (All2_length a) in H.
-    eapply All2_over_impl in iha; tea.
-    intuition auto.
-    eapply All2_over_impl in iha; tea.
-    intuition auto.
-    depelim a => //.
+    destruct args; invs Hc''. now depelim a.
 Qed.
 
 Lemma remove_last_length {X} {l : list X} : 

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -50,16 +50,16 @@ Class Qpres {etfl : ETermFlags} (Q : nat -> term -> Type) := qpres : forall n t,
 Class Qapp {etfl : ETermFlags} (Q : nat -> term -> Type) := qapp : has_tApp -> forall n f args, Q n (mkApps f args) <~> Q n f × All (Q n) args.
 #[export] Hint Mode Qapp - ! : typeclass_instances.
 
-Class Qcase {etfl : ETermFlags} (Q : nat -> term -> Type) := qcase : has_tCoFix -> has_tCase -> forall n ci discr brs, Q n (tCase ci discr brs) <~> 
-  Q n discr × All (fun br => Q (#|br.1| + n) br.2) brs.
+Class Qcase {etfl : ETermFlags} (Q : nat -> term -> Type) := qcase : has_tCase -> 
+  forall n ci discr brs, Q n (tCase ci discr brs) -> forall discr', Q n discr' -> Q n (tCase ci discr' brs).
 #[export] Hint Mode Qcase - ! : typeclass_instances.
 
-Class Qproj {etfl : ETermFlags} (Q : nat -> term -> Type) := qproj : has_tProj -> forall n p discr, Q n (tProj p discr) <~> Q n discr.
+Class Qproj {etfl : ETermFlags} (Q : nat -> term -> Type) := qproj : has_tProj -> forall n p discr, Q n (tProj p discr) -> forall discr', Q n discr' -> Q n (tProj p discr').
 #[export] Hint Mode Qproj - ! : typeclass_instances.
 
 Class Qfix {etfl : ETermFlags} (Q : nat -> term -> Type) := qfix : has_tFix -> forall n mfix idx, idx < #|mfix| -> Q n (tFix mfix idx) -> forall idx', idx' < #|mfix| -> Q n (tFix mfix idx').
 #[export] Hint Mode Qfix - ! : typeclass_instances.
-Class Qcofix {etfl : ETermFlags} (Q : nat -> term -> Type) := qcofix : has_tCoFix -> forall n mfix idx, idx < #|mfix| -> Q n (tCoFix mfix idx) <~>  All (fun d => Q (#|mfix| + n) d.(dbody)) mfix.
+Class Qcofix {etfl : ETermFlags} (Q : nat -> term -> Type) := qcofix : has_tCoFix -> forall n mfix idx, idx < #|mfix| -> Q n (tCoFix mfix idx) -> forall idx', idx' < #|mfix| -> Q n (tCoFix mfix idx').
 #[export] Hint Mode Qcofix - ! : typeclass_instances.
 Class Qsubst (Q : nat -> term -> Type) := qsubst : forall t l, Q (#|l|) t -> All (Q 0) l -> Q 0 (substl l t).
 #[export] Hint Mode Qsubst ! : typeclass_instances.
@@ -82,13 +82,14 @@ Proof.
   eapply IHn. lia. 2:tea. assumption.
 Qed.
 
-Lemma Qcofix_subst {etfl : ETermFlags} mfix Q : has_tCoFix -> Qcofix Q -> All (λ d : def term, Q (#|mfix| + 0) (dbody d)) mfix -> All (Q 0) (cofix_subst mfix).
+Lemma Qcofix_subst {etfl : ETermFlags} mfix Q : has_tCoFix -> Qcofix Q -> Qpres Q -> forall idx, idx < #|mfix| -> Q 0 (tCoFix mfix idx) -> All (Q 0) (cofix_subst mfix).
 Proof.
-  intros hasfix qfix; unfold cofix_subst.
+  intros hascofix qcofix qpre; unfold cofix_subst.
   generalize (Nat.le_refl #|mfix|).
   generalize #|mfix| at 1 4.
   induction n. intros. constructor; auto.
-  intros. constructor. eapply qfix => //. eapply IHn. lia. exact X. 
+  intros. constructor. eapply qcofix => //. 2:tea. tea. 
+  eapply IHn. lia. 2:tea. assumption.
 Qed.
 
 #[export] Instance Qsubst_Qfixs {etfl : ETermFlags} Q : Qpres Q -> Qfix Q -> Qsubst Q -> Qfixs Q.
@@ -109,18 +110,18 @@ Qed.
 
 #[export] Instance Qsubst_Qcofixs {etfl : ETermFlags} Q : Qpres Q -> Qcofix Q -> Qsubst Q -> Qcofixs Q.
 Proof.
-  move=> qpres qfix; rewrite /Qsubst /Qcofixs.
+  move=> qpres qfix; rewrite /Qsubst /Qfixs.
   intros Hs mfix idx hfix args fn.
-  assert (hastcofix : has_tCoFix).
+  assert (hasfix : has_tCoFix).
   { eapply qpres in hfix. now depelim hfix. }
   rewrite /cunfold_cofix.
-  eapply qpres in hfix. depelim hfix => //.
   destruct nth_error eqn:hnth => //.
-  eapply nth_error_all in hnth; tea. cbn in hnth.
-  rewrite Nat.add_0_r in hnth.
+  pose proof (nth_error_Some_length hnth).
+  epose proof (Qcofix_subst _ _ hasfix qfix qpres idx H hfix).
   intros [= <-]. subst fn.
   eapply Hs. rewrite cofix_subst_length //.
-  now apply Qcofix_subst.
+  eapply qpres in hfix. depelim hfix. depelim i0. eapply nth_error_all in a; tea. now rewrite Nat.add_0_r in a.
+  assumption.
 Qed.
 
 Class Qconst Σ (Q : nat -> term -> Type) := qconst :
@@ -517,11 +518,9 @@ Proof.
       iheta qa.
   - simp_eta. move=> /andP[etad etabrs].
     assert (qa : Q 0 (tCase ip (mkApps fn args) brs)).
-    { pose proof (ev1' := ev1). eapply P'Q in ev1' => //.
+    { eapply qcase; tea => //.
+      pose proof (ev1' := ev1). eapply P'Q in ev1' => //.
       eapply qapp in ev1' as [hfix qargs] => //.
-      unshelve eapply (qcase _ _ _ _ _ _).2 => //.
-      { now eapply qpres in hfix; depelim hfix. } auto.
-      split => //.
       eapply qapp => //. split => //.
       eapply (qcofixs mfix idx) in hfix; tea. 
       clear ev1'; ih. }
@@ -543,7 +542,7 @@ Proof.
     assert (qa : Q 0 (tProj p (mkApps fn args))).
     { pose proof (ev1' := ev1). eapply P'Q in ev1' => //.
       eapply qapp in ev1' as [hfix ?] => //.
-      eapply qproj => //. eapply qapp => //. split => //.
+      eapply qproj; tea => //. eapply qapp => //. split => //.
       eapply (qcofixs mfix idx) in hfix; tea.
       clear ev1'; ih. }
     assert (etafn : isEtaExp Σ fn && forallb (isEtaExp Σ) args).
@@ -704,32 +703,40 @@ Definition env_flags :=
     |}.
   
 From MetaCoq.Erasure Require Import ELiftSubst.
-Lemma Qpreserves_wellformed (efl := env_flags) Σ : wf_glob Σ -> Qpreserves (fun n x => wellformed Σ n x) Σ.
+Lemma Qpreserves_wellformed (efl : EEnvFlags) Σ :
+  cstr_as_blocks = false ->
+  wf_glob Σ -> Qpreserves (fun n x => wellformed Σ n x) Σ.
 Proof.
-  intros clΣ.
+  intros cstbl clΣ.
   split.
   - red. move=> n t.
-    destruct t; cbn; intuition auto; try solve [constructor; auto].
+    destruct t; cbn [wellformed]; rtoProp; intuition auto; try solve [constructor; auto].
+    all:cbn; rtoProp; intuition auto.
+    constructor; cbn => //.
+    eapply on_evar; auto. solve_all.
+    eapply on_lambda; auto.
     eapply on_letin; rtoProp; intuition auto.
     eapply on_app; rtoProp; intuition auto.
+    constructor; cbn; auto. rewrite cstbl in H0.
+    destruct l => //. constructor => //.
     eapply on_case; rtoProp; intuition auto. ELiftSubst.solve_all.
-    eapply on_fix. eauto. move/andP: H => [] isl /andP[] _ wf. ELiftSubst.solve_all.
+    eapply on_proj; auto.
+    eapply on_fix; eauto. move/andP: H0 => [] _ wf. solve_all.
+    eapply on_cofix; eauto. move/andP: H0 => [] _ wf. solve_all.
   - red. intros kn decl.
     move/(lookup_env_wellformed clΣ).
     unfold wf_global_decl. destruct cst_body => //.
   - red. move=> hasapp n t args. rewrite wellformed_mkApps //. 
     split; intros; rtoProp; intuition auto; solve_all.
-  - red. cbn => //.
-    (* move=> hascase n ci discr brs. simpl.
-    destruct lookup_inductive eqn:hl => /= //.
-    split; intros; rtoProp; intuition auto; solve_all. *)
-  - red. now move=> hasproj n p discr.
+  - red. intros. simpl in H0. simpl. rtoProp; intuition auto.
+  - red. move=> hasproj n p discr. simpl; rtoProp; intuition auto.
+    rtoProp; intuition auto.
   - red. move=> t args clt cll.
     eapply wellformed_substl. solve_all. now rewrite Nat.add_0_r.
   - red. move=> n mfix idx. cbn. unfold EWellformed.wf_fix.
     intros; rtoProp; intuition auto; solve_all. now apply Nat.ltb_lt.
-  - red. move=> n mfix idx. cbn.
-    split; intros; rtoProp; intuition auto; solve_all.
+  - red. move=> n mfix idx. cbn. unfold EWellformed.wf_fix.
+    intros; rtoProp; intuition auto; solve_all. now apply Nat.ltb_lt.
 Qed.
 
 Ltac destruct_nary_times :=
@@ -750,7 +757,7 @@ Proof.
   intros hcon etaΣ wfΣ wf ev eta.
   revert a a' wf eta ev.
   eapply (eval_preserve_mkApps_ind (efl:=env_flags) fl hcon Σ (fun _ x => isEtaExp Σ x) (fun n t => wellformed Σ n t) 
-    (Qpres := Qpreserves_wellformed Σ wfΣ)) => //.
+    (Qpres := Qpreserves_wellformed env_flags Σ eq_refl wfΣ)) => //.
   all:intros; repeat destruct_nary_times.
   all:intuition auto.
   - eapply eval_wellformed; tea => //.

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -30,7 +30,7 @@ Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellf
  Transform.t TemplateProgram.template_program EProgram.eprogram 
   Ast.term EAst.term
   TemplateProgram.eval_template_program
-  (EProgram.eval_eprogram {| with_prop_case := false; with_guarded_fix := false |}) := 
+  (EProgram.eval_eprogram {| with_prop_case := false; with_guarded_fix := false; with_constructor_as_block := true |}) := 
   (* Casts are removed, application is binary, case annotations are inferred from the global environment *)
   template_to_pcuic_transform ▷
   (* Branches of cases are expanded to bind only variables, constructor types are expanded accordingly *)
@@ -50,7 +50,9 @@ Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellf
   (* Rebuild the efficient lookup table *)
   rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
   (* Inline projections to cases *)
-  inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl).
+  inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
+  (* First-order constructor representation *)
+  constructors_as_blocks_transformation (hastrel := eq_refl) (hastbox := eq_refl).
 (* At the end of erasure we get a well-formed program (well-scoped globally and localy), without 
    parameters in inductive declarations. The constructor applications are also expanded, and
    the evaluation relation does not need to consider guarded fixpoints or case analyses on propositional

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -51,12 +51,17 @@ Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellf
   rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
   (* Inline projections to cases *)
   inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
+  let efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags) in
+  (* Rebuild the efficient lookup table *)
+  rebuild_wf_env_transform (efl :=  efl) ▷
   (* First-order constructor representation *)
-  constructors_as_blocks_transformation (hastrel := eq_refl) (hastbox := eq_refl).
+  constructors_as_blocks_transformation efl (has_app := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl).
+
 (* At the end of erasure we get a well-formed program (well-scoped globally and localy), without 
-   parameters in inductive declarations. The constructor applications are also expanded, and
-   the evaluation relation does not need to consider guarded fixpoints or case analyses on propositional
-   content. All fixpoint bodies start with a lambda as well. *)
+   parameters in inductive declarations. The constructor applications are also transformed to a first-order
+   "block"  application, of the right length, and the evaluation relation does not need to consider guarded 
+   fixpoints or case analyses on propositional content. All fixpoint bodies start with a lambda as well.
+   Finally, projections are inlined to cases, so no `tProj` remains. *)
 
 Import EGlobalEnv EWellformed.
 
@@ -74,7 +79,12 @@ Program Definition erasure_pipeline_fast {guard : abstract_guard_impl} (efl := E
   guarded_to_unguarded_fix (wcon := eq_refl) eq_refl ▷
   remove_params_fast_optimization (wcon := eq_refl)  _ ▷ 
   rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
-  optimize_prop_discr_optimization (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl).
+  optimize_prop_discr_optimization (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
+  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
+  inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
+  let efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags) in
+  rebuild_wf_env_transform (efl :=  efl) ▷
+  constructors_as_blocks_transformation efl (has_app := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl).
 Next Obligation.
   destruct H; split => //. now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs. 
 Qed.


### PR DESCRIPTION
This includes the optimization/change of representation in the erasure pipeline, also improve it to use a GlobalContextMap for efficiency of lookups. It works only if the input terms have eta-expanded constructors.
To help work with this we have a new induction principle for evaluation with `cstr_as_blocks = true`.