### PR TITLE
Add `trans_one_inductive_entry`

### DIFF
--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -234,76 +234,6 @@ Definition isLambda t :=
 Lemma isLambda_inv t : isLambda t -> exists na ty bod, t = tLambda na ty bod.
 Proof. destruct t => //; eauto. Qed.
 
-(** ** Entries
-
-  The kernel accepts these inputs and typechecks them to produce
-  declarations. Reflects [kernel/entries.mli].
-*)
-
-(** *** Constant and axiom entries *)
-
-Record parameter_entry := {
-  parameter_entry_type      : term;
-  parameter_entry_universes : universes_decl }.
-
-Record definition_entry := {
-  definition_entry_type      : term;
-  definition_entry_body      : term;
-  definition_entry_universes : universes_decl;
-  definition_entry_opaque    : bool }.
-
-Inductive constant_entry :=
-| ParameterEntry  (p : parameter_entry)
-| DefinitionEntry (def : definition_entry).
-
-Derive NoConfusion for parameter_entry definition_entry constant_entry.
-
-(** *** Inductive entries *)
-
-(** This is the representation of mutual inductives.
-    nearly copied from [kernel/entries.mli]
-
-  Assume the following definition in concrete syntax:
-
-[[
-  Inductive I1 (x1:X1) ... (xn:Xn) : A1 := c11 : T11 | ... | c1n1 : T1n1
-  ...
-  with      Ip (x1:X1) ... (xn:Xn) : Ap := cp1 : Tp1  ... | cpnp : Tpnp.
-]]
-
-  then, in [i]th block, [mind_entry_params] is [xn:Xn;...;x1:X1];
-  [mind_entry_arity] is [Ai], defined in context [x1:X1;...;xn:Xn];
-  [mind_entry_lc] is [Ti1;...;Tini], defined in context
-  [A'1;...;A'p;x1:X1;...;xn:Xn] where [A'i] is [Ai] generalized over
-  [x1:X1;...;xn:Xn].
-*)
-
-Inductive local_entry :=
-| LocalDef : term -> local_entry (* local let binding *)
-| LocalAssum : term -> local_entry.
-
-Record one_inductive_entry := {
-  mind_entry_typename : ident;
-  mind_entry_arity : term;
-  mind_entry_template : bool; (* template polymorphism *)
-  mind_entry_consnames : list ident;
-  mind_entry_lc : list term (* constructor list *) }.
-
-Record mutual_inductive_entry := {
-  mind_entry_record    : option (option ident);
-  (* Is this mutual inductive defined as a record?
-     If so, is it primitive, using binder name [ident]
-     for the record in primitive projections ? *)
-  mind_entry_finite    : recursivity_kind;
-  mind_entry_params    : list (ident * local_entry);
-  mind_entry_inds      : list one_inductive_entry;
-  mind_entry_universes : universes_decl;
-  mind_entry_private   : option bool
-  (* Private flag for sealing an inductive definition in an enclosing
-     module. Not handled by Template Coq yet. *) }.
-
-Derive NoConfusion for local_entry one_inductive_entry mutual_inductive_entry.
-
 (** Basic operations on the AST: lifting, substitution and tests for variable occurrences. *)
 
 Fixpoint lift n k t : term :=
@@ -1317,3 +1247,73 @@ Module PCUICGlobalMaps := EnvironmentTyping.GlobalMaps
   PCUICLookup
 .
 Include PCUICGlobalMaps.
+
+(** ** Entries
+
+  The kernel accepts these inputs and typechecks them to produce
+  declarations. Reflects [kernel/entries.mli].
+*)
+
+(** *** Constant and axiom entries *)
+
+Record parameter_entry := {
+  parameter_entry_type      : term;
+  parameter_entry_universes : universes_decl }.
+
+Record definition_entry := {
+  definition_entry_type      : term;
+  definition_entry_body      : term;
+  definition_entry_universes : universes_decl;
+  definition_entry_opaque    : bool }.
+
+Inductive constant_entry :=
+| ParameterEntry  (p : parameter_entry)
+| DefinitionEntry (def : definition_entry).
+
+Derive NoConfusion for parameter_entry definition_entry constant_entry.
+
+(** *** Inductive entries *)
+
+(** This is the representation of mutual inductives.
+    nearly copied from [kernel/entries.mli]
+
+  Assume the following definition in concrete syntax:
+
+[[
+  Inductive I1 (x1:X1) ... (xn:Xn) : A1 := c11 : T11 | ... | c1n1 : T1n1
+  ...
+  with      Ip (x1:X1) ... (xn:Xn) : Ap := cp1 : Tp1  ... | cpnp : Tpnp.
+]]
+
+  then, in [i]th block, [mind_entry_params] is [xn:Xn;...;x1:X1];
+  [mind_entry_arity] is [Ai], defined in context [x1:X1;...;xn:Xn];
+  [mind_entry_lc] is [Ti1;...;Tini], defined in context
+  [A'1;...;A'p;x1:X1;...;xn:Xn] where [A'i] is [Ai] generalized over
+  [x1:X1;...;xn:Xn].
+*)
+
+Inductive local_entry :=
+| LocalDef : term -> local_entry (* local let binding *)
+| LocalAssum : term -> local_entry.
+
+Record one_inductive_entry := {
+  mind_entry_typename : ident;
+  mind_entry_arity : term;
+  mind_entry_template : bool; (* template polymorphism *)
+  mind_entry_consnames : list ident;
+  mind_entry_lc : list term (* constructor list *) }.
+
+Record mutual_inductive_entry := {
+  mind_entry_record    : option (option ident);
+  (* Is this mutual inductive defined as a record?
+     If so, is it primitive, using binder name [ident]
+     for the record in primitive projections ? *)
+  mind_entry_finite    : recursivity_kind;
+  mind_entry_params    : list (ident * local_entry);
+  mind_entry_inds      : list one_inductive_entry;
+  mind_entry_universes : universes_decl;
+  mind_entry_private   : option bool
+  (* Private flag for sealing an inductive definition in an enclosing
+     module. Not handled by Template Coq yet. *) }.
+
+Derive NoConfusion for local_entry one_inductive_entry mutual_inductive_entry.

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -1309,7 +1309,7 @@ Record mutual_inductive_entry := {
      If so, is it primitive, using binder name [ident]
      for the record in primitive projections ? *)
   mind_entry_finite    : recursivity_kind;
-  mind_entry_params    : list (ident * local_entry);
+  mind_entry_params    : context;
   mind_entry_inds      : list one_inductive_entry;
   mind_entry_universes : universes_decl;
   mind_entry_private   : option bool

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -117,3 +117,25 @@ Definition trans_one_inductive_entry (oie : PCUICAst.one_inductive_entry) : one_
        mind_entry_arity := trans oie.(PCUICAst.mind_entry_arity);
        mind_entry_consnames := oie.(PCUICAst.mind_entry_consnames);
        mind_entry_lc := List.map trans oie.(PCUICAst.mind_entry_lc); |}.
+
+(*
+(* It would be nice to have this, but it seems to not be possible *)
+Definition trans_mutual_inductive_entry (mie : PCUICAst.mutual_inductive_entry) : mutual_inductive_entry.
+  refine {| mind_entry_record := mie.(PCUICAst.mind_entry_record);
+           mind_entry_finite := mie.(PCUICAst.mind_entry_finite);
+           mind_entry_private := mie.(PCUICAst.mind_entry_private);
+           mind_entry_universes := universes_entry_of_decl mie.(PCUICAst.mind_entry_universes);
+           mind_entry_inds := List.map trans_one_inductive_entry mie.(PCUICAst.mind_entry_inds);
+           mind_entry_params := trans_local
+                                  (* TODO Should this be extracted? *)
+                                  (List.map (fun '(id, le)
+                                             => let dname := {| binder_name := nNamed id ; binder_relevance := _ (* ??? *) |} in
+                                                match le with
+                                                | LocalDef x => {| decl_name := dname ; decl_type := _ (* ??? *) ; decl_body := Some x |}
+                                                | LocalAssum x => {| decl_name := dname ; decl_type := x ; decl_body := None |}
+                                                end)
+                                            mie.(PCUICAst.mind_entry_params));
+           mind_entry_variance := _ (* ??? *);
+           mind_entry_template := false |}.
+Abort.
+*)

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -111,3 +111,9 @@ Definition trans_global_env (d : PCUICEnvironment.global_env) : global_env :=
 
 Definition trans_global (Σ : PCUICEnvironment.global_env_ext) : global_env_ext :=
   (trans_global_env (fst Σ), snd Σ).
+
+Definition trans_one_inductive_entry (oie : PCUICAst.one_inductive_entry) : one_inductive_entry
+  := {| mind_entry_typename := oie.(PCUICAst.mind_entry_typename);
+       mind_entry_arity := trans oie.(PCUICAst.mind_entry_arity);
+       mind_entry_consnames := oie.(PCUICAst.mind_entry_consnames);
+       mind_entry_lc := List.map trans oie.(PCUICAst.mind_entry_lc); |}.

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -118,24 +118,12 @@ Definition trans_one_inductive_entry (oie : PCUICAst.one_inductive_entry) : one_
        mind_entry_consnames := oie.(PCUICAst.mind_entry_consnames);
        mind_entry_lc := List.map trans oie.(PCUICAst.mind_entry_lc); |}.
 
