### PR TITLE
Fix line ending issues with generated code on Windows

### DIFF
--- a/template-coq/update_plugin.sh
+++ b/template-coq/update_plugin.sh
@@ -12,6 +12,12 @@ then
     echo "Renaming files to camelCase"
     (cd gen-src; ./to-lower.sh)
     rm -f gen-src/*.d gen-src/*.cm*
+    echo "Prepare line endings for patching (for Windows)"
+    for f in gen-src/*.ml*
+    do
+      tr -d '\r' < "$f" > tmp
+      mv -f tmp $f
+    done
     # Fix an extraction bug: wrong type annotation on eq_equivalence
     patch -N -p0 < extraction.patch
     patch -N -p0 < specFloat.patch


### PR DESCRIPTION
This PR fixes #764.

I checked in a local build that there are no other Windows issues with coq-metacoq.

One could reduce the CR removal to those files patched, but I think the few extra seconds CPU time are worth the flexibility.

Currently I have the patch in the Coq Platform local opam patch repo. There are a few options:
- I keep this Coq Platform local
- I push the patched opam package to the main Coq opam repo
- You update the tag
- You create a new tag

Please let me know which way you want to go. I would recommend to push the patched opam package upstream and keep the tag as is.