### PR TITLE
Use `match` for `on_constructor.on_ctype_variance`

### DIFF
--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -4832,9 +4832,8 @@ Proof.
           apply/and3P; split => //.
           rewrite on_free_vars_ctx_smash //.
           len. rewrite on_free_vars_expand_lets_k //. }
-        { intros v indv.
-          move: (on_ctype_variance v indv). clear -indv parsfvs onVariance onc X onu ond onud IHX onParams oncargs oncindices.
-          rewrite indv in onVariance.
+        { move: (on_ctype_variance). clear -parsfvs onVariance onc X onu ond onud IHX onParams oncargs oncindices.
+          cbn. destruct ind_variance => //.
           eapply variance_universes_insts in onVariance as [univs' [u [u' [eqv hunivs cu cu' equlen eqvlen equ' cli equ]]]].
           rewrite /cstr_respects_variance.
           rewrite eqv.

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -2612,7 +2612,7 @@ Proof.
     destruct ind_variance eqn:indv => //.
     move=> [=] eq. subst l0.
     pose proof (onc.(on_ctype_variance)) as respv.
-    specialize (respv _ indv).
+    rewrite indv in respv.
     simpl in respv.
     unfold cstr_respects_variance in respv.
     destruct variance_universes as [[[v i] i']|] eqn:vu => //.
@@ -3043,7 +3043,7 @@ Proof.
     constructor. eapply eq_term_leq_term.
       eapply eq_term_upto_univ_subst_instance; eauto. all:tc. }
   simpl in Ru.
-  epose proof (on_ctype_variance o _ eqv).
+  pose proof (on_ctype_variance o) as X. rewrite eqv in X.
   red in X.
   destruct variance_universes as [[[udecl inst] inst']|] eqn:vu => //.
   destruct X as [onctx _]. simpl in onctx.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -3181,9 +3181,8 @@ Proof.
                 constructor 4. len. eapply trans_closedn => //.
                 now apply IHp. }
               { cbn. now apply IHon_ctype_positive. }
-            + intros v indv.
-              specialize (on_ctype_variance _ indv).
-              cbn -[Σg].
+            + cbn -[Σg].
+              destruct Ast.Env.ind_variance => //.
               eapply trans_cstr_respects_variance => //.
               { do 2 red in onty. destruct onty as [s hs].
                 rewrite ceq in hs. eapply PCUICClosedTyp.subject_closed in hs.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -165,8 +165,8 @@ Proof.
         generalize (cstr_indices x0).
         induction 1; constructor; eauto.
       * simpl.
-        intros v indv. specialize (on_ctype_variance v indv).
         simpl in *. move: on_ctype_variance.
+        destruct ind_variance => //.
         unfold cstr_respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
         intros [args idxs]. split.
         ** eapply (All2_fold_impl args); intros.
@@ -242,8 +242,8 @@ Proof.
         generalize (cstr_indices x0).
         induction 1; constructor; eauto.
       * simpl.
-        intros v indv. specialize (on_ctype_variance v indv).
         simpl in *. move: on_ctype_variance.
+        destruct ind_variance => //.
         unfold cstr_respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
         intros [args idxs]. split.
         ** eapply (All2_fold_impl args); intros.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1617,9 +1617,8 @@ Section CheckEnv.
     (mdeclvar : forall Σ, abstract_env_rel X Σ -> ∥ on_variance Σ mdecl.(ind_universes) mdecl.(ind_variance) ∥) cs
     (wfX : forall Σ, abstract_env_rel X Σ -> ∥ wf_ext (Σ, ind_universes mdecl) ∥)
     (wfΓ : forall Σ, abstract_env_rel X Σ -> ∥ wt_indices (Σ, ind_universes mdecl) mdecl indices cs ∥) :
-    EnvCheck X_env_ext_type (forall Σ, abstract_env_rel X Σ -> ∥ forall v : list Variance.t,
-                    mdecl.(ind_variance) = Some v ->
-                    cstr_respects_variance cumulSpec0 Σ mdecl v cs ∥) :=
+    EnvCheck X_env_ext_type (forall Σ, abstract_env_rel X Σ -> ∥ match mdecl.(ind_variance) with None => True | Some v =>
+                    cstr_respects_variance cumulSpec0 Σ mdecl v cs end ∥) :=
     match mdecl.(ind_variance) with
     | None => ret _
     | Some v =>
@@ -1700,9 +1699,6 @@ Section CheckEnv.
     now rewrite /wf_ctx_universes /app_context forallb_app andb_comm.
   Qed.
 
-  Next Obligation.
-      sq. by [].
-    Qed.
     Next Obligation.
       pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]].
       specialize (mdeclvar _ wfΣ0). specialize_Σ wfΣ0.
@@ -1783,7 +1779,6 @@ Section CheckEnv.
       pose proof (abstract_env_exists X) as [[Σ0 wfΣ0]].
       destruct Xprop as [Xprop ?]; eauto.
       specialize (Xprop Σ0 wfΣ0). specialize_Σ Xprop. sq.
-      intros v0 [= <-].
       red. rewrite -Heq_anonymous.
       split; auto. erewrite (abstract_env_irr _ _ wfΣ0); eauto.
       now apply leq_context_cumul_context.
@@ -1901,6 +1896,7 @@ Section CheckEnv.
         rewrite it_mkProd_or_LetIn_app. autorewrite with len. lia_f_equal.
         rewrite /cstr_concl /=. f_equal. rewrite /cstr_concl_head. lia_f_equal.
       - now destruct wtinds.
+      - destruct ind_variance => //.
       - destruct lets_in_constructor_types; eauto.
     Qed.
 

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -944,8 +944,8 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
 
       on_ctype_variance : (* The constructor type respect the variance annotation
         on polymorphic universes, if any. *)
-        forall v, ind_variance mdecl = Some v ->
-        cstr_respects_variance Σ mdecl v cdecl;
+        match ind_variance mdecl with None => True | Some v =>
+        cstr_respects_variance Σ mdecl v cdecl end;
 
       on_lets_in_type : if lets_in_constructor_types
                         then True else is_true (is_assumption_context (cstr_args cdecl))


### PR DESCRIPTION
This improves code consistency a bit (I hope) and makes my job in quoting typing judgments easier.