-(*
-(* It would be nice to have this, but it seems to not be possible *)
-Definition trans_mutual_inductive_entry (mie : PCUICAst.mutual_inductive_entry) : mutual_inductive_entry.
-  refine {| mind_entry_record := mie.(PCUICAst.mind_entry_record);
-           mind_entry_finite := mie.(PCUICAst.mind_entry_finite);
-           mind_entry_private := mie.(PCUICAst.mind_entry_private);
-           mind_entry_universes := universes_entry_of_decl mie.(PCUICAst.mind_entry_universes);
-           mind_entry_inds := List.map trans_one_inductive_entry mie.(PCUICAst.mind_entry_inds);
-           mind_entry_params := trans_local
-                                  (* TODO Should this be extracted? *)
-                                  (List.map (fun '(id, le)
-                                             => let dname := {| binder_name := nNamed id ; binder_relevance := _ (* ??? *) |} in
-                                                match le with
-                                                | LocalDef x => {| decl_name := dname ; decl_type := _ (* ??? *) ; decl_body := Some x |}
-                                                | LocalAssum x => {| decl_name := dname ; decl_type := x ; decl_body := None |}
-                                                end)
-                                            mie.(PCUICAst.mind_entry_params));
-           mind_entry_variance := _ (* ??? *);
-           mind_entry_template := false |}.
-Abort.
-*)
+Definition trans_mutual_inductive_entry (mie : PCUICAst.mutual_inductive_entry) : mutual_inductive_entry
+  := {| mind_entry_record := mie.(PCUICAst.mind_entry_record);
+       mind_entry_finite := mie.(PCUICAst.mind_entry_finite);
+       mind_entry_private := mie.(PCUICAst.mind_entry_private);
+       mind_entry_universes := universes_entry_of_decl mie.(PCUICAst.mind_entry_universes);
+       mind_entry_inds := List.map trans_one_inductive_entry mie.(PCUICAst.mind_entry_inds);
+       mind_entry_params := trans_local mie.(PCUICAst.mind_entry_params);
+       mind_entry_variance := None (* Should something go here??? *);
+       mind_entry_template := false |}.

