### PR TITLE
Register projections when defining a new inductive type

### DIFF
--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -292,16 +292,38 @@ let declare_inductive (env: Environ.env) (evm: Evd.evar_map) (infer_univs : bool
   let mind = reduce_all env evm mind in
   let evm' = Evd.from_env env in
   let evm', mind = unquote_mutual_inductive_entry env evm' mind in
-  let evm, mind = 
+  let evm, mind =
     if infer_univs then
       let ctx, mind = Tm_util.RetypeMindEntry.infer_mentry_univs env evm' mind in
       debug (fun () -> Pp.(str "Declaring universe context " ++ Univ.pr_universe_context_set (Level.pr) ctx));
-      DeclareUctx.declare_universe_context ~poly:false ctx; 
+      DeclareUctx.declare_universe_context ~poly:false ctx;
       Evd.merge_context_set Evd.UnivRigid evm ctx, mind
     else evm, mind
   in
   let names = Id.Map.empty in
-  ignore (DeclareInd.declare_mutual_inductive_with_eliminations mind names []);
+  let primitive_expected =
+    match mind.mind_entry_record with
+    | Some (Some _) -> true
+    | _ -> false
+  in
+  let ind_kn = DeclareInd.declare_mutual_inductive_with_eliminations ~primitive_expected mind names [] in
+  if primitive_expected
+  then begin
+    let open Record.Internal in
+    let dflt_pf = {pf_subclass = false ; pf_canonical = false} in
+    let decl_projs i oie =
+      let ind = (ind_kn, i) in
+      let univs = Entries.Monomorphic_entry Univ.ContextSet.empty in
+      let inhabitant_id = List.hd oie.mind_entry_consnames in
+      let fields, _ = Term.decompose_prod_assum (List.hd oie.mind_entry_lc) in
+      let fieldimpls = List.map (fun _ -> []) fields in
+      let pfs = List.map (fun _ -> dflt_pf) fields in
+      let projections = Record.Internal.declare_projections ind univs ~kind:Decls.Definition inhabitant_id pfs fieldimpls fields in
+      let struc = Structures.Structure.make (Global.env()) ind projections in
+      Record.Internal.declare_structure_entry struc
+    in
+    List.iteri decl_projs mind.mind_entry_inds
+  end;
   evm
 
 let not_in_tactic s =

--- a/test-suite/bug369.v
+++ b/test-suite/bug369.v
@@ -1,0 +1,40 @@
+From MetaCoq.Template Require Import utils All.
+
+Definition anonb := {| binder_name := nAnon; binder_relevance := Relevant |}.
+Definition bnamed n := {| binder_name := nNamed n; binder_relevance := Relevant |}.
+
+Definition mkImpl (A B : term) : term :=
+  tProd anonb A B.
+
+Definition mkImplN name (A B : term) : term :=
+  tProd (bnamed name) A B.
+
+Definition one_pt_i : one_inductive_entry :=
+{|
+  mind_entry_typename := "Point";
+  mind_entry_arity := tSort Universe.type0;
+  mind_entry_consnames := ["mkPoint"];
+  mind_entry_lc := [
+    mkImplN "coordx"%bs (tRel 0) (mkImplN "coordy"%bs (tRel 1) (tApp (tRel 3) [tRel 2]))];
+|}.
+
+Definition mut_pt_i : mutual_inductive_entry :=
+{|
+  mind_entry_record := Some (Some "mkPoint" (* Irrelevant *));
+  mind_entry_finite := BiFinite;
+  mind_entry_params := [{| decl_name := bnamed "A"; decl_body := None;
+                         decl_type := (tSort Universe.type0) |}];
+  mind_entry_inds := [one_pt_i];
+  mind_entry_universes := Monomorphic_entry ContextSet.empty;
+  mind_entry_template := false;
+  mind_entry_variance := None;
+  mind_entry_private := None;
+|}.
+
+MetaCoq Unquote Inductive mut_pt_i.
+
+Check fun p => p.(coordx _).
+Check {| coordx := 0 ; coordy := 1 |}.
+
+Check eq_refl : {| coordx := 0 ; coordy := 1 |}.(coordx _) = 0.
+


### PR DESCRIPTION
Should fix #369

Inspired from the corresponding implementation in [coq-elpi](https://github.com/LPCIC/coq-elpi/blob/640b3cf38d7f84c6f107f6482c8a52f7f9ddda72/src/coq_elpi_builtins.ml#L1801-L1827).

For coq 8.15, [this branch](https://github.com/kyoDralliam/metacoq/tree/register-projections) should be adapted once this PR is merged and ported. 