### PR TITLE
Primitives and cofixpoints

### DIFF
--- a/erasure/_CoqProject.in
+++ b/erasure/_CoqProject.in
@@ -34,5 +34,6 @@ theories/ERemoveParams.v
 theories/EInlineProjections.v
 theories/ETransform.v
 theories/EConstructorsAsBlocks.v
+theories/ECoInductiveToInductive.v
 theories/EWcbvEvalCstrsAsBlocksInd.v
 theories/Erasure.v

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -14,8 +14,6 @@ src/uGraph0.ml
 src/uGraph0.mli
 src/wGraph.ml
 src/wGraph.mli
-src/mCProd.mli
-src/mCProd.ml
 src/etaExpand.mli
 src/etaExpand.ml
 
@@ -27,8 +25,8 @@ src/etaExpand.ml
 # src/wcbvEval.mli
 # src/wcbvEval.ml
 # From PCUIC
-# src/pCUICPrimitive.mli
-# src/pCUICPrimitive.ml
+src/pCUICPrimitive.mli
+src/pCUICPrimitive.ml
 src/pCUICAst.ml
 src/pCUICAst.mli
 src/pCUICCases.mli

--- a/erasure/_PluginProject.in
+++ b/erasure/_PluginProject.in
@@ -139,6 +139,8 @@ src/eInlineProjections.mli
 src/eInlineProjections.ml
 src/eConstructorsAsBlocks.mli
 src/eConstructorsAsBlocks.ml
+src/eCoInductiveToInductive.mli
+src/eCoInductiveToInductive.ml
 src/eTransform.mli
 src/eTransform.ml
 src/erasure.mli

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -6,7 +6,6 @@ Utils
 
 WGraph
 UGraph0
-MCProd
 EtaExpand
 
 WcbvEval
@@ -14,6 +13,7 @@ Classes0
 Logic1
 Relation
 Relation_Properties
+PCUICPrimitive
 PCUICAst
 PCUICCases
 PCUICAstUtils

--- a/erasure/src/metacoq_erasure_plugin.mlpack
+++ b/erasure/src/metacoq_erasure_plugin.mlpack
@@ -57,6 +57,7 @@ ErasureFunction
 EOptimizePropDiscr
 EInlineProjections
 EConstructorsAsBlocks
+ECoInductiveToInductive
 EProgram
 ETransform
 Erasure

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -106,11 +106,6 @@ Inductive constant_entry :=
   [x1:X1;...;xn:Xn].
 *)
 
-Inductive recursivity_kind :=
-  | Finite (* = inductive *)
-  | CoFinite (* = coinductive *)
-  | BiFinite (* = non-recursive, like in "Record" definitions *).
-
 Inductive local_entry : Set :=
 | LocalDef : term -> local_entry (* local let binding *)
 | LocalAssum : term -> local_entry.
@@ -199,6 +194,7 @@ Derive NoConfusion for one_inductive_body.
 
 (** See [mutual_inductive_body] from [declarations.ml]. *)
 Record mutual_inductive_body := {
+  ind_finite : recursivity_kind;
   ind_npars : nat;
   ind_bodies : list one_inductive_body }.
 Derive NoConfusion for mutual_inductive_body.