--- a/pcuic/theories/PCUICToTemplate.v
+++ b/pcuic/theories/PCUICToTemplate.v
@@ -125,5 +125,5 @@ Definition trans_mutual_inductive_entry (mie : PCUICAst.mutual_inductive_entry) 
        mind_entry_universes := universes_entry_of_decl mie.(PCUICAst.mind_entry_universes);
        mind_entry_inds := List.map trans_one_inductive_entry mie.(PCUICAst.mind_entry_inds);
        mind_entry_params := trans_local mie.(PCUICAst.mind_entry_params);
-       mind_entry_variance := None (* Should something go here??? *);
-       mind_entry_template := false |}.
+       mind_entry_variance := None (* TODO: support universe variance in PCUIC *);
+       mind_entry_template := false (* TODO: support template polymorphism in PCUIC? *) |}.

--- a/pcuic/theories/utils/PCUICAstUtils.v
+++ b/pcuic/theories/utils/PCUICAstUtils.v
@@ -233,9 +233,7 @@ Proof.
     destruct typ as [[names types] _].
     apply (List.firstn decl.(ind_npars)) in names.
     apply (List.firstn decl.(ind_npars)) in types.
-    refine (List.combine _ _).
-    exact (List.map string_of_aname names).
-    exact (List.map LocalAssum types).
+    refine (map (fun '(x, ty) => vass x ty) (combine names types)).
   - refine (List.map _ decl.(ind_bodies)).
     intros [].
     refine {| mind_entry_typename := ind_name0;


### PR DESCRIPTION
Also add a comment with a partial `trans_mutual_inductive_entry`.  It seems not possible to write this method yet?  (I could also drop the commit that adds this partially, if that's preferred.)  This is towards #776