### PR TITLE
Move Template.TypingWf.on_option to Template.utils.MCOption.on_some_or_none

### DIFF
--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -845,18 +845,11 @@ Section WfRed.
     eauto using wf_extends.
   Qed.
 
-  (* TODO MOVE *)
-  Definition on_option {A} (P : A -> Type) (o : option A) :=
-    match o with
-    | Some x => P x
-    | None => unit
-    end.
-
   Lemma declared_constant_wf cst decl :
     on_global_env cumul_gen wf_decl_pred Σ ->
     declared_constant Σ cst decl ->
     WfAst.wf Σ decl.(cst_type) *
-    on_option (WfAst.wf Σ) decl.(cst_body).
+    on_some_or_none (WfAst.wf Σ) decl.(cst_body).
   Proof using Type.
     intros wΣ h.
     unfold declared_constant in h.

--- a/template-coq/theories/utils/MCOption.v
+++ b/template-coq/theories/utils/MCOption.v
@@ -27,6 +27,12 @@ Proof.
 Qed.
 
 
+Definition on_some_or_none {A} (P : A -> Type) : option A -> Type :=
+  fun x => match x with
+        | Some x => P x
+        | None => True
+        end.
+
 Definition on_Some_or_None {A} (P : A -> Prop) : option A -> Prop :=
   fun x => match x with
         | Some x => P x


### PR DESCRIPTION
We match pre-existing naming conventions with on_some vs on_Some.