### PR TITLE
Bring back ReflectEq instances in ReflectAst

### DIFF
--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -163,10 +163,10 @@ Defined.
 
 #[global] Instance eqb_ctx : ReflectEq context := _.
 
-(* Definition eqb_constant_body (x y : constant_body) :=
-  let (tyx, bodyx, univx) := x in
-  let (tyy, bodyy, univy) := y in
-  eqb tyx tyy && eqb bodyx bodyy && eqb univx univy.
+Definition eqb_constant_body (x y : constant_body) :=
+  let (tyx, bodyx, univx, relx) := x in
+  let (tyy, bodyy, univy, rely) := y in
+  eqb tyx tyy && eqb bodyx bodyy && eqb univx univy && eqb relx rely.
 
 #[global] Instance reflect_constant_body : ReflectEq constant_body.
 Proof.
@@ -187,6 +187,18 @@ Proof.
   refine {| eqb := eqb_constructor_body |}.
   intros [] [].
   unfold eqb_constructor_body; cbn -[eqb]. finish_reflect.
+Defined.
+
+Definition eqb_projection_body (x y : projection_body) :=
+  x.(proj_name) ==? y.(proj_name) &&
+  x.(proj_type) ==? y.(proj_type) &&
+  x.(proj_relevance) ==? y.(proj_relevance).
+
+#[global] Instance reflect_projection_body : ReflectEq projection_body.
+Proof.
+  refine {| eqb := eqb_projection_body |}.
+  intros [] [].
+  unfold eqb_projection_body; cbn -[eqb]; finish_reflect.
 Defined.
 
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
@@ -230,4 +242,4 @@ Proof.
   refine {| eqb := eqb_global_decl |}.
   unfold eqb_global_decl.
   intros [] []; finish_reflect.
-Defined. *)
+Defined.

--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -188,7 +188,7 @@ Proof.
   intros [] [].
   unfold eqb_constructor_body; cbn -[eqb]. finish_reflect.
 Defined.
-  
+
 Definition eqb_one_inductive_body (x y : one_inductive_body) :=
   x.(ind_name) ==? y.(ind_name) &&
   x.(ind_indices) ==? y.(ind_indices) &&


### PR DESCRIPTION
I want them for proving well-typedness of quotation of terms in proving Löb's theorem.