--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import utils BasicAst Universes.
+From MetaCoq.PCUIC Require Import PCUICPrimitive.
 (** * Extracted terms
 
   These are the terms produced by extraction: compared to kernel terms,
@@ -38,8 +39,8 @@ Inductive term : Set :=
                term (* discriminee *) -> list (list name * term) (* branches *) -> term
 | tProj      : projection -> term -> term
 | tFix       : mfixpoint term -> nat -> term
-| tCoFix     : mfixpoint term -> nat -> term.
-(* | tPrim      : prim_val term -> term. *)
+| tCoFix     : mfixpoint term -> nat -> term
+| tPrim      : prim_val term -> term.
 
 Derive NoConfusion for term.
 

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -287,6 +287,13 @@ Definition isConstruct t :=
   | _ => false
   end.
 
+Definition isPrim t :=
+  match t with
+  | tPrim _ => true
+  | _ => false
+  end.
+
+  
 Definition isBox t :=
   match t with
   | tBox => true
@@ -301,11 +308,14 @@ Definition is_box c :=
 
 Definition isFixApp t := isFix (head t).
 Definition isConstructApp t := isConstruct (head t).
+Definition isPrimApp t := isPrim (head t).
 
 Lemma isFixApp_mkApps f l : isFixApp (mkApps f l) = isFixApp f.
 Proof. rewrite /isFixApp head_mkApps //. Qed.
 Lemma isConstructApp_mkApps f l : isConstructApp (mkApps f l) = isConstructApp f.
 Proof. rewrite /isConstructApp head_mkApps //. Qed.
+Lemma isPrimApp_mkApps f l : isPrimApp (mkApps f l) = isPrimApp f.
+Proof. rewrite /isPrimApp head_mkApps //. Qed.
 
 Lemma is_box_mkApps f a : is_box (mkApps f a) = is_box f.
 Proof.
@@ -322,6 +332,8 @@ Proof. destruct args using rev_case => //. rewrite mkApps_app /= //. Qed.
 Lemma nisFix_mkApps f args : ~~ isFix f -> ~~ isFix (mkApps f args).
 Proof. destruct args using rev_case => //. rewrite mkApps_app /= //. Qed.
 Lemma nisBox_mkApps f args : ~~ isBox f -> ~~ isBox (mkApps f args).
+Proof. destruct args using rev_case => //. rewrite mkApps_app /= //. Qed.
+Lemma nisPrim_mkApps f args : ~~ isPrim f -> ~~ isPrim (mkApps f args).
 Proof. destruct args using rev_case => //. rewrite mkApps_app /= //. Qed.
 
 Definition string_of_def {A : Set} (f : A -> string) (def : def A) :=
@@ -349,7 +361,7 @@ Fixpoint string_of_term (t : term) : string :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  (* | tPrim p => "Prim(" ^ PCUICPrimitive.string_of_prim string_of_term p ^ ")" *)
+  | tPrim p => "Prim(" ^ PCUICPrimitive.string_of_prim string_of_term p ^ ")"
   end.
 
 (** Compute all the global environment dependencies of the term *)

--- a/erasure/theories/ECoInductiveToInductive.v
+++ b/erasure/theories/ECoInductiveToInductive.v
@@ -1,0 +1,996 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import Utf8 Program.
+From MetaCoq.Template Require Import config utils Kernames.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+     PCUICReflect PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
+     PCUICTyping PCUICInversion
+     PCUICSafeLemmata. (* for welltyped *)
+From MetaCoq.SafeChecker Require Import PCUICWfEnvImpl.
+From MetaCoq.Erasure Require Import EAst EAstUtils EDeps EExtends
+    EEtaExpanded
+    ELiftSubst ECSubst ESpineView EGlobalEnv EInduction EWellformed EWcbvEval Extract Prelim
+    EEnvMap EArities EProgram.
+
+Import MCList (map_InP, map_InP_elim, map_InP_spec).
+
+Local Open Scope string_scope.
+Set Asymmetric Patterns.
+Import MCMonadNotation.
+
+From Equations Require Import Equations.
+Set Equations Transparent.
+Local Set Keyed Unification.
+Require Import ssreflect ssrbool.
+
+(** We assumes [Prop </= Type] and universes are checked correctly in the following. *)
+Local Existing Instance extraction_checker_flags.
+
+Ltac introdep := let H := fresh in intros H; depelim H.
+
+#[global]
+Hint Constructors eval : core.
+
+Module Thunk.
+  Definition make (t : term) : term := 
+    tLambda nAnon (lift 1 0 t).
+
+  Definition force (t : term) := 
+    tApp t tBox.
+End Thunk.
+
+Section trans.
+  Context (Σ : GlobalContextMap.t).
+
+  Fixpoint trans (t : term) : term :=
+    match t with
+    | tRel i => tRel i
+    | tEvar ev args => tEvar ev (List.map trans args)
+    | tLambda na M => tLambda na (trans M)
+    | tApp u v => tApp (trans u) (trans v)
+    | tLetIn na b b' => tLetIn na (trans b) (trans b')
+    | tCase ind c brs =>
+      let brs' := List.map (on_snd trans) brs in
+      match GlobalContextMap.lookup_inductive_kind Σ (fst ind).(inductive_mind) with
+      | Some CoFinite =>
+        tCase ind (Thunk.force (trans c)) brs'
+      | _ => tCase ind (trans c) brs'
+      end
+    | tProj p c =>
+      match GlobalContextMap.lookup_inductive_kind Σ p.(proj_ind).(inductive_mind) with 
+      | Some CoFinite => tProj p (Thunk.force (trans c))
+      | _ => tProj p (trans c)
+      end
+    | tFix mfix idx =>
+      let mfix' := List.map (map_def trans) mfix in
+      tFix mfix' idx
+    | tCoFix mfix idx =>
+      let mfix' := List.map (map_def trans) mfix in
+      tFix mfix' idx
+    | tBox => t
+    | tVar _ => t
+    | tConst _ => t
+    | tConstruct ind i args =>
+      match GlobalContextMap.lookup_inductive_kind Σ ind.(inductive_mind) with 
+      | Some CoFinite => Thunk.make (tConstruct ind i (map trans args))
+      | _ => tConstruct ind i (map trans args)
+      end
+    | tPrim _ => t
+    end.
+
+  (* cofix succ x := match x with Stream x xs => Stream (x + 1) (succ xs) -> 
+
+    fix succ x := match x () with Stream x xs => fun () => Stream (x + 1) (succ xs)
+  
+    cofix ones := Stream 1 ones ->
+    fix ones := fun () => Stream 1 ones
+  *)
+
+  Lemma trans_mkApps f l : trans (mkApps f l) = mkApps (trans f) (map trans l).
+  Proof using Type.
+    induction l using rev_ind; simpl; auto.
+    now rewrite mkApps_app /= IHl map_app /= mkApps_app /=.
+  Qed.
+
+  Lemma map_repeat {A B} (f : A -> B) x n : map f (repeat x n) = repeat (f x) n.
+  Proof using Type.
+    now induction n; simpl; auto; rewrite IHn.
+  Qed.
+  
+  Lemma map_trans_repeat_box n : map trans (repeat tBox n) = repeat tBox n.
+  Proof using Type. by rewrite map_repeat. Qed.
+
+  Import ECSubst.
+
+  Lemma csubst_mkApps {a k f l} : csubst a k (mkApps f l) = mkApps (csubst a k f) (map (csubst a k) l).
+  Proof using Type.
+    induction l using rev_ind; simpl; auto.
+    rewrite mkApps_app /= IHl.
+    now rewrite -[EAst.tApp _ _](mkApps_app _ _ [_]) map_app.
+  Qed.
+
+  Lemma csubst_closed t k x : closedn k x -> csubst t k x = x.
+  Proof using Type.
+    induction x in k |- * using EInduction.term_forall_list_ind; simpl; auto.
+    all:try solve [intros; f_equal; solve_all; eauto].
+    intros Hn. eapply Nat.ltb_lt in Hn.
+    - destruct (Nat.compare_spec k n); try lia. reflexivity.
+    - move/andP => []. intros. f_equal; solve_all; eauto.
+    - move/andP => []. intros. f_equal; solve_all; eauto.
+    - move/andP => []. intros. f_equal; solve_all; eauto.
+      destruct x0; cbn in *. f_equal; auto.
+  Qed.
+
+  Lemma closed_trans t k : closedn k t -> closedn k (trans t).
+  Proof using Type.
+    induction t in k |- * using EInduction.term_forall_list_ind; simpl; auto;
+    intros; try easy;
+    rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
+    unfold test_def in *;
+    simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
+    - admit.
+     (* move/andP: H => [] clt cll. 
+      destruct GlobalContextMap.lookup_inductive_kind as [[]|] => /= //.
+      destruct l as [|[br n] [|l']] eqn:eql; simpl.
+      rewrite IHt //.
+      depelim X. cbn in *.
+      rewrite andb_true_r in cll.
+      specialize (i _ cll). rewrite IHt // i //. *)
+  Admitted.
+      (* eapply closed_substl. solve_all. eapply All_repeat => //.
+      now rewrite repeat_length.
+      rtoProp; solve_all. depelim cll. solve_all.
+      depelim cll. depelim cll. solve_all.
+      depelim cll. depelim cll. solve_all.
+      rtoProp; solve_all. solve_all.
+      rtoProp; solve_all. solve_all.
+    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|]; cbn; auto.
+  Qed.
+  *)
+  Lemma subst_csubst_comm l t k b : 
+    forallb (closedn 0) l -> closed t ->
+    subst l 0 (csubst t (#|l| + k) b) = 
+    csubst t k (subst l 0 b).
+  Proof using Type.
+    intros hl cl.
+    rewrite !closed_subst //.
+    rewrite distr_subst. f_equal.
+    symmetry. solve_all.
+    rewrite subst_closed //.
+    eapply closed_upwards; tea. lia. 
+  Qed.
+
+  Lemma substl_subst s t : 
+    forallb (closedn 0) s ->
+    substl s t = subst s 0 t.
+  Proof using Type.
+    induction s in t |- *; cbn; auto.
+    intros _. now rewrite subst_empty.
+    move/andP=> []cla cls.
+    rewrite (subst_app_decomp [_]).
+    cbn. rewrite lift_closed //.
+    rewrite closed_subst //. now eapply IHs.
+  Qed.
+
+  Lemma substl_csubst_comm l t k b : 
+    forallb (closedn 0) l -> closed t ->
+    substl l (csubst t (#|l| + k) b) = 
+    csubst t k (substl l b).
+  Proof using Type.
+    intros hl cl.
+    rewrite substl_subst //.
+    rewrite substl_subst //.
+    apply subst_csubst_comm => //.
+  Qed.
+
+  (*Lemma trans_csubst a k b : 
+    closed a ->
+    trans (ECSubst.csubst a k b) = ECSubst.csubst (trans a) k (trans b).
+  Proof using Type.
+    induction b in k |- * using EInduction.term_forall_list_ind; simpl; auto;
+    intros cl; try easy; 
+    rewrite -> ?map_map_compose, ?compose_on_snd, ?compose_map_def, ?map_length;
+    unfold test_def in *;
+    simpl closed in *; try solve [simpl subst; simpl closed; f_equal; auto; rtoProp; solve_all]; try easy.
+    - destruct (k ?= n)%nat; auto.
+    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+      destruct l as [|[br n] [|l']] eqn:eql; simpl.
+      all:unfold on_snd; cbn.
+      * f_equal; auto.
+      * depelim X. simpl in *.
+        rewrite e //.
+        assert (#|br| = #|repeat tBox #|br| |). now rewrite repeat_length.
+        rewrite {2}H.
+        rewrite substl_csubst_comm //.
+        solve_all. eapply All_repeat => //.
+        now eapply closed_trans.
+      * depelim X. depelim X.
+        f_equal; eauto.
+        unfold on_snd; cbn. f_equal; eauto.
+        f_equal; eauto.
+        f_equal; eauto. f_equal; eauto.
+        rewrite map_map_compose; solve_all.
+      * rewrite ?map_map_compose; f_equal; eauto; solve_all.
+      * rewrite ?map_map_compose; f_equal; eauto; solve_all.
+    - destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|]=> //;
+      now rewrite IHb.
+  Qed.
+
+  Lemma trans_substl s t : 
+    forallb (closedn 0) s ->
+    trans (substl s t) = substl (map trans s) (trans t).
+  Proof using Type.
+    induction s in t |- *; simpl; auto.
+    move/andP => [] cla cls.
+    rewrite IHs //. f_equal.
+    now rewrite trans_csubst.
+  Qed.
+
+  Lemma trans_iota_red pars args br :
+    forallb (closedn 0) args ->
+    trans (EGlobalEnv.iota_red pars args br) = EGlobalEnv.iota_red pars (map trans args) (on_snd trans br).
+  Proof using Type.
+    intros cl.
+    unfold EGlobalEnv.iota_red.
+    rewrite trans_substl //.
+    rewrite forallb_rev forallb_skipn //.
+    now rewrite map_rev map_skipn.
+  Qed.
+  
+  Lemma trans_fix_subst mfix : EGlobalEnv.fix_subst (map (map_def trans) mfix) = map trans (EGlobalEnv.fix_subst mfix).
+  Proof using Type.
+    unfold EGlobalEnv.fix_subst.
+    rewrite map_length.
+    generalize #|mfix|.
+    induction n; simpl; auto.
+    f_equal; auto.
+  Qed.
+
+  Lemma trans_cofix_subst mfix : EGlobalEnv.cofix_subst (map (map_def trans) mfix) = map trans (EGlobalEnv.cofix_subst mfix).
+  Proof using Type.
+    unfold EGlobalEnv.cofix_subst.
+    rewrite map_length.
+    generalize #|mfix|.
+    induction n; simpl; auto.
+    f_equal; auto.
+  Qed.
+
+  Lemma trans_cunfold_fix mfix idx n f : 
+    forallb (closedn 0) (EGlobalEnv.fix_subst mfix) ->
+    cunfold_fix mfix idx = Some (n, f) ->
+    cunfold_fix (map (map_def trans) mfix) idx = Some (n, trans f).
+  Proof using Type.
+    intros hfix.
+    unfold cunfold_fix.
+    rewrite nth_error_map.
+    destruct nth_error.
+    intros [= <- <-] => /=. f_equal.
+    now rewrite trans_substl // trans_fix_subst.
+    discriminate.
+  Qed.
+
+  Lemma trans_cunfold_cofix mfix idx n f : 
+    forallb (closedn 0) (EGlobalEnv.cofix_subst mfix) ->
+    cunfold_cofix mfix idx = Some (n, f) ->
+    cunfold_cofix (map (map_def trans) mfix) idx = Some (n, trans f).
+  Proof using Type.
+    intros hcofix.
+    unfold cunfold_cofix.
+    rewrite nth_error_map.
+    destruct nth_error.
+    intros [= <- <-] => /=. f_equal.
+    now rewrite trans_substl // trans_cofix_subst.
+    discriminate.
+  Qed.
+
+  Lemma trans_nth {n l d} : 
+    trans (nth n l d) = nth n (map trans l) (trans d).
+  Proof using Type.
+    induction l in n |- *; destruct n; simpl; auto.
+  Qed.*)
+
+End trans.
+
+Lemma is_box_inv b : is_box b -> ∑ args, b = mkApps tBox args.
+Proof.
+  unfold is_box, EAstUtils.head.
+  destruct decompose_app eqn:da.
+  simpl. destruct t => //.
+  eapply decompose_app_inv in da. subst.
+  eexists; eauto.
+Qed.
+
+Lemma eval_is_box {wfl:WcbvFlags} Σ t u : Σ ⊢ t ▷ u -> is_box t -> u = EAst.tBox.
+Proof.
+  intros ev; induction ev => //.
+  - rewrite is_box_tApp.
+    intros isb. intuition congruence.
+  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?; solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst => //.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst. solve_discr.
+  - rewrite is_box_tApp. move/IHev1 => ?. subst. cbn in i.
+    destruct EWcbvEval.with_guarded_fix => //.
+  - destruct t => //.
+Qed. 
+
+Lemma isType_tSort {cf:checker_flags} {Σ : global_env_ext} {Γ l A} {wfΣ : wf Σ} : Σ ;;; Γ |- tSort (Universe.make l) : A -> isType Σ Γ (tSort (Universe.make l)).
+Proof.
+  intros HT.
+  eapply inversion_Sort in HT as [l' [wfΓ Hs]]; auto.
+  eexists; econstructor; eauto.
+Qed.
+
+Lemma isType_it_mkProd {cf:checker_flags} {Σ : global_env_ext} {Γ na dom codom A} {wfΣ : wf Σ} :   
+  Σ ;;; Γ |- tProd na dom codom : A -> 
+  isType Σ Γ (tProd na dom codom).
+Proof.
+  intros HT.
+  eapply inversion_Prod in HT as (? & ? & ? & ? & ?); auto.
+  eexists; econstructor; eauto.
+Qed.
+
+Definition trans_constant_decl Σ cb := 
+  {| cst_body := option_map (trans Σ) cb.(cst_body) |}.
+  
+Definition trans_decl Σ d :=
+  match d with
+  | ConstantDecl cb => ConstantDecl (trans_constant_decl Σ cb)
+  | InductiveDecl idecl => d
+  end.
+
+Definition trans_env Σ := 
+  map (on_snd (trans_decl Σ)) Σ.(GlobalContextMap.global_decls).
+  
+Import EnvMap.
+
+Program Fixpoint trans_env' Σ : EnvMap.fresh_globals Σ -> global_context :=
+  match Σ with
+  | [] => fun _ => []
+  | hd :: tl => fun HΣ =>
+    let Σg := GlobalContextMap.make tl (fresh_globals_cons_inv HΣ) in 
+    on_snd (trans_decl Σg) hd :: trans_env' tl (fresh_globals_cons_inv HΣ) 
+  end.
+
+Import EGlobalEnv EExtends.
+
+(* Lemma extends_is_propositional {Σ Σ'} : 
+  wf_glob Σ' -> extends Σ Σ' ->
+  forall ind, 
+  match inductive_isprop_and_pars Σ ind with
+  | Some b => inductive_isprop_and_pars Σ' ind = Some b
+  | None => inductive_isprop_and_pars Σ' ind = None
+  end.
+Proof.
+  intros wf ex ind.
+  rewrite /inductive_isprop_and_pars.
+  destruct lookup_env eqn:lookup => //.
+  now rewrite (extends_lookup wf ex lookup).
+
+Qed. *)
+
+Lemma extends_inductive_isprop_and_pars {efl : EEnvFlags} {Σ Σ' ind} : extends Σ Σ' -> wf_glob Σ' ->
+  isSome (lookup_inductive Σ ind) -> 
+  inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars Σ' ind.
+Proof.
+  intros ext wf; cbn.
+  unfold inductive_isprop_and_pars. cbn.
+  destruct lookup_env as [[]|] eqn:hl => //.
+  rewrite (extends_lookup wf ext hl).
+  destruct nth_error => //.
+Qed.
+
+Lemma wellformed_trans_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t : 
+  forall n, EWellformed.wellformed Σ n t ->
+  forall {Σ' : GlobalContextMap.t}, extends Σ Σ' -> wf_glob Σ' ->
+  trans Σ t = trans Σ' t.
+Proof.
+  induction t using EInduction.term_forall_list_ind; cbn -[lookup_constant lookup_inductive
+    lookup_projection
+    GlobalContextMap.inductive_isprop_and_pars]; intros => //.
+  all:unfold wf_fix_gen in *; rtoProp; intuition auto.  
+  all:try now f_equal; eauto; solve_all.
+  - admit.
+   (* destruct cstr_as_blocks; rtoProp; eauto. f_equal. solve_all. destruct args; inv H2. reflexivity. *)
+  - admit.
+    (* rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
+    assert (map (on_snd (trans Σ)) l = map (on_snd (trans Σ')) l) as -> by solve_all.
+    rewrite (extends_inductive_isprop_and_pars H0 H1 H2).
+    destruct inductive_isprop_and_pars as [[[]]|].
+    destruct map => //. f_equal; eauto.
+    destruct l0 => //. destruct p0 => //. f_equal; eauto.
+    all:f_equal; eauto; solve_all.*)
+  - admit.
+    (* rewrite !GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite (extends_inductive_isprop_and_pars H0 H1).
+    destruct (lookup_projection) as [[[[mdecl idecl] cdecl] pdecl]|] eqn:hl => //.
+    eapply lookup_projection_lookup_constructor in hl.
+    eapply lookup_constructor_lookup_inductive in hl. now rewrite hl.
+    destruct inductive_isprop_and_pars as [[[]]|] => //.
+    all:f_equal; eauto.*)
+Admitted.
+
+Lemma wellformed_trans_decl_extends {wfl: EEnvFlags} {Σ : GlobalContextMap.t} t : 
+  wf_global_decl Σ t ->
+  forall {Σ' : GlobalContextMap.t}, extends Σ Σ' -> wf_glob Σ' ->
+  trans_decl Σ t = trans_decl Σ' t.
+Proof.
+  destruct t => /= //.
+  intros wf Σ' ext wf'. f_equal. unfold trans_constant_decl. f_equal.
+  destruct (cst_body c) => /= //. f_equal.
+  now eapply wellformed_trans_extends.
+Qed.
+
+Lemma lookup_env_trans_env_Some {efl : EEnvFlags} {Σ : GlobalContextMap.t} kn d : 
+  wf_glob Σ ->
+  GlobalContextMap.lookup_env Σ kn = Some d ->
+  ∑ Σ' : GlobalContextMap.t, 
+    [× extends Σ' Σ, wf_global_decl Σ' d &
+      lookup_env (trans_env Σ) kn = Some (trans_decl Σ' d)].
+Proof.
+  rewrite GlobalContextMap.lookup_env_spec.
+  destruct Σ as [Σ map repr wf].
+  induction Σ in map, repr, wf |- *; simpl; auto => //.
+  intros wfg.
+  case: eqb_specT => //.
+  - intros ->. cbn. intros [= <-].
+    exists (GlobalContextMap.make Σ (fresh_globals_cons_inv wf)). split.
+    now eexists [_].
+    cbn. now depelim wfg.
+    f_equal. symmetry. eapply wellformed_trans_decl_extends. cbn. now depelim wfg.
+    cbn. now exists [a]. now cbn.
+  - intros _. 
+    set (Σ' := GlobalContextMap.make Σ (fresh_globals_cons_inv wf)).
+    specialize (IHΣ (GlobalContextMap.map Σ') (GlobalContextMap.repr Σ') (GlobalContextMap.wf Σ')).
+    cbn in IHΣ. forward IHΣ. now depelim wfg.
+    intros hl. specialize (IHΣ hl) as [Σ'' [ext wfgd hl']].
+    exists Σ''. split => //.
+    * destruct ext as [? ->].
+      now exists (a :: x).
+    * rewrite -hl'. f_equal.
+      clear -wfg.
+      eapply map_ext_in => kn hin. unfold on_snd. f_equal.
+      symmetry. eapply wellformed_trans_decl_extends => //. cbn.
+      eapply lookup_env_In in hin. 2:now depelim wfg.
+      depelim wfg. eapply lookup_env_wellformed; tea.
+      cbn. now exists [a].
+Qed.
+
+Lemma lookup_env_map_snd Σ f kn : lookup_env (List.map (on_snd f) Σ) kn = option_map f (lookup_env Σ kn).
+Proof.
+  induction Σ; cbn; auto.
+  case: eqb_spec => //.
+Qed.
+
+Lemma lookup_env_trans_env_None {efl : EEnvFlags} {Σ : GlobalContextMap.t} kn : 
+  GlobalContextMap.lookup_env Σ kn = None ->
+  lookup_env (trans_env Σ) kn = None.
+Proof.
+  rewrite GlobalContextMap.lookup_env_spec.
+  destruct Σ as [Σ map repr wf].
+  cbn. intros hl. rewrite lookup_env_map_snd hl //.
+Qed.
+
+Lemma lookup_env_trans {efl : EEnvFlags} {Σ : GlobalContextMap.t} kn : 
+  wf_glob Σ ->
+  lookup_env (trans_env Σ) kn = option_map (trans_decl Σ) (lookup_env Σ kn).
+Proof.
+  intros wf.
+  rewrite -GlobalContextMap.lookup_env_spec.
+  destruct (GlobalContextMap.lookup_env Σ kn) eqn:hl.
+  - eapply lookup_env_trans_env_Some in hl as [Σ' [ext wf' hl']] => /=.
+    rewrite hl'. f_equal.
+    eapply wellformed_trans_decl_extends; eauto. auto.
+    
+  - cbn. now eapply lookup_env_trans_env_None in hl. 
+Qed.
+
+Lemma is_propositional_trans {efl : EEnvFlags} {Σ : GlobalContextMap.t} ind : 
+  wf_glob Σ ->
+  inductive_isprop_and_pars Σ ind = inductive_isprop_and_pars (trans_env Σ) ind.
+Proof.
+  rewrite /inductive_isprop_and_pars => wf.
+  rewrite /lookup_inductive /lookup_minductive.
+  rewrite (lookup_env_trans (inductive_mind ind) wf).
+  rewrite /GlobalContextMap.inductive_isprop_and_pars /GlobalContextMap.lookup_inductive
+    /GlobalContextMap.lookup_minductive.  
+  destruct lookup_env as [[decl|]|] => //.
+Qed.
+
+Lemma is_propositional_cstr_trans {efl : EEnvFlags} {Σ : GlobalContextMap.t} ind c : 
+  wf_glob Σ ->
+  constructor_isprop_pars_decl Σ ind c = constructor_isprop_pars_decl (trans_env Σ) ind c.
+Proof.
+  rewrite /constructor_isprop_pars_decl => wf.
+  rewrite /lookup_constructor /lookup_inductive /lookup_minductive.
+  rewrite (lookup_env_trans (inductive_mind ind) wf).
+  rewrite /GlobalContextMap.inductive_isprop_and_pars /GlobalContextMap.lookup_inductive
+    /GlobalContextMap.lookup_minductive.  
+  destruct lookup_env as [[decl|]|] => //.
+Qed.
+
+
+Lemma closed_iota_red pars c args brs br :
+  forallb (closedn 0) args ->
+  nth_error brs c = Some br ->
+  #|skipn pars args| = #|br.1| ->
+  closedn #|br.1| br.2 ->
+  closed (iota_red pars args br).
+Proof.
+  intros clargs hnth hskip clbr.
+  rewrite /iota_red.
+  eapply ECSubst.closed_substl => //.
+  now rewrite forallb_rev forallb_skipn.
+  now rewrite List.rev_length hskip Nat.add_0_r.
+Qed.
+
+Lemma isFix_mkApps t l : isFix (mkApps t l) = isFix t && match l with [] => true | _ => false end.
+Proof.
+  induction l using rev_ind; cbn.
+  - now rewrite andb_true_r.
+  - rewrite mkApps_app /=. now destruct l => /= //; rewrite andb_false_r.
+Qed.
+
+Lemma lookup_constructor_trans {efl : EEnvFlags} {Σ : GlobalContextMap.t} {ind c} :
+  wf_glob Σ ->
+  lookup_constructor Σ ind c = lookup_constructor (trans_env Σ) ind c.
+Proof.
+  intros wfΣ. rewrite /lookup_constructor /lookup_inductive /lookup_minductive.
+  rewrite lookup_env_trans // /=. destruct lookup_env => // /=.
+  destruct g => //.
+Qed.
+
+Lemma constructor_isprop_pars_decl_inductive {Σ ind c} {prop pars cdecl} :
+  constructor_isprop_pars_decl Σ ind c = Some (prop, pars, cdecl)  -> 
+  inductive_isprop_and_pars Σ ind = Some (prop, pars).
+Proof.
+  rewrite /constructor_isprop_pars_decl /inductive_isprop_and_pars /lookup_constructor.
+  destruct lookup_inductive as [[mdecl idecl]|]=> /= //.
+  destruct nth_error => //. congruence.
+Qed.
+
+Lemma trans_correct {efl : EEnvFlags} {fl} {wcon : with_constructor_as_block = true} 
+  {Σ : GlobalContextMap.t} t v :
+  wf_glob Σ ->
+  closed_env Σ ->
+  @Ee.eval fl Σ t v ->
+  closed t ->
+  @Ee.eval fl (trans_env Σ) (trans Σ t) (trans Σ v).
+Proof.
+Admitted.
+  (*intros wfΣ clΣ ev.
+  induction ev; simpl in *.
+
+  - move/andP => [] cla clt. econstructor; eauto.
+  - move/andP => [] clf cla.
+    eapply eval_closed in ev2; tea.
+    eapply eval_closed in ev1; tea.
+    econstructor; eauto.
+    rewrite trans_csubst // in IHev3.
+    apply IHev3. eapply closed_csubst => //.
+
+  - move/andP => [] clb0 clb1. rewrite trans_csubst in IHev2.
+    now eapply eval_closed in ev1.
+    econstructor; eauto. eapply IHev2, closed_csubst => //.
+    now eapply eval_closed in ev1.
+
+  - move/andP => [] cld clbrs. rewrite trans_mkApps in IHev1.
+    have := (eval_closed _ clΣ _ _ cld ev1); rewrite closedn_mkApps => /andP[] _ clargs.
+    rewrite trans_iota_red in IHev2.
+    eapply eval_closed in ev1 => //.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite (constructor_isprop_pars_decl_inductive e1).
+    eapply eval_iota; eauto.
+    now rewrite -is_propositional_cstr_trans.
+    rewrite nth_error_map e2 //. now len. cbn.
+    rewrite -e4. rewrite !skipn_length map_length //.
+    eapply IHev2.
+    eapply closed_iota_red => //; tea.
+    eapply nth_error_forallb in clbrs; tea. cbn in clbrs.
+    now rewrite Nat.add_0_r in clbrs.
+  
+  - congruence.
+  
+  - move/andP => [] cld clbrs.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite e0 e1 /=.
+    subst brs. cbn in clbrs. rewrite Nat.add_0_r andb_true_r in clbrs.
+    rewrite trans_substl in IHev2. 
+    eapply All_forallb, All_repeat => //.
+    rewrite map_trans_repeat_box in IHev2.
+    apply IHev2.
+    eapply closed_substl.
+    eapply All_forallb, All_repeat => //.
+    now rewrite repeat_length Nat.add_0_r.
+
+  - move/andP => [] clf cla. rewrite trans_mkApps in IHev1.
+    simpl in *.
+    eapply eval_closed in ev1 => //.
+    rewrite closedn_mkApps in ev1.
+    move: ev1 => /andP [] clfix clargs.
+    eapply Ee.eval_fix; eauto.
+    rewrite map_length.
+    eapply trans_cunfold_fix; tea.
+    eapply closed_fix_subst. tea.
+    rewrite trans_mkApps in IHev3. apply IHev3.
+    rewrite closedn_mkApps clargs.
+    eapply eval_closed in ev2; tas. rewrite ev2 /= !andb_true_r.
+    eapply closed_cunfold_fix; tea.
+
+  - move/andP => [] clf cla.
+    eapply eval_closed in ev1 => //.
+    rewrite closedn_mkApps in ev1.
+    move: ev1 => /andP [] clfix clargs.
+    eapply eval_closed in ev2; tas.
+    rewrite trans_mkApps in IHev1 |- *.
+    simpl in *. eapply Ee.eval_fix_value. auto. auto. auto.
+    eapply trans_cunfold_fix; eauto.
+    eapply closed_fix_subst => //.
+    now rewrite map_length. 
+  
+  - move/andP => [] clf cla.
+    eapply eval_closed in ev1 => //.
+    eapply eval_closed in ev2; tas.
+    simpl in *. eapply Ee.eval_fix'. auto. auto.
+    eapply trans_cunfold_fix; eauto.
+    eapply closed_fix_subst => //.
+    eapply IHev2; tea. eapply IHev3.
+    apply/andP; split => //.
+    eapply closed_cunfold_fix; tea.
+
+  - move/andP => [] cd clbrs. specialize (IHev1 cd).
+    rewrite closedn_mkApps in IHev2.
+    move: (eval_closed _ clΣ _ _ cd ev1).
+    rewrite closedn_mkApps.
+    move/andP => [] clfix clargs.
+    forward IHev2.
+    { rewrite clargs clbrs !andb_true_r.
+      eapply closed_cunfold_cofix; tea. }
+    rewrite -> trans_mkApps in IHev1, IHev2. simpl.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec in IHev2 |- *.
+    destruct EGlobalEnv.inductive_isprop_and_pars as [[[] pars]|] eqn:isp => //.
+    destruct brs as [|[a b] []]; simpl in *; auto.
+    simpl in IHev1.
+    eapply Ee.eval_cofix_case. tea.
+    apply trans_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    apply IHev2.
+    eapply Ee.eval_cofix_case; tea.
+    apply trans_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    simpl in *.
+    eapply Ee.eval_cofix_case; tea.
+    apply trans_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    eapply Ee.eval_cofix_case; tea.
+    apply trans_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    
+  - intros cd. specialize (IHev1 cd).
+    move: (eval_closed _ clΣ _ _ cd ev1).
+    rewrite closedn_mkApps; move/andP => [] clfix clargs. forward IHev2.
+    { rewrite closedn_mkApps clargs andb_true_r. eapply closed_cunfold_cofix; tea. }
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec in IHev2 |- *.
+    destruct EGlobalEnv.inductive_isprop_and_pars as [[[] pars]|] eqn:isp; auto.
+    rewrite -> trans_mkApps in IHev1, IHev2. simpl in *.
+    econstructor; eauto.
+    apply trans_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+    rewrite -> trans_mkApps in IHev1, IHev2. simpl in *.
+    econstructor; eauto.
+    apply trans_cunfold_cofix; tea. eapply closed_cofix_subst; tea.
+  
+  - rewrite /declared_constant in isdecl.
+    move: (lookup_env_trans c wfΣ).
+    rewrite isdecl /= //.
+    intros hl.
+    econstructor; tea. cbn. rewrite e //.
+    apply IHev.
+    eapply lookup_env_closed in clΣ; tea.
+    move: clΣ. rewrite /closed_decl e //.
+  
+  - move=> cld.
+    eapply eval_closed in ev1; tea.
+    move: ev1; rewrite closedn_mkApps /= => clargs.
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    rewrite (constructor_isprop_pars_decl_inductive e1).
+    rewrite trans_mkApps in IHev1.
+    specialize (IHev1 cld).
+    eapply Ee.eval_proj; tea.
+    now rewrite -is_propositional_cstr_trans.
+    now len. rewrite nth_error_map e3 //.
+    eapply IHev2.
+    eapply nth_error_forallb in e3; tea.
+
+  - congruence.
+
+  - rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    now rewrite e0.
+
+  - move/andP=> [] clf cla.
+    rewrite trans_mkApps.
+    eapply eval_construct; tea.
+    rewrite -lookup_constructor_trans //. exact e0.
+    rewrite trans_mkApps in IHev1. now eapply IHev1.
+    now len.
+    now eapply IHev2.
+
+  - congruence.
+
+  - move/andP => [] clf cla.
+    specialize (IHev1 clf). specialize (IHev2 cla).
+    eapply Ee.eval_app_cong; eauto.
+    eapply Ee.eval_to_value in ev1.
+    destruct ev1; simpl in *; eauto.
+    * destruct t => //; rewrite trans_mkApps /=.
+    * destruct with_guarded_fix.
+      + move: i. 
+        rewrite !negb_or.
+        rewrite trans_mkApps !isFixApp_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
+        destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
+        rewrite !andb_true_r.
+        rtoProp; intuition auto.
+        destruct v => /= //. 
+        destruct v => /= //.
+        destruct v => /= //.
+      + move: i. 
+        rewrite !negb_or.
+        rewrite trans_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
+        destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
+        destruct v => /= //. 
+  - destruct t => //.
+    all:constructor; eauto. cbn [atom trans] in i |- *.
+    rewrite -lookup_constructor_trans //. destruct l => //.
+Qed.
+*)
+From MetaCoq.Erasure Require Import EEtaExpanded.
+
+Lemma isLambda_trans Σ t : isLambda t -> isLambda (trans Σ t).
+Proof. destruct t => //. Qed.
+Lemma isBox_trans Σ t : isBox t -> isBox (trans Σ t).
+Proof. destruct t => //. Qed.
+
+Lemma trans_expanded {Σ : GlobalContextMap.t} t : expanded Σ t -> expanded Σ (trans Σ t).
+Proof.
+  induction 1 using expanded_ind.
+  all:try solve[constructor; eauto; solve_all].
+  all:rewrite ?trans_mkApps.
+  - eapply expanded_mkApps_expanded => //. solve_all.
+  - cbn -[GlobalContextMap.lookup_inductive_kind].
+    rewrite GlobalContextMap.lookup_inductive_kind_spec.
+    destruct lookup_inductive_kind as [[]|] => /= //.
+    2-3:constructor; eauto; solve_all.
+    constructor; eauto; solve_all. cbn.
+    unfold Thunk.force.
+    eapply isEtaExp_expanded.
+  Admitted.
+    (*cbn.
+    eapply isEtaExp_substl. eapply forallb_repeat => //.
+    destruct branches as [|[]]; cbn in heq; noconf heq.
+    cbn -[isEtaExp] in *. depelim H1. cbn in H1.
+    now eapply expanded_isEtaExp.
+    constructor; eauto; solve_all.
+    depelim H1. depelim H1. do 2 (constructor; intuition auto).
+    solve_all.
+  - cbn -[GlobalContextMap.inductive_isprop_and_pars].
+    rewrite GlobalContextMap.inductive_isprop_and_pars_spec.
+    destruct inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    constructor. all:constructor; auto.
+  - cbn. eapply expanded_tFix. solve_all.
+    rewrite isLambda_trans //.
+  - eapply expanded_tConstruct_app; tea.
+    now len. solve_all.
+Qed.
+*)
+Lemma trans_expanded_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t : wf_glob Σ -> expanded Σ t -> expanded (trans_env Σ) t.
+Proof.
+  intros wf; induction 1 using expanded_ind.
+  all:try solve[constructor; eauto; solve_all].
+  eapply expanded_tConstruct_app.
+  destruct H as [[H ?] ?].
+  split => //. split => //. red.
+  red in H. rewrite lookup_env_trans // /= H //. 1-2:eauto. auto. solve_all. 
+Qed.
+
+Lemma trans_expanded_decl {Σ : GlobalContextMap.t} t : expanded_decl Σ t -> expanded_decl Σ (trans_decl Σ t).
+Proof.
+  destruct t as [[[]]|] => /= //.
+  unfold expanded_constant_decl => /=.
+  apply trans_expanded.
+Qed.
+
+Lemma trans_expanded_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t : wf_glob Σ -> expanded_decl Σ t -> expanded_decl (trans_env Σ) t.
+Proof.
+  destruct t as [[[]]|] => /= //.
+  unfold expanded_constant_decl => /=.
+  apply trans_expanded_irrel.
+Qed.
+
+Lemma trans_env_extends' {efl : EEnvFlags} {Σ Σ' : GlobalContextMap.t} : 
+  extends Σ Σ' ->
+  wf_glob Σ' -> 
+  List.map (on_snd (trans_decl Σ)) Σ.(GlobalContextMap.global_decls) =
+  List.map (on_snd (trans_decl Σ')) Σ.(GlobalContextMap.global_decls).
+Proof.
+  intros ext.
+  destruct Σ as [Σ map repr wf]; cbn in *.
+  move=> wfΣ.
+  assert (extends Σ Σ); auto. now exists [].
+  assert (wf_glob Σ).
+  { eapply extends_wf_glob. exact ext. tea. }
+  revert H H0.
+  generalize Σ at 1 3 5 6. intros Σ''.
+  induction Σ'' => //. cbn.
+  intros hin wfg. depelim wfg.
+  f_equal.
+  2:{ eapply IHΣ'' => //. destruct hin. exists (x ++ [(kn, d)]). rewrite -app_assoc /= //. }
+  unfold on_snd. cbn. f_equal.
+  eapply wellformed_trans_decl_extends => //. cbn.
+  eapply extends_wf_global_decl. 3:tea.
+  eapply extends_wf_glob; tea.
+  destruct hin. exists (x ++ [(kn, d)]). rewrite -app_assoc /= //.
+Qed.
+
+Lemma trans_env_eq {efl : EEnvFlags} (Σ : GlobalContextMap.t) : wf_glob Σ -> trans_env Σ = trans_env' Σ.(GlobalContextMap.global_decls) Σ.(GlobalContextMap.wf).
+Proof.
+  intros wf.
+  unfold trans_env.
+  destruct Σ; cbn. cbn in wf.
+  induction global_decls in map, repr, wf0, wf |- * => //.
+  cbn. f_equal.
+  destruct a as [kn d]; unfold on_snd; cbn. f_equal. symmetry.
+  eapply wellformed_trans_decl_extends => //. cbn. now depelim wf. cbn. now exists [(kn, d)]. cbn.
+  set (Σg' := GlobalContextMap.make global_decls (fresh_globals_cons_inv wf0)).
+  erewrite <- (IHglobal_decls (GlobalContextMap.map Σg') (GlobalContextMap.repr Σg')).
+  2:now depelim wf.
+  set (Σg := {| GlobalContextMap.global_decls := _ :: _ |}).
+  symmetry. eapply (trans_env_extends' (Σ := Σg') (Σ' := Σg)) => //.
+  cbn. now exists [a].
+Qed.
+
+Lemma trans_env_expanded {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
+  wf_glob Σ -> expanded_global_env Σ -> expanded_global_env (trans_env Σ).
+Proof.
+  unfold expanded_global_env; move=> wfg.
+  rewrite trans_env_eq //.
+  destruct Σ as [Σ map repr wf]. cbn in *.
+  clear map repr.
+  induction 1; cbn; constructor; auto.
+  cbn in IHexpanded_global_declarations.
+  unshelve eapply IHexpanded_global_declarations. now depelim wfg. cbn. 
+  set (Σ' := GlobalContextMap.make _ _).
+  rewrite -(trans_env_eq Σ'). cbn. now depelim wfg.
+  eapply (trans_expanded_decl_irrel (Σ := Σ')). now depelim wfg.
+  now unshelve eapply (trans_expanded_decl (Σ:=Σ')).
+Qed.
+
+Lemma trans_wellformed {efl : EEnvFlags} {Σ : GlobalContextMap.t} n t :
+  has_tBox -> has_tRel ->
+  wf_glob Σ -> EWellformed.wellformed Σ n t -> EWellformed.wellformed Σ n (trans Σ t).
+Proof.
+  intros wfΣ hbox hrel.
+  induction t in n |- * using EInduction.term_forall_list_ind => //.
+  all:try solve [cbn; rtoProp; intuition auto; solve_all].
+  - admit.
+    (* cbn -[lookup_constructor]. intros. destruct cstr_as_blocks; rtoProp; repeat split; eauto. 2:solve_all.
+    2: now destruct args; inv H0. len. eauto. *)
+  - admit.
+  (* cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/and3P => [] hasc /andP[]hs ht hbrs.
+    destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    destruct l as [|[br n'] [|l']] eqn:eql; simpl.
+    all:rewrite ?hasc ?hs /= ?andb_true_r.
+    rewrite IHt //.
+    depelim X. cbn in hbrs.
+    rewrite andb_true_r in hbrs.
+    specialize (i _ hbrs).
+    eapply wellformed_substl => //. solve_all. eapply All_repeat => //.
+    now rewrite repeat_length.
+    cbn in hbrs; rtoProp; solve_all. depelim X; depelim X. solve_all.
+    do 2 depelim X. solve_all.
+    do 2 depelim X. solve_all.
+    rtoProp; solve_all. solve_all.
+    rtoProp; solve_all. solve_all.*)
+  - admit.
+     (* cbn -[GlobalContextMap.inductive_isprop_and_pars lookup_inductive]. move/andP => [] /andP[]hasc hs ht.
+    destruct GlobalContextMap.inductive_isprop_and_pars as [[[|] _]|] => /= //.
+    all:rewrite hasc hs /=; eauto. *)
+  - cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now eapply isLambda_trans. now len.
+    unfold test_def in *. len. eauto.
+  - admit.
+     (* cbn. unfold wf_fix; rtoProp; intuition auto; solve_all. now len. *)
+    (* unfold test_def in *. len. eauto. *)
+Admitted.
+
+Import EWellformed.
+
+Lemma trans_wellformed_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} t :
+  wf_glob Σ ->
+  forall n, wellformed Σ n t -> wellformed (trans_env Σ) n t.
+Proof.
+  intros wfΣ. induction t using EInduction.term_forall_list_ind; cbn => //.
+  all:try solve [intros; unfold wf_fix_gen in *; rtoProp; intuition eauto; solve_all].
+  - rewrite lookup_env_trans //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //. subst g.
+    destruct (cst_body c) => //.
+  - rewrite lookup_env_trans //.
+    destruct lookup_env eqn:hl => // /=; intros; rtoProp; eauto.
+    destruct g eqn:hg => /= //; intros; rtoProp; eauto.
+    repeat split; eauto. destruct cstr_as_blocks; rtoProp; repeat split; len; eauto. 1: solve_all.
+  - rewrite lookup_env_trans //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //. subst g.
+    destruct nth_error => /= //.
+    intros; rtoProp; intuition auto; solve_all.
+  - rewrite lookup_env_trans //.
+    destruct lookup_env eqn:hl => // /=.
+    destruct g eqn:hg => /= //.
+    rewrite andb_false_r => //.
+    destruct nth_error => /= //.
+    all:intros; rtoProp; intuition auto; solve_all.
+Qed.
+
+Lemma trans_wellformed_decl_irrel {efl : EEnvFlags} {Σ : GlobalContextMap.t} d :
+  wf_glob Σ ->
+  wf_global_decl Σ d -> wf_global_decl (trans_env Σ) d.
+Proof.
+  intros wf; destruct d => /= //.
+  destruct (cst_body c) => /= //.
+  now eapply trans_wellformed_irrel.
+Qed.
+
+Lemma trans_decl_wf {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
+  has_tBox -> has_tRel -> wf_glob Σ -> 
+  forall d, wf_global_decl Σ d -> wf_global_decl (trans_env Σ) (trans_decl Σ d).
+Proof.
+  intros hasb hasr wf d.
+  intros hd.
+  eapply trans_wellformed_decl_irrel; tea.
+  move: hd.
+  destruct d => /= //.
+  destruct (cst_body c) => /= //.
+  now eapply trans_wellformed => //.
+Qed.
+
+Lemma fresh_global_trans_env {Σ : GlobalContextMap.t} kn : 
+  fresh_global kn Σ ->
+  fresh_global kn (trans_env Σ).
+Proof.
+  destruct Σ as [Σ map repr wf]; cbn in *.
+  induction 1; cbn; constructor; auto.
+  now eapply Forall_map; cbn.
+Qed.
+
+Lemma trans_env_wf {efl : EEnvFlags} {Σ : GlobalContextMap.t} :
+  has_tBox -> has_tRel -> 
+  wf_glob Σ -> wf_glob (trans_env Σ).
+Proof.
+  intros hasb hasrel.
+  intros wfg. rewrite trans_env_eq //.
+  destruct Σ as [Σ map repr wf]; cbn in *.
+  clear map repr.
+  induction wfg; cbn; constructor; auto.
+  - rewrite /= -(trans_env_eq (GlobalContextMap.make Σ (fresh_globals_cons_inv wf))) //.
+    eapply trans_decl_wf => //.
+  - rewrite /= -(trans_env_eq (GlobalContextMap.make Σ (fresh_globals_cons_inv wf))) //.
+    now eapply fresh_global_trans_env.
+Qed.
+
+Definition trans_program (p : eprogram_env) :=
+  (trans_env p.1, trans p.1 p.2).
+
+Definition trans_program_wf {efl} (p : eprogram_env) {hastbox : has_tBox} {hastrel : has_tRel} :
+  wf_eprogram_env efl p -> wf_eprogram efl (trans_program p).
+Proof.
+  intros []; split.
+  now eapply trans_env_wf.
+  cbn. eapply trans_wellformed_irrel => //. now eapply trans_wellformed.
+Qed.
+
+Definition trans_program_expanded {efl} (p : eprogram_env) :
+  wf_eprogram_env efl p ->
+  expanded_eprogram_env_cstrs p -> expanded_eprogram_cstrs (trans_program p).
+Proof.
+  unfold expanded_eprogram_env_cstrs.
+  move=> [wfe wft] /andP[] etae etat.
+  apply/andP; split.
+  cbn. eapply expanded_global_env_isEtaExp_env, trans_env_expanded => //.
+  now eapply isEtaExp_env_expanded_global_env.
+  eapply expanded_isEtaExp.
+  eapply trans_expanded_irrel => //.
+  now apply trans_expanded, isEtaExp_expanded.
+Qed.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -400,7 +400,8 @@ Lemma erases_deps_forall_ind Σ Σ'
   (Hcofix : forall (defs : list (Extract.E.def Extract.E.term)) (i : nat),
          Forall (fun d : Extract.E.def Extract.E.term => erases_deps Σ Σ' (Extract.E.dbody d)) defs ->
          Forall (fun d => P (E.dbody d)) defs ->
-         P (Extract.E.tCoFix defs i)) :
+         P (Extract.E.tCoFix defs i))
+  (Hprim : forall p, P (Extract.E.tPrim p)):
   forall t, erases_deps Σ Σ' t -> P t.
 Proof.
   fix f 2.
@@ -463,7 +464,7 @@ Qed. *)
 
 Lemma erases_deps_cons Σ Σ' kn decl decl' t :
   on_global_univs Σ.(universes) ->
-  on_global_decls cumulSpec0 (lift_typing typing) Σ.(universes) ((kn, decl) :: Σ.(declarations)) ->
+  on_global_decls cumulSpec0 (lift_typing typing) Σ.(universes) Σ.(retroknowledge) ((kn, decl) :: Σ.(declarations)) ->
   erases_deps Σ Σ' t ->
   erases_deps (add_global_decl Σ (kn, decl)) ((kn, decl') :: Σ') t.
 Proof.
@@ -681,7 +682,7 @@ Lemma erases_global_all_deps Σ Σ' :
   globals_erased_with_deps Σ Σ'.
 Proof.
   intros wf erg.
-  set (Σg := Σ). destruct Σ as [univs Σ]; cbn in *.
+  set (Σg := Σ). destruct Σ as [univs Σ retro]; cbn in *.
   induction Σ as [|(kn, decl) Σ IH] in Σ', Σg, wf, erg |- *; cbn in *.
   - depelim erg.
     split; [intros ? ? decl; discriminate decl|].
@@ -719,7 +720,7 @@ Proof.
         now split; cbn; eauto.
         depelim wf. depelim o0. do 2 red in o2. now rewrite E in o2.
         apply IH; eauto. depelim wf. now depelim o0.
-    + set (Σu := {| universes := univs; declarations := Σ |}).
+    + set (Σu := {| universes := univs; declarations := Σ; retroknowledge := retro |}).
       assert (wfΣu : PCUICTyping.wf Σu).
       { depelim wf. now depelim o0. }
       assert (exists decl' Σ'', Σ' = (kn, decl') :: Σ'' /\ erases_global Σu Σ'')

--- a/erasure/theories/EEnvMap.v
+++ b/erasure/theories/EEnvMap.v
@@ -1,6 +1,6 @@
 From Coq Require Import ssreflect ssrbool.
 From Equations Require Import Equations.
-From MetaCoq.Template Require Import utils Kernames EnvMap.
+From MetaCoq.Template Require Import utils Kernames EnvMap BasicAst.
 From MetaCoq.Erasure Require Import EAst EGlobalEnv EAstUtils EGlobalEnv EAstUtils.
 Import MCMonadNotation.
 
@@ -76,6 +76,16 @@ Module GlobalContextMap.
   Lemma lookup_inductive_pars_spec Σ kn : lookup_inductive_pars Σ kn = EGlobalEnv.lookup_inductive_pars Σ kn.
   Proof.
     rewrite /lookup_inductive_pars /EGlobalEnv.lookup_inductive_pars.
+    now rewrite lookup_minductive_spec.
+  Qed.
+
+  Definition lookup_inductive_kind Σ kn : option recursivity_kind := 
+    mdecl <- lookup_minductive Σ kn ;;
+    ret mdecl.(ind_finite).
+
+  Lemma lookup_inductive_kind_spec Σ kn : lookup_inductive_kind Σ kn = EGlobalEnv.lookup_inductive_kind Σ kn.
+  Proof.
+    rewrite /lookup_inductive_kind /EGlobalEnv.lookup_inductive_kind.
     now rewrite lookup_minductive_spec.
   Qed.
 

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -74,6 +74,7 @@ Section isEtaExp.
     | tBox => true
     | tVar _ => true
     | tConst _ => true
+    | tPrim _ => true
     | tConstruct ind i block_args => isEtaExp_app ind i 0 && is_nil block_args }.
   Proof.
     all:try lia.
@@ -467,6 +468,7 @@ Inductive expanded : term -> Prop :=
     #|args| >= cstr_arity mind cdecl -> 
     Forall expanded args ->
     expanded (mkApps (tConstruct ind idx []) args)
+| expanded_tPrim p : expanded (tPrim p)
 | expanded_tBox : expanded tBox.
 
 End expanded.
@@ -505,18 +507,19 @@ forall (Σ : global_declarations) (P : term -> Prop),
    (args : list term),
  declared_constructor Σ (ind, idx) mind idecl cdecl ->
  #|args| >= cstr_arity mind cdecl -> Forall (expanded Σ) args -> Forall P args -> P (mkApps (tConstruct ind idx []) args)) ->
+(forall p, P (tPrim p)) ->
 (P tBox) ->
 forall t : term, expanded Σ t -> P t.
 Proof. 
-  intros. revert t H12.
+  intros. revert t H13.
   fix f 2.
   intros t Hexp. destruct Hexp; eauto.
-  - eapply H1; eauto. induction H12; econstructor; cbn in *; eauto.
-  - eapply H4; eauto. clear H13. induction H14; econstructor; cbn in *; eauto.
-  - eapply H6; eauto. induction H12; econstructor; cbn in *; eauto.
-  - eapply H8; eauto. induction H12; econstructor; cbn in *; intuition eauto.
-  - eapply H9; eauto. induction H12; econstructor; cbn in *; eauto.
-  - eapply H10; eauto. clear - H14 f. induction H14; econstructor; cbn in *; eauto.
+  - eapply H1; eauto. induction H13; econstructor; cbn in *; eauto.
+  - eapply H4; eauto. clear H14. induction H15; econstructor; cbn in *; eauto.
+  - eapply H6; eauto. induction H13; econstructor; cbn in *; eauto.
+  - eapply H8; eauto. induction H13; econstructor; cbn in *; intuition eauto.
+  - eapply H9; eauto. induction H13; econstructor; cbn in *; eauto.
+  - eapply H10; eauto. clear - H15 f. induction H15; econstructor; cbn in *; eauto.
 Qed.
 
 Local Hint Constructors expanded : core.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -59,6 +59,7 @@ Inductive expanded (Γ : list nat): term -> Prop :=
     #|args| >= ind_npars mind + cdecl.(cstr_nargs) -> 
     Forall (expanded Γ) args ->
     expanded Γ (mkApps (tConstruct ind idx []) args)
+| expanded_tPrim p : expanded Γ (tPrim p)
 | expanded_tBox : expanded Γ tBox.
 
 End expanded.
@@ -136,10 +137,11 @@ Lemma expanded_ind :
         → Forall (expanded Σ Γ) args
         → Forall (P Γ) args
         → P Γ (mkApps (tConstruct ind idx []) args))
+    → (∀ Γ p, P Γ (tPrim p))
     → (∀ Γ : list nat, P Γ tBox)
     → ∀ (Γ : list nat) (t : term), expanded Σ Γ t → P Γ t.
 Proof.
-  intros Σ P HRel_app HVar HEvar HLamdba HLetIn HmkApps HConst HCase HProj HFix HCoFix HConstruct HBox.
+  intros Σ P HRel_app HVar HEvar HLamdba HLetIn HmkApps HConst HCase HProj HFix HCoFix HConstruct HPrim HBox.
   fix f 3.
   intros Γ t Hexp.  destruct Hexp; eauto.
   - eapply HRel_app; eauto. clear - f H0. induction H0; econstructor; eauto.
@@ -289,6 +291,7 @@ Section isEtaExp.
     | tBox => true
     | tVar _ => true
     | tConst _ => true
+    | tPrim _ => true
     | tConstruct ind i block_args => isEtaExp_app ind i 0 && is_nil block_args }.
   Proof using Σ.
     all:try lia.

--- a/erasure/theories/EGlobalEnv.v
+++ b/erasure/theories/EGlobalEnv.v
@@ -73,6 +73,10 @@ Section Lookups.
     mdecl <- lookup_minductive kn ;;
     ret mdecl.(ind_npars).
   
+  Definition lookup_inductive_kind kn : option recursivity_kind := 
+    mdecl <- lookup_minductive kn ;;
+    ret mdecl.(ind_finite).
+    
   Definition lookup_constructor kn c : option (mutual_inductive_body * one_inductive_body * constructor_body) :=
     '(mdecl, idecl) <- lookup_inductive kn ;;
     cdecl <- nth_error idecl.(ind_ctors) c ;;

--- a/erasure/theories/EInduction.v
+++ b/erasure/theories/EInduction.v
@@ -33,7 +33,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n)) ->
-    (* (forall p, P (tPrim p)) -> *)
+    (forall p, P (tPrim p)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -215,7 +215,8 @@ Section MkApps_rec.
         All (fun x => P x.2) l -> P (tCase p t l))
     (pproj : forall (s : projection) (t : term), P t -> P (tProj s t))
     (pfix : forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tFix m n))
-    (pcofix : forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n)).
+    (pcofix : forall (m : mfixpoint term) (n : nat), All (fun x => P (dbody x)) m -> P (tCoFix m n))
+    (pprim : forall p, P (tPrim p)).
 
   Definition inspect {A} (x : A) : { y : A | x = y } := exist _ x eq_refl.
 
@@ -240,7 +241,8 @@ Section MkApps_rec.
     | tCase ina c brs => pcase ina c (rec c) brs (All_rec P (fun x => x.2) brs (fun x H => rec x))
     | tProj p c => pproj p c (rec c)
     | tFix mfix idx => pfix mfix idx (All_rec P dbody mfix (fun x H => rec x))
-    | tCoFix mfix idx => pcofix mfix idx (All_rec P dbody mfix (fun x H => rec x)).
+    | tCoFix mfix idx => pcofix mfix idx (All_rec P dbody mfix (fun x H => rec x))
+    | tPrim p => pprim p.
   Proof.
     all:unfold MR; cbn; auto with arith. 4:lia.
     - clear -napp nonnil da rec.
@@ -271,7 +273,8 @@ Section MkApps_rec.
     (pcase : forall (p : inductive * nat) (t : term) (l : list (list name * term)), P (tCase p t l))
     (pproj : forall (s : projection) (t : term), P (tProj s t))
     (pfix : forall (m : mfixpoint term) (n : nat), P (tFix m n))
-    (pcofix : forall (m : mfixpoint term) (n : nat), P (tCoFix m n)).
+    (pcofix : forall (m : mfixpoint term) (n : nat), P (tCoFix m n))
+    (pprim : forall p, P (tPrim p)).
 
   Import EqNotations.
   
@@ -292,7 +295,8 @@ Section MkApps_rec.
     | tCase ina c brs => pcase ina c brs
     | tProj p c => pproj p c
     | tFix mfix idx => pfix mfix idx
-    | tCoFix mfix idx => pcofix mfix idx.
+    | tCoFix mfix idx => pcofix mfix idx
+    | tPrim p => pprim p.
 
   End MkApps_case.
 

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -98,7 +98,7 @@ Section optimize.
     | tVar _ => t
     | tConst _ => t
     | tConstruct ind n args => tConstruct ind n (map optimize args)
-    (* | tPrim _ => t *)
+    | tPrim _ => t
     end.
 
   Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).
@@ -665,15 +665,16 @@ Proof.
     * destruct with_guarded_fix.
       + move: i. 
         rewrite !negb_or.
-        rewrite optimize_mkApps !isFixApp_mkApps !isConstructApp_mkApps.
+        rewrite optimize_mkApps !isFixApp_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         rewrite !andb_true_r.
         rtoProp; intuition auto.
         destruct v => /= //. 
         destruct v => /= //.
+        destruct v => /= //.
       + move: i. 
         rewrite !negb_or.
-        rewrite optimize_mkApps !isConstructApp_mkApps.
+        rewrite optimize_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         destruct v => /= //. 
   - destruct t => //.
@@ -799,6 +800,7 @@ Definition disable_projections_term_flags (et : ETermFlags) :=
     ; has_tProj := false
     ; has_tFix := has_tFix
     ; has_tCoFix := has_tCoFix
+    ; has_tPrim := has_tPrim
   |}.
 
 Definition disable_projections_env_flag (efl : EEnvFlags) := 

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -35,7 +35,7 @@ Fixpoint lift n k t : term :=
   | tVar _ => t
   | tConst _ => t
   | tConstruct ind i args => tConstruct ind i (map (lift n k) args)
-  (* | tPrim _ => t *)
+  | tPrim _ => t
   end.
 
 Notation lift0 n := (lift n 0).

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -62,7 +62,7 @@ Section optimize.
     | tVar _ => t
     | tConst _ => t
     | tConstruct ind i args => tConstruct ind i (map optimize args)
-    (* | tPrim _ => t *)
+    | tPrim _ => t
     end.
 
   Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).
@@ -693,15 +693,16 @@ Proof.
     * destruct with_guarded_fix.
       + move: i. 
         rewrite !negb_or.
-        rewrite optimize_mkApps !isFixApp_mkApps !isConstructApp_mkApps.
+        rewrite optimize_mkApps !isFixApp_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         rewrite !andb_true_r.
         rtoProp; intuition auto.
         destruct v => /= //. 
         destruct v => /= //.
+        destruct v => /= //.
       + move: i. 
         rewrite !negb_or.
-        rewrite optimize_mkApps !isConstructApp_mkApps.
+        rewrite optimize_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         destruct v => /= //. 
   - destruct t => //.

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -84,6 +84,12 @@ Module PrintTermTree.
       let ctx' := List.map (fun d => {| decl_name := dname d; decl_body := None |}) defs in
       print_list (print_def (print_term (ctx' ++ Γ)%list true false)) (nl ^ " with ") defs.
 
+    Definition print_prim {term} (soft : term -> Tree.t) (p : @prim_val EAst.term) : Tree.t :=
+      match p.π2 return Tree.t with
+      | primIntModel f => "(int: " ^ Primitive.string_of_prim_int f ^ ")"
+      | primFloatModel f => "(float: " ^ Primitive.string_of_float f ^ ")"
+      (* | primArrayModel a => "(array:" ^ ")" *)
+      end.
 
     Fixpoint print_term (Γ : context) (top : bool) (inapp : bool) (t : term) {struct t} : Tree.t :=
     match t with
@@ -163,8 +169,7 @@ Module PrintTermTree.
     | tCoFix l n =>
       parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                                 " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ dname) l) n)
-    (* | tPrim p =>  *)
-      (* parens top (string_of_prim (print_term Γ false false) p) *)
+    | tPrim p => parens top (print_prim (print_term Γ false false) p)
     end.
   End print_term.
 

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -201,10 +201,18 @@ Module PrintTermTree.
     | _ => nl ^ "projections: " ^ print_list (fun x => x.(proj_name)) ", " body.(ind_projs) 
     end
     in
-    "Inductive " ^ body.(ind_name) ^ "(" ^ params ^ "," ^ prop ^ ", elimination " ^ kelim ^ ") := " ^ nl ^ ctors ^ projs.
+    body.(ind_name) ^ "(" ^ params ^ "," ^ prop ^ ", elimination " ^ kelim ^ ") := " ^ nl ^ ctors ^ projs.
+
+  Definition print_recursivity_kind k :=
+    match k with
+    | Finite => "Inductive"
+    | CoFinite => "CoInductive"
+    | BiFinite => "Variant"
+    end.
 
   Definition print_inductive_body decl :=
-    print_list (print_one_inductive_body decl.(ind_npars)) nl decl.(ind_bodies).
+    print_recursivity_kind decl.(ind_finite) ^ " " ^
+    print_list (print_one_inductive_body decl.(ind_npars)) (nl ^ " with ") decl.(ind_bodies).
 
   Definition print_decl Σ '(kn, d) := 
     match d with

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -110,6 +110,8 @@ Proof.
         subst. inversion e0. subst.
         destruct (eq_dec rarg rarg0) ; nodec.
         subst. left. reflexivity.
+  - destruct (eq_dec p p0); nodec.
+    left; subst. reflexivity.
 Defined.
 
 #[global]

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -27,6 +27,7 @@ Local Ltac term_dec_tac term_dec :=
          | x : inductive * nat, y : inductive * nat |- _ =>
            fcase (eq_dec x y)
          | x : projection, y : projection |- _ => fcase (eq_dec x y)
+         | x : recursivity_kind, y : recursivity_kind |- _ => fcase (eq_dec x y)
          end.
 
 Ltac nodec :=
@@ -171,9 +172,9 @@ Proof.
 Defined.
 
 Definition eqb_mutual_inductive_body (x y : mutual_inductive_body) :=
-  let (n, b) := x in
-  let (n', b') := y in
-  eqb n n' && eqb b b'.
+  let (f, n, b) := x in
+  let (f', n', b') := y in
+  eqb f f' && eqb n n' && eqb b b'.
 
 #[global, program]
 Instance reflect_mutual_inductive_body : ReflectEq mutual_inductive_body := 

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -360,7 +360,7 @@ Definition strip_constant_decl Σ cb :=
   {| cst_body := option_map (strip Σ) cb.(cst_body) |}.
   
 Definition strip_inductive_decl idecl := 
-  {| ind_npars := 0; ind_bodies := idecl.(ind_bodies) |}.
+  {| ind_finite := idecl.(ind_finite); ind_npars := 0; ind_bodies := idecl.(ind_bodies) |}.
 
 Definition strip_decl Σ d :=
   match d with
@@ -598,7 +598,7 @@ Module Fast.
     {| cst_body := option_map (strip' Σ) cb.(cst_body) |}.
     
   Definition strip_inductive_decl idecl := 
-    {| ind_npars := 0; ind_bodies := idecl.(ind_bodies) |}.
+    {| ind_finite := idecl.(ind_finite); ind_npars := 0; ind_bodies := idecl.(ind_bodies) |}.
 
   Definition strip_decl Σ d :=
     match d with

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -57,7 +57,8 @@ Section strip.
     | tBox => EAst.tBox
     | tVar n => EAst.tVar n
     | tConst n => EAst.tConst n
-    | tConstruct ind i block_args => EAst.tConstruct ind i block_args }.
+    | tConstruct ind i block_args => EAst.tConstruct ind i block_args
+    | tPrim p => EAst.tPrim p }.
   Proof.
     all:try lia.
     all:try apply (In_size); tea.
@@ -727,6 +728,14 @@ Proof.
   all:rewrite isConstructApp_mkApps isConstructApp_mkApps //.
 Qed.
 
+Lemma strip_isPrimApp Σ f : 
+  isPrimApp f = isPrimApp (strip Σ f).
+Proof.
+  funelim (strip Σ f); cbn -[strip] => //.
+  all:rewrite map_InP_spec.
+  all:rewrite !isPrimApp_mkApps //.
+Qed.
+
 Lemma lookup_inductive_pars_is_prop_and_pars {Σ ind b pars} :
   inductive_isprop_and_pars Σ ind = Some (b, pars) ->
   lookup_inductive_pars Σ (inductive_mind ind) = Some pars.
@@ -958,7 +967,7 @@ Proof.
   - rewrite !strip_tApp //.
     eapply eval_app_cong; tea.
     move: H1. eapply contraNN.
-    rewrite -strip_isLambda -strip_isConstructApp -strip_isFixApp -strip_isBox //.
+    rewrite -strip_isLambda -strip_isConstructApp -strip_isFixApp -strip_isBox -strip_isPrimApp //.
     rewrite -strip_isFix //.
   
   - rewrite !strip_mkApps // /=.

--- a/erasure/theories/ESpineView.v
+++ b/erasure/theories/ESpineView.v
@@ -21,7 +21,8 @@ Inductive t : term -> Set :=
 | tCase ci p brs : t (tCase ci p brs)
 | tProj p c : t (tProj p c)
 | tFix mfix idx : t (tFix mfix idx)
-| tCoFix mfix idx : t (tCoFix mfix idx).
+| tCoFix mfix idx : t (tCoFix mfix idx)
+| tPrim p : t (tPrim p).
 Derive Signature for t.
 
 Definition view : forall x : term, t x :=
@@ -36,7 +37,8 @@ Definition view : forall x : term, t x :=
     (fun p t l => tCase p t l)
     (fun p t => tProj p t)
     (fun mfix n => tFix mfix n)
-    (fun mfix n => tCoFix mfix n).
+    (fun mfix n => tCoFix mfix n)
+    (fun p => tPrim p).
 
 Lemma view_mkApps {f v} (vi : t (mkApps f v)) : ~~ isApp f -> v <> [] -> 
   exists hf vn, vi = tApp f v hf vn.

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -49,11 +49,12 @@ Lemma Informative_extends:
 Proof.
   repeat intros ?.
   assert (extends_decls Σ Σ'0).
-  { destruct X0, X2. subst. cbn. split => //.
-    rewrite e -e0 //.
-    destruct s as [Σ'' eq]. destruct s0 as [Σ''' ->].
-    rewrite eq. cbn. exists (Σ''' ++ Σ''). cbn.
-    now rewrite <- app_assoc. }
+  { destruct X0 as [eu [Σ'' eq] er], X2 as [eu' [Σ''' eq'] er'].
+    subst. cbn in *. split => //.
+    * rewrite eu -eu' //.
+    * exists (Σ''' ++ Σ''). cbn. rewrite <- app_assoc.
+      congruence.
+    * congruence. }
   edestruct H0; eauto. destruct H3.
 
   eapply weakening_env_declared_inductive in H; eauto; tc.
@@ -559,6 +560,9 @@ Proof.
         eapply typing_wf_local.  eassumption.
     + econstructor.
       eapply is_type_subst; eauto.
+  - cbn. depelim H1.
+    * cbn; constructor.
+    * constructor. eapply is_type_subst in X3; tea.
   - eapply H; eauto.
 Qed.
 

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
@@ -14,7 +14,7 @@ Hint Constructors eval : core.
 
 Definition atomic_term (t : term) :=
   match t with
-  | tBox | tConst _ | tRel _ | tVar _ => true
+  | tBox | tConst _ | tRel _ | tVar _ | tPrim _ => true
   | _ => false
   end.
 
@@ -24,6 +24,7 @@ Definition has_atom {etfl : ETermFlags} (t : term) :=
   | tConst _ => has_tConst
   | tRel _ => has_tRel
   | tVar _ => has_tVar
+  | tPrim _ => has_tPrim
   | _ => false
   end.
 
@@ -293,7 +294,8 @@ Lemma eval_preserve_mkApps_ind :
      forall (ev : eval Σ f11 f'), 
      P f11 f' ->  
      (forall t u (ev' : eval Σ t u), eval_depth ev' <= eval_depth ev -> Q 0 t -> P t u) →
-     ~~ (isLambda f' || (if with_guarded_fix then isFixApp f' else isFix f') || isBox f' || isConstructApp f') → 
+     ~~ (isLambda f' || (if with_guarded_fix then isFixApp f' else isFix f') || isBox f' 
+      || isConstructApp f' || isPrimApp f') → 
      eval Σ a a' → P a a' → 
      P' (tApp f11 a) (tApp f' a')) → 
   (∀ ind i mdecl idecl cdecl args args',

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -14,7 +14,7 @@ Hint Constructors eval : core.
 
 Definition atomic_term (t : term) :=
   match t with
-  | tBox | tConstruct _ _ _ | tConst _ | tRel _ | tVar _ => true
+  | tBox | tConstruct _ _ _ | tConst _ | tRel _ | tVar _ | tPrim _ => true
   | _ => false
   end.
 
@@ -25,6 +25,7 @@ Definition has_atom {etfl : ETermFlags} (t : term) :=
   | tConst _ => has_tConst
   | tRel _ => has_tRel
   | tVar _ => has_tVar
+  | tPrim _ => has_tPrim
   | _ => false
   end.
 
@@ -303,7 +304,8 @@ Lemma eval_preserve_mkApps_ind :
      forall (ev : eval Σ f11 f'), 
      P f11 f' ->  
      (forall t u (ev' : eval Σ t u), eval_depth ev' <= eval_depth ev -> Q 0 t -> isEtaExp Σ t -> P t u) →
-     ~~ (isLambda f' || (if with_guarded_fix then isFixApp f' else isFix f') || isBox f' || isConstructApp f') → 
+     ~~ (isLambda f' || (if with_guarded_fix then isFixApp f' else isFix f') || isBox f' || isConstructApp f' || 
+      isPrimApp f') → 
      eval Σ a a' → P a a' → 
      isEtaExp Σ (tApp f' a') ->
      P' (tApp f11 a) (tApp f' a')) → 
@@ -692,7 +694,8 @@ Definition term_flags :=
     has_tCase := true;
     has_tProj := false;
     has_tFix := true;
-    has_tCoFix := false
+    has_tCoFix := false;
+    has_tPrim := true
   |}.
   
 Definition env_flags := 

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -237,7 +237,7 @@ Section eval_mkApps_rect.
                  then isFixApp f'
                  else isFix f') || 
                 isBox f' || 
-                isConstructApp f')) 
+                isConstructApp f' || isPrimApp f')) 
           (e0 : eval Σ a a'),
           P a a'
           → P (tApp f15 a) 
@@ -274,10 +274,10 @@ Proof using Type.
   | [ H : _ |- _ ] =>
     unshelve eapply H; try match goal with |- eval _ _ _ => tea end; tea; unfold IH; intros; unshelve eapply IH'; tea; cbn; try lia
   end].
-  eapply X15; tea; auto.
-  clear -a IH'. induction a; constructor.
-  eapply (IH' _ _ r). cbn. lia. apply IHa.
-  intros. eapply (IH' _ _ H). cbn. lia.
+  - eapply X15; tea; auto.
+    clear -a IH'. induction a; constructor.
+    eapply (IH' _ _ r). cbn. lia. apply IHa.
+    intros. eapply (IH' _ _ H). cbn. lia.
 Qed.
 
 End eval_mkApps_rect. 

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -33,6 +33,7 @@ Class ETermFlags :=
   ; has_tProj : bool
   ; has_tFix : bool
   ; has_tCoFix : bool
+  ; has_tPrim : bool
   }.
 
 Set Warnings "-future-coercion-class-field".
@@ -58,6 +59,7 @@ Definition all_term_flags :=
     ; has_tProj := true
     ; has_tFix := true
     ; has_tCoFix := true
+    ; has_tPrim := true
   |}.
 
 Definition all_env_flags := 
@@ -115,6 +117,7 @@ Section wf.
         | _ => true end 
         && forallb (wellformed k) block_args else is_nil block_args
     | tVar _ => has_tVar
+    | tPrim _ => has_tPrim
     end.
 
 End wf.

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -51,7 +51,7 @@ Next Obligation.
   apply assume_preservation_template_program_env_expansion in ev as [ev']; eauto.
 Qed.
 
-Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellformed.all_env_flags) :
+Program Definition erasure_pipeline_gen {guard : abstract_guard_impl} (efl := EWellformed.all_env_flags) :
  Transform.t TemplateProgram.template_program EProgram.eprogram 
   Ast.term EAst.term
   TemplateProgram.eval_template_program
@@ -73,16 +73,16 @@ Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellf
   (* Remove all constructor parameters *)
   remove_params_optimization (wcon := eq_refl) ▷ 
   (* Rebuild the efficient lookup table *)
-  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
+  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) true ▷
   (* Remove all cases / projections on propositional content *)
   optimize_prop_discr_optimization (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
   (* Rebuild the efficient lookup table *)
-  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
+  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) true  ▷
   (* Inline projections to cases *)
   inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
   let efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags) in
   (* Rebuild the efficient lookup table *)
-  rebuild_wf_env_transform (efl :=  efl) ▷
+  rebuild_wf_env_transform (efl :=  efl) true ▷
   (* First-order constructor representation *)
   constructors_as_blocks_transformation efl (has_app := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl).
 
@@ -99,6 +99,20 @@ Next Obligation.
   now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs. 
 Qed.
 
+(* This includes an additional transformation from cofixpoints to fixpoints, thunking coinductive values *)
+
+Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellformed.all_env_flags) :
+ Transform.t TemplateProgram.template_program EProgram.eprogram 
+  Ast.term EAst.term
+  TemplateProgram.eval_template_program
+  (EProgram.eval_eprogram {| with_prop_case := false; with_guarded_fix := false; with_constructor_as_block := true |}) := 
+  erasure_pipeline_gen ▷
+  let efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags) in
+  (* Rebuild the efficient lookup table *)
+  rebuild_wf_env_transform (fl := EConstructorsAsBlocks.block_wcbv_flags) (efl := EConstructorsAsBlocks.switch_cstr_as_blocks efl) false ▷
+  (* Represent coinductive values as thunked inductive values *)
+  coinductive_to_inductive_transformation (EConstructorsAsBlocks.switch_cstr_as_blocks efl) (has_box := eq_refl) (has_trel := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl).
+
 Definition run_erase_program {guard : abstract_guard_impl} := run erasure_pipeline.
 
 Program Definition erasure_pipeline_fast {guard : abstract_guard_impl} (efl := EWellformed.all_env_flags) := 
@@ -109,12 +123,12 @@ Program Definition erasure_pipeline_fast {guard : abstract_guard_impl} (efl := E
   erase_transform ▷ 
   guarded_to_unguarded_fix (wcon := eq_refl) eq_refl ▷
   remove_params_fast_optimization (wcon := eq_refl)  _ ▷ 
-  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
+  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) true ▷
   optimize_prop_discr_optimization (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
-  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) ▷
+  rebuild_wf_env_transform (efl := ERemoveParams.switch_no_params EWellformed.all_env_flags) true ▷
   inline_projections_optimization (fl := EWcbvEval.target_wcbv_flags) (wcon := eq_refl) (hastrel := eq_refl) (hastbox := eq_refl) ▷
   let efl := EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags) in
-  rebuild_wf_env_transform (efl :=  efl) ▷
+  rebuild_wf_env_transform (efl :=  efl) true ▷
   constructors_as_blocks_transformation efl (has_app := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl).
 Next Obligation.
   destruct H; split => //. now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs. 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -1073,13 +1073,17 @@ Proof.
           ++ cbn. invs H1. cbn in *.
             eapply ssrbool.negbTE, is_FixApp_erases.
             econstructor; eauto.
-            rewrite orb_false_r !negb_or in i. now move/andP: i => [].
+            rewrite orb_false_r !negb_or in i.
+            now move/andP: i => [] /andP [].
           ++ cbn in *.
             invs H1. invs i.
         -- eauto.
         -- rewrite !negb_or in i.
            rtoProp; intuition auto.
-           eapply is_ConstructApp_erases in H8; tea.
+           eapply is_ConstructApp_erases in H9; tea.
+           now move/negbTE: H9.
+        -- rewrite !negb_or in i. rtoProp; intuition auto.
+           eapply is_PrimApp_erases in H8; tea.
            now move/negbTE: H8.
     + exists EAst.tBox. split. 2: now constructor; econstructor.
       econstructor.
@@ -1116,6 +1120,10 @@ Proof.
       * eexists. split. 2: now constructor; econstructor.
         econstructor; eauto.
         Unshelve. all: repeat econstructor.
+    + invs He.
+      * eexists. split; eauto. now constructor; econstructor.
+      * eexists. split. 2: now constructor; econstructor.
+        econstructor; eauto.
 Qed.
 
 (* Print Assumptions erases_correct. *)
@@ -1138,17 +1146,19 @@ Proof.
     cbn. apply IHer, wf.
 Qed.
 
-Lemma erases_global_decls_fresh univs {Σ : global_declarations} kn Σ' : fresh_global kn Σ -> erases_global_decls univs Σ Σ' -> EGlobalEnv.fresh_global kn Σ'.
+Lemma erases_global_decls_fresh univs retro {Σ : global_declarations} kn Σ' : fresh_global kn Σ -> 
+  erases_global_decls univs retro Σ Σ' -> EGlobalEnv.fresh_global kn Σ'.
 Proof.
   induction 2; constructor; eauto; now depelim H.
 Qed.
 
 Import EWellformed.
 
-Lemma erases_mutual_inductive_body_wf (efl := all_env_flags) {Σ univs Σ' kn mib mib'} :
+Lemma erases_mutual_inductive_body_wf (efl := all_env_flags) {Σ univs retro Σ' kn mib mib'} :
   erases_mutual_inductive_body mib mib' ->
   let udecl := PCUICLookup.universes_decl_of_decl (InductiveDecl mib) in
-  on_global_decl cumulSpec0 (PCUICEnvTyping.lift_typing typing) ({| universes := univs; declarations := Σ |}, udecl) kn
+  on_global_decl cumulSpec0 (PCUICEnvTyping.lift_typing typing) 
+    ({| universes := univs; declarations := Σ; retroknowledge := retro |}, udecl) kn
        (InductiveDecl mib) ->
   wf_global_decl Σ' (E.InductiveDecl mib').
 Proof.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -374,10 +374,6 @@ Section Erase.
     | _ => try red; try reflexivity || discriminates
     end.
 
-  Equations erase_prim (ep : prim_val term) : PCUICPrimitive.prim_val E.term :=
-  erase_prim (_; primIntModel i) := (_; primIntModel i);
-  erase_prim (_; primFloatModel f) := (_; primFloatModel f).
-  
   Opaque is_erasableb.
   
   #[tactic="idtac"]
@@ -419,8 +415,8 @@ Section Erase.
       | tCoFix mfix n :=
         let Γ' := (fix_context mfix ++ Γ)%list in
         let mfix' := erase_cofix Γ' mfix _ in
-        E.tCoFix mfix' n }
-      (* erase Γ (tPrim p) Ht _ := E.tPrim (erase_prim p) *)
+        E.tCoFix mfix' n
+      | tPrim p := E.tPrim (erase_prim_val p) }
     } } 
   where erase_terms (Γ : context) (l : list term) (Hl : forall Σ : global_env_ext, abstract_env_ext_rel X Σ -> ∥ All (welltyped Σ Γ) l ∥) : list E.term :=
   { erase_terms Γ [] _ := [];
@@ -791,11 +787,16 @@ Proof.
   intro ext. 
   (* ext eqext. *)
   assert (hl : Hlookup X_type X X_type' X').
-  { red. intros.
+  { red. intros. specialize (ext _ _ H H0) as [[?] ?].
+    split. intros.
     rewrite -(abstract_env_lookup_correct _ _ H).
     rewrite -(abstract_env_lookup_correct _ _ H0).
-    rewrite H1 H2. specialize (ext _ _ H H0) as [[?] ?]. pose proof (abstract_env_ext_wf _ H) as [?].
-    eapply extends_lookup_env in H2; try apply e; eauto. clear -H1 H2. congruence. }
+    rewrite H2 H3. pose proof (abstract_env_ext_wf _ H) as [?].
+    eapply extends_lookup_env in H3; try apply e; eauto. clear -H2 H3. congruence.
+    destruct X0.
+    rewrite -(abstract_env_ext_retroknowledge_correct _ H).
+    rewrite -(abstract_env_ext_retroknowledge_correct _ H0).
+    congruence. }
   simp is_erasableb.
   set (obl := is_erasableb_obligation_2 _ _ _ _). clearbody obl.
   set(ty := (type_of_typing X_type' _ _ _ wt')) in *.
@@ -904,7 +905,7 @@ Next Obligation.
   pose proof (abstract_env_wf _ HX) as [wfX].
   assert (prop': forall Σ : global_env, abstract_env_rel X Σ -> exists d, Σ.(declarations) = d :: decls).
   { now eexists. }
-  pose proof (abstract_pop_decls_correct X decls prop' _ _ HX H). 
+  destruct (abstract_pop_decls_correct X decls prop' _ _ HX H) as [? []].
   clear H. specialize (prop _ HX). destruct x, Σ, H0; cbn in *.
   subst. sq. destruct wfX. depelim o0. split => //.
 Qed.
@@ -916,11 +917,11 @@ Next Obligation.
   pose proof (abstract_env_wf _ HX) as [wfX].
   assert (prop': forall Σ : global_env, abstract_env_rel X Σ -> exists d, Σ.(declarations) = d :: decls).
   { now eexists. }
-  pose proof (abstract_pop_decls_correct X decls prop' _ _ HX HX'). 
+  pose proof (abstract_pop_decls_correct X decls prop' _ _ HX HX') as [? []].
   pose proof (abstract_make_wf_env_ext_correct _ _ _ _ _ HX' H). 
   clear H HX'. specialize (prop _ HX). destruct x, Σ as [[] u], H0; cbn in *.
-  subst. sq. inversion H1. subst. clear H1. destruct wfX. cbn in *.
-  rewrite prop in o0. depelim o0. apply o2.
+  subst. sq. inversion H3. subst. clear H3. destruct wfX. cbn in *.
+  rewrite prop in o0. depelim o0. cbn in o2. apply o2.
 Qed.
 Next Obligation.
   pose proof (abstract_env_exists X) as [[? HX]]. 
@@ -1442,20 +1443,21 @@ Proof.
         red. simpl. unshelve epose (abstract_pop_decls_correct X decls _ Σ Σpop wfΣ wfpop).
         { intros. now eexists. }
         split => //. intuition eauto.
-        exists [(kn, ConstantDecl c)]; intuition eauto. rewrite H0; eauto.  
-        rewrite indeps. unshelve epose proof (abstract_pop_decls_correct X decls _ Σ Σpop wfΣ wfpop) as [Hpop Hpop'].
+        exists [(kn, ConstantDecl c)]; intuition eauto. rewrite H0; eauto.
+        now destruct a. 
+        rewrite indeps. unshelve epose proof (abstract_pop_decls_correct X decls _ Σ Σpop wfΣ wfpop) as [Hpop [Hpop' Hpop'']].
         { intros. now eexists. }
         pose (prf' := prf _ wfΣ).
-        destruct Σ. cbn in *. rewrite Hpop' prf'. rewrite <- Hpop at 1.  
+        destruct Σ. cbn in *. rewrite Hpop' Hpop'' prf'. rewrite <- Hpop at 1.  
         eapply (erases_deps_cons Σpop). 
           rewrite <- Hpop'. apply wf.
-          rewrite Hpop. rewrite prf' in wf. destruct wf. now rewrite Hpop' in o0. 
+          rewrite Hpop. rewrite prf' in wf. destruct wf. now rewrite Hpop'' Hpop' in o0. 
 
         pose proof (erase_constant_body_correct' H0). specialize_Σ wfmake. 
         sq. destruct H1 as [bod [bodty [[Hbod Hebod] Heqdeps]]].
         rewrite (abstract_make_wf_env_ext_correct Xpop (cst_universes c) _ Σpop Σmake wfpop wfmake) in Hbod, Hebod. 
         eapply (erase_global_erases_deps (Σ := (Σpop, cst_universes c))); simpl; auto.
-        { constructor; simpl; auto. depelim wf. rewrite Hpop' in o0.
+        { constructor; simpl; auto. depelim wf. rewrite Hpop' Hpop'' in o0.
           cbn in o0, o. rewrite prf' in o0. rewrite  <- Hpop in o0. rewrite Hpop' in o. clear -o o0. 
           now depelim o0.
           depelim wf. rewrite Hpop' in o0.
@@ -1491,7 +1493,7 @@ Proof.
         set (Xmake :=  abstract_make_wf_env_ext Xpop (cst_universes c) _).
         epose proof (abstract_env_exists Xpop) as [[Σp wfpop]].
         pose proof (abstract_env_wf _ wfpop) as [wfΣp].
-        unshelve epose proof (abstract_pop_decls_correct X decls _ _ _ wfΣ wfpop) as [Hpop Hpop'].
+        unshelve epose proof (abstract_pop_decls_correct X decls _ _ _ wfΣ wfpop) as [Hpop [Hpop' Hpop'']].
         { intros. now eexists. }
         pose proof (prf _ wfΣ). destruct Σ. cbn in *. subst.
         eapply global_erases_with_deps_cons; eauto.
@@ -1509,7 +1511,7 @@ Proof.
         cbn. set (Xpop := abstract_pop_decls X).
         epose proof (abstract_env_exists Xpop) as [[Σp wfpop]].
         pose proof (abstract_env_wf _ wfpop) as [wfΣp].   
-        unshelve epose proof (abstract_pop_decls_correct X decls _ Σ Σp wfΣ wfpop) as [Hpop Hpop'].
+        unshelve epose proof (abstract_pop_decls_correct X decls _ Σ Σp wfΣ wfpop) as [Hpop [Hpop' Hpop'']].
         { intros. now eexists. }
         pose proof (prf _ wfΣ). destruct Σ. cbn in *. subst.
         eapply global_erases_with_deps_weaken. eauto.
@@ -1524,7 +1526,7 @@ Proof.
       ++ simpl. set (Xpop := abstract_pop_decls X).
       epose proof (abstract_env_exists Xpop) as [[Σp wfpop]].
       pose proof (abstract_env_wf _ wfpop) as [wfΣp].      
-      unshelve epose proof (abstract_pop_decls_correct X decls _ Σ Σp wfΣ wfpop) as [Hpop Hpop'].
+      unshelve epose proof (abstract_pop_decls_correct X decls _ Σ Σp wfΣ wfpop) as [Hpop [Hpop' Hpop'']].
       { intros. now eexists. }
       pose proof (prf _ wfΣ). destruct Σ. cbn in *. subst.
       destruct (KernameSet.mem kn deps) eqn:eqkn.
@@ -1546,7 +1548,7 @@ Proof.
           intros. pose proof (abstract_env_irr _ H0 wfpop). subst. 
           sq; eexists; eauto.
           eapply KernameSet.subset_spec.
-          intros ? hin'. eapply sub. eapply KernameSet.singleton_spec in hin'. now subst. }
+          intros ? hin'. eapply sub. eapply KernameSet.singleton_spec in hin'. now subst. }          
 Qed.
 
 Lemma erase_correct (wfl := Ee.default_wcbv_flags) X_type (X : X_type.π1) 
@@ -1580,7 +1582,8 @@ Proof.
   rewrite (abstract_make_wf_env_ext_correct X univs wfext _ _ wfΣX wfΣex); eauto.
 Qed.
 
-Lemma global_env_ind (P : global_env -> Type) (Pnil : forall univs, P {| universes := univs; declarations := [] |})
+Lemma global_env_ind (P : global_env -> Type) 
+  (Pnil : forall univs retro, P {| universes := univs; declarations := []; retroknowledge := retro |})
   (Pcons : forall (Σ : global_env) d, P Σ -> P (add_global_decl Σ d))
   (Σ : global_env) : P Σ.
 Proof.
@@ -1590,15 +1593,16 @@ Proof.
 Qed.
 
 Lemma on_global_env_ind (P : forall Σ : global_env, wf Σ -> Type)
-  (Pnil : forall univs (onu : on_global_univs univs), P {| universes := univs; declarations := [] |}
-    (onu, globenv_nil _ _ _))
+  (Pnil : forall univs retro (onu : on_global_univs univs), P {| universes := univs; declarations := []; retroknowledge := retro |}
+    (onu, globenv_nil _ _ _ _))
   (Pcons : forall (Σ : global_env) kn d (wf : wf Σ) 
     (Hfresh : fresh_global kn Σ.(declarations))
     (udecl := PCUICLookup.universes_decl_of_decl d)
     (onud : on_udecl Σ.(universes) udecl)
-    (pd : on_global_decl cumulSpec0 (lift_typing typing) ({| universes := Σ.(universes); declarations := Σ.(declarations) |}, udecl) kn d),
+    (pd : on_global_decl cumulSpec0 (lift_typing typing) 
+    ({| universes := Σ.(universes); declarations := Σ.(declarations); retroknowledge := Σ.(retroknowledge) |}, udecl) kn d),
     P Σ wf -> P (add_global_decl Σ (kn, d)) 
-    (fst wf, globenv_decl _ _ Σ.(universes) Σ.(declarations) kn d (snd wf) Hfresh onud pd))
+    (fst wf, globenv_decl _ _ Σ.(universes) Σ.(retroknowledge) Σ.(declarations) kn d (snd wf) Hfresh onud pd))
   (Σ : global_env) (wfΣ : wf Σ) : P Σ wfΣ.
 Proof.
   destruct Σ as [univs Σ]. destruct wfΣ; cbn in *.
@@ -1945,6 +1949,7 @@ Section wffix.
     | tConstruct ind c _ => true
     | tVar _ => true
     | tBox => true
+    | tPrim _ => true
     end.
 
 End wffix.
@@ -2095,7 +2100,7 @@ Proof.
   pose proof (abstract_env_wf _ wf) as [wfΣ].
   assert (erases_mutual_inductive_body m (erase_mutual_inductive_body m)).
   { eapply (erases_mutual (mdecl:=kn)); tea. }
-  eapply (erases_mutual_inductive_body_wf (univs := Σ.(universes)) (Σ := decls) (kn := kn) (Σ' := Σ')) in H; tea.
+  eapply (erases_mutual_inductive_body_wf (univs := Σ.(universes)) (retro := Σ.(retroknowledge)) (Σ := decls) (kn := kn) (Σ' := Σ')) in H; tea.
   rewrite -(heq _ wf). now destruct Σ.
 Qed.
 
@@ -2178,10 +2183,10 @@ Proof.
       pose proof (prf _ wf) as prf'.
       eapply (erase_global_ind_decl_wf_glob (kn:=kn')).
       intros. 
-      unshelve epose proof (abstract_pop_decls_correct X decls _ _ _ wf H) as [? ?].
+      unshelve epose proof (abstract_pop_decls_correct X decls _ _ _ wf H) as [? [? ?]].
       { now eexists. }
       destruct Σ, Σ0. cbn in *. rewrite prf' in wfΣ.
-      depelim wfΣ. cbn in *. rewrite <- H1, H0. 
+      depelim wfΣ. cbn in *. rewrite <- H1, H0, <- H2. 
       now depelim o0.
       eapply erase_global_decls_fresh => //.
       pose proof (abstract_env_wf _ wf) as [wfΣ].
@@ -2238,9 +2243,9 @@ Proof.
   revert deps X prf.
   induction etaΣ; intros deps. intros. constructor. intros.
   pose proof (abstract_env_exists (abstract_pop_decls X)) as [[Σpop wfpop]]. 
-  unshelve epose proof (abstract_pop_decls_correct X Σ _ _ _ wf wfpop) as [? ?].
+  unshelve epose proof (abstract_pop_decls_correct X Σ _ _ _ wf wfpop) as [? [? ?]].
   { now eexists. }
-  destruct Σpop. cbn in H0, H1.  subst. 
+  destruct Σpop. cbn in H0, H1, H2. subst. 
   destruct decl as [kn []];
   destruct (KernameSet.mem kn deps) eqn:eqkn; simpl; rewrite eqkn.
   constructor; [eapply IHetaΣ; auto|].
@@ -2453,9 +2458,9 @@ Section EraseGlobalFast.
 Definition decls_prefix decls (Σ' : global_env) := 
   ∑ Σ'', declarations Σ' = Σ'' ++ decls.
 
-Lemma on_global_decls_prefix {cf} Pcmp P univs decls decls' :
-  on_global_decls Pcmp P univs (decls ++ decls') ->
-  on_global_decls Pcmp P univs decls'.
+Lemma on_global_decls_prefix {cf} Pcmp P univs retro decls decls' :
+  on_global_decls Pcmp P univs retro (decls ++ decls') ->
+  on_global_decls Pcmp P univs retro decls'.
 Proof.
   induction decls => //.
   intros ha; depelim ha.
@@ -2463,7 +2468,7 @@ Proof.
 Qed.
 
 Lemma decls_prefix_wf {decls Σ} : 
-  decls_prefix decls Σ -> wf Σ -> wf {| universes := Σ.(universes); declarations := decls |}.
+  decls_prefix decls Σ -> wf Σ -> wf {| universes := Σ.(universes); declarations := decls; retroknowledge := Σ.(retroknowledge) |}.
 Proof.
   intros [Σ' hd] wfΣ.
   split. apply wfΣ.
@@ -2479,14 +2484,15 @@ Qed.
 Lemma weaken_prefix {decls Σ kn decl} :
   decls_prefix decls Σ ->
   wf Σ -> 
-  lookup_env {| universes := Σ; declarations := decls |} kn = Some decl ->
+  lookup_env {| universes := Σ; declarations := decls; retroknowledge := Σ.(retroknowledge) |} kn = Some decl ->
   on_global_decl cumulSpec0 (lift_typing typing) (Σ, universes_decl_of_decl decl) kn decl.
 Proof.
   intros prefix wfΣ.
   have wfdecls := decls_prefix_wf prefix wfΣ.
   epose proof (weakening_env_lookup_on_global_env (lift_typing typing) _ Σ kn decl 
     weaken_env_prop_typing wfdecls wfΣ).
-  forward X. red; split => //. cbn. apply incl_cs_refl.
+  forward X. red; split => //. cbn. apply incl_cs_refl. cbn.
+  apply Retroknowledge.extends_refl.
   now apply (X wfdecls).
 Qed.
 
@@ -2568,12 +2574,8 @@ Proof.
     now apply IHsuffix.
 Qed.
 
-Definition add_suffix suffix Σ :=
-  {| universes := Σ.(universes); declarations := suffix ++ Σ.(declarations) |}.
+Definition add_suffix suffix Σ := set_declarations Σ (suffix ++ Σ.(declarations)).
 
-Lemma eta_global_env Σ : Σ = {| universes := Σ.(universes); declarations := Σ.(declarations) |}.
-Proof. now destruct Σ. Qed.
-  
 Lemma add_suffix_cons d suffix Σ : add_suffix (d :: suffix) Σ = add_global_decl (add_suffix suffix Σ) d. 
 Proof. reflexivity. Qed.
 
@@ -2584,7 +2586,7 @@ Lemma global_erased_with_deps_weaken_prefix suffix Σ Σ' kn :
 Proof.
   induction suffix.
   - unfold add_suffix; cbn. intros wf hg.
-    now rewrite -eta_global_env.
+    now rewrite /set_declarations /= -eta_global_env.
   - rewrite add_suffix_cons. intros wf H.
     destruct a as [kn' d]. eapply global_erases_with_deps_weaken => //.
     apply IHsuffix => //.
@@ -2689,7 +2691,7 @@ Qed.*)
   
 Lemma erase_global_deps_fast_spec_gen {deps} 
   {X_type X X'} {decls hprefix hprefix'} :
-  (forall Σ Σ', abstract_env_rel X Σ -> abstract_env_rel X' Σ' -> universes Σ = universes Σ') -> 
+  (forall Σ Σ', abstract_env_rel X Σ -> abstract_env_rel X' Σ' -> universes Σ = universes Σ' /\ retroknowledge Σ = retroknowledge Σ') -> 
   erase_global_decls_fast deps X_type X decls hprefix = 
   erase_global_decls X_type deps X' decls hprefix'.
 Proof.
@@ -2699,7 +2701,7 @@ Proof.
   pose proof (abstract_env_exists X') as [[Σ' wfΣ']].
   pose proof (abstract_env_wf _ wfΣ) as [wf]. 
   pose proof (abstract_env_exists (abstract_pop_decls X')) as [[? wfpop]].
-  unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' wfpop) as [? ?].
+  unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' wfpop) as [? [? ?]].
   { now eexists. }
 
   destruct a as [kn []].
@@ -2713,24 +2715,28 @@ Proof.
       destruct (hprefix _ wfΣ) as [[Σ'' eq]].
       eapply erase_constant_body_suffix; cbn => //.
       intros.
-      epose proof (abstract_make_wf_env_ext_correct X (cst_universes c) _ _ _ wfΣ H1).
-      epose proof (abstract_make_wf_env_ext_correct (abstract_pop_decls X') (cst_universes c) _ _ _ wfpop H2).
+      epose proof (abstract_make_wf_env_ext_correct X (cst_universes c) _ _ _ wfΣ H2).
+      epose proof (abstract_make_wf_env_ext_correct (abstract_pop_decls X') (cst_universes c) _ _ _ wfpop H3).
       subst. split => //. 
       sq; red. cbn. 
-      rewrite eq. rewrite <- H0. split. symmetry. apply equ; eauto.
-      eexists (Σ'' ++ [(kn, ConstantDecl c)]). subst. now rewrite -app_assoc. }
+      rewrite eq. rewrite <- H0, <- H1. split. symmetry. apply equ; eauto.
+      eexists (Σ'' ++ [(kn, ConstantDecl c)]). subst. now rewrite -app_assoc. subst.
+      symmetry. now apply equ.
+      }
     destruct KernameSet.mem => //; f_equal; eapply IHdecls.
-    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H2) as [? ?].
-    { now eexists. } rewrite <- H4. apply equ; eauto.
-    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H2) as [? ?].
-    { now eexists. } rewrite <- H4. apply equ; eauto.
+    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H3) as [? ?].
+    { now eexists. } intuition auto. rewrite <- H6. apply equ; eauto. rewrite <- H7; apply equ; auto.
+    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H3) as [? ?].
+    { now eexists. }  intuition auto. rewrite <- H6. apply equ; eauto. rewrite <- H7; apply equ; auto. 
   
     - cbn.
     destruct KernameSet.mem => //; f_equal; eapply IHdecls.
-    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H2) as [? ?].
-    { now eexists. } rewrite <- H4. apply equ; eauto.
-    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H2) as [? ?].
-    { now eexists. } rewrite <- H4. apply equ; eauto.
+    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H3) as [? ?].
+    { now eexists. }
+    intuition auto. rewrite <- H6. apply equ; eauto. rewrite <- H7; apply equ; auto.
+    intros. unshelve epose proof (abstract_pop_decls_correct X' decls _ _ _ wfΣ' H3) as [? ?].
+    { now eexists. }
+    intuition auto. rewrite <- H6. apply equ; eauto. rewrite <- H7; apply equ; auto.
 Qed.
 
 Lemma erase_global_deps_fast_spec {deps} {X_type X} {decls hprefix hprefix'} :

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -714,7 +714,8 @@ Definition erase_mutual_inductive_body (mib : mutual_inductive_body) : E.mutual_
   let bds := mib.(ind_bodies) in
   let arities := arities_context bds in
   let bodies := map erase_one_inductive_body bds in
-  {| E.ind_npars := mib.(ind_npars);
+  {| E.ind_finite := mib.(ind_finite);
+     E.ind_npars := mib.(ind_npars);
      E.ind_bodies := bodies; |}.
 
 Lemma is_arity_irrel {X_type : abstract_env_ext_impl} {X : X_type.π1}

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -152,6 +152,16 @@ Proof.   induction 1; cbn; try congruence.
   cbn. now rewrite EAstUtils.head_tApp.
 Qed.
 
+Lemma is_PrimApp_erases Σ Γ t t' :
+  Σ;;; Γ |- t ⇝ℇ t' ->
+  negb (isPrimApp t) -> negb (EAstUtils.isPrimApp t').
+Proof.   induction 1; cbn; try congruence.
+- unfold isPrimApp in *. clear IHerases2.
+  cbn. rewrite head_tapp. 
+  unfold EAstUtils.isPrimApp in *.
+  cbn. now rewrite EAstUtils.head_tApp.
+Qed.
+
 Lemma erases_isLambda {Σ Γ t u} :
   Σ ;;; Γ |- t ⇝ℇ u -> isLambda t -> EAst.isLambda u || EAstUtils.isBox u.
 Proof.
@@ -494,6 +504,7 @@ Section wellscoped.
   Fixpoint wellformed (t : term) : bool :=
   match t with
   | tRel i => true
+  | tPrim p => true
   | tEvar ev args => List.forallb (wellformed) args
   | tLambda _ N M => wellformed N && wellformed M
   | tApp u v => wellformed u && wellformed v

--- a/erasure/theories/Extract.v
+++ b/erasure/theories/Extract.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Program.
-From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping
+From MetaCoq.Template Require Import config utils Primitive.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICPrimitive PCUICTyping
      PCUICElimination PCUICWcbvEval.
 From MetaCoq.Erasure Require EAst EGlobalEnv.
 
@@ -34,6 +34,15 @@ Reserved Notation "Σ ;;; Γ |- s ⇝ℇ t" (at level 50, Γ, s, t at next level
 
 Definition erase_context (Γ : context) : list name :=
   map (fun d => d.(decl_name).(binder_name)) Γ.
+
+Definition erase_prim_model {t : prim_tag} (e : @prim_model term t) : @prim_model E.term t :=
+  match e in @prim_model _ x return prim_model E.term x with
+  | primIntModel i => primIntModel i
+  | primFloatModel f => primFloatModel f
+  end.
+  
+Definition erase_prim_val (p : prim_val term) : prim_val E.term :=
+  (p.π1; erase_prim_model p.π2).
 
 Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :=
     erases_tRel : forall i : nat, Σ;;; Γ |- tRel i ⇝ℇ E.tRel i
@@ -84,7 +93,9 @@ Inductive erases (Σ : global_env_ext) (Γ : context) : term -> E.term -> Prop :
                          × Σ;;; Γ ,,, fix_context mfix |-
                            dbody d ⇝ℇ E.dbody d') mfix mfix' ->
                     Σ;;; Γ |- tCoFix mfix n ⇝ℇ E.tCoFix mfix' n
-  | erases_box : forall t : term, isErasable Σ Γ t -> Σ;;; Γ |- t ⇝ℇ E.tBox where "Σ ;;; Γ |- s ⇝ℇ t" := (erases Σ Γ s t).
+  | erases_tPrim : forall p, Σ;;; Γ |- tPrim p ⇝ℇ E.tPrim (erase_prim_val p)
+  | erases_box : forall t : term, isErasable Σ Γ t -> Σ;;; Γ |- t ⇝ℇ E.tBox 
+  where "Σ ;;; Γ |- s ⇝ℇ t" := (erases Σ Γ s t).
 
 Lemma erases_forall_list_ind
       Σ (P : context -> term -> E.term -> Prop)
@@ -153,6 +164,7 @@ Lemma erases_forall_list_ind
                        (dbody d)
                        (EAst.dbody d') ) mfix mfix' ->
           P Γ (tCoFix mfix n) (E.tCoFix mfix' n))
+      (Hprim : forall Γ p, P Γ (tPrim p) (E.tPrim (erase_prim_val p)))
       (Hbox : forall Γ t, isErasable Σ Γ t -> P Γ t E.tBox) :
   forall Γ t t0,
     Σ;;; Γ |- t ⇝ℇ t0 ->
@@ -215,18 +227,18 @@ Definition erases_mutual_inductive_body (mib : mutual_inductive_body) (mib' : E.
   Forall2 erases_one_inductive_body bds (mib'.(E.ind_bodies)) /\
   mib.(ind_npars) = mib'.(E.ind_npars).
 
-Inductive erases_global_decls (univs : ContextSet.t) : global_declarations -> E.global_declarations -> Prop :=
-| erases_global_nil : erases_global_decls univs [] []
+Inductive erases_global_decls (univs : ContextSet.t) retro : global_declarations -> E.global_declarations -> Prop :=
+| erases_global_nil : erases_global_decls univs retro [] []
 | erases_global_cnst Σ cb cb' kn Σ' :
-    erases_constant_body ({| universes := univs; declarations := Σ |}, cst_universes cb) cb cb' ->
-    erases_global_decls univs Σ Σ' ->
-    erases_global_decls univs ((kn, ConstantDecl cb) :: Σ) ((kn, E.ConstantDecl cb') :: Σ')
+    erases_constant_body ({| universes := univs; declarations := Σ; retroknowledge := retro |}, cst_universes cb) cb cb' ->
+    erases_global_decls univs retro Σ Σ' ->
+    erases_global_decls univs retro ((kn, ConstantDecl cb) :: Σ) ((kn, E.ConstantDecl cb') :: Σ')
 | erases_global_ind Σ mib mib' kn Σ' :
     erases_mutual_inductive_body mib mib' ->
-    erases_global_decls univs Σ Σ' ->
-    erases_global_decls  univs((kn, InductiveDecl mib) :: Σ) ((kn, E.InductiveDecl mib') :: Σ').
+    erases_global_decls univs retro Σ Σ' ->
+    erases_global_decls univs retro ((kn, InductiveDecl mib) :: Σ) ((kn, E.InductiveDecl mib') :: Σ').
 
-Definition erases_global Σ Σ' := erases_global_decls Σ.(universes) Σ.(declarations) Σ'.
+Definition erases_global Σ Σ' := erases_global_decls Σ.(universes) Σ.(retroknowledge) Σ.(declarations) Σ'.
 
 Definition inductive_arity (t : term) :=
   match fst (decompose_app t) with
@@ -287,7 +299,8 @@ Inductive erases_deps (Σ : global_env) (Σ' : E.global_declarations) : E.term -
     erases_deps Σ Σ' (E.tFix defs i)
 | erases_deps_tCoFix defs i :
     Forall (fun d => erases_deps Σ Σ' (E.dbody d)) defs ->
-    erases_deps Σ Σ' (E.tCoFix defs i).
+    erases_deps Σ Σ' (E.tCoFix defs i)
+| erases_deps_tPrim p : erases_deps Σ Σ' (E.tPrim p).
 
 Definition option_is_none {A} (o : option A) :=
   match o with

--- a/erasure/theories/Extraction.v
+++ b/erasure/theories/Extraction.v
@@ -1,5 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import Ascii FSets ExtrOcamlBasic ExtrOcamlZInt ExtrOCamlFloats ExtrOCamlInt63.
+From Coq Require Import Ascii FSets ExtrOcamlBasic ExtrOCamlFloats ExtrOCamlInt63.
 From MetaCoq.Template Require Import utils.
 
 (** * Extraction setup for the erasure phase of template-coq.

--- a/examples/metacoq_tour_prelude.v
+++ b/examples/metacoq_tour_prelude.v
@@ -23,7 +23,8 @@ Definition univ := Level.Level "s".
 (* TODO move to SafeChecker *)
 
 Definition gctx : global_env_ext := 
-  ({| universes := (LS.union (LevelSet.singleton Level.lzero) (LevelSet.singleton univ), ConstraintSet.empty); declarations := [] |}, Monomorphic_ctx).
+  ({| universes := (LS.union (LevelSet.singleton Level.lzero) (LevelSet.singleton univ), ConstraintSet.empty);
+      declarations := []; retroknowledge := Retroknowledge.empty |}, Monomorphic_ctx).
 
 (** We use the environment checker to produce the proof that gctx, which is a singleton with only 
     universe "s" declared is well-formed. *)

--- a/examples/typing_correctness.v
+++ b/examples/typing_correctness.v
@@ -1,4 +1,4 @@
-From MetaCoq.Template Require Import config All.
+(*From MetaCoq.Template Require Import config All.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICLiftSubst TemplateToPCUIC.
 From MetaCoq.SafeChecker Require Import PCUICErrors PCUICWfEnv PCUICWfEnvImpl PCUICTypeChecker PCUICSafeChecker.
 From Equations Require Import Equations.
@@ -62,7 +62,7 @@ Proof.
    (* idtac z ; fail "Couldn't prove the global environment is well-formed" *)
   end.
 Defined.
-
+*)
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config Universes Loader.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICLiftSubst.
@@ -88,7 +88,8 @@ Definition univ := Level.Level "s".
 (* TODO move to SafeChecker *)
 
 Definition gctx : global_env_ext := 
-  ({| universes := (LS.union (LevelSet.singleton Level.lzero) (LevelSet.singleton univ), ConstraintSet.empty); declarations := [] |}, Monomorphic_ctx).
+  ({| universes := (LS.union (LevelSet.singleton Level.lzero) (LevelSet.singleton univ), ConstraintSet.empty); declarations := []
+    ; retroknowledge := Retroknowledge.empty |}, Monomorphic_ctx).
 
 (** We use the environment checker to produce the proof that gctx, which is a singleton with only 
     universe "s" declared  is well-formed. *)
@@ -158,7 +159,8 @@ Lemma identity_typing (u := Universe.make univ):
            universes :=
              (LS.union (LevelSet.singleton Level.lzero)
                 (LevelSet.singleton univ), ConstraintSet.empty);
-           declarations := []
+           declarations := [];
+           retroknowledge := Retroknowledge.empty
          |}, Monomorphic_ctx) ->
         ∥ Σ0;;; [] |- t
           : tProd (bNamed "s") (tSort u) (tImpl (tRel 0) (tRel 0)) ∥).

--- a/examples/typing_correctness.v
+++ b/examples/typing_correctness.v
@@ -1,3 +1,68 @@
+From MetaCoq.Template Require Import config All.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICLiftSubst TemplateToPCUIC.
+From MetaCoq.SafeChecker Require Import PCUICErrors PCUICWfEnv PCUICWfEnvImpl PCUICTypeChecker PCUICSafeChecker.
+From Equations Require Import Equations.
+
+
+
+
+Polymorphic Inductive list@{u} (A : Type@{u}) : Type@{u} :=
+(* | nil : list A *)
+(* | cons : A -> list A -> list A *)
+.
+
+Polymorphic Inductive rtree@{u} : Type@{u} :=
+| node : list rtree -> rtree.
+
+Universe u.
+
+Polymorphic Inductive empty@{u} : Type@{u} :=.
+
+Polymorphic Inductive unit@{u} : Type@{u} := tt.
+
+MetaCoq Quote Recursively Definition empty_sig_full_template := (fun (A : Type@{u}) (x : A) => x).
+Definition empty_sig_full := trans_template_program empty_sig_full_template.
+
+MetaCoq Quote Recursively Definition empty_full_template := empty@{u}.
+Definition empty_full := trans_template_program empty_full_template.
+
+MetaCoq Quote Recursively Definition unit_full_template := tt@{u}.
+Definition unit_full := trans_template_program unit_full_template.
+
+MetaCoq Quote Recursively Definition list_full_template := list@{u}.
+Definition list_full := trans_template_program list_full_template.
+
+MetaCoq Quote Recursively Definition rtree_full_template := rtree@{u}.
+Definition rtree_full := trans_template_program rtree_full_template.
+
+Definition extract_gctx : PCUICProgram.pcuic_program -> global_env_ext :=
+  fun p => (p.1.1.(PCUICProgram.trans_env_env), p.1.2).
+
+Definition gctx := Eval cbv in extract_gctx empty_full. (* Change here *)
+
+Global Program Instance fake_guard_impl : abstract_guard_impl :=
+{| guard_impl := fake_guard_impl |}.
+Next Obligation. Admitted.
+
+Local Existing Instance PCUICSN.default_normalizing.
+Import MCMonadNotation.
+
+Definition make_wf_env_ext (Σ : global_env_ext) : EnvCheck wf_env_ext wf_env_ext :=
+  '(exist Σ' pf) <- check_wf_ext optimized_abstract_env_impl Σ ;;
+  ret Σ'.
+
+Local Existing Instance default_checker_flags.
+
+Definition gctx_wf_env : wf_env_ext.
+Proof.
+  let wf_proof := eval hnf in (make_wf_env_ext gctx) in 
+  match wf_proof with
+  | CorrectDecl _ ?x => exact x
+  | ?z => set (error := z)
+   (* idtac z ; fail "Couldn't prove the global environment is well-formed" *)
+  end.
+Defined.
+
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config Universes Loader.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping PCUICLiftSubst.
@@ -86,7 +151,6 @@ Time Qed. *)
 
 
 Lemma identity_typing (u := Universe.make univ): 
-typing_result
      (∑ t : term,
         forall Σ0 : global_env_ext,
         Σ0 =
@@ -106,7 +170,7 @@ Proof.
   pose (T := tProd (bNamed "s") (tSort u) (tImpl (tRel 0) (tRel 0))).
   pose (Σ := gctx_wf_env).
   let t := uconstr:(check_inh Σ [] wfΓ impl (T:=T)) in
-  let proof := eval cbn in t in
+  let proof := eval hnf in t in
   match proof with
   | Checked ?d => exact_no_check d
   | TypeError ?e => 
@@ -115,7 +179,6 @@ Proof.
   | _ => set (blocked := proof)
   (* fail "Anomaly: unexpected return value: " proof *)
   end.
-  exact blocked. 
 Defined. 
 
 (* Print Opaque Dependencies identity_typing. *)

--- a/pcuic/theories/Bidirectional/BDFromPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDFromPCUIC.v
@@ -372,6 +372,10 @@ Proof.
       intros ? [? s].
       by apply conv_check in s ; auto.
   
+  - intros p prim_ty cdecl wfΓ' hp hdecl pinv.
+    eexists. split; [econstructor; tea|]. 
+    eapply ws_cumul_pb_refl; fvs.
+
   - intros ? ? ? ? ? ? (?&?&?) ? (?&?&?) ?.
     eexists.
     split.

--- a/pcuic/theories/Bidirectional/BDStrengthening.v
+++ b/pcuic/theories/Bidirectional/BDStrengthening.v
@@ -467,6 +467,7 @@ Section OnFreeVars.
       by move: Hmfix => /andP [].
     
     - easy.
+    - easy.
 
     - intros ? ? ? ? ? ? _ HT Hred.
       intros ? HΓ Ht.
@@ -857,6 +858,9 @@ Proof using wfΣ.
         by rewrite shiftnP0.
     + by apply rename_wf_cofixpoint. 
   
+  - intros. red. intros P Δ f hf ht.
+    cbn. econstructor; tea.
+    
   - intros. red. intros P Δ f hf ht.
     econstructor ; eauto.
     rewrite -/(rename f (tSort u)).

--- a/pcuic/theories/Bidirectional/BDToPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDToPCUIC.v
@@ -413,6 +413,9 @@ Section BDToPCUICTyping.
         apply weakening.
         all: auto.
 
+    - red; intros.
+      now econstructor.
+
     - red ; intros.
       now eapply type_reduction.
 

--- a/pcuic/theories/Bidirectional/BDUnique.v
+++ b/pcuic/theories/Bidirectional/BDUnique.v
@@ -56,7 +56,7 @@ Proof using wfΣ.
 
   all: intros ; red ; auto.
   1-9,11-13: intros ? T' ty_T' ; inversion_clear ty_T'.
-  14-16: intros.
+  14-17: intros.
 
   - rewrite H in H0.
     inversion H0. subst. clear H0.
@@ -224,6 +224,12 @@ Proof using wfΣ.
         now apply r.
       * fvs.
       * now eapply type_is_open_term, infering_typing.
+
+  - inversion X1; subst.
+    rewrite H in H2; noconf H2.
+    have eq := (declared_constant_inj _ _ H0 H3); subst cdecl0.
+    exists (tConst prim_ty []).
+    split; eapply closed_red_refl; fvs.
 
   - inversion X3 ; subst.
     eapply X0 in X4 as [T'' []]; subst ; tea.

--- a/pcuic/theories/PCUICAlpha.v
+++ b/pcuic/theories/PCUICAlpha.v
@@ -994,6 +994,8 @@ Section Alpha.
         now apply infer_typing_sort_impl with id ihmfix; intros [].
       + apply eq_term_upto_univ_cumulSpec, eq_term_leq_term, upto_names_impl_eq_term.
         now symmetry.
+    - intros p prim_ty cdecl IH prim decl pinv Δ v e e'.
+      depelim e. econstructor; tea. now apply IH.
 
     - intros t A B X wf ht iht har ihar hcu Δ v e e'.
       eapply (type_ws_cumul_pb (pb:=Cumul)).

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -206,9 +206,8 @@ Inductive term :=
 | tCase (indn : case_info) (p : predicate term) (c : term) (brs : list (branch term))
 | tProj (p : projection) (c : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
-| tCoFix (mfix : mfixpoint term) (idx : nat).
-(** We use faithful models of primitive type values in PCUIC *)
-(* | tPrim (prim : prim_val term). *)
+| tCoFix (mfix : mfixpoint term) (idx : nat)
+| tPrim (prim : prim_val term).
 
 Derive NoConfusion for term.
 
@@ -487,7 +486,7 @@ Instance subst_instance_constr : UnivSubst term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def (subst_instance_constr u) (subst_instance_constr u)) mfix in
     tCoFix mfix' idx
-  (* | tPrim _ => c *)
+  | tPrim _ => c
   end.
 
 (** Tests that the term is closed over [k] universe variables *)

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -771,6 +771,56 @@ Section WeakNormalization.
     Σ ;;; [] |- t : ty ->
     False.
   Proof. eauto using wh_neutral_empty_gen. Qed.
+  
+  Require Import Equations.Type.Relation_Properties.
+
+  (* TODO move *)
+  Lemma invert_red_axiom {Γ cst u cdecl T} :
+    declared_constant Σ cst cdecl -> 
+    cst_body cdecl = None ->
+    Σ ;;; Γ ⊢ tConst cst u ⇝ T ->
+    T = tConst cst u.
+  Proof using wfΣ.
+    intros hdecl hb.
+    generalize_eq x (tConst cst u).
+    move=> e [clΓ clt] red.
+    revert cst u hdecl hb e.
+    eapply clos_rt_rt1n_iff in red.
+    induction red; simplify_dep_elim.
+    - reflexivity.
+    - depelim r; solve_discr. congruence.
+  Qed.
+
+  Lemma ws_cumul_pb_Axiom_l_inv {pb Γ cst u cdecl T} :
+    declared_constant Σ cst cdecl -> 
+    cst_body cdecl = None ->
+    Σ ;;; Γ ⊢ tConst cst u ≤[pb] T ->
+    ∑ u', Σ ;;; Γ ⊢ T ⇝ tConst cst u' × PCUICEquality.R_universe_instance (eq_universe Σ) u u'.
+  Proof using wfΣ.
+    intros hdecl hb H.
+    eapply ws_cumul_pb_red in H as (v & v' & [tv tv' eqp]).
+    epose proof (invert_red_axiom hdecl hb tv). subst v.
+    depelim eqp.
+    exists u'. split => //.
+  Qed.
+
+  Lemma invert_cumul_axiom_ind {Γ cst cdecl u ind u' args} :
+    declared_constant Σ cst cdecl -> 
+    cst_body cdecl = None ->
+    Σ ;;; Γ ⊢ tConst cst u ≤ mkApps (tInd ind u') args -> False.
+  Proof using wfΣ.
+    intros hd hb ht; eapply ws_cumul_pb_Axiom_l_inv in ht as (u'' & hred & hcmp); eauto.
+    eapply invert_red_mkApps_tInd in hred as (? & []); auto. solve_discr.
+  Qed.
+
+  Lemma invert_cumul_axiom_prod {Γ cst cdecl u na dom codom} :
+    declared_constant Σ cst cdecl -> 
+    cst_body cdecl = None ->
+    Σ ;;; Γ ⊢ tConst cst u ≤ tProd na dom codom -> False.
+  Proof using wfΣ.
+    intros hd hb ht; eapply ws_cumul_pb_Axiom_l_inv in ht as (u'' & hred & hcmp); eauto.
+    eapply invert_red_prod in hred as (? & ? & []); auto. discriminate.
+  Qed.
 
   Lemma wh_normal_ind_discr t i u args :
     axiom_free_value Σ [] t ->
@@ -792,7 +842,9 @@ Section WeakNormalization.
     - exfalso; eapply invert_ind_ind; eauto.
     - exfalso; eapply invert_fix_ind; eauto.
     - now rewrite head_mkApps /head /=.
-    (* - now eapply inversion_Prim in typed. *)
+    - eapply inversion_Prim in typed as [prim_ty [cdecl [? ? ? [? hp]]]]; eauto.
+      eapply invert_cumul_axiom_ind in w; eauto.
+      apply hp. 
   Qed.
 
   Lemma whnf_ind_finite t ind u indargs :

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -1097,7 +1097,7 @@ Proof using Hcf Hcf'.
   [ H : leq_term_napp _ _ _ _ |- _ ] => depelim H
   end; assert (wf_ext Σ) by (split; assumption).
 
-  14:{ assert (wf_ext Σ) by (split; assumption). specialize (X1 _ _ H X5 _ X6).
+  15:{ assert (wf_ext Σ) by (split; assumption). specialize (X1 _ _ H X5 _ X6).
        eapply cumul_prop_cum_l; tea.
        eapply cumulSpec_cumulAlgo_curry in X4; tea; fvs. }
 
@@ -1315,6 +1315,10 @@ Proof using Hcf Hcf'.
     { now eapply cumul_prop_is_open in cum as []. }
     eapply eq_term_eq_term_prop_impl; eauto.
     now symmetry in a.
+
+  - depelim X2.
+    eapply inversion_Prim in X1 as [prim_ty' [cdecl' []]]; tea.
+    rewrite H in e. noconf e. eapply cumul_cumul_prop; eauto. pcuic.
 Qed.
 
 End no_prop_leq_type.

--- a/pcuic/theories/PCUICEquality.v
+++ b/pcuic/theories/PCUICEquality.v
@@ -360,7 +360,7 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
     ) mfix mfix' ->
     Σ ⊢ tCoFix mfix idx <==[ Rle , napp ] tCoFix mfix' idx
     
-(* | eq_Prim i : eq_term_upto_univ_napp Σ Re Rle napp (tPrim i) (tPrim i) *)
+| eq_Prim i : eq_term_upto_univ_napp Σ Re Rle napp (tPrim i) (tPrim i)
 where " Σ ⊢ t <==[ Rle , napp ] u " := (eq_term_upto_univ_napp Σ _ Rle napp t u) : type_scope.
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).

--- a/pcuic/theories/PCUICExpandLets.v
+++ b/pcuic/theories/PCUICExpandLets.v
@@ -40,7 +40,7 @@ Fixpoint trans (t : term) : term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  (* | tPrim i => tPrim i *)
+  | tPrim i => tPrim i
   end.
 
 Notation trans_decl := (map_decl trans).
@@ -108,7 +108,8 @@ Definition trans_global_decls (d : PCUICEnvironment.global_declarations) : globa
 
 Definition trans_global_env (d : PCUICEnvironment.global_env) : global_env :=
   {| universes := d.(PCUICEnvironment.universes);
-     declarations := trans_global_decls d.(PCUICEnvironment.declarations) |}.
+     declarations := trans_global_decls d.(PCUICEnvironment.declarations);
+     retroknowledge := d.(PCUICEnvironment.retroknowledge) |}.
   
 Definition trans_global (Σ : PCUICEnvironment.global_env_ext) : global_env_ext :=
   (trans_global_env (fst Σ), snd Σ).

--- a/pcuic/theories/PCUICFirstorder.v
+++ b/pcuic/theories/PCUICFirstorder.v
@@ -274,13 +274,13 @@ Lemma plookup_env_lookup_env {Σ : global_env_ext} kn b :
       b = firstorder_mutind (firstorder_env' (declarations Σ')) mind
     end.
 Proof using.
-  destruct Σ as [[univs Σ] ext].
+  destruct Σ as [[univs Σ retro] ext].
   induction Σ; cbn => //.
   destruct a as [kn' d] => //. cbn.
   case: eqb_specT.
   * intros ->.
     destruct d => //; cbn; rewrite eqb_refl => [=] <-;
-    exists {| universes := univs; declarations := Σ |}.
+    exists {| universes := univs; declarations := Σ; retroknowledge := retro |}.
     eexists; split => //. cbn. split => //.
     red. split => //. eexists (_ :: []); cbn; trea.
     eexists; split => //. cbn; split => //.
@@ -385,8 +385,8 @@ Lemma plookup_env_extends {Σ Σ' : global_env} kn b :
   plookup_env (firstorder_env' (declarations Σ')) kn = Some b ->
   plookup_env (firstorder_env' (declarations Σ)) kn = Some b.
 Proof.
-  intros [equ [Σ'' eq]]. rewrite eq.
-  clear equ. intros []. clear o. 
+  intros [equ [Σ'' eq] eqr]. rewrite eq.
+  clear equ eqr. intros []. clear o. 
   rewrite eq in o0. clear eq. move: o0.
   generalize (declarations Σ'). clear Σ'.
   induction Σ''.
@@ -667,6 +667,8 @@ Proof using Type.
       eapply andb_true_iff in Hfo as [Hfo _].
       rewrite /check_recursivity_kind Hlookup in Hty.
       apply eqb_eq in Hfo, Hty. congruence.
+    + eapply inversion_Prim in Hty as [prim_ty [cdecl [wf hp hdecl [s []] cum]]]; eauto.
+      now eapply invert_cumul_axiom_ind in cum; tea.
   - destruct t; inv Hhead.
     + exfalso. now eapply invert_ind_ind in Hty.
     + apply inversion_mkApps in Hty as Hcon; auto.

--- a/pcuic/theories/PCUICInversion.v
+++ b/pcuic/theories/PCUICInversion.v
@@ -335,13 +335,23 @@ Section Inversion.
     intros Γ mfix idx T h. invtac h.
   Qed.
 
-  (** At this stage we don't typecheck primitive values *)
-  (* Lemma inversion_Prim :
-    forall {Γ i T},
-      Σ ;;; Γ |- tPrim i : T -> False.
+  Lemma inversion_Prim :
+    forall {Γ p T},
+    Σ ;;; Γ |- tPrim p : T -> 
+    ∑ prim_ty cdecl, 
+      [× wf_local Σ Γ,
+        primitive_constant Σ (prim_val_tag p) = Some prim_ty,
+        declared_constant Σ prim_ty cdecl,
+        primitive_invariants cdecl & 
+        Σ ;;; Γ ⊢ tConst prim_ty [] ≤ T].
   Proof.
-    intros Γ i T h. now depind h.
-  Qed. *)
+    intros Γ p T h. depind h.
+    - exists prim_ty, cdecl; split => //.
+      eapply ws_cumul_pb_refl; fvs.
+    - destruct IHh1 as [prim_ty [cdecl []]].
+      exists prim_ty, cdecl. split => //.
+      transitivity A; tea. eapply cumulSpec_cumulAlgo_curry; tea; fvs. 
+  Qed.
 
   Lemma inversion_it_mkLambda_or_LetIn :
     forall {Γ Δ t T},

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -118,7 +118,7 @@ Section Normal.
     end ->
     whnf Γ (mkApps (tFix mfix idx) v)
   | whnf_cofixapp mfix idx v : whnf Γ (mkApps (tCoFix mfix idx) v)
-  (* | whnf_prim p : whnf Γ (tPrim p) *).
+  | whnf_prim p : whnf Γ (tPrim p).
 
   Lemma whne_mkApps :
     forall Γ t args,
@@ -257,8 +257,8 @@ Proof.
     lia.
   - destruct (mkApps_elim t l).
     apply mkApps_eq_inj in eq as (<-&<-); auto.
-  (* - destruct l using MCList.rev_ind; [|now rewrite mkApps_app in eq]. *)
-    (* cbn in *; subst; auto. *)
+  - destruct l using MCList.rev_ind; [|now rewrite mkApps_app in eq].
+    cbn in *; subst; auto.
 Qed.
 
 Lemma whnf_fixapp' {flags} Σ Γ mfix idx narg body v :
@@ -391,11 +391,11 @@ Proof with eauto using sq with pcuic; try congruence.
                  constructor.
                  assumption.
         -- left. constructor. eapply whnf_fixapp. rewrite E1. eauto.
-      (* * destruct v as [ | ? v]...
+      * destruct v as [ | ? v]...
         right. intros [w]. depelim w. depelim w. all:help. clear IHt.
         eapply whne_mkApps_inv in w as []...
         -- depelim w. help.
-        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence. *)
+        -- destruct s0 as [? [? [? [? [? [? ?]]]]]]. congruence. 
     + right. intros [w]. eapply n. constructor. now eapply whnf_mkApps_inv. 
   - destruct (IHt Γ) as [_ []].
     + left. destruct s as [w]. constructor. now eapply whne_mkApps.
@@ -941,7 +941,7 @@ Proof.
       destruct s as [->|(?&?)]; [easy|].
       now inv e.
   - eapply red1_mkApps_tCoFix_inv in r as [[(?&->&?)|(?&->&?)]|(?&->&?)]; eauto.
-  (* - depelim r. solve_discr. *)
+  - depelim r. solve_discr.
 Qed.
 
 Lemma whnf_pres Σ Γ t t' :
@@ -1014,8 +1014,8 @@ Inductive whnf_red Σ Γ : term -> term -> Type :=
                       red Σ Γ (dtype d) (dtype d') ×
                       red Σ (Γ,,, fix_context mfix) (dbody d) (dbody d'))
          mfix mfix' ->
-    whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx).
-(* | whnf_red_tPrim i : whnf_red Σ Γ (tPrim i) (tPrim i). *)
+    whnf_red Σ Γ (tCoFix mfix idx) (tCoFix mfix' idx)
+| whnf_red_tPrim i : whnf_red Σ Γ (tPrim i) (tPrim i).
 
 Derive Signature for whnf_red.
 
@@ -1517,7 +1517,7 @@ Proof.
       cbn.
       intros ? ? (?&[= -> -> ->]).
       auto.
-  (* - depelim r; solve_discr. *)
+  - depelim r; solve_discr.
 Qed.
 
 Lemma whnf_red_inv {cf:checker_flags} {Σ : global_env_ext} Γ t t' :
@@ -1608,7 +1608,7 @@ Proof.
   - apply eq_term_upto_univ_napp_mkApps_l_inv in eq as (?&?&(?&?)&->).
     depelim e.
     apply whnf_cofixapp.
-  (* - depelim eq; auto. *)
+  - depelim eq; auto.
 Qed.
 
 Lemma whnf_eq_term {cf:checker_flags} f Σ φ Γ t t' :

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -231,7 +231,7 @@ Section ParallelReduction.
     | tSort _
     | tInd _ _
     | tConstruct _ _ _  => true
-    (* | tPrim _ => true *)
+    | tPrim _ => true
     | _ => false
     end.
 

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -1527,7 +1527,7 @@ Section Rho.
     rename r (rho Γ t) = rho Δ (rename r t).
   Proof using cf Σ wfΣ.
     revert t Γ Δ r P.
-    refine (PCUICDepth.term_ind_depth_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
+    refine (PCUICDepth.term_ind_depth_app _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _);
       intros until Γ; intros Δ r P Hr ont; try subst Γ; try rename Γ0 into Γ; repeat inv_on_free_vars.
     all:auto 2.
 

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -333,7 +333,11 @@ Section Principality.
       rewrite nthe' in nthe; noconf nthe.
       repeat split; eauto.
       eapply type_CoFix; eauto.
-    (* - now apply inversion_Prim in hA. *)
+    - apply inversion_Prim in hA as [prim_ty [cdecl []]] => //; pcuic.
+      exists (tConst prim_ty []).
+      intros B hB.
+      apply inversion_Prim in hB as [prim_ty' [cdecl' []]] => //; pcuic.
+      econstructor; tea.
   Qed.
 
   (** A weaker version that is often convenient to use. *)
@@ -471,9 +475,7 @@ Proof.
     [ H : leq_term _ _ _ _ |- _ ] => depelim H
     end.
   all:try solve [econstructor; eauto].
-  13:{ eapply type_Cumul'.
-       eapply X1; eauto. now exists s.
-       auto. }
+
   - eapply inversion_Sort in X0 as [wf [wfs cum]]; auto.
     eapply type_Cumul' with (tSort (Universe.super s)).
     constructor; auto. eapply PCUICArities.isType_Sort; pcuic.
@@ -717,8 +719,14 @@ Proof.
     destruct a as [[[eqty _] _] _].
     constructor. apply eq_term_empty_leq_term in eqty.
     now eapply leq_term_empty_leq_term.
-Qed.
 
+  - depelim X2.
+    econstructor; tea.
+
+  - eapply type_Cumul'.
+    eapply X1; eauto. now exists s.
+    auto.
+Qed.
 
 Lemma typing_eq_term {cf:checker_flags} (Σ : global_env_ext) Γ t t' T T' : 
   wf_ext Σ ->

--- a/pcuic/theories/PCUICProgress.v
+++ b/pcuic/theories/PCUICProgress.v
@@ -255,6 +255,13 @@ forall (P : global_env_ext -> context -> term -> term -> Type)
       wf_cofixpoint Σ.1 mfix ->
       P Σ Γ (tCoFix mfix n) decl.(dtype)) ->
 
+  (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : prim_val) prim_ty cdecl,
+    PΓ Σ Γ ->
+    primitive_constant Σ.1 (prim_val_tag p) = Some prim_ty ->
+    declared_constant Σ.1 prim_ty cdecl ->
+    primitive_invariants cdecl ->
+    P Σ Γ (tPrim p) (tConst prim_ty [])) ->
+
   (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t A B : term) s,
       PΓ Σ Γ ->
       Σ ;;; Γ |- t : A ->
@@ -429,6 +436,13 @@ Lemma typing_ind_env `{cf : checker_flags} :
         wf_cofixpoint Σ.1 mfix ->
         P Σ Γ (tCoFix mfix n) decl.(dtype)) ->
 
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : prim_val) prim_ty cdecl,
+        PΓ Σ Γ ->
+        primitive_constant Σ.1 (prim_val_tag p) = Some prim_ty ->
+        declared_constant Σ.1 prim_ty cdecl ->
+        primitive_invariants cdecl ->
+        P Σ Γ (tPrim p) (tConst prim_ty [])) ->
+
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t A B : term) s,
         PΓ Σ Γ ->
         Σ ;;; Γ |- t : A ->
@@ -441,7 +455,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
        env_prop P PΓ.
 Proof.
   intros P Pdecl PΓ; unfold env_prop.
-  intros XΓ X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 Σ wfΣ Γ t T H.
+  intros XΓ X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 X13 Σ wfΣ Γ t T H.
   apply typing_ind_env_app_size; eauto.
 Qed.
 
@@ -540,6 +554,17 @@ Proof.
   now eapply ws_cumul_pb_Sort_Prod_inv in w.
 Qed.
 
+Lemma typing_spine_axiom {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} Γ cst u cdecl args T :
+  declared_constant Σ cst cdecl -> 
+  cdecl.(cst_body) = None ->
+  typing_spine Σ Γ (tConst cst u) args T -> args = [].
+Proof.
+  intros hdecl hb.
+  induction args => //.
+  intros sp. depelim sp.
+  now eapply invert_cumul_axiom_prod in w.
+Qed.
+
 Lemma typing_value_head_napp {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} fn args hd T : 
   negb (isApp fn) ->
   Σ ;;; [] |- mkApps fn (args ++ [hd]) : T -> 
@@ -594,6 +619,11 @@ Proof.
   * (* cofix *)
     right. eapply value_app; eauto with pcuic.
     now constructor.
+  * (* primitive *)
+    cbn.
+    eapply inversion_Prim in hfn as [prim_ty [cdecl [hwf hp hdecl [s []]]]]; tea.
+    eapply typing_spine_strengthen in hcum. 3:tea. 2:{ eapply validity; econstructor; eauto. now exists s. }
+    now eapply typing_spine_axiom, app_tip_nil in hcum.
 Qed.
 
 Lemma typing_value_head {cf : checker_flags} {Σ : global_env_ext} {wfΣ : wf Σ} fn args hd T : 
@@ -876,7 +906,7 @@ Lemma wcbv_standardization {Σ i u args mind} {t v : term} : wf_ext Σ -> axiom_
   @firstorder_ind Σ (firstorder_env Σ) i ->
   red Σ [] t v ->
   (forall v', PCUICReduction.red1 Σ [] v v' -> False) ->
-  squash (eval Σ t v).
+  ∥ eval Σ t v ∥.
 Proof.
   intros Hwf Hax Hty Hdecl Hfo Hred Hirred.
   unshelve edestruct @ws_wcbv_standardization.

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -11,11 +11,11 @@ Definition uint63_from_model (i : uint63_model) : Uint63.int :=
 Definition float64_from_model (f : float64_model) : PrimFloat.float :=
   FloatOps.SF2Prim (proj1_sig f).
     
-(* Definition trans_prim (t : prim_val) : Ast.term :=
+Definition trans_prim (t : prim_val) : Ast.term :=
   match t.π2 with
-  | primIntModel i => Ast.tInt (uint63_from_model i)
-  | primFloatModel f => Ast.tFloat (float64_from_model f)
-  end. *)
+  | primIntModel i => Ast.tInt i
+  | primFloatModel f => Ast.tFloat f
+  end.
 
 Definition trans_predicate (t : PCUICAst.predicate Ast.term) : predicate Ast.term :=
   {| pparams := t.(PCUICAst.pparams); 
@@ -51,7 +51,7 @@ Fixpoint trans (t : PCUICAst.term) : Ast.term :=
   | PCUICAst.tCoFix mfix idx =>
     let mfix' := List.map (map_def trans trans) mfix in
     tCoFix mfix' idx
-  (* | PCUICAst.tPrim i => trans_prim i *)
+  | PCUICAst.tPrim i => trans_prim i
   end.
 
 Notation trans_decl := (map_decl trans).

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -106,7 +106,8 @@ Definition trans_global_decls (d : PCUICEnvironment.global_declarations) : globa
 
 Definition trans_global_env (d : PCUICEnvironment.global_env) : global_env :=
   {| universes := d.(PCUICEnvironment.universes); 
-     declarations := trans_global_decls d.(PCUICEnvironment.declarations) |}.
+     declarations := trans_global_decls d.(PCUICEnvironment.declarations);
+     retroknowledge := d.(PCUICEnvironment.retroknowledge) |}.
   
 Definition trans_global (Σ : PCUICEnvironment.global_env_ext) : global_env_ext :=
   (trans_global_env (fst Σ), snd Σ).

--- a/pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/pcuic/theories/PCUICToTemplateCorrectness.v
@@ -102,7 +102,7 @@ Proof.
     rewrite b. now rewrite forget_types_length map_context_length. 
   - f_equal; auto; red in X; solve_list.
   - f_equal; auto; red in X; solve_list.
-  (* - destruct p as [? []]; eauto. *)
+  - destruct p as [? []]; eauto.
 Qed.
 
 Definition on_fst {A B C} (f:A->C) (p:A×B) := (f p.1, p.2).
@@ -275,7 +275,7 @@ Proof.
       cbn in *.
       now rewrite e e0.  
     + apply IHX.
-  (* - destruct p as [? []]; eauto. *)
+  - destruct p as [? []]; eauto.
 Qed.
 
 Lemma trans_subst10 u B:
@@ -325,7 +325,7 @@ Proof.
       destruct p.
       now rewrite e e0.
     + apply IHX.
-  (* - destruct p as [? []]; eauto. *)
+  - destruct p as [? []]; eauto.
 Qed.
 
 Lemma trans_subst_instance_ctx Γ u :
@@ -441,7 +441,7 @@ Proof.
   - rewrite <- IHx3.
     reflexivity.
   - destruct (trans x1);cbn;trivial.
-  (* - destruct prim as [? []]; eauto. *)
+  - destruct prim as [? []]; eauto.
 Qed.
 
 Lemma trans_mkProd_or_LetIn a t:
@@ -474,7 +474,7 @@ Proof.
   destruct t; cbnr.
   generalize (trans t1) (trans t2); clear.
   induction t; intros; cbnr.
-  (* destruct prim as [? []]; cbnr. *)
+  destruct prim as [? []]; cbnr.
 Qed.
 
 Lemma trans_unfold_fix mfix idx narg fn :
@@ -1019,7 +1019,7 @@ Proof.
     cbn; eauto. cbn in p0. destruct p0. eauto.
   - cbn. red in X. solve_all.
   - cbn. red in X. solve_all.
-  (* - destruct p as [? []]; constructor. *)
+  - destruct p as [? []]; constructor.
 Qed.
 
 #[global] Hint Resolve trans_wf : wf.
@@ -1433,7 +1433,7 @@ Proof.
     red in X0. solve_all_one.
     eapply trans_eq_context_gen_eq_binder_annot in a.
     now rewrite !map_context_trans.
-  (* - destruct p as [? []]; constructor. *)
+  - destruct p as [? []]; constructor.
 Qed.
 
 Lemma trans_leq_term {cf} Σ ϕ T U :
@@ -1666,26 +1666,26 @@ Proof.
   - eapply IHt3 in e as e'. assumption.
   - noconf e. simpl.
     now destruct (mkApp_ex (trans t1) (trans t2)) as [f [args ->]].
-  (* - noconf e. now destruct prim as [? []] => /=. *)
+  - noconf e. now destruct prim as [? []] => /=.
 Qed.
 
 Lemma trans_isApp t : PCUICAst.isApp t = false -> Ast.isApp (trans t) = false.
 Proof.
   destruct t => //.
-  (* now destruct prim as [? []]. *)
+  now destruct prim as [? []].
 Qed.
 
 Lemma trans_nisApp t : ~~ PCUICAst.isApp t -> ~~ Ast.isApp (trans t).
 Proof.
   destruct t => //.
-  (* now destruct prim as [? []]. *)
+  now destruct prim as [? []].
 Qed.
 
 Lemma trans_destInd t : ST.destInd t = TT.destInd (trans t).
 Proof.
   destruct t => //. simpl.
   now destruct (mkApp_ex (trans t1) (trans t2)) as [f [u ->]].
-  (* now destruct prim as [? []]. *)
+  now destruct prim as [? []]. 
 Qed.
 
 Lemma trans_decompose_app t : 
@@ -2347,6 +2347,7 @@ Proof.
     + fold trans;subst types.
       now apply trans_mfix_All2.
     + now rewrite trans_wf_cofixpoint.
+  - todo "type_Prim in template".
   - eapply TT.type_Conv.
     + eassumption.
     + eassumption.

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -137,8 +137,13 @@ Definition wf_cofixpoint_gen
   | _ => false
   end.
 
-
 Definition wf_cofixpoint (Σ : global_env) := wf_cofixpoint_gen (lookup_env Σ).
+
+Definition primitive_constant (Σ : global_env) (p : prim_tag) : option kername :=
+  match p with
+  | primInt => Σ.(retroknowledge).(Retroknowledge.retro_int63)
+  | primFloat => Σ.(retroknowledge).(Retroknowledge.retro_float64)
+  end.
 
 Reserved Notation "'wf_local' Σ Γ " (at level 9, Σ, Γ at next level).
 
@@ -261,6 +266,11 @@ Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term ->
     All (fun d => Σ ;;; Γ ,,, fix_context mfix |- d.(dbody) : lift0 #|fix_context mfix| d.(dtype)) mfix ->
     wf_cofixpoint Σ mfix ->
     Σ ;;; Γ |- tCoFix mfix n : decl.(dtype)
+
+| type_Prim p prim_ty cdecl : 
+   primitive_constant (prim_tag p) = Some prim_ty ->
+   declared_constant Σ prim_ty cdecl ->
+   Σ ;;; Γ |- tPrim p : tConst prim_ty []
 
 | type_Cumul : forall t A B s,
     Σ ;;; Γ |- t : A ->

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+From MetaCoq.Template Require Import config utils Primitive.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICPrimitive
   PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils PCUICPosition.
 From MetaCoq.PCUIC Require Export PCUICCumulativitySpec.
 From MetaCoq.PCUIC Require Export PCUICCases.
@@ -10,7 +10,7 @@ Import MCMonadNotation.
 (* TODO: remove this export *)
 From MetaCoq Require Export LibHypsNaming.
 
-Require Import ssreflect.
+Require Import ssreflect ssrbool.
 Require Import Equations.Type.Relation.
 From Equations Require Import Equations.
 Set Equations With UIP.
@@ -145,6 +145,10 @@ Definition primitive_constant (Σ : global_env) (p : prim_tag) : option kername 
   | primFloat => Σ.(retroknowledge).(Retroknowledge.retro_float64)
   end.
 
+Definition primitive_invariants (cdecl : constant_body) :=
+  ∑ s, [/\ cdecl.(cst_type) = tSort s, cdecl.(cst_body) = None &
+       cdecl.(cst_universes) = Monomorphic_ctx].
+
 Reserved Notation "'wf_local' Σ Γ " (at level 9, Σ, Γ at next level).
 
 Reserved Notation " Σ ;;; Γ |- t : T " (at level 50, Γ, t, T at next level).
@@ -268,8 +272,10 @@ Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term ->
     Σ ;;; Γ |- tCoFix mfix n : decl.(dtype)
 
 | type_Prim p prim_ty cdecl : 
-   primitive_constant (prim_tag p) = Some prim_ty ->
+   wf_local Σ Γ ->  
+   primitive_constant Σ (prim_val_tag p) = Some prim_ty ->
    declared_constant Σ prim_ty cdecl ->
+   primitive_invariants cdecl ->
    Σ ;;; Γ |- tPrim p : tConst prim_ty []
 
 | type_Cumul : forall t A B s,
@@ -409,6 +415,7 @@ Proof.
     (all_size _ (fun x p => (infer_sort_size (typing_sort_size typing_size)) Σ _ _ p) a0)) (all_size _ (fun x p => typing_size Σ _ _ _ p) a1))).
   - exact (S (Nat.max (Nat.max (All_local_env_size typing_size _ _ a)
     (all_size _ (fun x p => (infer_sort_size (typing_sort_size typing_size)) Σ _ _ p) a0)) (all_size _ (fun x p => typing_size Σ _ _ _ p) a1))).
+  - exact (S (All_local_env_size typing_size _ _ a)).
 Defined.
 
 Lemma typing_size_pos `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t : T) : typing_size d > 0.
@@ -728,6 +735,13 @@ Lemma typing_ind_env_app_size `{cf : checker_flags} :
        All (on_def_body (lift_typing2 typing P Σ) types Γ) mfix ->
        wf_cofixpoint Σ mfix ->
        P Σ Γ (tCoFix mfix n) decl.(dtype)) ->
+  
+  (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : prim_val term) prim_ty cdecl,
+      PΓ Σ Γ ->
+      primitive_constant Σ (prim_val_tag p) = Some prim_ty ->
+      declared_constant Σ prim_ty cdecl ->
+      primitive_invariants cdecl ->
+      P Σ Γ (tPrim p) (tConst prim_ty [])) ->
 
    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t A B : term) s,
        PΓ Σ Γ ->
@@ -741,7 +755,7 @@ Lemma typing_ind_env_app_size `{cf : checker_flags} :
       env_prop P PΓ.
 Proof.
   intros P Pdecl PΓ.
-  intros XΓ X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 Σ wfΣ Γ t T H.
+  intros XΓ X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 X13 Σ wfΣ Γ t T H.
   (* NOTE (Danil): while porting to 8.9, I had to split original "pose" into 2 pieces,
     otherwise it takes forever to execure the "pose", for some reason *)
   pose proof (@Fix_F { Σ & { wfΣ : wf Σ.1 & { Γ & { t & { T & Σ ;;; Γ |- t : T }}}}}) as p0.
@@ -763,7 +777,7 @@ Proof.
   intros (Σ & wfΣ & Γ & t & t0 & H). simpl.
   intros IH. simpl in IH.
   split.
-  - clear X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12.
+  - clear X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 X13.
     destruct Σ as [Σ φ].
     red. cbn. do 2 red in wfΣ. cbn in wfΣ.
     destruct Σ as [univs Σ]; cbn in *.
@@ -838,7 +852,7 @@ Proof.
       forward IH.
       constructor 2. simpl. apply H0.
       split; apply IH. }
-    rename X13 into X14.
+    (* rename X13 into X14. *)
 
     assert (Hdecls: typing_size H > 1 -> Forall_decls_typing P Σ.1).
     { specialize (X14 _ _ _  (type_Prop _)).
@@ -1173,6 +1187,13 @@ Lemma typing_ind_env `{cf : checker_flags} :
         All (on_def_body (lift_typing2 typing P Σ) types Γ) mfix ->
         wf_cofixpoint Σ mfix ->
         P Σ Γ (tCoFix mfix n) decl.(dtype)) ->
+    
+    (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (p : prim_val term) prim_ty cdecl,
+        PΓ Σ Γ ->
+        primitive_constant Σ (prim_val_tag p) = Some prim_ty ->
+        declared_constant Σ prim_ty cdecl ->
+        primitive_invariants cdecl ->
+        P Σ Γ (tPrim p) (tConst prim_ty [])) ->
 
     (forall Σ (wfΣ : wf Σ.1) (Γ : context) (wfΓ : wf_local Σ Γ) (t A B : term) s,
         PΓ Σ Γ ->
@@ -1186,7 +1207,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
        env_prop P PΓ.
 Proof.
   intros P Pdecl PΓ; unfold env_prop.
-  intros XΓ X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 Σ wfΣ Γ t T H.
+  intros XΓ X X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 X13 Σ wfΣ Γ t T H.
   apply typing_ind_env_app_size; eauto.
 Qed.
 
@@ -1230,22 +1251,23 @@ Section All_local_env.
     { Σ' : global_env & [× extends Σ' Σ, on_global_env cumulSpec0 P Σ' &
        on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl] }.
   Proof using Type.
-    destruct Σ as [univs Σ]; rewrite /on_global_env /lookup_env; cbn.
+    destruct Σ as [univs Σ retro]; rewrite /on_global_env /lookup_env; cbn.
     intros [cu Σp].
     induction Σp; simpl. congruence.
     destruct (eqb_specT c kn); subst.
     - intros [= ->].
-      exists ({| universes := univs; declarations := Σ |}).
+      exists ({| universes := univs; declarations := Σ; retroknowledge := retro |}).
       split.
-      * red; cbn. split; [split;[lsets|csets]|].
+      * red; cbn. split; [split;[lsets|csets]| |].
         exists [(kn, decl)] => //.
+        apply Retroknowledge.extends_refl.
       * split => //.
       * apply o0.
     - intros hl. destruct (IHΣp hl) as [Σ' []].
       exists Σ'.
       split=> //.
       destruct e as [eu ed]. red; cbn in *.
-      split; [auto|].
+      split; [auto| |auto].
       destruct ed as [Σ'' ->].
       exists (Σ'' ,, (kn, d)) => //.
   Qed.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -393,6 +393,14 @@ Section Validity.
     - (* CoFix *)
       eapply nth_error_all in X0 as [s Hs]; pcuic.
 
+    - (* Primitive *) 
+      destruct X0 as [s [hty hbod huniv]].
+      exists s@[[]].
+      change (tSort s@[[]]) with (tSort s)@[[]].
+      rewrite -hty.
+      refine (type_Const _ _ _ [] _ wfΓ H0 _).
+      rewrite huniv //.
+
     - (* Conv *)
       now exists s.
   Qed.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -436,6 +436,7 @@ Proof using P Pcmp cf.
   split => //. 
   - red. rewrite eq. apply onu.
   - rewrite eq. rewrite eq' in ond.
+    rewrite -e in ond.
     revert ond; clear.
     induction Σ''; cbn; auto.
     intros H; depelim H.

--- a/pcuic/theories/Syntax/PCUICDepth.v
+++ b/pcuic/theories/Syntax/PCUICDepth.v
@@ -1,5 +1,4 @@
 (* Distributed under the terms of the MIT license. *)
-(* Distributed under the terms of the MIT license. *)
 From Coq Require Import ssreflect Program Lia BinPos Arith.Compare_dec Bool. 
 From MetaCoq.Template Require Import utils LibHypsNaming.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCases PCUICSize PCUICInduction.
@@ -335,10 +334,10 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (m : mfixpoint term) (n : nat),
         All_local_env (PCUICInduction.on_local_decl (fun Γ' t => P (Γ ,,, Γ') t)) (fix_context m) ->
         tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
-    (* (forall Γ p, P Γ (tPrim p)) -> *)
+    (forall Γ p, P Γ (tPrim p)) ->
     forall Γ (t : term), P Γ t.
 Proof.
-  intros ???????????????? Γ t.
+  intros ????????????????? Γ t.
   revert Γ t. set(foo:=CoreTactics.the_end_of_the_section). intros.
   Subterm.rec_wf_rel aux t (MR lt depth); unfold MR in *; simpl. clear H1.
   assert (auxl : forall Γ {A} (l : list A) (f : A -> term),
@@ -456,10 +455,10 @@ Lemma term_ind_depth_app :
     (forall (m : mfixpoint term) (n : nat),
         onctx P (fix_context m) ->
         tFixProp P P m -> P (tCoFix m n)) ->
-    (* (forall p, P (tPrim p)) -> *)
+    (forall p, P (tPrim p)) ->
     forall (t : term), P t.
 Proof.
-  intros ???????????????? t.
+  intros ????????????????? t.
   revert t. set(foo:=CoreTactics.the_end_of_the_section). intros.
   Subterm.rec_wf_rel aux t (MR lt depth); unfold MR in *; simpl. clear H0.
   assert (auxl : forall {A} (l : list A) (f : A -> term),

--- a/pcuic/theories/Syntax/PCUICInduction.v
+++ b/pcuic/theories/Syntax/PCUICInduction.v
@@ -19,7 +19,7 @@ Import PCUICEnvTyping.
   Allows to get the right induction principle on lists of terms appearing
   in the term syntax (in evar, applications, branches of cases and (co-)fixpoints. *)
 
-(* Notation prim_ind P p := (P (tPrim p)). *)
+Notation prim_ind P p := (P (tPrim p)).
 
 (** Custom induction principle on syntax, dealing with the various lists appearing in terms. *)
 
@@ -43,7 +43,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (* (forall p, prim_ind P p) -> *)
+    (forall p, prim_ind P p) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -261,11 +261,11 @@ Lemma term_forall_mkApps_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (* (forall i, prim_ind P i) -> *)
+    (forall i, prim_ind P i) ->
     forall t : term, P t.
 Proof.
   intros until t.
-  (* rename X14 into Pprim. *)
+  rename X14 into Pprim.
   assert (Acc (MR lt size) t) by eapply measure_wf, Wf_nat.lt_wf.
   induction H. rename X14 into auxt. clear H. rename x into t.
   move auxt at top.
@@ -487,10 +487,10 @@ Lemma term_forall_ctx_list_ind :
     (forall Γ (m : mfixpoint term) (n : nat),
         All_local_env (on_local_decl (fun Γ' t => P (Γ ,,, Γ') t)) (fix_context m) ->
         tFixProp (P Γ) (P (Γ ,,, fix_context m)) m -> P Γ (tCoFix m n)) ->
-    (* (forall Γ p, P Γ (tPrim p)) -> *)
+    (forall Γ p, P Γ (tPrim p)) ->
     forall Γ (t : term), P Γ t.
 Proof.
-  intros ???????????????? Γ t.
+  intros ????????????????? Γ t.
   revert Γ t. set(foo:=CoreTactics.the_end_of_the_section). intros.
   Subterm.rec_wf_rel aux t (MR lt size); unfold MR in *; simpl. clear H1.
   assert (auxl : forall Γ {A} (l : list A) (f : A -> term),
@@ -594,7 +594,7 @@ Lemma term_ind_size_app :
         tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat),
         tFixProp (P) P m -> P (tCoFix m n)) ->
-    (* (forall p, P (tPrim p)) -> *)
+    (forall p, P (tPrim p)) ->
     forall (t : term), P t.
 Proof.
   intros.

--- a/pcuic/theories/Syntax/PCUICInduction.v
+++ b/pcuic/theories/Syntax/PCUICInduction.v
@@ -19,8 +19,6 @@ Import PCUICEnvTyping.
   Allows to get the right induction principle on lists of terms appearing
   in the term syntax (in evar, applications, branches of cases and (co-)fixpoints. *)
 
-Notation prim_ind P p := (P (tPrim p)).
-
 (** Custom induction principle on syntax, dealing with the various lists appearing in terms. *)
 
 Lemma term_forall_list_ind :
@@ -43,7 +41,7 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall p, prim_ind P p) ->
+    (forall p, P (tPrim p)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -261,7 +259,7 @@ Lemma term_forall_mkApps_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (forall i, prim_ind P i) ->
+    (forall i, P (tPrim i)) ->
     forall t : term, P t.
 Proof.
   intros until t.

--- a/pcuic/theories/Syntax/PCUICNamelessDef.v
+++ b/pcuic/theories/Syntax/PCUICNamelessDef.v
@@ -57,7 +57,7 @@ Fixpoint nameless (t : term) : bool :=
   | tCoFix mfix idx =>
     forallb (fun d => banon d.(dname)) mfix &&
     forallb (test_def nameless nameless) mfix
-  (* | tPrim _ => true *)
+  | tPrim _ => true
   end.
 
 Notation nameless_ctx := (forallb (nameless_decl nameless)).
@@ -105,7 +105,7 @@ Fixpoint nl (t : term) : term :=
   | tProj p c => tProj p (nl c)
   | tFix mfix idx => tFix (map (map_def_anon nl nl) mfix) idx
   | tCoFix mfix idx => tCoFix (map (map_def_anon nl nl) mfix) idx
-  (* | tPrim p => tPrim p *)
+  | tPrim p => tPrim p
   end.
 
 Definition nlctx (Γ : context) : context :=
@@ -158,7 +158,8 @@ Definition nl_global_declarations (Σ : global_declarations) : global_declaratio
 
 Definition nl_global_env (Σ : global_env) : global_env :=
   {| universes := Σ.(universes); 
-     declarations := nl_global_declarations Σ.(declarations) |}.
+     declarations := nl_global_declarations Σ.(declarations);
+     retroknowledge := Σ.(retroknowledge) |}.
   
 Definition nlg (Σ : global_env_ext) : global_env_ext :=
   let '(Σ, φ) := Σ in

--- a/pcuic/theories/Syntax/PCUICOnFreeVars.v
+++ b/pcuic/theories/Syntax/PCUICOnFreeVars.v
@@ -87,7 +87,7 @@ Fixpoint on_free_vars (p : nat -> bool) (t : term) : bool :=
   | tFix mfix idx | tCoFix mfix idx =>
     List.forallb (test_def (on_free_vars p) (on_free_vars (shiftnP #|mfix| p))) mfix
   | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => true
-  (* | tPrim _ => true *)
+  | tPrim _ => true
   end.
 
 Lemma on_free_vars_ext (p q : nat -> bool) t : 
@@ -1379,7 +1379,7 @@ Lemma term_on_free_vars_ind :
     (forall p (m : mfixpoint term) (i : nat), 
       tFixProp (on_free_vars p) (on_free_vars (shiftnP #|fix_context m| p)) m ->
       tFixProp (P p) (P (shiftnP #|fix_context m| p)) m -> P p (tCoFix m i)) ->
-    (* (forall p pr, P p (tPrim pr)) -> *)
+    (forall p pr, P p (tPrim pr)) ->
     forall p (t : term), on_free_vars p t -> P p t.
 Proof.
   intros until t. revert p t.

--- a/pcuic/theories/Syntax/PCUICReflect.v
+++ b/pcuic/theories/Syntax/PCUICReflect.v
@@ -114,6 +114,7 @@ Fixpoint eqb_term (u v : term) : bool :=
       eqb x.(rarg) y.(rarg) &&
       eqb x.(dname) y.(dname)) mfix mfix'
 
+  | tPrim p, tPrim p' => eqb p p'
   | _, _ => false
   end.
 

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -151,7 +151,7 @@ Lemma extends_trans_global_decls_acc (Σ' : global_env_map) (Σ : Ast.Env.global
   extends Σ' (trans_global_decls Σ' Σ).
 Proof.
   induction Σ.
-  * split; cbn. apply incl_cs_refl. now exists [].
+  * split; cbn. apply incl_cs_refl. now exists []. apply Retroknowledge.extends_refl.
   * rewrite /=.
     destruct IHΣ as [univs [Σ'' eq]]. cbn in *.
     split; cbn; auto.
@@ -177,14 +177,14 @@ Lemma trans_lookup_env {cf} {Σ : Ast.Env.global_env} cst {wfΣ : Typing.wf Σ} 
         lookup_env (trans_global_env Σ) cst = Some (trans_global_decl (trans_global_env Σ') d)]
   end. 
 Proof.
-  destruct Σ as [univs Σ].
+  destruct Σ as [univs Σ retro].
   induction Σ.
   - cbn; auto.
   - unfold Ast.Env.lookup_env. cbn -[trans_global_env].
     destruct eq_kername eqn:eqk.
     change (eq_kername cst a.1) with (eqb cst a.1) in eqk.
     apply eqb_eq in eqk; subst.
-    eexists {| S.Env.universes := univs; S.Env.declarations := Σ |}.
+    eexists {| S.Env.universes := univs; S.Env.declarations := Σ; S.Env.retroknowledge := retro |}.
     split.
     * split => //. now exists [a].
     * destruct wfΣ as [onu ond]. depelim ond.
@@ -192,7 +192,8 @@ Proof.
     * eapply TypingWf.typing_wf_sigma in wfΣ.
       destruct wfΣ as [onu ond]. now depelim ond.
     * split => //.
-      now exists [(a.1, trans_global_decl (trans_global_env {| S.Env.universes := univs; S.Env.declarations := Σ |}) a.2)].
+      now exists [(a.1, trans_global_decl (trans_global_env {| S.Env.universes := univs; S.Env.declarations := Σ;
+        S.Env.retroknowledge := retro |}) a.2)].
     * cbn. now rewrite eq_kername_refl.
     * destruct wfΣ as [onu ond]. depelim ond.
       specialize (IHΣ (onu, ond)).
@@ -218,12 +219,25 @@ Proof.
   intros [] []; split; [lsets|csets].
 Qed.
 
+From Coq Require Import RelationClasses.
+
+#[export] Instance option_extends_trans {A} : RelationClasses.Transitive (@option_extends A).
+Proof.
+  intros x y z [] H; depelim H; constructor.
+Qed.
+
+#[export] Instance retro_knowledge_extends_trans : RelationClasses.Transitive Retroknowledge.extends.
+Proof.
+  intros x y z [] []; split; cbn; now etransitivity.
+Qed.
+
 Lemma extends_trans {Σ Σ' Σ'' : global_env} : extends Σ Σ' -> extends Σ' Σ'' -> extends Σ Σ''.
 Proof.
   intros [u [s eq]] [u' [s' eq']]; subst.
   split.
   - eapply cs_subset_trans; tea.
   - eexists (s' ++ s); cbn. rewrite eq' eq. now rewrite app_assoc.
+  - now etransitivity.
 Qed.
 
 Lemma trans_weakening {cf} Σ {Σ' : global_env_map} t : 
@@ -2954,9 +2968,18 @@ Proof.
   induction Σ => /= //.
 Qed. 
 
+Lemma trans_env_env_retroknowledge {Σ : Ast.Env.global_env} : 
+  retroknowledge (trans_env_env (trans_global_env Σ)) = Ast.Env.retroknowledge Σ.
+Proof.
+  destruct Σ as [univs Σ] .
+  unfold trans_global_env; cbn -[trans_global_decls].
+  induction Σ => /= //.
+Qed. 
+
 Lemma env_eq (g g' : global_env) : 
   g.(universes) = g'.(universes) ->
   g.(declarations) = g'.(declarations) ->
+  g.(retroknowledge) = g'.(retroknowledge) ->
   g = g'.
 Proof.
   destruct g, g'; cbn. congruence.
@@ -2983,7 +3006,7 @@ Lemma trans_on_global_env `{checker_flags} Σ :
 Proof.
   intros X X0.
   simpl in *.
-  destruct Σ as [univs Σ].
+  destruct Σ as [univs Σ retro].
   destruct X0 as [onu ond]. split => //.
   { now rewrite trans_env_env_universes. }
   cbn -[trans_global_env] in *.
@@ -2995,13 +3018,14 @@ Proof.
     clear -o.
     now erewrite trans_global_decl_universes in o.
   - simpl.
-    set (Σg := {| Ast.Env.universes := univs; Ast.Env.declarations := Σ |}).
+    set (Σg := {| Ast.Env.universes := univs; Ast.Env.declarations := Σ; Ast.Env.retroknowledge := retro |}).
     set (X0 := (onu, ond) : Typing.wf Σg).
     assert (trans_env_env (trans_global_env Σg) =
        {| universes := univs;
-          declarations := declarations (trans_global_decls (empty_trans_env univs) Σ) |}) as <-.
-    { apply env_eq. 
-      now rewrite trans_env_env_universes. reflexivity. }    
+          declarations := declarations (trans_global_decls (empty_trans_env univs retro) Σ) |}) as <-.
+    { apply env_eq.
+      now rewrite trans_env_env_universes. reflexivity.
+      now rewrite trans_env_env_retroknowledge. }
     assert (wfΣg : PCUICTyping.wf (trans_global_env Σg)).
     { split; rewrite trans_env_env_universes //. }
     have wfdecl := on_global_decl_wf (Σ := (Σg, udecl)) X0 o0.
@@ -3014,7 +3038,7 @@ Proof.
     * destruct o0 as [onI onP onNP].
       simpl.
       change (trans_env_env (trans_global_env Σg), Ast.Env.ind_universes m) with (global_env_ext_map_global_env_ext (trans_global (Σg, Ast.Env.ind_universes m))) in *.
-      change (trans_global_decls (empty_trans_env univs) Σ) with (global_env_ext_map_global_env_map (trans_global (Σg, Ast.Env.ind_universes m))).
+      change (trans_global_decls (empty_trans_env univs retro) Σ) with (global_env_ext_map_global_env_map (trans_global (Σg, Ast.Env.ind_universes m))).
       constructor; auto.
       -- have wfpars := on_global_inductive_wf_params wfdecl.
         eapply on_global_inductive_wf_bodies in wfdecl.
@@ -3223,7 +3247,7 @@ Proof.
           move=> [univs' [i [i' []]]] vu cu cu' hl.
           exists univs', i, i'; split => //.
           all:change (trans_env_env (trans_global_env Σg), univs') with (global_env_ext_map_global_env_ext (trans_global (Σg, univs')));
-            now eapply trans_consistent_instance_ext_gen.
+            now eapply trans_consistent_instance_ext_gen.          
 Qed.
 
 Lemma template_to_pcuic_env {cf} Σ : Template.Typing.wf Σ -> wf (trans_global_env Σ).

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -219,25 +219,13 @@ Proof.
   intros [] []; split; [lsets|csets].
 Qed.
 
-From Coq Require Import RelationClasses.
-
-#[export] Instance option_extends_trans {A} : RelationClasses.Transitive (@option_extends A).
-Proof.
-  intros x y z [] H; depelim H; constructor.
-Qed.
-
-#[export] Instance retro_knowledge_extends_trans : RelationClasses.Transitive Retroknowledge.extends.
-Proof.
-  intros x y z [] []; split; cbn; now etransitivity.
-Qed.
-
 Lemma extends_trans {Σ Σ' Σ'' : global_env} : extends Σ Σ' -> extends Σ' Σ'' -> extends Σ Σ''.
 Proof.
   intros [u [s eq]] [u' [s' eq']]; subst.
   split.
   - eapply cs_subset_trans; tea.
   - eexists (s' ++ s); cbn. rewrite eq' eq. now rewrite app_assoc.
-  - now etransitivity.
+  - now etransitivity; tea.
 Qed.
 
 Lemma trans_weakening {cf} Σ {Σ' : global_env_map} t : 

--- a/pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -432,7 +432,7 @@ Qed.
 
 Lemma eval_mkApps_cong Σ f args : 
   value Σ f -> All (value Σ) args ->
-  ~~ (isLambda f || isFixApp f || isArityHead f || isConstructApp f) ->
+  ~~ (isLambda f || isFixApp f || isArityHead f || isConstructApp f || isPrimApp f) ->
   eval Σ (mkApps f args) (mkApps f args).
 Proof.
   intros vf a. move: a.
@@ -447,8 +447,10 @@ Proof.
     destruct args using rev_case; cbn in hf' => //.
     rewrite !mkApps_app /= orb_false_r in hf'.
     rewrite -[tApp _ _](mkApps_app _ _ [x0]) in hf'.
-    rewrite isFixApp_mkApps isConstructApp_mkApps in hf'.
-    move/orP: hf' => [] ->; now rewrite !orb_true_r.
+    rewrite isFixApp_mkApps isConstructApp_mkApps isPrimApp_mkApps in hf'.
+    move/orP: hf' => [].
+    * move/orP => [] ->; now rewrite !orb_true_r.
+    * move=> ->; now rewrite orb_true_r.
 Qed.
 
 Lemma isLambda_mkApps {f args} : args <> [] -> ~~ isLambda (mkApps f args).
@@ -458,6 +460,12 @@ Proof.
 Qed.
 
 Lemma isArityHead_mkApps {f args} : args <> [] -> ~~ isArityHead (mkApps f args).
+Proof.
+  destruct args using rev_case; cbn; try congruence.
+  rewrite mkApps_app /= //.
+Qed.
+
+Lemma isPrim_mkApps {f args} : args <> [] -> ~~ isPrim (mkApps f args).
 Proof.
   destruct args using rev_case; cbn; try congruence.
   rewrite mkApps_app /= //.
@@ -778,9 +786,11 @@ Proof.
     eapply isLambda_mkApps. destruct args => //.
     eapply isArityHead_mkApps. destruct args => //.
     rewrite isConstructApp_mkApps //.
+    rewrite isPrimApp_mkApps //.
     eapply isLambda_mkApps. destruct args => //.
     eapply isArityHead_mkApps. destruct args => //.
     rewrite isConstructApp_mkApps //.
+    rewrite isPrimApp_mkApps //.
       
   - eapply eval_atom.
     destruct t => //.

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -834,7 +834,7 @@ Lemma term_closedn_list_ind :
     (forall k (s : projection) (t : term), P k t -> P k (tProj s t)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tFix m n)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tCoFix m n)) ->
-    (* (forall k p, P k (tPrim p)) -> *)
+    (forall k p, P k (tPrim p)) ->
     forall k (t : term), closedn k t -> P k t.
 Proof.
   intros until t. revert k t.
@@ -946,7 +946,7 @@ Lemma term_noccur_between_list_ind :
     (forall k n (s : projection) (t : term), P k n t -> P k n (tProj s t)) ->
     (forall k n (m : mfixpoint term) (i : nat), tFixProp (P k n) (P (#|fix_context m| + k) n) m -> P k n (tFix m i)) ->
     (forall k n (m : mfixpoint term) (i : nat), tFixProp (P k n) (P (#|fix_context m| + k) n) m -> P k n (tCoFix m i)) ->
-    (* (forall k n p, P k n (tPrim p)) -> *)
+    (forall k n p, P k n (tPrim p)) ->
     forall k n (t : term), noccur_between k n t -> P k n t.
 Proof.
   intros until t. revert k n t.

--- a/pcuic/theories/Typing/PCUICInstTyp.v
+++ b/pcuic/theories/Typing/PCUICInstTyp.v
@@ -572,6 +572,9 @@ Proof.
     * now apply inst_wf_cofixpoint.
     * reflexivity.
 
+  - intros Σ wfΣ Γ wfΓ p pty cdecl _ hp hdecl pinv Δ σ hΔ hσ.
+    cbn. econstructor; tea.
+    
   - intros Σ wfΣ Γ wfΓ t A B X hwf ht iht hB ihB hcum Δ σ hΔ hσ.
     eapply type_Cumul.
     + eapply iht. all: auto.

--- a/pcuic/theories/Typing/PCUICRenameTyp.v
+++ b/pcuic/theories/Typing/PCUICRenameTyp.v
@@ -1044,6 +1044,9 @@ Proof.
       * now eapply rename_wf_cofixpoint.
     + reflexivity.
 
+  - intros Σ wfΣ Γ wfΓ p pty cdecl _ hp hdecl pinv P Δ f hf.
+    cbn. econstructor; tea. apply hf.
+
   - intros Σ wfΣ Γ wfΓ t A B X hwf ht iht htB ihB cum P Δ f hf.
     eapply type_Cumul.
     + eapply iht; tea.

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -366,7 +366,9 @@ Proof using Type.
         unfold wf_cofixpoint, wf_cofixpoint_gen.
         rewrite map_map_compose.
         now rewrite subst_instance_check_one_cofix.
-      
+
+  - econstructor; eauto.
+
   - intros t0 A B X X0 X1 X2 X3 X4 cum u univs wfΣ' H.
     econstructor.
     + eapply X2; aa.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -74,6 +74,20 @@ Qed.
 #[global]
 Hint Resolve extends_wf_fixpoint extends_wf_cofixpoint : extends.
 
+Lemma extends_primitive_constant Σ Σ' p t : 
+  extends Σ Σ' ->
+  primitive_constant Σ p = Some t ->
+  primitive_constant Σ' p = Some t.
+Proof.
+  intros [_ _ ext].
+  unfold primitive_constant.
+  case: ext.
+  destruct p; case => //.
+  - move=> _. case => //.
+  - move=> _; case => //.
+  - case => //.
+Qed.
+Local Hint Resolve extends_primitive_constant : extends.
 
 Lemma weakening_env `{checker_flags} :
   env_prop (fun Σ Γ t T =>
@@ -277,9 +291,9 @@ Proof.
   intros HP wfΣ' Hext HΣ.
   assert (wfΣ := extends_decls_wf _ _ wfΣ' Hext).
   destruct HΣ as [onu onΣ].
-  destruct Σ as [univs Σ]; cbn in *.
+  destruct Σ as [univs Σ retro]; cbn in *.
   induction onΣ; simpl. 1: congruence.
-  assert (HH: extends_decls {| universes := univs; declarations := Σ |} Σ'). {
+  assert (HH: extends_decls {| universes := univs; declarations := Σ; retroknowledge := retro |} Σ'). {
     destruct Hext as [univs' [Σ'' HΣ'']]. split; eauto.
     exists (Σ'' ++ [(kn, d)]). now rewrite <- app_assoc.
   }
@@ -298,9 +312,9 @@ Lemma weakening_env_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
 Proof.
   intros HP wfΣ wfΣ' Hext HΣ.
   destruct HΣ as [onu onΣ].
-  destruct Σ as [univs Σ]; cbn in *.
+  destruct Σ as [univs Σ retro]; cbn in *.
   induction onΣ; simpl. 1: congruence.
-  assert (HH: extends {| universes := univs; declarations := Σ |} Σ'). {
+  assert (HH: extends {| universes := univs; declarations := Σ; retroknowledge := retro |} Σ'). {
     destruct Hext as [univs' [Σ'' HΣ'']]. split; eauto.
     exists (Σ'' ++ [(kn, d)]). now rewrite <- app_assoc.
   }
@@ -322,6 +336,7 @@ Proof.
   split => //. 
   - split; [lsets|csets].
   - exists []; simpl; destruct Σ; eauto.
+  - apply Retroknowledge.extends_refl.
 Qed.
 
 Lemma weaken_decls_lookup_on_global_env `{checker_flags} P Σ c decl :

--- a/pcuic/theories/utils/PCUICAstUtils.v
+++ b/pcuic/theories/utils/PCUICAstUtils.v
@@ -40,7 +40,7 @@ Fixpoint string_of_term (t : term) :=
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  (* | tPrim i => "Int(" ^ string_of_prim string_of_term i ^ ")" *)
+  | tPrim i => "Int(" ^ string_of_prim string_of_term i ^ ")"
   end.
 
 Ltac change_Sk :=

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -291,6 +291,13 @@ Module PrintTermTree.
       else print_list (print_one_cstr Γpars mib) nl oib.(ind_ctors).
   End env.
 
+  Definition print_recursivity_kind k :=
+    match k with
+    | Finite => "Inductive"
+    | CoFinite => "CoInductive"
+    | BiFinite => "Variant"
+    end.
+
   Fixpoint print_env_aux (short : bool) (prefix : nat) (Σ : global_env) (acc : t) : t := 
     match prefix with 
     | 0 => match Σ.(declarations) with [] => acc | _ => ("..." ^ nl ^ acc) end
@@ -301,8 +308,8 @@ Module PrintTermTree.
         let Σ' := (set_declarations Σ decls, mib.(ind_universes)) in
         let names := fresh_names Σ' [] (arities_context mib.(ind_bodies)) in
         print_env_aux short n Σ'.1
-          ("Inductive " ^ 
-          print_list (print_one_ind Σ' short names mib) nl mib.(ind_bodies) ^ "." ^ 
+          (print_recursivity_kind mib.(ind_finite) ^ " " ^
+          print_list (print_one_ind Σ' short names mib) (nl ^ "with ") mib.(ind_bodies) ^ "." ^ 
           nl ^ acc)
       | (kn, ConstantDecl cb) :: decls =>
         let Σ' := (set_declarations Σ decls, cb.(cst_universes)) in

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -295,18 +295,17 @@ Module PrintTermTree.
     match prefix with 
     | 0 => match Σ.(declarations) with [] => acc | _ => ("..." ^ nl ^ acc) end
     | S n => 
-      let univs := Σ.(universes) in
       match Σ.(declarations) with
       | [] => acc
-      | (kn, InductiveDecl mib) :: Σ => 
-        let Σ' := ({| universes := univs; declarations := Σ |}, mib.(ind_universes)) in
+      | (kn, InductiveDecl mib) :: decls => 
+        let Σ' := (set_declarations Σ decls, mib.(ind_universes)) in
         let names := fresh_names Σ' [] (arities_context mib.(ind_bodies)) in
         print_env_aux short n Σ'.1
           ("Inductive " ^ 
           print_list (print_one_ind Σ' short names mib) nl mib.(ind_bodies) ^ "." ^ 
           nl ^ acc)
-      | (kn, ConstantDecl cb) :: Σ =>
-        let Σ' := ({| universes := univs; declarations := Σ |}, cb.(cst_universes)) in
+      | (kn, ConstantDecl cb) :: decls =>
+        let Σ' := (set_declarations Σ decls, cb.(cst_universes)) in
         print_env_aux short n Σ'.1
           ((match cb.(cst_body) with 
             | Some _ => "Definition "

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -117,6 +117,13 @@ Module PrintTermTree.
     Import bytestring.Tree.
     Infix "^" := append.
 
+    Definition print_prim {term} (soft : term -> Tree.t) (p : prim_val) : Tree.t :=
+      match p.π2 return Tree.t with
+      | primIntModel f => "(int: " ^ Primitive.string_of_prim_int f ^ ")"
+      | primFloatModel f => "(float: " ^ Primitive.string_of_float f ^ ")"
+      (* | primArrayModel a => "(array:" ^ ")" *)
+      end.
+
     Section Aux.
       Context (print_term : list ident -> bool -> bool -> term -> t).
 
@@ -260,7 +267,7 @@ Module PrintTermTree.
     | tCoFix l n =>
       parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                                 " in " ^ List.nth_default (string_of_nat n) (map (string_of_aname ∘ dname) l) n)
-    (* | tPrim i => parens top (string_of_prim (print_term Γ true false) i) *)
+    | tPrim i => parens top (print_prim (print_term Γ true false) i)
     end.
   End env.
 

--- a/pcuic/theories/utils/PCUICPrimitive.v
+++ b/pcuic/theories/utils/PCUICPrimitive.v
@@ -1,14 +1,9 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import utils Universes BasicAst Reflect
+From MetaCoq.Template Require Import utils Universes BasicAst Primitive Reflect
      Environment EnvironmentTyping.
 From Equations Require Import Equations.
 From Coq Require Import ssreflect.
-
-Variant prim_tag := 
-  | primInt
-  | primFloat.
-  (* | primArray. *)
-Derive NoConfusion EqDec for prim_tag.
+From Coq Require Import Int63 SpecFloat.
 
 (** We don't enforce the type of the array here*)
 Record array_model (term : Type) :=
@@ -22,8 +17,11 @@ Instance array_model_eqdec {term} (e : EqDec term) : EqDec (array_model term).
 Proof. eqdec_proof. Qed.
 
 Inductive prim_model (term : Type) : prim_tag -> Type :=
-| primIntModel (i : uint63_model) : prim_model term primInt
-| primFloatModel (f : float64_model) : prim_model term primFloat.
+| primIntModel (i : Int63.int) : prim_model term primInt
+| primFloatModel (f : PrimFloat.float) : prim_model term primFloat.
+
+(* | primIntModel (i : Int63.t) : prim_model term primInt *)
+(* | primFloatModel (f : float64_model) : prim_model term primFloat. *)
 (* | primArrayModel (a : array_model term) : prim_model term primArray. *)
 Arguments primIntModel {term}.
 Arguments primFloatModel {term}.
@@ -33,8 +31,8 @@ Derive Signature NoConfusion for prim_model.
 
 Definition prim_model_of (term : Type) (p : prim_tag) : Type := 
   match p with
-  | primInt => uint63_model
-  | primFloat => float64_model
+  | primInt => Int63.int
+  | primFloat => PrimFloat.float
   (* | primArray => array_model term *)
   end.
 
@@ -62,11 +60,11 @@ Local Obligation Tactic := idtac.
 #[program]
 #[global]
 Instance reflect_eq_uint63 : ReflectEq uint63_model := 
-  { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
+  { eqb x y := Z.eqb (proj1_sig x) (proj1_sig y) }.
 Next Obligation.
   cbn -[eqb].
   intros x y.
-  elim: eqb_spec. constructor.
+  elim: Z.eqb_spec. constructor.
   now apply exist_irrel_eq.
   intros neq; constructor => H'; apply neq; now subst x.
 Qed.
@@ -74,7 +72,7 @@ Qed.
 #[global]
 Instance reflect_eq_spec_float : ReflectEq SpecFloat.spec_float := EqDec_ReflectEq _.
   
-#[program]
+(* #[program]
 #[global]
 Instance reflect_eq_float64 : ReflectEq float64_model := 
   { eqb x y := eqb (proj1_sig x) (proj1_sig y) }.
@@ -84,7 +82,7 @@ Next Obligation.
   elim: eqb_spec. constructor.
   now apply exist_irrel_eq.
   intros neq; constructor => H'; apply neq; now subst x.
-Qed.
+Qed. *)
 
 (** Propositional UIP is needed below *)
 Set Equations With UIP.
@@ -107,7 +105,7 @@ Definition string_of_float64_model (f : float64_model) :=
 
 Definition string_of_prim {term} (soft : term -> string) (p : prim_val term) : string :=
   match p.π2 return string with
-  | primIntModel f => "(int: " ^ string_of_Z (proj1_sig f) ^ ")"
-  | primFloatModel f => "(float: " ^ string_of_float64_model f ^ ")"
+  | primIntModel f => "(int: " ^ string_of_prim_int f ^ ")"
+  | primFloatModel f => "(float: " ^ string_of_float f ^ ")"
   (* | primArrayModel a => "(array:" ^ ")" *)
   end.

--- a/safechecker/_PluginProject.in
+++ b/safechecker/_PluginProject.in
@@ -12,12 +12,10 @@ src/uGraph0.ml
 src/uGraph0.mli
 src/wGraph.ml
 src/wGraph.mli
-src/mCProd.mli
-src/mCProd.ml
 
 # From PCUIC
-# src/pCUICPrimitive.mli
-# src/pCUICPrimitive.ml
+src/pCUICPrimitive.mli
+src/pCUICPrimitive.ml
 src/pCUICAst.ml
 src/pCUICAst.mli
 src/pCUICAstUtils.ml

--- a/safechecker/src/metacoq_safechecker_plugin.mlpack
+++ b/safechecker/src/metacoq_safechecker_plugin.mlpack
@@ -9,6 +9,7 @@ Classes0
 Logic1
 Relation
 Relation_Properties
+PCUICPrimitive
 PCUICAst
 PCUICCases
 PCUICAstUtils

--- a/safechecker/theories/Extraction.v
+++ b/safechecker/theories/Extraction.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import OrdersTac Ascii ExtrOcamlBasic ExtrOcamlZInt ExtrOCamlInt63 ExtrOCamlFloats.
-From MetaCoq.Template Require Import utils MC_ExtrOCamlZPosInt.
+From Coq Require Import OrdersTac Ascii ExtrOcamlBasic ExtrOCamlInt63 ExtrOCamlFloats.
+From MetaCoq.Template Require Import utils. 
 From MetaCoq.SafeChecker Require Import PCUICSafeChecker PCUICSafeConversion
      SafeTemplateChecker.
 

--- a/safechecker/theories/PCUICConsistency.v
+++ b/safechecker/theories/PCUICConsistency.v
@@ -116,7 +116,7 @@ Qed.
 Definition binder := {| binder_name := nNamed "P"; binder_relevance := Relevant |}.
 
 Definition global_env_add (Σ : global_env) d :=
-  {| universes := Σ.(universes); declarations := d :: Σ.(declarations) |}.
+  {| universes := Σ.(universes); declarations := d :: Σ.(declarations); retroknowledge := Σ.(retroknowledge) |}.
 
 Theorem pcuic_consistent {cf:checker_flags} {nor : normalizing_flags} {guard : abstract_guard_impl}
   (_Σ :referenced_impl_ext) t :
@@ -164,7 +164,8 @@ Proof.
   eapply (env_prop_typing weakening_env) in cons; auto.
   2:instantiate (1:=Σext.1).
   3:{ split; auto; cbn. split; [lsets|csets].
-      exists [(make_fresh_name Σ.1, InductiveDecl False_mib)]; reflexivity. }
+      exists [(make_fresh_name Σ.1, InductiveDecl False_mib)]; reflexivity.
+      apply Retroknowledge.extends_refl. }
   2: now destruct wf'.
 
   set (Σ' := Σext.1) in cons.

--- a/safechecker/theories/PCUICEqualityDec.v
+++ b/safechecker/theories/PCUICEqualityDec.v
@@ -157,7 +157,7 @@ Fixpoint eqb_term_upto_univ_napp
       eqb_binder_annot x.(dname) y.(dname)
     ) mfix mfix'
 
-(*  | tPrim p, tPrim p' => eqb p p' *)
+  | tPrim p, tPrim p' => eqb p p'
 
   | _, _ => false
   end.
@@ -740,7 +740,7 @@ Proof.
         constructor. constructor. constructor ; try easy.
         now inversion e3.
 
-(*  - cbn - [eqb]. eqspecs. do 2 constructor. *)
+ - cbn - [eqb]. eqspecs. do 2 constructor.
 Qed.
 
  Lemma eqb_term_upto_univ_impl (equ lequ : _ -> _ -> bool)

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -5143,7 +5143,7 @@ Qed.
     - reflexivity.
   Qed.
 
-  (* TODO move to PCUICNormal
+  (* TODO move to PCUICNormal *)
   Lemma whnf_mkApps_tPrim_inv : 
     forall (f : RedFlags.t) (Σ : global_env) (Γ : context) p (args : list term),
       whnf f Σ Γ (mkApps (tPrim p) args) -> args = [].
@@ -5159,7 +5159,7 @@ Qed.
     rewrite mkApps_app in teq.
     cbn in teq. noconf teq.
     eauto.
-  Qed. *)
+  Qed.
 
   Lemma reducible_head_None Σ (wfΣ : abstract_env_ext_rel X Σ) Γ t π h :
     isApp t = false ->
@@ -5219,9 +5219,9 @@ Qed.
     - constructor; eexists _, (decompose_stack π).1.
       split; [constructor; eauto with pcuic|].
       eauto with pcuic.
-(*    - apply whnf_mkApps_tPrim_inv in wh as ->.
+    - apply whnf_mkApps_tPrim_inv in wh as ->.
       constructor; eexists _, [].
-      eauto using whnf_red with pcuic.*)
+      eauto using whnf_red with pcuic.
     - constructor; eexists _, (decompose_stack π).1.
       clear H. erewrite <- abstract_env_lookup_correct in e; eauto. 
       split; [econstructor|]; eauto.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1314,6 +1314,8 @@ Corollary R_Acc_aux :
       unfold is_true in typ.
       unfold PCUICAst.PCUICEnvironment.fst_ctx in *.
       congruence.
+    - eapply inversion_Prim in typ as (prim_ty & cdecl & [? ? ? [? []]]); tea.
+      now eapply invert_cumul_axiom_ind in w; tea.
   Qed.
 
   Definition isCoFix_app t :=
@@ -1345,7 +1347,8 @@ Corollary R_Acc_aux :
     - exfalso; eapply invert_fix_ind; eauto.
     - unfold isCoFix_app in cof.
       now rewrite decompose_app_mkApps in cof.
-    (* - now eapply inversion_Prim in typ. *)
+    - eapply inversion_Prim in typ as [prim_ty [cdecl [? ? ? [? []]]]]; tea.
+      now eapply invert_cumul_axiom_ind in w; tea.
   Qed.
 
   Lemma whnf_fix_arg_whne mfix idx body Σ Γ t before args aftr ty :
@@ -1509,13 +1512,21 @@ Corollary R_Acc_aux :
           apply inversion_App in h as (?&?&?&?&?); auto.
           apply inversion_Prod in t0 as (?&?&?&?&?); auto.
           eapply PCUICConversion.ws_cumul_pb_Sort_Prod_inv; eauto.
-      (* + pose proof hΣ.
-        sq.
-        exfalso.
-        destruct (hΣ _ wfΣ) as [hΣ].
-        specialize (h _ wfΣ).
-        eapply welltyped_context in h as [s Hs]; tas.
-        now eapply inversion_Prim in Hs. *)
+        + unfold zipp.
+          case_eq (decompose_stack π). intros l ρ e.
+          apply decompose_stack_eq in e. subst.
+          destruct l.
+          * simpl. eauto with pcuic.
+          * exfalso.
+            destruct (hΣ _ wfΣ) as [hΣ].
+            cbn in h. zip fold in h.
+            specialize (h _ wfΣ).
+            apply welltyped_context in h; auto.
+            simpl in h. rewrite stack_context_appstack in h.
+            destruct h as [T h].
+            apply inversion_App in h as (?&?&?&?&?); auto.
+            apply inversion_Prim in t0 as (prim_ty & cdecl & [? ? ? [s []]]); auto.
+            eapply PCUICCanonicity.invert_cumul_axiom_prod; eauto.
     - unfold zipp. case_eq (decompose_stack π). intros l ρ e.
       constructor. constructor. eapply whne_mkApps.
       eapply whne_rel_nozeta. assumption.

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -1227,6 +1227,24 @@ Section Typecheck.
     now do 3 eapply (proj1 (eq_annots_fold _ _ _)) in e.
   Qed.
 
+  Definition primitive_constant (tag : Primitive.prim_tag) : option kername :=
+    let retro := abstract_env_ext_retroknowledge X in
+    match tag with
+    | Primitive.primInt => Retroknowledge.retro_int63 retro
+    | Primitive.primFloat => Retroknowledge.retro_float64 retro
+    end.
+
+  Lemma primitive_constant_spec tag :
+    forall Σ (wfΣ : abstract_env_ext_rel X Σ),
+    primitive_constant tag = PCUICTyping.primitive_constant Σ tag.
+  Proof.
+    intros.
+    unfold primitive_constant, PCUICTyping.primitive_constant.
+    destruct tag => //;
+    now rewrite <- (abstract_env_ext_retroknowledge_correct (Σ := Σ) X).
+  Qed.
+
+
   Section check_mfix.
   Context (infer : forall (Γ : context) (HΓ : forall Σ (wfΣ : abstract_env_ext_rel X Σ), ∥ wf_local Σ Γ ∥) (t : term), typing_result_comp ({ A : term & forall Σ (wfΣ : abstract_env_ext_rel X Σ),  ∥ Σ ;;; Γ |- t ▹ A ∥ }))
      (Γ : context) (wfΓ : forall Σ (wfΣ : abstract_env_ext_rel X Σ), ∥ wf_local Σ Γ ∥).
@@ -1459,9 +1477,20 @@ Section Typecheck.
       guarded <- check_eq_true (abstract_env_cofixguard X Γ mfix) (Msg "Unguarded cofixpoint") ;;
       wfcofix <- check_eq_true (wf_cofixpoint_gen (abstract_env_lookup X) mfix) (Msg "Ill-formed cofixpoint: not producing values in a mutually coinductive family") ;;
       ret (dtype decl; _)
-    }.
+    };
 
-  (* infer Γ HΓ (tPrim _) := raise (Msg "Primitive types are not supported"). *)
+  infer Γ HΓ (tPrim p) with inspect (primitive_constant p.π1) :=
+    { | exist None _ := raise (Msg "primitive type is not registered in the environment");
+      | exist (Some prim_ty) eqp with inspect (abstract_env_lookup X prim_ty) := {
+        | exist (Some (ConstantDecl d)) HH =>
+            let ty := d.(cst_type) in
+            check_eq_true (eqb d.(cst_body) None) (Msg "primitive type is registered to a defined constant") ;;
+            check_eq_true (eqb d.(cst_universes) Monomorphic_ctx) (Msg "primitive type is registered to a polymorphic constant") ;;
+            check_eq_true (isSort d.(cst_type)) (Msg "primitive type is registered to an axiom whose type is not a sort") ;;
+            ret (tConst prim_ty []; _)
+        | _ => raise (UndeclaredConstant prim_ty)
+        }
+    }.
 
   (* tRel *)
   Next Obligation. intros; sq; now econstructor. Qed.
@@ -2511,19 +2540,82 @@ Section Typecheck.
     inversion X1 ; subst.
     congruence.
   Qed.
-
-(* 
-  Program Definition check_isWfArity Γ (HΓ : ∥ wf_local Σ Γ ∥) A
-    : typing_result_comp (∥ isWfArity Σ Γ A ∥) :=
-    match destArity [] A with
-    | None => raise (Msg (print_term Σ Γ A ^ " is not an arity"))
-    | Some (ctx, s) => XX <- check_context (Γ ,,, ctx) ;;
-                      ret _
-    end.
   Next Obligation.
-    destruct XX. constructor. exists ctx, s.
-    split; auto.
-  Defined. *)
+    eapply eqb_eq in i. eapply eqb_eq in i0.
+    rewrite -(abstract_env_lookup_correct _ (Σ := Σ)) // in HH.
+    split. econstructor. rewrite eqp.
+    now rewrite -primitive_constant_spec. red. 
+    now rewrite -HH. 
+    destruct (cst_type d) eqn:hty => //.
+    exists u. split => //.
+  Qed.
+  Next Obligation.
+    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
+    cbn in *. specialize_Σ wfΣ ; sq. 
+    depelim X1.
+    eapply eqb_eq in i. eapply eqb_eq in i0.
+    rewrite -(abstract_env_lookup_correct _ (Σ := Σ)) // in HH.
+    rewrite (primitive_constant_spec _ _ wfΣ) in eqp.
+    rewrite e1 in eqp. noconf eqp.
+    symmetry in HH. rewrite /declared_constant in d0.
+    rewrite d0 in HH; noconf HH.
+    destruct p1 as [s' []]. rewrite H in absurd. now apply absurd.
+  Qed. 
+  Next Obligation.
+    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
+    cbn in *. specialize_Σ wfΣ ; sq. 
+    depelim X1.
+    eapply eqb_eq in i.
+    rewrite -(abstract_env_lookup_correct _ (Σ := Σ)) // in HH.
+    rewrite (primitive_constant_spec _ _ wfΣ) in eqp.
+    rewrite e1 in eqp. noconf eqp.
+    symmetry in HH. rewrite /declared_constant in d0.
+    rewrite d0 in HH; noconf HH.
+    destruct p1 as [s' []]. apply absurd. case: eqb_spec => //.
+  Qed.
+
+
+  Next Obligation.
+    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
+    cbn in *. specialize_Σ wfΣ ; sq. 
+    depelim X1.
+    rewrite -(abstract_env_lookup_correct _ (Σ := Σ)) // in HH.
+    rewrite (primitive_constant_spec _ _ wfΣ) in eqp.
+    rewrite e1 in eqp. noconf eqp.
+    symmetry in HH. rewrite /declared_constant in d0.
+    rewrite d0 in HH; noconf HH.
+    destruct p1 as [s' []]. apply absurd. case: eqb_spec => //.
+  Qed.
+
+  Next Obligation.
+    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
+    cbn in *. specialize_Σ wfΣ ; sq. 
+    depelim X1.
+    rewrite -(abstract_env_lookup_correct _ (Σ := Σ)) // in e0.
+    rewrite (primitive_constant_spec _ _ wfΣ) in eqp.
+    rewrite e1 in eqp. noconf eqp.
+    symmetry in e0. rewrite /declared_constant in d.
+    rewrite d in e0; noconf e0.
+  Qed.
+
+  Next Obligation.
+    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
+    cbn in *. specialize_Σ wfΣ ; sq. 
+    depelim X1.
+    rewrite -(abstract_env_lookup_correct _ (Σ := Σ)) // in e0.
+    rewrite (primitive_constant_spec _ _ wfΣ) in eqp.
+    rewrite e1 in eqp. noconf eqp.
+    symmetry in e0. rewrite /declared_constant in d.
+    rewrite e0 in d; noconf d.
+  Qed.
+  
+  Next Obligation.
+    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
+    cbn in *. specialize_Σ wfΣ ; sq. 
+    depelim X1.
+    rewrite (primitive_constant_spec _ _ wfΣ) in e0. 
+    unfold prim_val_tag in e1. congruence.
+  Qed.
 
   Definition check_isType := infer_isType infer.
 

--- a/safechecker/theories/PCUICWfEnvImpl.v
+++ b/safechecker/theories/PCUICWfEnvImpl.v
@@ -87,7 +87,8 @@ Record referenced_impl {cf:checker_flags} := {
       referenced_impl_graph_wf := projT2 (graph_of_wf referenced_impl_wf)
   }.
 
-Definition init_env : global_env := {| universes := (LS.singleton Level.lzero , CS.empty); declarations := [] |}.
+Definition init_env : global_env :=
+   {| universes := (LS.singleton Level.lzero , CS.empty); declarations := []; retroknowledge := Retroknowledge.empty |}.
 
 Definition on_global_univ_init_env : on_global_univs init_env.
   repeat split. 
@@ -121,6 +122,7 @@ Defined.
 Global Instance canonical_abstract_env_ext_struct {cf:checker_flags} {guard : abstract_guard_impl} :
   abstract_env_ext_struct referenced_impl_ext :=
   {| abstract_env_lookup := fun Σ => lookup_env (referenced_impl_env_ext Σ) ;
+     abstract_env_ext_retroknowledge := fun Σ => (referenced_impl_env_ext Σ).(retroknowledge) ;
      abstract_env_conv_pb_relb := fun Σ conv_pb => conv_pb_relb (referenced_impl_ext_graph Σ) conv_pb ;
      abstract_env_compare_global_instance := fun Σ =>
       compare_global_instance (referenced_impl_env_ext Σ)
@@ -137,7 +139,7 @@ Global Instance canonical_abstract_env_ext_struct {cf:checker_flags} {guard : ab
     match Σ.(declarations) with 
      [] => Σ
      | (d::decls) =>
-       {| referenced_impl_env := {| universes := Σ.(universes); declarations := decls |} |}
+       {| referenced_impl_env := {| universes := Σ.(universes); declarations := decls; retroknowledge := Σ.(retroknowledge) |} |}
     end.
    Next Obligation.
     destruct Σ.(referenced_impl_wf). sq.
@@ -154,10 +156,10 @@ Program Global Instance canonical_abstract_env_struct {cf:checker_flags} {guard 
   abstract_env_struct referenced_impl referenced_impl_ext :=
  {|
  abstract_env_empty := {|
- referenced_impl_env := {| universes := init_env ; declarations := [] |};
+ referenced_impl_env := {| universes := init_env ; declarations := []; retroknowledge := Retroknowledge.empty |};
  |} ;
- abstract_env_init := fun cs H =>  {|
- referenced_impl_env := {| universes := cs ; declarations := [] |};
+ abstract_env_init := fun cs retro H =>  {|
+ referenced_impl_env := {| universes := cs ; declarations := []; retroknowledge := retro |};
  |} ;
  abstract_env_add_decl := fun X kn d H => 
   {| referenced_impl_env := add_global_decl X.(referenced_impl_env) (kn,d);
@@ -166,6 +168,7 @@ Program Global Instance canonical_abstract_env_struct {cf:checker_flags} {guard 
  |} ;
  abstract_env_univ X := X ;
  abstract_env_global_declarations X := declarations X;
+ abstract_env_retroknowledge X := X.(retroknowledge) ;
  abstract_env_is_consistent uctx := wGraph.is_acyclic (make_graph uctx);
  abstract_env_is_consistent_uctx X uctx :=
    let G := referenced_impl_graph X in
@@ -206,6 +209,7 @@ Record wf_env_ext {cf:checker_flags} {guard : abstract_guard_impl} := {
 Global Instance optimized_abstract_env_ext_struct {cf:checker_flags} {guard : abstract_guard_impl} :
   abstract_env_ext_struct wf_env_ext :=
   {| abstract_env_lookup := fun Σ k => EnvMap.lookup k (wf_env_ext_map Σ);
+     abstract_env_ext_retroknowledge := fun X => X.(wf_env_ext_referenced).(retroknowledge);
      abstract_env_conv_pb_relb X := abstract_env_conv_pb_relb X.(wf_env_ext_referenced);
      abstract_env_compare_global_instance X := abstract_env_compare_global_instance X.(wf_env_ext_referenced);
      abstract_env_level_mem X := abstract_env_level_mem X.(wf_env_ext_referenced);
@@ -215,7 +219,8 @@ Global Instance optimized_abstract_env_ext_struct {cf:checker_flags} {guard : ab
      abstract_env_ext_rel X := abstract_env_ext_rel X.(wf_env_ext_referenced);
   |}.
 
-Lemma wf_env_eta {cf : checker_flags} (Σ : wf_env) : {| universes := Σ.(universes); declarations := Σ.(declarations) |} = Σ.
+Lemma wf_env_eta {cf : checker_flags} (Σ : wf_env) :
+ {| universes := Σ.(universes); declarations := Σ.(declarations); retroknowledge := Σ.(retroknowledge) |} = Σ.
 Proof.
   destruct Σ => /= //. destruct referenced_impl_env => //.
 Qed.
@@ -245,10 +250,10 @@ Program Definition wf_env_empty {cf:checker_flags} {guard : abstract_guard_impl}
   wf_env_map := EnvMap.empty;
   |}.
 
-Program Definition wf_env_init {cf:checker_flags} {guard : abstract_guard_impl} cs : 
+Program Definition wf_env_init {cf:checker_flags} {guard : abstract_guard_impl} cs retro : 
   on_global_univs cs -> wf_env := fun H =>
   {|   
-  wf_env_referenced := abstract_env_init cs H;
+  wf_env_referenced := abstract_env_init cs retro H;
   wf_env_map := EnvMap.empty;
   |}.
 
@@ -257,7 +262,8 @@ Lemma reference_pop_decls_correct {cf:checker_flags} (X:referenced_impl) decls
   exists d, Σ.(declarations) = d :: decls) :
   let X' := referenced_pop X in
   forall Σ Σ', Σ = X -> Σ' = X' -> 
-          Σ'.(declarations) = decls /\ Σ.(universes) = Σ'.(universes).
+          Σ'.(declarations) = decls /\ Σ.(universes) = Σ'.(universes) /\
+          Σ.(retroknowledge) = Σ'.(retroknowledge).
 Proof.
   cbn; intros; subst. specialize (prf _ eq_refl).
   unfold referenced_pop. cbn. set (referenced_pop_obligation_1 cf X).
@@ -495,7 +501,8 @@ Next Obligation.
   apply: consistent_ext_on_full_ext=> //.
   apply: add_uctx_subgraph.
 Qed.
-Next Obligation. apply (reference_pop_decls_correct X decls prf X (referenced_pop X) eq_refl eq_refl).
+Next Obligation. 
+  apply (reference_pop_decls_correct X decls prf X (referenced_pop X) eq_refl eq_refl).
 Qed. 
 
 Program Global Instance optimized_abstract_env_prop {cf:checker_flags} {guard : abstract_guard_impl} :

--- a/template-coq/_CoqProject
+++ b/template-coq/_CoqProject
@@ -31,6 +31,8 @@ theories/utils/MCUtils.v
 theories/utils/MC_ExtrOCamlZPosInt.v
 theories/utils/ReflectEq.v
 
+theories/Primitive.v
+
 # common
 theories/common/uGraph.v
 

--- a/template-coq/_PluginProject
+++ b/template-coq/_PluginProject
@@ -19,6 +19,8 @@ gen-src/ast0.ml
 gen-src/ast0.mli
 gen-src/ast_denoter.ml
 gen-src/ast_quoter.ml
+gen-src/primitive.mli
+gen-src/primitive.ml
 gen-src/astUtils.ml
 gen-src/astUtils.mli
 gen-src/basicAst.ml
@@ -100,6 +102,8 @@ gen-src/logic2.mli
 gen-src/logic2.ml
 gen-src/relation.mli
 gen-src/relation.ml
+gen-src/mCProd.mli
+gen-src/mCProd.ml
 gen-src/mCPrelude.mli
 gen-src/mCPrelude.ml
 gen-src/mCCompare.ml

--- a/template-coq/gen-src/metacoq_template_plugin.mlpack
+++ b/template-coq/gen-src/metacoq_template_plugin.mlpack
@@ -82,6 +82,7 @@ Universes0
 Environment
 EnvironmentTyping
 Ast0
+Primitive
 AstUtils
 LiftSubst
 UnivSubst0

--- a/template-coq/gen-src/specFloat.ml.orig
+++ b/template-coq/gen-src/specFloat.ml.orig
@@ -1,0 +1,546 @@
+open BinInt
+open BinNums
+open BinPos
+open Bool
+open Datatypes
+open Zbool
+open Zpower
+
+type spec_float =
+| S754_zero of bool
+| S754_infinity of bool
+| S754_nan
+| S754_finite of bool * positive * coq_Z
+
+(** val emin : coq_Z -> coq_Z -> coq_Z **)
+
+let emin prec emax =
+  Z.sub (Z.sub (Zpos (Coq_xI Coq_xH)) emax) prec
+
+(** val fexp : coq_Z -> coq_Z -> coq_Z -> coq_Z **)
+
+let fexp prec emax e =
+  Z.max (Z.sub e prec) (emin prec emax)
+
+(** val digits2_pos : positive -> positive **)
+
+let rec digits2_pos = function
+| Coq_xI p -> Pos.succ (digits2_pos p)
+| Coq_xO p -> Pos.succ (digits2_pos p)
+| Coq_xH -> Coq_xH
+
+(** val coq_Zdigits2 : coq_Z -> coq_Z **)
+
+let coq_Zdigits2 n = match n with
+| Z0 -> n
+| Zpos p -> Zpos (digits2_pos p)
+| Zneg p -> Zpos (digits2_pos p)
+
+(** val canonical_mantissa : coq_Z -> coq_Z -> positive -> coq_Z -> bool **)
+
+let canonical_mantissa prec emax m e =
+  coq_Zeq_bool (fexp prec emax (Z.add (Zpos (digits2_pos m)) e)) e
+
+(** val bounded : coq_Z -> coq_Z -> positive -> coq_Z -> bool **)
+
+let bounded prec emax m e =
+  (&&) (canonical_mantissa prec emax m e) (Z.leb e (Z.sub emax prec))
+
+(** val valid_binary : coq_Z -> coq_Z -> spec_float -> bool **)
+
+let valid_binary prec emax = function
+| S754_finite (_, m, e) -> bounded prec emax m e
+| _ -> true
+
+(** val iter_pos : ('a1 -> 'a1) -> positive -> 'a1 -> 'a1 **)
+
+let rec iter_pos f n x =
+  match n with
+  | Coq_xI n' -> iter_pos f n' (iter_pos f n' (f x))
+  | Coq_xO n' -> iter_pos f n' (iter_pos f n' x)
+  | Coq_xH -> f x
+
+type location =
+| Coq_loc_Exact
+| Coq_loc_Inexact of int
+
+(** val location_rect : 'a1 -> (int -> 'a1) -> location -> 'a1 **)
+
+let location_rect f f0 = function
+| Coq_loc_Exact -> f
+| Coq_loc_Inexact c -> f0 c
+
+(** val location_rec : 'a1 -> (int -> 'a1) -> location -> 'a1 **)
+
+let location_rec f f0 = function
+| Coq_loc_Exact -> f
+| Coq_loc_Inexact c -> f0 c
+
+type shr_record = { shr_m : coq_Z; shr_r : bool; shr_s : bool }
+
+(** val shr_m : shr_record -> coq_Z **)
+
+let shr_m s =
+  s.shr_m
+
+(** val shr_r : shr_record -> bool **)
+
+let shr_r s =
+  s.shr_r
+
+(** val shr_s : shr_record -> bool **)
+
+let shr_s s =
+  s.shr_s
+
+(** val shr_1 : shr_record -> shr_record **)
+
+let shr_1 mrs =
+  let { shr_m = m; shr_r = r; shr_s = s } = mrs in
+  let s0 = (||) r s in
+  (match m with
+   | Z0 -> { shr_m = Z0; shr_r = false; shr_s = s0 }
+   | Zpos p0 ->
+     (match p0 with
+      | Coq_xI p -> { shr_m = (Zpos p); shr_r = true; shr_s = s0 }
+      | Coq_xO p -> { shr_m = (Zpos p); shr_r = false; shr_s = s0 }
+      | Coq_xH -> { shr_m = Z0; shr_r = true; shr_s = s0 })
+   | Zneg p0 ->
+     (match p0 with
+      | Coq_xI p -> { shr_m = (Zneg p); shr_r = true; shr_s = s0 }
+      | Coq_xO p -> { shr_m = (Zneg p); shr_r = false; shr_s = s0 }
+      | Coq_xH -> { shr_m = Z0; shr_r = true; shr_s = s0 }))
+
+(** val loc_of_shr_record : shr_record -> location **)
+
+let loc_of_shr_record mrs =
+  let { shr_m = _; shr_r = shr_r0; shr_s = shr_s0 } = mrs in
+  if shr_r0
+  then if shr_s0 then Coq_loc_Inexact 1 else Coq_loc_Inexact 0
+  else if shr_s0 then Coq_loc_Inexact (-1) else Coq_loc_Exact
+
+(** val shr_record_of_loc : coq_Z -> location -> shr_record **)
+
+let shr_record_of_loc m = function
+| Coq_loc_Exact -> { shr_m = m; shr_r = false; shr_s = false }
+| Coq_loc_Inexact c ->
+  (match c with
+   | 0 -> { shr_m = m; shr_r = true; shr_s = false }
+   | (-1) -> { shr_m = m; shr_r = false; shr_s = true }
+   | 1 -> { shr_m = m; shr_r = true; shr_s = true })
+
+(** val shr : shr_record -> coq_Z -> coq_Z -> shr_record * coq_Z **)
+
+let shr mrs e n = match n with
+| Zpos p -> ((iter_pos shr_1 p mrs), (Z.add e n))
+| _ -> (mrs, e)
+
+(** val shr_fexp :
+    coq_Z -> coq_Z -> coq_Z -> coq_Z -> location -> shr_record * coq_Z **)
+
+let shr_fexp prec emax m e l =
+  shr (shr_record_of_loc m l) e
+    (Z.sub (fexp prec emax (Z.add (coq_Zdigits2 m) e)) e)
+
+(** val round_nearest_even : coq_Z -> location -> coq_Z **)
+
+let round_nearest_even mx = function
+| Coq_loc_Exact -> mx
+| Coq_loc_Inexact c ->
+  (match c with
+   | 0 -> if Z.even mx then mx else Z.add mx (Zpos Coq_xH)
+   | (-1) -> mx
+   | 1 -> Z.add mx (Zpos Coq_xH))
+
+(** val binary_round_aux :
+    coq_Z -> coq_Z -> bool -> coq_Z -> coq_Z -> location -> spec_float **)
+
+let binary_round_aux prec emax sx mx ex lx =
+  let (mrs', e') = shr_fexp prec emax mx ex lx in
+  let (mrs'', e'') =
+    shr_fexp prec emax
+      (round_nearest_even mrs'.shr_m (loc_of_shr_record mrs')) e'
+      Coq_loc_Exact
+  in
+  (match mrs''.shr_m with
+   | Z0 -> S754_zero sx
+   | Zpos m ->
+     if Z.leb e'' (Z.sub emax prec)
+     then S754_finite (sx, m, e'')
+     else S754_infinity sx
+   | Zneg _ -> S754_nan)
+
+(** val shl_align : positive -> coq_Z -> coq_Z -> positive * coq_Z **)
+
+let shl_align mx ex ex' =
+  match Z.sub ex' ex with
+  | Zneg d -> ((shift_pos d mx), ex')
+  | _ -> (mx, ex)
+
+(** val binary_round :
+    coq_Z -> coq_Z -> bool -> positive -> coq_Z -> spec_float **)
+
+let binary_round prec emax sx mx ex =
+  let (mz, ez) =
+    shl_align mx ex (fexp prec emax (Z.add (Zpos (digits2_pos mx)) ex))
+  in
+  binary_round_aux prec emax sx (Zpos mz) ez Coq_loc_Exact
+
+(** val binary_normalize :
+    coq_Z -> coq_Z -> coq_Z -> coq_Z -> bool -> spec_float **)
+
+let binary_normalize prec emax m e szero =
+  match m with
+  | Z0 -> S754_zero szero
+  | Zpos m0 -> binary_round prec emax false m0 e
+  | Zneg m0 -> binary_round prec emax true m0 e
+
+(** val coq_SFopp : spec_float -> spec_float **)
+
+let coq_SFopp = function
+| S754_zero sx -> S754_zero (negb sx)
+| S754_infinity sx -> S754_infinity (negb sx)
+| S754_nan -> S754_nan
+| S754_finite (sx, mx, ex) -> S754_finite ((negb sx), mx, ex)
+
+(** val coq_SFabs : spec_float -> spec_float **)
+
+let coq_SFabs = function
+| S754_zero _ -> S754_zero false
+| S754_infinity _ -> S754_infinity false
+| S754_nan -> S754_nan
+| S754_finite (_, mx, ex) -> S754_finite (false, mx, ex)
+
+(** val coq_SFcompare : spec_float -> spec_float -> int option **)
+
+let coq_SFcompare f1 f2 =
+  match f1 with
+  | S754_zero _ ->
+    (match f2 with
+     | S754_zero _ -> Some 0
+     | S754_infinity s -> Some (if s then 1 else (-1))
+     | S754_nan -> None
+     | S754_finite (s, _, _) -> Some (if s then 1 else (-1)))
+  | S754_infinity s ->
+    (match f2 with
+     | S754_infinity s0 ->
+       Some (if s then if s0 then 0 else (-1) else if s0 then 1 else 0)
+     | S754_nan -> None
+     | _ -> Some (if s then (-1) else 1))
+  | S754_nan -> None
+  | S754_finite (s1, m1, e1) ->
+    (match f2 with
+     | S754_zero _ -> Some (if s1 then (-1) else 1)
+     | S754_infinity s -> Some (if s then 1 else (-1))
+     | S754_nan -> None
+     | S754_finite (s2, m2, e2) ->
+       Some
+         (if s1
+          then if s2
+               then (match Z.compare e1 e2 with
+                     | 0 -> coq_CompOpp (Pos.compare_cont 0 m1 m2)
+                     | (-1) -> 1
+                     | 1 -> (-1))
+               else (-1)
+          else if s2
+               then 1
+               else (match Z.compare e1 e2 with
+                     | 0 -> Pos.compare_cont 0 m1 m2
+                     | x -> x)))
+
+(** val coq_SFeqb : spec_float -> spec_float -> bool **)
+
+let coq_SFeqb f1 f2 =
+  match coq_SFcompare f1 f2 with
+  | Some c -> (match c with
+               | 0 -> true
+               | _ -> false)
+  | None -> false
+
+(** val coq_SFltb : spec_float -> spec_float -> bool **)
+
+let coq_SFltb f1 f2 =
+  match coq_SFcompare f1 f2 with
+  | Some c -> (match c with
+               | (-1) -> true
+               | _ -> false)
+  | None -> false
+
+(** val coq_SFleb : spec_float -> spec_float -> bool **)
+
+let coq_SFleb f1 f2 =
+  match coq_SFcompare f1 f2 with
+  | Some c -> (match c with
+               | 1 -> false
+               | _ -> true)
+  | None -> false
+
+(** val coq_SFclassify : coq_Z -> spec_float -> Float64.float_class **)
+
+let coq_SFclassify prec = function
+| S754_zero s -> if s then PZero else NZero
+| S754_infinity s -> if s then NInf else PInf
+| S754_nan -> NaN
+| S754_finite (s, m, _) ->
+  if s
+  then if Pos.eqb (digits2_pos m) (Z.to_pos prec) then NNormal else NSubn
+  else if Pos.eqb (digits2_pos m) (Z.to_pos prec) then PNormal else PSubn
+
+(** val coq_SFmul :
+    coq_Z -> coq_Z -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFmul prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_zero sy -> S754_zero (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_zero (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_infinity sx ->
+    (match y with
+     | S754_infinity sy -> S754_infinity (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_infinity (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero sy -> S754_zero (xorb sx sy)
+     | S754_infinity sy -> S754_infinity (xorb sx sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       binary_round_aux prec emax (xorb sx sy) (Zpos (Pos.mul mx my))
+         (Z.add ex ey) Coq_loc_Exact)
+
+(** val cond_Zopp : bool -> coq_Z -> coq_Z **)
+
+let cond_Zopp b m =
+  if b then Z.opp m else m
+
+(** val coq_SFadd :
+    coq_Z -> coq_Z -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFadd prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_zero sy -> if eqb sx sy then x else S754_zero false
+     | S754_nan -> S754_nan
+     | _ -> y)
+  | S754_infinity sx ->
+    (match y with
+     | S754_infinity sy -> if eqb sx sy then x else S754_nan
+     | S754_nan -> S754_nan
+     | _ -> x)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero _ -> x
+     | S754_infinity _ -> y
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       let ez = Z.min ex ey in
+       binary_normalize prec emax
+         (Z.add (cond_Zopp sx (Zpos (fst (shl_align mx ex ez))))
+           (cond_Zopp sy (Zpos (fst (shl_align my ey ez))))) ez false)
+
+(** val coq_SFsub :
+    coq_Z -> coq_Z -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFsub prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_zero sy -> if eqb sx (negb sy) then x else S754_zero false
+     | S754_infinity sy -> S754_infinity (negb sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) -> S754_finite ((negb sy), my, ey))
+  | S754_infinity sx ->
+    (match y with
+     | S754_infinity sy -> if eqb sx (negb sy) then x else S754_nan
+     | S754_nan -> S754_nan
+     | _ -> x)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero _ -> x
+     | S754_infinity sy -> S754_infinity (negb sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       let ez = Z.min ex ey in
+       binary_normalize prec emax
+         (Z.sub (cond_Zopp sx (Zpos (fst (shl_align mx ex ez))))
+           (cond_Zopp sy (Zpos (fst (shl_align my ey ez))))) ez false)
+
+(** val new_location_even : coq_Z -> coq_Z -> location **)
+
+let new_location_even nb_steps k =
+  if coq_Zeq_bool k Z0
+  then Coq_loc_Exact
+  else Coq_loc_Inexact (Z.compare (Z.mul (Zpos (Coq_xO Coq_xH)) k) nb_steps)
+
+(** val new_location_odd : coq_Z -> coq_Z -> location **)
+
+let new_location_odd nb_steps k =
+  if coq_Zeq_bool k Z0
+  then Coq_loc_Exact
+  else Coq_loc_Inexact
+         (match Z.compare
+                  (Z.add (Z.mul (Zpos (Coq_xO Coq_xH)) k) (Zpos Coq_xH))
+                  nb_steps with
+          | 0 -> (-1)
+          | x -> x)
+
+(** val new_location : coq_Z -> coq_Z -> location **)
+
+let new_location nb_steps =
+  if Z.even nb_steps
+  then new_location_even nb_steps
+  else new_location_odd nb_steps
+
+(** val coq_SFdiv_core_binary :
+    coq_Z -> coq_Z -> coq_Z -> coq_Z -> coq_Z -> coq_Z ->
+    (coq_Z * coq_Z) * location **)
+
+let coq_SFdiv_core_binary prec emax m1 e1 m2 e2 =
+  let d1 = coq_Zdigits2 m1 in
+  let d2 = coq_Zdigits2 m2 in
+  let e' =
+    Z.min (fexp prec emax (Z.sub (Z.add d1 e1) (Z.add d2 e2))) (Z.sub e1 e2)
+  in
+  let s = Z.sub (Z.sub e1 e2) e' in
+  let m' = match s with
+           | Z0 -> m1
+           | Zpos _ -> Z.shiftl m1 s
+           | Zneg _ -> Z0 in
+  let (q, r) = Z.div_eucl m' m2 in ((q, e'), (new_location m2 r))
+
+(** val coq_SFdiv :
+    coq_Z -> coq_Z -> spec_float -> spec_float -> spec_float **)
+
+let coq_SFdiv prec emax x y =
+  match x with
+  | S754_zero sx ->
+    (match y with
+     | S754_infinity sy -> S754_zero (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_zero (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_infinity sx ->
+    (match y with
+     | S754_zero sy -> S754_infinity (xorb sx sy)
+     | S754_finite (sy, _, _) -> S754_infinity (xorb sx sy)
+     | _ -> S754_nan)
+  | S754_nan -> S754_nan
+  | S754_finite (sx, mx, ex) ->
+    (match y with
+     | S754_zero sy -> S754_infinity (xorb sx sy)
+     | S754_infinity sy -> S754_zero (xorb sx sy)
+     | S754_nan -> S754_nan
+     | S754_finite (sy, my, ey) ->
+       let (p, lz) = coq_SFdiv_core_binary prec emax (Zpos mx) ex (Zpos my) ey
+       in
+       let (mz, ez) = p in binary_round_aux prec emax (xorb sx sy) mz ez lz)
+
+(** val coq_SFsqrt_core_binary :
+    coq_Z -> coq_Z -> coq_Z -> coq_Z -> (coq_Z * coq_Z) * location **)
+
+let coq_SFsqrt_core_binary prec emax m e =
+  let d = coq_Zdigits2 m in
+  let e' =
+    Z.min (fexp prec emax (Z.div2 (Z.add (Z.add d e) (Zpos Coq_xH))))
+      (Z.div2 e)
+  in
+  let s = Z.sub e (Z.mul (Zpos (Coq_xO Coq_xH)) e') in
+  let m' = match s with
+           | Z0 -> m
+           | Zpos _ -> Z.shiftl m s
+           | Zneg _ -> Z0 in
+  let (q, r) = Z.sqrtrem m' in
+  let l =
+    if coq_Zeq_bool r Z0
+    then Coq_loc_Exact
+    else Coq_loc_Inexact (if Z.leb r q then (-1) else 1)
+  in
+  ((q, e'), l)
+
+(** val coq_SFsqrt : coq_Z -> coq_Z -> spec_float -> spec_float **)
+
+let coq_SFsqrt prec emax x = match x with
+| S754_zero _ -> x
+| S754_infinity s -> if s then S754_nan else x
+| S754_nan -> S754_nan
+| S754_finite (sx, mx, ex) ->
+  if sx
+  then S754_nan
+  else let (p, lz) = coq_SFsqrt_core_binary prec emax (Zpos mx) ex in
+       let (mz, ez) = p in binary_round_aux prec emax false mz ez lz
+
+(** val coq_SFnormfr_mantissa : coq_Z -> spec_float -> coq_N **)
+
+let coq_SFnormfr_mantissa prec = function
+| S754_finite (_, mx, ex) -> if Z.eqb ex (Z.opp prec) then Npos mx else N0
+| _ -> N0
+
+(** val coq_SFldexp : coq_Z -> coq_Z -> spec_float -> coq_Z -> spec_float **)
+
+let coq_SFldexp prec emax f e =
+  match f with
+  | S754_finite (sx, mx, ex) -> binary_round prec emax sx mx (Z.add ex e)
+  | _ -> f
+
+(** val coq_SFfrexp : coq_Z -> coq_Z -> spec_float -> spec_float * coq_Z **)
+
+let coq_SFfrexp prec emax f = match f with
+| S754_finite (sx, mx, ex) ->
+  if Pos.leb (Z.to_pos prec) (digits2_pos mx)
+  then ((S754_finite (sx, mx, (Z.opp prec))), (Z.add ex prec))
+  else let d = Z.sub prec (Zpos (digits2_pos mx)) in
+       ((S754_finite (sx, (shift_pos (Z.to_pos d) mx), (Z.opp prec))),
+       (Z.sub (Z.add ex prec) d))
+| _ -> (f, (Z.sub (Z.mul (Zneg (Coq_xO Coq_xH)) emax) prec))
+
+(** val coq_SFone : coq_Z -> coq_Z -> spec_float **)
+
+let coq_SFone prec emax =
+  binary_round prec emax false Coq_xH Z0
+
+(** val coq_SFulp : coq_Z -> coq_Z -> spec_float -> spec_float **)
+
+let coq_SFulp prec emax x =
+  coq_SFldexp prec emax (coq_SFone prec emax)
+    (fexp prec emax (snd (coq_SFfrexp prec emax x)))
+
+(** val coq_SFpred_pos : coq_Z -> coq_Z -> spec_float -> spec_float **)
+
+let coq_SFpred_pos prec emax x = match x with
+| S754_finite (_, mx, _) ->
+  let d =
+    if Pos.eqb (Coq_xO mx) (shift_pos (Z.to_pos prec) Coq_xH)
+    then coq_SFldexp prec emax (coq_SFone prec emax)
+           (fexp prec emax
+             (Z.sub (snd (coq_SFfrexp prec emax x)) (Zpos Coq_xH)))
+    else coq_SFulp prec emax x
+  in
+  coq_SFsub prec emax x d
+| _ -> x
+
+(** val coq_SFmax_float : coq_Z -> coq_Z -> spec_float **)
+
+let coq_SFmax_float prec emax =
+  S754_finite (false, (Pos.sub (shift_pos (Z.to_pos prec) Coq_xH) Coq_xH),
+    (Z.sub emax prec))
+
+(** val coq_SFsucc : coq_Z -> coq_Z -> spec_float -> spec_float **)
+
+let coq_SFsucc prec emax x = match x with
+| S754_zero _ -> coq_SFldexp prec emax (coq_SFone prec emax) (emin prec emax)
+| S754_infinity s -> if s then coq_SFopp (coq_SFmax_float prec emax) else x
+| S754_nan -> x
+| S754_finite (s, _, _) ->
+  if s
+  then coq_SFopp (coq_SFpred_pos prec emax (coq_SFopp x))
+  else coq_SFadd prec emax x (coq_SFulp prec emax x)
+
+(** val coq_SFpred : coq_Z -> coq_Z -> spec_float -> spec_float **)
+
+let coq_SFpred prec emax f =
+  coq_SFopp (coq_SFsucc prec emax (coq_SFopp f))

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -51,7 +51,7 @@ struct
   type quoted_constant_body = constant_body
   type quoted_global_decl = global_decl
   type quoted_global_declarations = (kername * global_decl) list
-  type quoted_retroknowledge = Retroknowledge.t
+  type quoted_retroknowledge = Environment.Retroknowledge.t
   type quoted_global_env = global_env
   type quoted_program = program
 

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -123,8 +123,8 @@ struct
     | Coq_tProj (a,b) -> ACoq_tProj (a,b)
     | Coq_tFix (a,b) -> ACoq_tFix (List.map unquote_def a,b)
     | Coq_tCoFix (a,b) -> ACoq_tCoFix (List.map unquote_def a,b)
-    (* | Coq_tInt i -> ACoq_tInt i *)
-    (* | Coq_tFloat f -> ACoq_tFloat f *)
+    | Coq_tInt i -> ACoq_tInt i
+    | Coq_tFloat f -> ACoq_tFloat f
 
   let unquote_string = Caml_bytestring.caml_string_of_bytestring
 

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -51,6 +51,7 @@ struct
   type quoted_constant_body = constant_body
   type quoted_global_decl = global_decl
   type quoted_global_declarations = (kername * global_decl) list
+  type quoted_retroknowledge = Retroknowledge.t
   type quoted_global_env = global_env
   type quoted_program = program
 

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -52,6 +52,7 @@ struct
   type quoted_constant_body = constant_body
   type quoted_global_decl = global_decl
   type quoted_global_declarations = global_declarations
+  type quoted_retroknowledge = Retroknowledge.t
   type quoted_global_env = global_env
   type quoted_program = program
 
@@ -321,7 +322,14 @@ struct
 
   let add_global_decl kn a b = (kn, a) :: b
 
-  let mk_global_env universes declarations = { universes; declarations }
+  type pre_quoted_retroknowledge = 
+    { retro_int63 : quoted_kernel_name option;
+      retro_float64 : quoted_kernel_name option }
+
+  let quote_retroknowledge r = 
+    { Retroknowledge.retro_int63 = r.retro_int63; Retroknowledge.retro_float64 = r.retro_float64 }
+
+  let mk_global_env universes declarations retroknowledge = { universes; declarations; retroknowledge }
   let mk_program decls tm = (decls, tm)
 
   let quote_mind_finiteness = function

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -244,8 +244,8 @@ struct
   let mkInd i u = Coq_tInd (i, u)
   let mkConstruct (ind, i) u = Coq_tConstruct (ind, i, u)
   let mkLetIn na b t t' = Coq_tLetIn (na,b,t,t')
-  (* let mkInt i = Coq_tInt i
-  let mkFloat f = Coq_tFloat f *)
+  let mkInt i = Coq_tInt i
+  let mkFloat f = Coq_tFloat f
 
   let rec seq f t =
     if f < t then

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -139,8 +139,8 @@ struct
   let quote_proj ind p a = { proj_ind = ind; proj_npars = p; proj_arg = a }
 
   let quote_constraint_type = function
-    | Univ.Lt -> Universes0.ConstraintType.Le 1
-    | Univ.Le -> Universes0.ConstraintType.Le 0
+    | Univ.Lt -> Universes0.ConstraintType.Le BinNums.(Zpos Coq_xH)
+    | Univ.Le -> Universes0.ConstraintType.Le BinNums.Z0
     | Univ.Eq -> Universes0.ConstraintType.Eq
 
   let is_Lt = function
@@ -272,7 +272,7 @@ struct
     in
     let defs = List.fold_left mk_fun [] (seq 0 (Array.length ns)) in
     let block = List.rev defs in
-    Coq_tFix (block, a)
+    Coq_tCoFix (block, a)
 
   let mkCase (ind, npar, r) (univs, pars, pctx, pret) c brs =
     let info = { ci_ind = ind; ci_npar = npar; ci_relevance = r } in

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -52,7 +52,7 @@ struct
   type quoted_constant_body = constant_body
   type quoted_global_decl = global_decl
   type quoted_global_declarations = global_declarations
-  type quoted_retroknowledge = Retroknowledge.t
+  type quoted_retroknowledge = Environment.Retroknowledge.t
   type quoted_global_env = global_env
   type quoted_program = program
 
@@ -327,7 +327,8 @@ struct
       retro_float64 : quoted_kernel_name option }
 
   let quote_retroknowledge r = 
-    { Retroknowledge.retro_int63 = r.retro_int63; Retroknowledge.retro_float64 = r.retro_float64 }
+    { Environment.Retroknowledge.retro_int63 = r.retro_int63; 
+      Environment.Retroknowledge.retro_float64 = r.retro_float64 }
 
   let mk_global_env universes declarations retroknowledge = { universes; declarations; retroknowledge }
   let mk_program decls tm = (decls, tm)

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -419,8 +419,17 @@ struct
     let pair = pairl tkername tglobal_decl kn d in
     constr_mkApp (c_cons, [| global_pairty (); pair; l|])
 
-  let mk_global_env univs decls =
-    constr_mkApp (tBuild_global_env, [| univs; decls |])
+  type pre_quoted_retroknowledge = 
+    { retro_int63 : quoted_kernel_name option;
+      retro_float64 : quoted_kernel_name option }
+
+  let quote_retroknowledge r = 
+    let rint63 = to_coq_option (Lazy.force tkername) (fun x -> x) r.retro_int63 in
+    let rfloat64 = to_coq_option (Lazy.force tkername) (fun x -> x) r.retro_float64 in
+    constr_mkApp (tmk_retroknowledge, [| rint63; rfloat64 |])
+
+  let mk_global_env univs decls retro =
+    constr_mkApp (tBuild_global_env, [| univs; decls; retro |])
 
   let mk_program f s = pairl tglobal_env tTerm f s
 

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -48,6 +48,7 @@ struct
   type quoted_global_decl = Constr.t (* of type Ast.global_decl *)
   type quoted_global_declarations = Constr.t (* of type Ast.global_declarations *)
   type quoted_global_env = Constr.t (* of type Ast.global_env *)
+  type quoted_retroknowledge = Constr.t (* of type Retroknowledge.t *)
   type quoted_program = Constr.t (* of type Ast.program *)
 
   let resolve (tm : string) : Constr.t Lazy.t =
@@ -220,6 +221,7 @@ struct
   let tglobal_decl = ast "global_decl"
   let tConstantDecl = ast "ConstantDecl"
   let tInductiveDecl = ast "InductiveDecl"
+  let tmk_retroknowledge = ast "mk_retroknowledge"
   let tBuild_global_env = ast "Build_global_env"
   let tglobal_env = ast "global_env"
 

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -159,8 +159,8 @@ struct
          let p' = Names.Projection.make (Projection.Repr.make ind' ~proj_npars ~proj_arg l) false in
          let evm, t' = aux env evm t in
          evm, Constr.mkProj (p', t')
-      (* | ACoq_tInt x -> evm, Constr.mkInt (D.unquote_int63 x) *)
-      (* | ACoq_tFloat x -> evm, Constr.mkFloat (D.unquote_float64 x) *)
+      | ACoq_tInt x -> evm, Constr.mkInt (D.unquote_int63 x)
+      | ACoq_tFloat x -> evm, Constr.mkFloat (D.unquote_float64 x)
 
     in aux env evm trm
 

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -153,7 +153,13 @@ sig
   val empty_global_declarations : unit -> quoted_global_declarations
   val add_global_decl : quoted_kernel_name -> quoted_global_decl -> quoted_global_declarations -> quoted_global_declarations
   
-  val mk_global_env : quoted_univ_contextset -> quoted_global_declarations -> quoted_global_env
+  type pre_quoted_retroknowledge = 
+    { retro_int63 : quoted_kernel_name option;
+      retro_float64 : quoted_kernel_name option }
+
+  val quote_retroknowledge : pre_quoted_retroknowledge -> quoted_retroknowledge
+
+  val mk_global_env : quoted_univ_contextset -> quoted_global_declarations -> quoted_retroknowledge -> quoted_global_env
   val mk_program : quoted_global_env -> t -> quoted_program
 end
 
@@ -560,7 +566,15 @@ struct
          time (Pp.str"Quoting empty universe context") 
            (fun uctx -> Q.quote_univ_contextset uctx) Univ.ContextSet.empty)
     in
-    let env = Q.mk_global_env univs decls in
+    let retro =
+      let retro = env.Environ.retroknowledge in
+      let quote_retro = Option.map (fun c -> Q.quote_kn (Names.Constant.canonical c)) in
+      let pre = 
+        { Q.retro_int63 = quote_retro retro.Retroknowledge.retro_int63 ;
+          Q.retro_float64 = quote_retro retro.Retroknowledge.retro_float64 }
+      in Q.quote_retroknowledge pre
+    in
+    let env = Q.mk_global_env univs decls retro in
     Q.mk_program env tm
 
   let quote_rel_context env ctx =

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -67,8 +67,8 @@ sig
   val mkProj : quoted_proj -> t -> t
   val mkFix : (quoted_int array * quoted_int) * (quoted_aname array * t array * t array) -> t
   val mkCoFix : quoted_int * (quoted_aname array * t array * t array) -> t
-  (* val mkInt : quoted_int63 -> t
-  val mkFloat : quoted_float64 -> t *)
+  val mkInt : quoted_int63 -> t
+  val mkFloat : quoted_float64 -> t
 
   val mkBindAnn : quoted_name -> quoted_relevance -> quoted_aname
   val mkName : quoted_ident -> quoted_name
@@ -336,11 +336,9 @@ struct
          let t', acc = quote_term acc env c in
          let mib = Environ.lookup_mind (fst (Projection.inductive p)) (snd env) in
          (Q.mkProj p' t', add_inductive (Projection.inductive p) mib acc)
-      (* | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
-      | Constr.Float f -> (Q.mkFloat (Q.quote_float64 f), acc) *)
+      | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
+      | Constr.Float f -> (Q.mkFloat (Q.quote_float64 f), acc)
       | Constr.Meta _ -> failwith "Meta not supported by TemplateCoq"
-      | Constr.Int _ -> failwith "Primitive ints not supported by TemplateCoq"
-      | Constr.Float _ -> failwith "Primitive floats not supported by TemplateCoq"
       | Constr.Array _ -> failwith "Primitive arrays not supported by TemplateCoq"
       in
       aux acc env trm

--- a/template-coq/src/reification.ml
+++ b/template-coq/src/reification.ml
@@ -48,6 +48,7 @@ sig
   type quoted_constant_body
   type quoted_global_decl
   type quoted_global_declarations
+  type quoted_retroknowledge
   type quoted_global_env
   type quoted_program  (* the return type of quote_recursively *)
 

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -299,6 +299,6 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | ACoq_tProj of 'projection * 'term
   | ACoq_tFix of ('term, 'name, 'nat) amfixpoint * 'nat
   | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
-  (* | ACoq_tInt of 'int63 *)
-  (* | ACoq_tFloat of 'float64 *)
+  | ACoq_tInt of 'int63
+  | ACoq_tFloat of 'float64
 

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -415,10 +415,9 @@ Inductive term : Type :=
         (discr:term) (branches : list (branch term))
 | tProj (proj : projection) (t : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
-| tCoFix (mfix : mfixpoint term) (idx : nat).
-(* Not supported yet *)
-(* | tInt (i : Int63.int) *)
-(* | tFloat (f : PrimFloat.float). *)
+| tCoFix (mfix : mfixpoint term) (idx : nat)
+| tInt (i : Int63.int)
+| tFloat (f : PrimFloat.float).
 
 (** This can be used to represent holes, that, when unquoted, turn into fresh existential variables. 
     The fresh evar will depend on the whole context at this point in the term, despite the empty instance.
@@ -557,8 +556,8 @@ Fixpoint noccur_between k n (t : term) : bool :=
 #[global] Instance subst_instance_constr : UnivSubst term :=
   fix subst_instance_constr u c {struct c} : term :=
   match c with
-  | tRel _ | tVar _  => c
-  (* | tInt _ | tFloat _ => c *)
+  | tRel _ | tVar _ => c
+  | tInt _ | tFloat _ => c
   | tEvar ev args => tEvar ev (List.map (subst_instance_constr u) args)
   | tSort s => tSort (subst_instance_univ u s)
   | tConst c u' => tConst c (subst_instance_instance u u')

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -1,18 +1,11 @@
 (* For primitive integers and floats  *)
 From Coq Require Numbers.Cyclic.Int63.Int63 Floats.PrimFloat.
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Template Require Import utils BasicAst Ast Environment monad_utils.
+From MetaCoq.Template Require Import utils BasicAst Primitive Ast Environment monad_utils.
 Require Import ssreflect ssrbool.
 Require Import ZArith.
 
 (** Raw term printing *)
-
-Definition string_of_prim_int (i:Int63.int) : string := 
-  (* Better? DecimalString.NilZero.string_of_uint (BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). ? *)
-  string_of_Z (Numbers.Cyclic.Int63.Uint63.to_Z i).
-
-Definition string_of_float (f : PrimFloat.float) :=
-  "<float>".
 
 Module string_of_term_tree.
   Import bytestring.Tree.
@@ -71,8 +64,8 @@ Module string_of_term_tree.
             ^ string_of_term c ^ ")"
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
-  (* | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
-  | tFloat f => "Float(" ^ string_of_float f ^ ")" *)
+  | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
+  | tFloat f => "Float(" ^ string_of_float f ^ ")"
   end.
 End string_of_term_tree.
 
@@ -258,7 +251,7 @@ Fixpoint strip_casts t :=
     let mfix' := List.map (map_def strip_casts strip_casts) mfix in
     tCoFix mfix' idx
   | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => t
-  (* | tInt _ | tFloat _ => t *)
+  | tInt _ | tFloat _ => t
   end.
   
 Fixpoint decompose_prod_assum (Γ : context) (t : term) : context * term :=

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -799,7 +799,7 @@ Section Typecheck.
       | None => raise (IllFormedFix mfix n)
       end
 
-    (* | tInt _ | tFloat _ => raise (NotSupported "primitive types") *)
+    | tInt _ | tFloat _ => raise (NotSupported "primitive types")
     end.
 
   Definition check (Γ : context) (t : term) (ty : term) : typing_result unit :=
@@ -892,27 +892,27 @@ Section Checker.
                   (fun ctr => wGraph.EdgeSet.add (edge_of_constraint ctr)) ctrs G.1.2,
         G.2).
 
-  Fixpoint check_wf_declarations (univs : ContextSet.t) (G : universes_graph) (g : global_declarations)
+  Fixpoint check_wf_declarations (univs : ContextSet.t) (retro : Retroknowledge.t) (G : universes_graph) (g : global_declarations)
     : EnvCheck () :=
     match g with
     | [] => ret tt
     | g :: env =>
-      check_wf_declarations univs G env ;;
-      check_wf_decl {| universes := univs; declarations := env |} G g.1 g.2 ;;
+      check_wf_declarations univs retro G env ;;
+      check_wf_decl {| universes := univs; declarations := env; retroknowledge := retro |} G g.1 g.2 ;;
       check_fresh g.1 env ;;
       ret tt
     end.
 
   Definition typecheck_program (p : program) : EnvCheck term :=
     let Σ := fst p in
-    let (univs, decls) := (Σ.(universes), Σ.(declarations)) in
+    let '(univs, decls, retro) := (Σ.(universes), Σ.(declarations), Σ.(retroknowledge)) in
     match gc_of_constraints (snd univs) with
     | None => EnvError (IllFormedDecl "toplevel"
         (UnsatisfiableConstraints univs.2))
     | Some ctrs =>
       let G := add_gc_constraints ctrs init_graph in
       if wGraph.is_acyclic G then
-        check_wf_declarations univs G decls ;;
+        check_wf_declarations univs retro G decls ;;
         infer_term Σ G (snd p)
       else EnvError (IllFormedDecl "toplevel" 
         (UnsatisfiableConstraints univs.2))

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -116,7 +116,6 @@ Register MetaCoq.Template.Universes.PropLevel.lProp as metacoq.ast.level.lprop.
 Register MetaCoq.Template.Universes.PropLevel.lSProp as metacoq.ast.level.lsprop.
 Register MetaCoq.Template.Universes.Level.lzero as metacoq.ast.level.lzero.
 Register MetaCoq.Template.Universes.Level.Var as metacoq.ast.level.Var.
-(* FIXME*)
 Register MetaCoq.Template.Universes.Universe.lType as metacoq.ast.levelexpr.npe.
 
 Register MetaCoq.Template.Universes.LevelExprSet.Mkt as metacoq.ast.levelexprset.mkt.
@@ -177,8 +176,8 @@ Register MetaCoq.Template.Ast.tCase as metacoq.ast.tCase.
 Register MetaCoq.Template.Ast.tProj as metacoq.ast.tProj.
 Register MetaCoq.Template.Ast.tFix as metacoq.ast.tFix.
 Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tCoFix.
-(* Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
-Register MetaCoq.Template.Ast.tFloat as metacoq.ast.tFloat. *)
+Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
+Register MetaCoq.Template.Ast.tFloat as metacoq.ast.tFloat.
 
 (* Local and global declarations *)
 Register MetaCoq.Template.Ast.parameter_entry as metacoq.ast.parameter_entry.
@@ -198,7 +197,6 @@ Register MetaCoq.Template.Ast.Build_one_inductive_entry as metacoq.ast.Build_one
 Register MetaCoq.Template.Ast.mutual_inductive_entry as metacoq.ast.mutual_inductive_entry.
 Register MetaCoq.Template.Ast.Build_mutual_inductive_entry as metacoq.ast.Build_mutual_inductive_entry.
 
-(* FIXME, now polymorphic *)
 Register MetaCoq.Template.BasicAst.context_decl as metacoq.ast.context_decl.
 Register MetaCoq.Template.BasicAst.mkdecl as metacoq.ast.mkdecl.
 Register MetaCoq.Template.Ast.Env.context as metacoq.ast.context.
@@ -217,7 +215,7 @@ Register MetaCoq.Template.Ast.Env.Build_constant_body as metacoq.ast.Build_const
 Register MetaCoq.Template.Ast.Env.global_decl as metacoq.ast.global_decl.
 Register MetaCoq.Template.Ast.Env.ConstantDecl as metacoq.ast.ConstantDecl.
 Register MetaCoq.Template.Ast.Env.InductiveDecl as metacoq.ast.InductiveDecl.
-Register MetaCoq.Template.Ast.Env.Retroknowledge.mk_retroknowledge as metacoq.ast.mk_retroknowledge.
+Register MetaCoq.Template.Environment.Retroknowledge.mk_retroknowledge as metacoq.ast.mk_retroknowledge.
 Register MetaCoq.Template.Ast.Env.mk_global_env as metacoq.ast.Build_global_env.
 Register MetaCoq.Template.Ast.Env.global_env as metacoq.ast.global_env.
 Register MetaCoq.Template.Ast.Env.global_env_ext as metacoq.ast.global_env_ext.

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -217,7 +217,8 @@ Register MetaCoq.Template.Ast.Env.Build_constant_body as metacoq.ast.Build_const
 Register MetaCoq.Template.Ast.Env.global_decl as metacoq.ast.global_decl.
 Register MetaCoq.Template.Ast.Env.ConstantDecl as metacoq.ast.ConstantDecl.
 Register MetaCoq.Template.Ast.Env.InductiveDecl as metacoq.ast.InductiveDecl.
-Register MetaCoq.Template.Ast.Env.Build_global_env as metacoq.ast.Build_global_env.
+Register MetaCoq.Template.Ast.Env.Retroknowledge.mk_retroknowledge as metacoq.ast.mk_retroknowledge.
+Register MetaCoq.Template.Ast.Env.mk_global_env as metacoq.ast.Build_global_env.
 Register MetaCoq.Template.Ast.Env.global_env as metacoq.ast.global_env.
 Register MetaCoq.Template.Ast.Env.global_env_ext as metacoq.ast.global_env_ext.
 Register MetaCoq.Template.Ast.Env.program as metacoq.ast.program.

--- a/template-coq/theories/Environment.v
+++ b/template-coq/theories/Environment.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import ssreflect ssrfun Morphisms Setoid.
-From MetaCoq.Template Require Import utils BasicAst.
+From MetaCoq.Template Require Import utils BasicAst Primitive.
 From MetaCoq.Template Require Import Universes.
 
 Module Type Term.
@@ -299,21 +299,52 @@ Module Environment (T : Term).
 
   Definition global_declarations := list (kername * global_decl).
 
-  Record global_env := 
+  Module Retroknowledge.
+
+    Record t := mk_retroknowledge { 
+      retro_int63 : option kername;
+      retro_float64 : option kername;
+    }.
+
+    Definition empty := {| retro_int63 := None; retro_float64 := None |}.
+
+    Inductive option_extends {A} : relation (option A) :=
+    | option_ext_fill t : option_extends None (Some t)
+    | option_ext_keep t : option_extends (Some t) (Some t)
+    | option_ext_non : option_extends None None.
+
+    Lemma option_extends_refl {A} (o : option A) : option_extends o o.
+    Proof. destruct o; constructor. Qed.
+
+    Definition extends (x y : t) :=
+      option_extends x.(retro_int63) y.(retro_int63) /\
+      option_extends x.(retro_float64) y.(retro_float64).
+
+    Lemma extends_refl x : extends x x.
+    Proof.
+      split; apply option_extends_refl.
+    Qed.
+  End Retroknowledge.
+
+  Record global_env := mk_global_env
     { universes : ContextSet.t;
-      declarations : global_declarations }.
+      declarations : global_declarations;
+      retroknowledge : Retroknowledge.t }.
 
   Coercion universes : global_env >-> ContextSet.t.
 
   Definition empty_global_env := 
     {| universes := ContextSet.empty;
-       declarations := [] |}.
+       declarations := [];
+       retroknowledge := Retroknowledge.empty |}.
 
   Definition add_global_decl Σ decl := 
     {| universes := Σ.(universes);
-       declarations := decl :: Σ.(declarations) |}.
+       declarations := decl :: Σ.(declarations);
+       retroknowledge := Σ.(retroknowledge) |}.
       
-  Lemma eta_global_env Σ : Σ = {| universes := Σ.(universes); declarations := Σ.(declarations) |}.
+  Lemma eta_global_env Σ : Σ = {| universes := Σ.(universes); declarations := Σ.(declarations);
+    retroknowledge := Σ.(retroknowledge) |}.
   Proof. now destruct Σ. Qed.
   
 
@@ -328,12 +359,14 @@ Module Environment (T : Term).
   Definition lookup_env (Σ : global_env) (kn : kername) := lookup_global Σ.(declarations) kn.
 
   Definition extends (Σ Σ' : global_env) :=
-    Σ.(universes) ⊂_cs Σ'.(universes) ×
-    ∑ Σ'', Σ'.(declarations) = Σ'' ++ Σ.(declarations).
+    [× Σ.(universes) ⊂_cs Σ'.(universes),
+      ∑ Σ'', Σ'.(declarations) = Σ'' ++ Σ.(declarations) & 
+      Retroknowledge.extends Σ.(retroknowledge) Σ'.(retroknowledge)].
   
   Definition extends_decls (Σ Σ' : global_env) :=
-    Σ.(universes) = Σ'.(universes) ×
-    ∑ Σ'', Σ'.(declarations) = Σ'' ++ Σ.(declarations).
+    [× Σ.(universes) = Σ'.(universes),
+       ∑ Σ'', Σ'.(declarations) = Σ'' ++ Σ.(declarations) &
+       Retroknowledge.extends Σ.(retroknowledge) Σ'.(retroknowledge)].
   
   Existing Class extends.
   Existing Class extends_decls.
@@ -345,10 +378,10 @@ Module Environment (T : Term).
   Qed.
 
   #[global] Instance extends_decls_refl : CRelationClasses.Reflexive extends_decls.
-  Proof. red. intros x. now split => //; exists []. Qed.
+  Proof. red. intros x. split => //; try exists [] => //. apply Retroknowledge.extends_refl. Qed.
   
   Lemma extends_refl : CRelationClasses.Reflexive extends.
-  Proof. red. intros x. split; [apply incl_cs_refl | now exists []]. Qed.
+  Proof. red. intros x. split; [apply incl_cs_refl | now exists [] | apply Retroknowledge.extends_refl]. Qed.
 
   (* easy prefers this to the local hypotheses, which is annoying
   #[global] Instance extends_refl : CRelationClasses.Reflexive extends.

--- a/template-coq/theories/Environment.v
+++ b/template-coq/theories/Environment.v
@@ -37,10 +37,16 @@ Module Retroknowledge.
   Definition extends (x y : t) :=
     option_extends x.(retro_int63) y.(retro_int63) /\
     option_extends x.(retro_float64) y.(retro_float64).
+  Existing Class extends.
 
-  Lemma extends_refl x : extends x x.
+  #[global] Instance extends_refl x : extends x x.
   Proof.
     split; apply option_extends_refl.
+  Qed.
+
+  #[global] Instance extends_trans : RelationClasses.Transitive Retroknowledge.extends.
+  Proof.
+    intros x y z [] []; split; cbn; now etransitivity; tea.
   Qed.
 
 End Retroknowledge.

--- a/template-coq/theories/EtaExpand.v
+++ b/template-coq/theories/EtaExpand.v
@@ -139,6 +139,7 @@ Section Eta.
                        ++ string_of_kername ind.(inductive_mind))
         end
     | tCast t1 k t2 => tCast (eta_expand Γ t1) k (eta_expand Γ t2)
+    | tInt _ | tFloat _ => t
     end.
 
 End Eta.
@@ -213,7 +214,8 @@ Definition eta_global_declarations (Σ : GlobalEnvMap.t) (decls : global_declara
   map (on_snd (eta_global_declaration Σ)) decls.
 
 Definition eta_expand_global_env (Σ : GlobalEnvMap.t) : global_env :=
-  {| universes := Σ.(universes); declarations := eta_global_declarations Σ Σ.(declarations) |}.
+  {| universes := Σ.(universes); declarations := eta_global_declarations Σ Σ.(declarations);
+     retroknowledge := Σ.(retroknowledge) |}.
 
 Definition eta_expand_program (p : template_program_env) : Ast.Env.program :=
   let Σ' := eta_expand_global_env p.1 in 
@@ -290,7 +292,9 @@ Inductive expanded (Γ : list nat): term -> Prop :=
     declared_constructor Σ (ind, c) mind idecl cdecl ->
     #|args| >= (ind_npars mind + context_assumptions (cstr_args cdecl)) ->
     Forall (expanded Γ) args ->
-    expanded Γ (tApp (tConstruct ind c u) args).
+    expanded Γ (tApp (tConstruct ind c u) args)
+| expanded_tInt i : expanded Γ (tInt i)
+| expanded_tFloat f : expanded Γ (tFloat f).
 
 End expanded.
 
@@ -352,9 +356,12 @@ forall (Σ : global_env) (P : list nat -> term -> Prop),
  #|args| >= ind_npars mind + context_assumptions (cstr_args cdecl) ->
  Forall (expanded Σ Γ) args ->
  Forall (P Γ) args ->
- P Γ(tApp (tConstruct ind c u) args)) -> forall Γ, forall t : term, expanded Σ Γ t -> P Γ t.
+ P Γ(tApp (tConstruct ind c u) args)) -> 
+(forall Γ i, P Γ (tInt i)) ->
+(forall Γ f, P Γ (tFloat f)) ->
+ forall Γ, forall t : term, expanded Σ Γ t -> P Γ t.
 Proof.
-  intros Σ P HRel HRel_app HVar HEvar HSort HCast HProd HLamdba HLetIn HApp HConst HInd HConstruct HCase HProj HFix HCoFix HConstruct_app.
+  intros Σ P HRel HRel_app HVar HEvar HSort HCast HProd HLamdba HLetIn HApp HConst HInd HConstruct HCase HProj HFix HCoFix HConstruct_app Hint Hfloat.
   fix f 3.
   intros Γ t Hexp.  destruct Hexp; eauto.
   all: match goal with [H : Forall _ _ |- _] => let all := fresh "all" in rename H into all end.
@@ -404,14 +411,14 @@ Definition expanded_decl Σ d :=
   | Ast.Env.InductiveDecl idecl => expanded_minductive_decl Σ idecl
   end.
     
-Inductive expanded_global_declarations (univs : ContextSet.t) : forall (Σ : Ast.Env.global_declarations), Prop :=
-| expanded_global_nil : expanded_global_declarations univs []
-| expanded_global_cons decl Σ : expanded_global_declarations univs Σ -> 
-  expanded_decl {| Ast.Env.universes := univs; Ast.Env.declarations := Σ |} decl.2 ->
-  expanded_global_declarations univs (decl :: Σ).
+Inductive expanded_global_declarations (univs : ContextSet.t) (retro : Retroknowledge.t) : forall (Σ : Ast.Env.global_declarations), Prop :=
+| expanded_global_nil : expanded_global_declarations univs retro []
+| expanded_global_cons decl Σ : expanded_global_declarations univs retro Σ -> 
+  expanded_decl {| Ast.Env.universes := univs; Ast.Env.declarations := Σ; Ast.Env.retroknowledge := retro |} decl.2 ->
+  expanded_global_declarations univs retro (decl :: Σ).
 
 Definition expanded_global_env (g : Ast.Env.global_env) :=
-  expanded_global_declarations g.(Ast.Env.universes) g.(Ast.Env.declarations).
+  expanded_global_declarations g.(Ast.Env.universes) g.(Ast.Env.retroknowledge) g.(Ast.Env.declarations).
 
 Definition expanded_program (p : Ast.Env.program) :=
   expanded_global_env p.1 /\ expanded p.1 [] p.2.
@@ -1480,7 +1487,10 @@ Proof.
 Qed.
 
 Lemma same_cstr_info_eta (Σ : global_env) (Σg: GlobalEnvMap.t) :
-  same_cstr_info Σ {| universes := Σ.(universes) ; declarations := List.map (on_snd (eta_global_declaration Σg)) Σ.(declarations) |}.
+  same_cstr_info Σ 
+    {| universes := Σ.(universes) ; 
+       declarations := List.map (on_snd (eta_global_declaration Σg)) Σ.(declarations);
+       retroknowledge := Σ.(retroknowledge) |}.
 Proof.
   destruct Σ as [univs Σ]; cbn.
   induction Σ; intros ind idx mdecl idecl cdecl.
@@ -1525,9 +1535,9 @@ Lemma lookup_global_extends Σ Σ' kn d :
   EnvMap.fresh_globals Σ'.(declarations) ->
   lookup_env Σ' kn = Some d.
 Proof.
-  destruct Σ as [univs Σ]. 
-  destruct Σ' as [univs' Σ'].
-  cbn. move=> hl [] /=; intros <- [Σ'' ->].
+  destruct Σ as [univs Σ retro]. 
+  destruct Σ' as [univs' Σ' retro'].
+  cbn. move=> hl [] /=; intros <- [Σ'' ->] extretro.
   induction Σ''; cbn; auto.
   case: eqb_spec.
   - intros ->. intros fr.
@@ -1545,15 +1555,17 @@ Proof.
   unfold Typing.wf, Typing.on_global_env. intros [onu ond].
   cbn in *.
   destruct Σ as []. cbn in *.
-  assert (extends_decls env env). red; split => //. now exists [].
+  assert (extends_decls env env). red; split => //. now exists []. apply Retroknowledge.extends_refl.
   revert X.
   move: map repr wf.
-  generalize env at 1 2 4 6.
-  destruct env as [univs' decls]. cbn in *.
+  generalize env at 1 2 4 6 7.
+  destruct env as [univs' decls retro']. cbn in *.
   induction ond; cbn; constructor; auto.
-  apply: IHond. cbn. destruct X as [equ [Σ' ext]]. red. split. auto. 
-  rewrite ext. cbn. unfold snoc. exists (Σ' ++ [(kn, d)])%list. now rewrite -app_assoc.
-  set (Σ' := {| universes := univs'; declarations := Σ |}) in *.
+  apply: IHond.
+  { cbn. destruct X as [equ [Σ' ext]]. red. split. auto. 
+    rewrite ext. cbn. unfold snoc. exists (Σ' ++ [(kn, d)])%list. now rewrite -app_assoc.
+    apply e. }
+  set (Σ' := {| universes := univs'; declarations := Σ; retroknowledge := retro' |}) in *.
   set (Σg := {| GlobalEnvMap.env := _ |}). Unshelve.
   destruct X as [equ [Σ'' ext]]. cbn in *. destruct env as [univs0 env]. cbn in *. subst univs0.
   subst env.
@@ -1565,7 +1577,7 @@ Proof.
     cbn. unfold snoc.
     eapply (lookup_global_extends {| universes := univs'; declarations := Σ |}
       {| universes := univs'; declarations := (Σ'' ++ (kn, d) :: Σ)%list |}); eauto.
-    split => //. cbn. now exists (Σ'' ++ [(kn, d)])%list; rewrite -app_assoc. }
+    split => //. cbn. now exists (Σ'' ++ [(kn, d)])%list; rewrite -app_assoc. eauto. }
   forward H. split. cbn. split => //. now cbn.
   specialize (H o0).
   eapply expanded_decl_env_irrel in H; tea.

--- a/template-coq/theories/EtaExpand.v
+++ b/template-coq/theories/EtaExpand.v
@@ -411,7 +411,7 @@ Definition expanded_decl Σ d :=
   | Ast.Env.InductiveDecl idecl => expanded_minductive_decl Σ idecl
   end.
     
-Inductive expanded_global_declarations (univs : ContextSet.t) (retro : Retroknowledge.t) : forall (Σ : Ast.Env.global_declarations), Prop :=
+Inductive expanded_global_declarations (univs : ContextSet.t) (retro : Environment.Retroknowledge.t) : forall (Σ : Ast.Env.global_declarations), Prop :=
 | expanded_global_nil : expanded_global_declarations univs retro []
 | expanded_global_cons decl Σ : expanded_global_declarations univs retro Σ -> 
   expanded_decl {| Ast.Env.universes := univs; Ast.Env.declarations := Σ; Ast.Env.retroknowledge := retro |} decl.2 ->
@@ -1555,7 +1555,7 @@ Proof.
   unfold Typing.wf, Typing.on_global_env. intros [onu ond].
   cbn in *.
   destruct Σ as []. cbn in *.
-  assert (extends_decls env env). red; split => //. now exists []. apply Retroknowledge.extends_refl.
+  assert (extends_decls env env). red; split => //. now exists [].
   revert X.
   move: map repr wf.
   generalize env at 1 2 4 6 7.
@@ -1575,9 +1575,8 @@ Proof.
     move=> kn' d' /= hl.
     rewrite GlobalEnvMap.lookup_env_spec /=.
     cbn. unfold snoc.
-    eapply (lookup_global_extends {| universes := univs'; declarations := Σ |}
-      {| universes := univs'; declarations := (Σ'' ++ (kn, d) :: Σ)%list |}); eauto.
-    split => //. cbn. now exists (Σ'' ++ [(kn, d)])%list; rewrite -app_assoc. eauto. }
+    eapply (lookup_global_extends Σ' (set_declarations Σ' (Σ'' ++ (kn, d) :: Σ)%list)); eauto.
+    split => //. cbn. now exists (Σ'' ++ [(kn, d)])%list; rewrite -app_assoc. }
   forward H. split. cbn. split => //. now cbn.
   specialize (H o0).
   eapply expanded_decl_env_irrel in H; tea.

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -7,10 +7,8 @@
 
 From Coq Require Ascii Extraction ZArith NArith.
 From MetaCoq.Template Require Import utils Ast Reflect Induction.
-From Coq Require Import FSets ExtrOcamlBasic ExtrOCamlFloats
-    ExtrOCamlInt63.
-From MetaCoq.Template Require Import MC_ExtrOCamlZPosInt.
- 
+From Coq Require Import FSets ExtrOcamlBasic ExtrOCamlFloats ExtrOCamlInt63.
+
 (* Ignore [Decimal.int] before the extraction issue is solved:
   https://github.com/coq/coq/issues/7017. *)
 Extract Inductive Decimal.int => unit [ "(fun _ -> ())" "(fun _ -> ())" ] "(fun _ _ _ -> assert false)".

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -30,8 +30,8 @@ Lemma term_forall_list_ind :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (* (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->     *)
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -73,8 +73,8 @@ Lemma term_forall_list_rect :
     (forall (s : projection) (t : term), P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tCoFix m n)) ->
-    (* (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) ->     *)
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -302,11 +302,18 @@ Module PrintTermTree.
     | Polymorphic_entry names uctx => Polymorphic_ctx (names, UContext.constraints uctx)
     end.
 
+  Definition print_recursivity_kind k :=
+    match k with
+    | Finite => "Inductive"
+    | CoFinite => "CoInductive"
+    | BiFinite => "Variant"
+    end.
+
   Definition print_mib Σ with_universes (short : bool) (mib : mutual_inductive_body) : t :=
     let Σ' := (Σ, mib.(ind_universes)) in
     let names := fresh_names Σ' [] (arities_context mib.(ind_bodies)) in
-      ("Inductive " ^ 
-      print_list (print_one_ind Σ' with_universes short names mib) nl mib.(ind_bodies) ^ "." ^ nl).
+      (print_recursivity_kind mib.(ind_finite) ^ " " ^ 
+      print_list (print_one_ind Σ' with_universes short names mib) (nl ^ "with ") mib.(ind_bodies) ^ "." ^ nl).
 
   Definition mie_arities_context mie := 
     rev_map (fun ind => vass (mkBindAnn (nNamed ind.(mind_entry_typename)) Relevant) 
@@ -316,8 +323,8 @@ Module PrintTermTree.
   Definition print_mie Σ with_universes (short : bool) (mie : mutual_inductive_entry) : t :=
     let Σ' := (Σ, universes_decl_of_universes_entry mie.(mind_entry_universes)) in
     let names := fresh_names Σ' [] (mie_arities_context mie) in
-      ("Inductive " ^ 
-      print_list (print_one_ind_entry Σ' with_universes short names mie) nl mie.(mind_entry_inds) ^ "." ^ nl).
+      (print_recursivity_kind mie.(mind_entry_finite) ^ " " ^
+      print_list (print_one_ind_entry Σ' with_universes short names mie) (nl ^ "with ") mie.(mind_entry_inds) ^ "." ^ nl).
     
   Fixpoint print_env_aux with_universes (short : bool) (prefix : nat) (Σ : global_env) (acc : t) : t := 
     match prefix with 

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -1,5 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq Require Import utils Ast AstUtils Environment LiftSubst Universes.
+From MetaCoq Require Import utils Ast AstUtils Primitive Environment LiftSubst Universes.
 
 (** * Pretty printing *)
 
@@ -248,8 +248,8 @@ Module PrintTermTree.
   | tCoFix l n =>
     parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ binder_name ∘ dname) l) n)
-  (* | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
-  | tFloat f => "Float(" ^ string_of_float f ^ ")" *)
+  | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
+  | tFloat f => "Float(" ^ string_of_float f ^ ")"
   end.
 
   Definition pr_context_decl Γ (c : context_decl) : ident * t :=
@@ -324,13 +324,14 @@ Module PrintTermTree.
     | 0 => match Σ.(declarations) with [] => acc | _ => ("..." ^ nl ^ acc) end
     | S n => 
       let univs := Σ.(Env.universes) in
+      let retro := Σ.(Env.retroknowledge) in
       match Σ.(declarations) with
       | [] => acc
       | (kn, InductiveDecl mib) :: Σ => 
-        let Σ := {| Env.universes := univs; declarations := Σ |} in
+        let Σ := {| Env.universes := univs; declarations := Σ; retroknowledge := retro |} in
         print_env_aux with_universes short n Σ (print_mib Σ with_universes short mib ^ acc)
       | (kn, ConstantDecl cb) :: Σ =>
-        let Σ' := ({| Env.universes := univs; declarations := Σ |}, cb.(cst_universes)) in
+        let Σ' := ({| Env.universes := univs; declarations := Σ; retroknowledge := retro |}, cb.(cst_universes)) in
         print_env_aux with_universes short n Σ'.1
           ((match cb.(cst_body) with 
             | Some _ => "Definition "

--- a/template-coq/theories/Primitive.v
+++ b/template-coq/theories/Primitive.v
@@ -1,6 +1,6 @@
 (* Primitive types *)
 
-From Coq Require Import Int63 PrimFloat.
+From Coq Require Import Uint63 PrimFloat.
 From MetaCoq.Template Require Import bytestring MCString.
 Local Open Scope bs.
 
@@ -10,9 +10,9 @@ Variant prim_tag :=
   (* | primArray. *)
 Derive NoConfusion EqDec for prim_tag.
 
-Definition string_of_prim_int (i:Int63.int) : string := 
+Definition string_of_prim_int (i:Uint63.int) : string := 
   (* Better? DecimalString.NilZero.string_of_uint (BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). ? *)
-  string_of_Z (Numbers.Cyclic.Int63.Uint63.to_Z i).
+  string_of_Z (Uint63.to_Z i).
 
 Definition string_of_float (f : PrimFloat.float) :=
   "<float>".

--- a/template-coq/theories/Primitive.v
+++ b/template-coq/theories/Primitive.v
@@ -1,0 +1,18 @@
+(* Primitive types *)
+
+From Coq Require Import Int63 PrimFloat.
+From MetaCoq.Template Require Import bytestring MCString.
+Local Open Scope bs.
+
+Variant prim_tag := 
+  | primInt
+  | primFloat.
+  (* | primArray. *)
+Derive NoConfusion EqDec for prim_tag.
+
+Definition string_of_prim_int (i:Int63.int) : string := 
+  (* Better? DecimalString.NilZero.string_of_uint (BinNat.N.to_uint (BinInt.Z.to_N (Int63.to_Z i))). ? *)
+  string_of_Z (Numbers.Cyclic.Int63.Uint63.to_Z i).
+
+Definition string_of_float (f : PrimFloat.float) :=
+  "<float>".

--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -152,10 +152,10 @@ Proof.
         subst. inversion e1. subst.
         destruct (eq_dec rarg rarg0) ; nodec.
         subst. left. reflexivity.
-  (* - destruct (Int63.eqs i i0) ; nodec.
+  - destruct (Int63.eqs i i0) ; nodec.
     subst. left. reflexivity.
   - destruct (eq_dec f f0) ; nodec.
-    subst. left. reflexivity. *)
+    subst. left. reflexivity.
 Defined.
 
 #[global] Instance reflect_term : ReflectEq term :=

--- a/template-coq/theories/TermEquality.v
+++ b/template-coq/theories/TermEquality.v
@@ -256,10 +256,10 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
   eq_term_upto_univ_napp Σ Re Re 0 t1 t1' ->
   eq_cast_kind c c' ->
   eq_term_upto_univ_napp Σ Re Re 0 t2 t2' ->
-  eq_term_upto_univ_napp Σ Re Rle napp (tCast t1 c t2) (tCast t1' c' t2').
+  eq_term_upto_univ_napp Σ Re Rle napp (tCast t1 c t2) (tCast t1' c' t2')
 
-(* | eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
-| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f). *)
+| eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
+| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f).
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -1545,7 +1545,7 @@ Proof.
   case: eqb_specT => [-> [= <-]| ne].
   - exists ({| universes := univs; declarations := Σ; retroknowledge := retro |}, udecl).
     split; try constructor; tas.
-    cbn. split => //=. now exists [(kn, d)]. apply Retroknowledge.extends_refl.
+    cbn. split => //=. now exists [(kn, d)].
   - intros hl.
     destruct (IHond hl) as [[Σ' udecl'] [ong [[equ ext extretro] ond']]].
     exists (Σ', udecl'). cbn in equ |- *. subst univs. split; cbn; auto; try apply ong.

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -1540,16 +1540,17 @@ Lemma lookup_on_global_env `{checker_flags} {Pcmp P} {Σ : global_env} {c decl} 
   { Σ' : global_env_ext & on_global_env Pcmp P Σ' × extends_decls Σ' Σ × on_global_decl Pcmp P Σ' c decl }.
 Proof.
   unfold on_global_env.
-  destruct Σ as [univs Σ]; cbn. intros [cu ond].
+  destruct Σ as [univs Σ retro]; cbn. intros [cu ond].
   induction ond; cbn in * => //.
   case: eqb_specT => [-> [= <-]| ne].
-  - exists ({| universes := univs; declarations := Σ |}, udecl).
+  - exists ({| universes := univs; declarations := Σ; retroknowledge := retro |}, udecl).
     split; try constructor; tas.
-    cbn. now split => //; exists [(kn, d)].
+    cbn. split => //=. now exists [(kn, d)]. apply Retroknowledge.extends_refl.
   - intros hl.
-    destruct (IHond hl) as [[Σ' udecl'] [ong [[equ ext] ond']]].
-    exists (Σ', udecl'). cbn in equ |- *. subst univs. repeat split; cbn; auto; try apply ong.
-    cbn in ext. destruct ext as [Σ'' ->]. cbn.
+    destruct (IHond hl) as [[Σ' udecl'] [ong [[equ ext extretro] ond']]].
+    exists (Σ', udecl'). cbn in equ |- *. subst univs. split; cbn; auto; try apply ong.
+    split; cbn; auto. split; cbn; auto.
+    cbn in ext. destruct ext as [Σ'' ->]. cbn in *.
     now exists ((kn, d) :: Σ'').
 Qed.
 

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -179,8 +179,8 @@ Hint Extern 10 => constructor : wf.
 #[global]
 Hint Resolve All_skipn : wf.
 
-Lemma on_global_decls_extends_not_fresh {cf} {univs} k (Σ : global_declarations) k' (Σ' : global_declarations) P : 
-  on_global_decls cumul_gen P univs ((k :: Σ) ++ [k'] ++ Σ') -> k.1 = k'.1 -> False.
+Lemma on_global_decls_extends_not_fresh {cf} {univs retro} k (Σ : global_declarations) k' (Σ' : global_declarations) P : 
+  on_global_decls cumul_gen P univs retro ((k :: Σ) ++ [k'] ++ Σ') -> k.1 = k'.1 -> False.
 Proof.
   intros H eq.
   depelim H.

--- a/template-coq/theories/WfAst.v
+++ b/template-coq/theories/WfAst.v
@@ -54,9 +54,9 @@ Inductive wf {Σ} : term -> Type :=
   wf (tProj p t)
 | wf_tFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix ->
                    wf (tFix mfix k)
-| wf_tCoFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix -> wf (tCoFix mfix k).
-(* | wf_tInt i : wf (tInt i) *)
-(* | wf_tFloat f : wf (tFloat f). *)
+| wf_tCoFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix -> wf (tCoFix mfix k)
+| wf_tInt i : wf (tInt i)
+| wf_tFloat f : wf (tFloat f).
 Arguments wf : clear implicits.
 Derive Signature for wf.
 
@@ -65,7 +65,7 @@ Derive Signature for wf.
 Definition wf_Inv Σ (t : term) : Type :=
   match t with
   | tRel _ | tVar _ | tSort _ => unit
-  (* | tInt _ | tFloat _  *)
+  | tInt _ | tFloat _ => unit
   | tEvar n l => All (wf Σ) l
   | tCast t k t' => wf Σ t * wf Σ t'
   | tProd na t b => wf Σ t * wf Σ b
@@ -147,11 +147,11 @@ Lemma term_wf_forall_list_ind Σ :
       P t -> P (tProj s t)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tFix m n)) ->
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
-    (* (forall i, P (tInt i)) ->
-    (forall f, P (tFloat f)) -> *)
+    (forall i, P (tInt i)) ->
+    (forall f, P (tFloat f)) ->
     forall t : term, wf Σ t -> P t.
 Proof.
-  intros P H2 H3 H4 H5 H6 H7 H8 H9 H10 H11 H12 H13 H14 H15 H16 H17 (*H18 H19*).
+  intros P H2 H3 H4 H5 H6 H7 H8 H9 H10 H11 H12 H13 H14 H15 H16 H17 H18 H19.
   intros until t. revert t.
   apply (term_forall_list_rect (fun t => wf Σ t -> P t));
     intros; try solve [match goal with

--- a/template-coq/theories/utils/MCOption.v
+++ b/template-coq/theories/utils/MCOption.v
@@ -187,3 +187,19 @@ Lemma foroptb_impl {A} (f g : A -> bool) x : (forall x, f x -> g x) -> foroptb f
 Proof.
   move=> Hf; destruct x; simpl => //; apply Hf.
 Qed.
+
+(* Extension *)
+
+Inductive option_extends {A} : relation (option A) :=
+| option_ext_fill t : option_extends None (Some t)
+| option_ext_keep t : option_extends (Some t) (Some t)
+| option_ext_non : option_extends None None.
+Derive Signature for option_extends.
+
+#[export] Instance option_extends_refl {A} : RelationClasses.Reflexive (@option_extends A).
+Proof. intros []; constructor. Qed.
+
+#[export] Instance option_extends_trans {A} : RelationClasses.Transitive (@option_extends A).
+Proof.
+  intros x y z [] H; inv H; constructor.
+Qed.

--- a/translations/param_binary.v
+++ b/translations/param_binary.v
@@ -144,7 +144,7 @@ Fixpoint tsl_rec1_app (app : list term) (E : tsl_table) (t : term) : term :=
   | tFix _ _ | tCoFix _ _ => todo "tsl"
   | tVar _ | tEvar _ _ => todo "tsl"
   | tLambda _ _ _ => tVar "impossible"
-  (* | tInt _ | tFloat _ => todo "impossible" *)
+  | tInt _ | tFloat _ => todo "tsl"
   end
   in apply app t1
   end.

--- a/translations/param_original.v
+++ b/translations/param_original.v
@@ -105,7 +105,7 @@ Fixpoint tsl_rec1_app (app : option term) (E : tsl_table) (t : term) : term :=
   | tFix _ _ | tCoFix _ _ => todo "tsl"
   | tVar _ | tEvar _ _ => todo "tsl"
   | tLambda _ _ _ => tVar "impossible"
-  (* | tInt _ | tFloat _ => todo "impossible" *)
+  | tInt _ | tFloat _ => todo "tsl"
   end in
   match app with Some t' => mkApp t1 (t' {3 := tRel 1} {2 := tRel 0})
                | None => t1 end


### PR DESCRIPTION
This PR adds back support for primitive values (including typing and erasure this time!) and fixes the treatment of cofix/coinductives.

- To typecheck primitive values, we reify the "retroknowledge" field of Coq's global environments. This is a mapping from a fixed set of primitive types (e.g. int and float, called primitive tags) to axioms in the environment (i.e. constants with no bodies). The typechecking rule for a primitive value requires the primitive tag to be bound to a monomorphic axiom whose sort is Set. Most of the theory goes through unmodified with this change. Note that we do not support the computational behavior of primitive functions in reduction at this point. Through all phases we just pass around these primitive values seen as black boxes. To simplify reasoning with weakening, we do not ask anything about the retroknowledge field for well-formed global environments, it is only the term typing rule which requires the tag to be bound to a declared constant.

- For CoFixpoints/CoInductives, we now pass around the `ind_finite` field of (co-)inductive declarations down to EAst, and fix a wrong quoting (in the extracted quoter) of CoFix into Fix. We add a pass to erasure which transforms cofixpoints to fixpoints and thunks coinductive constructors. `Stream.Cons x xs` becomes `fun _ => Stream.Cons x xs` and cases/projections on coinductive types force their discriminee. Using this we can simply transform `tCoFix` to `tFix`: the fixpoints will unroll freely but become blocked at the first thunk (which must appear before any recursive call due to the guarded-by-constructors syntactic criterion).

CertiCoq can be adapted with these two changes straightforwardly (the only subtlety there is to implement primitive ints correctly), I'll link the PR here.