### PR TITLE
Turn `normalisation` into a typeclass

### DIFF
--- a/erasure/theories/ETransform.v
+++ b/erasure/theories/ETransform.v
@@ -20,14 +20,14 @@ Definition build_wf_env_from_env {cf : checker_flags} (Σ : global_env_map) (wf�
      wf_env_map_repr := Σ.(trans_env_repr);
  |}.
 
-Program Definition erase_pcuic_program {guard : abstract_guard_impl} (p : pcuic_program)
+Program Definition erase_pcuic_program {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} (p : pcuic_program)
   (wfΣ : ∥ PCUICTyping.wf_ext (H := config.extraction_checker_flags) p.1 ∥)
   (wt : ∥ ∑ T, PCUICTyping.typing (H := config.extraction_checker_flags) p.1 [] p.2 T ∥) : eprogram_env :=
   let wfe := build_wf_env_from_env p.1.1 (map_squash (PCUICTyping.wf_ext_wf _) wfΣ) in
   let wfext := @abstract_make_wf_env_ext _ optimized_abstract_env_impl wfe p.1.2 _ in
-  let t := ErasureFunction.erase (nor:=PCUICSN.extraction_normalizing) optimized_abstract_env_impl wfext nil p.2
+  let t := ErasureFunction.erase (nor:=PCUICSN.extraction_normalizing) (normalisation_in:=let _ := @PCUICSN.normalisation in _) optimized_abstract_env_impl wfext nil p.2
     (fun Σ wfΣ => let '(sq (T; ty)) := wt in PCUICTyping.iswelltyped ty) in
-  let Σ' := ErasureFunction.erase_global_fast optimized_abstract_env_impl
+  let Σ' := ErasureFunction.erase_global_fast (nor:=PCUICSN.extraction_normalizing) (normalisation:=normalisation) optimized_abstract_env_impl
     (EAstUtils.term_global_deps t) wfe (p.1.(PCUICAst.PCUICEnvironment.declarations)) _ in
     (EEnvMap.GlobalContextMap.make Σ' _, t).
 
@@ -40,11 +40,11 @@ Obligation Tactic := idtac.
 
 Import Extract.
 
-Definition erase_program {guard : abstract_guard_impl} (p : pcuic_program)
+Definition erase_program {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} (p : pcuic_program)
   (wtp : ∥ wt_pcuic_program (cf:=config.extraction_checker_flags) p ∥) : eprogram_env :=
   erase_pcuic_program (guard := guard) p (map_squash fst wtp) (map_squash snd wtp).
 
-Lemma expanded_erase_program {guard : abstract_guard_impl}
+Lemma expanded_erase_program {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation}
   (cf := config.extraction_checker_flags) p (wtp : ∥ wt_pcuic_program p ∥) :
   PCUICEtaExpand.expanded_pcuic_program p ->
   EEtaExpandedFix.expanded_eprogram_env (erase_program (guard:=guard) p wtp).
@@ -67,7 +67,7 @@ Proof.
   - eapply EEtaExpanded.isEtaExpFix_isEtaExp. now eapply EEtaExpandedFix.expanded_isEtaExp.
 Qed.
 
-Program Definition erase_transform {guard : abstract_guard_impl}  : Transform.t pcuic_program eprogram_env PCUICAst.term EAst.term
+Program Definition erase_transform {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} : Transform.t pcuic_program eprogram_env PCUICAst.term EAst.term
   eval_pcuic_program (eval_eprogram_env EWcbvEval.default_wcbv_flags) :=
  {| name := "erasure";
     pre p :=
@@ -77,7 +77,7 @@ Program Definition erase_transform {guard : abstract_guard_impl}  : Transform.t 
     obseq g g' v v' := let Σ := g.1 in Σ ;;; [] |- v ⇝ℇ v' |}.
 Next Obligation.
   cbn -[erase_program].
-  intros ? p [wtp etap].
+  intros ? ? p [wtp etap].
   destruct erase_program eqn:e.
   split; cbn.
   - unfold erase_program, erase_pcuic_program in e. simpl. cbn in e. injection e. intros <- <-.
@@ -89,7 +89,7 @@ Next Obligation.
 Qed.
 
 Next Obligation.
-  red. move=> guard [Σ t] v [[wf [T HT]]]. unfold eval_pcuic_program, eval_eprogram.
+  red. move=> guard normalisation [Σ t] v [[wf [T HT]]]. unfold eval_pcuic_program, eval_eprogram.
   intros [ev].
   destruct erase_program eqn:e.
   unfold erase_program, erase_pcuic_program in e. simpl in e. injection e; intros <- <-.

--- a/erasure/theories/Erasure.v
+++ b/erasure/theories/Erasure.v
@@ -23,6 +23,7 @@ Import Transform.
 Obligation Tactic := program_simpl.
 
 #[local] Existing Instance extraction_checker_flags.
+#[local] Existing Instance PCUICSN.extraction_normalizing.
 
 Import EWcbvEval.
 
@@ -51,7 +52,7 @@ Next Obligation.
   apply assume_preservation_template_program_env_expansion in ev as [ev']; eauto.
 Qed.
 
-Program Definition erasure_pipeline {guard : abstract_guard_impl} (efl := EWellformed.all_env_flags) :
+Program Definition erasure_pipeline {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} (efl := EWellformed.all_env_flags) :
  Transform.t TemplateProgram.template_program EProgram.eprogram
   Ast.term EAst.term
   TemplateProgram.eval_template_program
@@ -99,9 +100,9 @@ Next Obligation.
   now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs.
 Qed.
 
-Definition run_erase_program {guard : abstract_guard_impl} := run erasure_pipeline.
+Definition run_erase_program {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} := run erasure_pipeline.
 
-Program Definition erasure_pipeline_fast {guard : abstract_guard_impl} (efl := EWellformed.all_env_flags) :=
+Program Definition erasure_pipeline_fast {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} (efl := EWellformed.all_env_flags) :=
   build_template_program_env ▷
   eta_expand ▷
   template_to_pcuic_transform ▷
@@ -120,7 +121,7 @@ Next Obligation.
   destruct H; split => //. now eapply ETransform.expanded_eprogram_env_expanded_eprogram_cstrs.
 Qed.
 
-Definition run_erase_program_fast {guard : abstract_guard_impl} := run erasure_pipeline_fast.
+Definition run_erase_program_fast {guard : abstract_guard_impl} {normalisation : PCUICSN.Normalisation} := run erasure_pipeline_fast.
 
 Local Open Scope string_scope.
 
@@ -135,6 +136,10 @@ PCUICTyping.guard fix_cofix Σ Γ mfix <-> fake_guard_impl fix_cofix Σ Γ mfix.
 Global Program Instance fake_guard_impl : abstract_guard_impl :=
 {| guard_impl := fake_guard_impl |}.
 Next Obligation. apply fake_guard_impl_properties. Qed.
+
+(** Ideally we'd have a MetaCoq template program that generates a proof of Strong Normalisation for the particular program we're erasing.  For now we just axiomatize SN. *)
+Axiom fake_normalisation : PCUICSN.Normalisation.
+Global Existing Instance fake_normalisation.
 
 (** This uses the retyping-based erasure and assumes that the global environment and term
   are welltyped (for speed). As such this should only be used for testing, or when we know that

--- a/examples/metacoq_tour_prelude.v
+++ b/examples/metacoq_tour_prelude.v
@@ -36,6 +36,10 @@ Global Program Instance fake_guard_impl : abstract_guard_impl :=
 {| guard_impl := fake_guard_impl |}.
 Next Obligation. Admitted.
 
+Global Existing Instance normalisation. (* to convert from Normalisation to NormalisationIn *)
+Global Instance assume_normalisation : Normalisation.
+Admitted.
+
 Definition make_wf_env_ext (Σ : global_env_ext) : EnvCheck wf_env_ext wf_env_ext :=
   '(exist Σ' pf) <- check_wf_ext optimized_abstract_env_impl Σ ;;
   ret Σ'.

--- a/examples/typing_correctness.v
+++ b/examples/typing_correctness.v
@@ -71,6 +71,7 @@ From Equations Require Import Equations.
 
 Local Existing Instance default_checker_flags.
 Local Existing Instance PCUICSN.default_normalizing.
+Local Existing Instance PCUICSN.normalisation.
 Import MCMonadNotation.
 
 (* ********************************************************* *)
@@ -100,6 +101,8 @@ Definition kername_of_string (s : string) : kername :=
 Global Program Instance fake_guard_impl : abstract_guard_impl :=
 {| guard_impl := fake_guard_impl |}.
 Next Obligation. Admitted.
+Global Instance assume_normalisation : PCUICSN.Normalisation.
+Admitted.
 
 Definition make_wf_env_ext (Σ : global_env_ext) : EnvCheck wf_env_ext wf_env_ext :=
   '(exist Σ' pf) <- check_wf_ext optimized_abstract_env_impl Σ ;;

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -81,6 +81,7 @@ theories/PCUICWcbvEval.v
 theories/PCUICCumulProp.v
 theories/PCUICElimination.v
 theories/PCUICSN.v
+theories/PCUICWeakeningEnvSN.v
 theories/PCUICPrincipality.v
 theories/PCUICSigmaCalculus.v
 theories/PCUICFirstorder.v

--- a/pcuic/theories/PCUICProgress.v
+++ b/pcuic/theories/PCUICProgress.v
@@ -820,11 +820,11 @@ Qed.
 
 From MetaCoq Require Import PCUICSN.
 
-Lemma WN {Σ t} : wf_ext Σ -> axiom_free Σ ->
+Lemma WN {no:normalizing_flags} {Σ} {normalisation:NormalisationIn Σ} {t} : wf_ext Σ -> axiom_free Σ ->
   welltyped Σ [] t  -> exists v, squash (eval Σ t v).
 Proof.
   intros Hwf Hax Hwt.
-  eapply PCUICSN.normalisation in Hwt as HSN; eauto.
+  eapply PCUICSN.normalisation_in in Hwt as HSN; eauto.
   induction HSN as [t H IH].
   destruct Hwt as [A HA].
   edestruct progress as [_ [_ [[t' Ht'] | Hval]]]; eauto.
@@ -873,7 +873,7 @@ Proof.
   - assert (x = y) as <- by eauto. eauto.
 Qed.
 
-Lemma ws_wcbv_standardization {Σ i u args mind} {t v : ws_term (fun _ => false)} : wf_ext Σ -> axiom_free Σ ->
+Lemma ws_wcbv_standardization {no:normalizing_flags} {Σ} {normalisation:NormalisationIn Σ} {i u args mind} {t v : ws_term (fun _ => false)} : wf_ext Σ -> axiom_free Σ ->
   Σ ;;; [] |- t : mkApps (tInd i u) args ->
   lookup_env Σ (i.(inductive_mind)) = Some (InductiveDecl mind) ->
   @firstorder_ind Σ (firstorder_env Σ) i ->
@@ -882,7 +882,7 @@ Lemma ws_wcbv_standardization {Σ i u args mind} {t v : ws_term (fun _ => false)
   squash (eval Σ t v).
 Proof.
   intros Hwf Hax Hty Hdecl Hfo Hred Hirred.
-  destruct (@WN Σ t) as (v' & Hv'); eauto.
+  destruct (@WN no Σ normalisation t) as (v' & Hv'); eauto.
   1:{ eexists; eauto. }
   sq.
   assert (Σ;;; [] |- t ⇝* v') as Hred' by now eapply wcbeval_red.
@@ -900,7 +900,7 @@ Proof.
   intros. eapply firstorder_value_irred; eauto.
 Qed.
 
-Lemma wcbv_standardization {Σ i u args mind} {t v : term} : wf_ext Σ -> axiom_free Σ ->
+Lemma wcbv_standardization {no:normalizing_flags} {Σ} {normalisation:NormalisationIn Σ} {i u args mind} {t v : term} : wf_ext Σ -> axiom_free Σ ->
   Σ ;;; [] |- t : mkApps (tInd i u) args ->
   lookup_env Σ (i.(inductive_mind)) = Some (InductiveDecl mind) ->
   @firstorder_ind Σ (firstorder_env Σ) i ->
@@ -910,7 +910,7 @@ Lemma wcbv_standardization {Σ i u args mind} {t v : term} : wf_ext Σ -> axiom_
 Proof.
   intros Hwf Hax Hty Hdecl Hfo Hred Hirred.
   unshelve edestruct @ws_wcbv_standardization.
-  1-5: shelve.
+  1-6: shelve.
   1: exists t; shelve.
   1: exists v; shelve.
   all: sq; eauto.

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -28,19 +28,15 @@ Proof.
   now constructor.
 Qed.
 
-Section Normalisation.
-
-  Context {cf : checker_flags} {no : normalizing_flags}.
-  Context (Σ : global_env_ext).
-
-  Axiom normalisation :
-    wf_ext Σ ->
+Class NormalisationIn {cf : checker_flags} {no : normalizing_flags} (Σ : global_env_ext) :=
+  normalisation_in :
     forall Γ t,
       welltyped Σ Γ t ->
       Acc (cored Σ Γ) t.
-
-End Normalisation.
-
+Class Normalisation {cf : checker_flags} {no : normalizing_flags} :=
+  normalisation : forall Σ, wf_ext Σ -> NormalisationIn Σ.
+#[export] Hint Mode NormalisationIn - - + : typeclass_instances.
+#[export] Typeclasses Opaque Normalisation.
 
 (** Since we are working with name annotations, reduction is sensitive to names.
     In this section we provide cored' which corresponds to reduction up to
@@ -51,8 +47,7 @@ End Normalisation.
 Section Alpha.
 
   Context {cf : checker_flags} {no : normalizing_flags}.
-  Context (Σ : global_env_ext).
-  Context (hΣ : ∥ wf_ext Σ ∥).
+  Context (Σ : global_env_ext) {normalisation : NormalisationIn Σ}.
 
   Notation eqt u v := (∥ upto_names u v ∥).
 
@@ -156,11 +151,9 @@ Section Alpha.
     forall Γ u,
       welltyped Σ Γ u ->
       Acc (cored' Γ) u.
-  Proof using hΣ.
-    destruct hΣ.
+  Proof using normalisation.
     intros Γ u h.
     apply normalisation in h.
-    2: assumption.
     eapply Acc_cored_cored'.
     - eassumption.
     - constructor; reflexivity.

--- a/pcuic/theories/PCUICWeakeningEnvSN.v
+++ b/pcuic/theories/PCUICWeakeningEnvSN.v
@@ -1,0 +1,32 @@
+From Coq Require Import ssreflect Wellfounded.Inclusion.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICSN PCUICTyping PCUICSafeLemmata PCUICWeakeningEnvTyp.
+Import PCUICEnvironment.
+
+(* It would be nice to prove this, but I'm not sure how -Jason Gross *)
+Class NormalisationInAdjustUniversesIn {cf} {no} (Σ : global_env_ext) :=
+  normalisation_in_adjust_universes
+    : forall kn cb,
+      lookup_env Σ.1 kn = Some (ConstantDecl cb) ->
+      PCUICTyping.wf_ext Σ ->
+      PCUICTyping.wf_ext (Σ.1, cst_universes cb) ->
+      @NormalisationIn cf no Σ -> @NormalisationIn cf no (Σ.1, cst_universes cb).
+
+Lemma weakening_env_normalisation_in {cf} {no}
+  Σ Σ' ϕ (Hext : extends Σ Σ')
+  (HΣ : PCUICTyping.wf Σ)
+  (HΣ' : PCUICTyping.wf Σ')
+  : @PCUICSN.NormalisationIn cf no (Σ', ϕ) -> @PCUICSN.NormalisationIn cf no (Σ, ϕ).
+Proof.
+  cbv [PCUICSN.NormalisationIn].
+  intros normalisation_in Γ t1 [T Hwt]; specialize (normalisation_in Γ t1); move: normalisation_in.
+  cbn in *.
+  move => normalisation_in.
+  eapply Acc_incl; [ | eapply normalisation_in; econstructor; instantiate (1:=T); revert Hwt ].
+  { repeat match goal with H : wf_ext _ |- _ => apply wf_ext_wf in H end.
+    hnf; eapply weakening_env_cored; eassumption. }
+  intro Hty.
+  destruct (weakening_env _ _ _ _ _ Hty) as (_&_&H').
+  cbn in *.
+  repeat match goal with H : wf_ext _ |- _ => apply wf_ext_wf in H end.
+  eapply H'; eauto.
+Qed.

--- a/safechecker/theories/PCUICConsistency.v
+++ b/safechecker/theories/PCUICConsistency.v
@@ -119,7 +119,12 @@ Definition global_env_add (Σ : global_env) d :=
   {| universes := Σ.(universes); declarations := d :: Σ.(declarations); retroknowledge := Σ.(retroknowledge) |}.
 
 Theorem pcuic_consistent {cf:checker_flags} {nor : normalizing_flags} {guard : abstract_guard_impl}
-  (_Σ :referenced_impl_ext) t :
+  (_Σ :referenced_impl_ext)
+  {normalisation_in
+    :let Σ := _Σ : global_env_ext in
+     let Σ' := global_env_add Σ.1 (make_fresh_name Σ, InductiveDecl False_mib) : global_env in
+     let Σext := (Σ', Σ.2) : global_env × universes_decl in NormalisationIn Σext}
+  t :
   axiom_free _Σ ->
   (* t : forall (P : Prop), P *)
   _Σ ;;; [] |- t : tProd binder (tSort Prop_univ) (tRel 0) ->
@@ -181,9 +186,9 @@ Proof.
   pose proof (iswelltyped typ_false) as wt.
   set (_Σ' := Build_referenced_impl_ext cf _ Σext (sq wf')). cbn in *.
   unshelve epose proof (hnf_sound (X_type := canonical_abstract_env_impl) (X := _Σ') (Γ := []) (t := tApp t False_ty) Σext eq_refl) as [r].
-  1: cbn; intros; subst; exact wt.
+  all: try solve [ cbn; intros; subst; assumption ].
   unshelve epose proof (hnf_complete (X_type := canonical_abstract_env_impl) (X := _Σ') (Γ := []) (t := tApp t False_ty) Σext eq_refl) as [w].
-  1 : cbn; intros; subst; exact wt.
+  all: try solve [ cbn; intros; subst; assumption ].
   eapply subject_reduction_closed in typ_false; eauto.
   eapply whnf_ind_finite with (indargs := []) in typ_false as ctor; auto.
   - unfold isConstruct_app in ctor.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -288,15 +288,15 @@ Section CheckEnv.
   Local Definition hΣ X_ext Σ (wfΣ : abstract_env_ext_rel X_ext Σ) :
     ∥ wf Σ ∥ := abstract_env_ext_sq_wf _ _ _ wfΣ.
 
-  Definition check_wf_type (kn : kername) X_ext t :
+  Definition check_wf_type (kn : kername) X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} t :
     EnvCheck X_env_ext_type (forall Σ : global_env_ext, abstract_env_ext_rel X_ext Σ -> ∥ isType Σ [] t ∥) :=
     wrap_error _ X_ext (string_of_kername kn) (check_isType X_impl X_ext [] (fun _ _ => sq_wfl_nil _) t).
 
-  Definition check_wf_judgement kn X_ext t ty :
+  Definition check_wf_judgement kn X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} t ty :
   EnvCheck X_env_ext_type (forall Σ : global_env_ext, abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; [] |- t : ty ∥)
     :=  wrap_error _ X_ext (string_of_kername kn) (check X_impl X_ext [] (fun _ _ => sq_wfl_nil _) t ty).
 
-  Definition infer_term X_ext t :=
+  Definition infer_term X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} t :=
     wrap_error _ X_ext "toplevel term" (infer X_impl X_ext [] (fun _ _ => sq_wfl_nil _) t).
 
   Definition abstract_env_ext_empty := @abstract_env_empty_ext _ X_impl abstract_env_empty.
@@ -420,7 +420,7 @@ Section CheckEnv.
   Ltac specialize_Σ wfΣ :=
     repeat match goal with | h : _ |- _ => specialize (h _ wfΣ) end.
 
-  Equations infer_typing X_ext Γ
+  Equations infer_typing X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ
       (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t :
       typing_result (∑ T, forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; Γ |- t : T ∥) :=
     infer_typing X_ext Γ wfΓ t := typing_error_forget (infer X_impl X_ext Γ wfΓ t) ;;  ret _.
@@ -429,15 +429,15 @@ Section CheckEnv.
     pose proof (hΣ _ _ H). specialize_Σ H. sq. cbn in *. now apply infering_typing.
   Qed.
 
-  Definition check_type_wf_env X_ext Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥)
+  Definition check_type_wf_env X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥)
       t T : typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; Γ |- t : T ∥) :=
     check X_impl X_ext Γ wfΓ t T.
 
-  Definition infer_wf_env X_ext Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t :
+  Definition infer_wf_env X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t :
     typing_result (∑ T, forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; Γ |- t ▹ T ∥) :=
     infer X_impl X_ext Γ wfΓ t.
 
-  Equations infer_type_wf_env X_ext Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t :
+  Equations infer_type_wf_env X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t :
     typing_result (∑ u, forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; Γ |- t : tSort u∥) :=
     infer_type_wf_env X_ext Γ wfΓ t :=
       '(y ; H) <- typing_error_forget (infer_type X_impl X_ext (infer X_impl X_ext) Γ wfΓ t) ;;
@@ -447,7 +447,7 @@ Section CheckEnv.
     sq. now apply infering_sort_typing.
   Qed.
 
-  Definition check_context_wf_env X_ext (Γ : context) :
+  Definition check_context_wf_env X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} (Γ : context) :
     typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) :=
     check_context X_impl X_ext (infer X_impl X_ext) Γ.
 
@@ -476,7 +476,7 @@ Section CheckEnv.
         reflexivity.
   Qed.
 
-  Program Fixpoint check_type_local_ctx X_ext
+  Program Fixpoint check_type_local_ctx X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ}
      Γ Δ s (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) :
     typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ type_local_ctx (lift_typing typing) Σ Γ Δ s ∥) :=
     match Δ with
@@ -510,7 +510,7 @@ Section CheckEnv.
       eapply PCUICValidity.validity in checkty; auto.
     Qed.
 
-  Program Fixpoint infer_sorts_local_ctx X_ext Γ Δ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) :
+  Program Fixpoint infer_sorts_local_ctx X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ Δ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) :
     typing_result (∑ s, forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ sorts_local_ctx (lift_typing typing) Σ Γ Δ s ∥) :=
     match Δ with
     | [] => ret ([]; fun _ _ => sq _)
@@ -540,16 +540,16 @@ Section CheckEnv.
 
   Definition cumul_decl Pcmp Σ Γ (d d' : context_decl) : Type := cumul_decls Pcmp Σ Γ Γ d d'.
 
-  Program Definition wf_env_conv X_ext (le : conv_pb) (Γ : context) (t u : term) :
+  Program Definition wf_env_conv X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} (le : conv_pb) (Γ : context) (t u : term) :
     (forall Σ, abstract_env_ext_rel X_ext Σ -> welltyped Σ Γ t) ->
     (forall Σ, abstract_env_ext_rel X_ext Σ -> welltyped Σ Γ u) ->
     typing_result (forall Σ, abstract_env_ext_rel X_ext Σ ->  ∥ Σ ;;; Γ ⊢ t ≤[le] u ∥) :=
     convert X_impl X_ext le Γ t u.
 
-  Program Definition wf_env_check_cumul_decl X_ext le Γ d d' :=
+  Program Definition wf_env_check_cumul_decl X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} le Γ d d' :=
     check_ws_cumul_pb_decl X_impl X_ext le Γ d d'.
 
-  Program Fixpoint wf_env_check_ws_cumul_ctx (le : conv_pb) X_ext Γ Δ Δ'
+  Program Fixpoint wf_env_check_ws_cumul_ctx (le : conv_pb) X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ Δ Δ'
     (wfΔ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ (Γ ,,, Δ) ∥)
     (wfΔ' : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ (Γ ,,, Δ') ∥) :
     typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ ws_cumul_ctx_pb_rel le Σ Γ Δ Δ' ∥) :=
@@ -684,7 +684,7 @@ Section CheckEnv.
 
   Definition wt_terms Σ Γ l := Forall (welltyped Σ Γ) l.
 
-  Program Fixpoint check_conv_args X_ext Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) l l'
+  Program Fixpoint check_conv_args X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ (wfΓ : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) l l'
     (wfl : forall Σ, abstract_env_ext_rel X_ext Σ -> wt_terms Σ Γ l)
     (wfl' : forall Σ, abstract_env_ext_rel X_ext Σ -> wt_terms Σ Γ l') :
     typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ ws_cumul_pb_terms Σ Γ l l' ∥) :=
@@ -803,7 +803,7 @@ Section CheckEnv.
       constructor; pcuic.
   Qed.
 
-  Program Definition check_constructor X_ext (ind : nat) (mdecl : mutual_inductive_body)
+  Program Definition check_constructor X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} (ind : nat) (mdecl : mutual_inductive_body)
     (wfar : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_ind_types Σ mdecl ∥)
     (wfpars : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ (ind_params mdecl) ∥)
     (cdecl : constructor_body) :
@@ -884,7 +884,7 @@ Section CheckEnv.
       sq (All2_cons rxy all)
     end.
 
-   Definition check_constructors_univs X_ext (id : ident) (mdecl : mutual_inductive_body)
+   Definition check_constructors_univs X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} (id : ident) (mdecl : mutual_inductive_body)
     (wfar : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_ind_types Σ mdecl ∥)
     (wfpars : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ (ind_params mdecl) ∥)
     (ind : nat)
@@ -1203,6 +1203,8 @@ Section CheckEnv.
 
     Context {X_ext : X_env_ext_type}.
 
+    Context {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ}.
+
     Obligation Tactic := Program.Tactics.program_simpl.
 
     Program Definition isRel (t : term) : typing_result (∑ n, t = tRel n) :=
@@ -1362,7 +1364,7 @@ Section CheckEnv.
   End PositivityCheck.
 
 
-  Program Fixpoint check_wf_local X_ext Γ :
+  Program Fixpoint check_wf_local X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ :
     typing_result (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) :=
     match Γ with
     | [] => ret (fun _ _ => sq localenv_nil)
@@ -1826,7 +1828,7 @@ Section CheckEnv.
 
     End MonadLiftExt.
 
-  Program Definition check_constructors X X_ext
+  Program Definition check_constructors X X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ}
     (id : kername) (mdecl : mutual_inductive_body)
     (HX : check_wf_env_ext_prop X X_ext (ind_universes mdecl))
     (wfar : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_ind_types Σ mdecl ∥)
@@ -1843,7 +1845,7 @@ Section CheckEnv.
     posc <- wrap_error _ X_ext (string_of_kername id)
       (monad_All_All
        (fun x px =>
-        @check_positive_cstr X_ext mdecl n
+        @check_positive_cstr X_ext _ mdecl n
           (arities_context mdecl.(ind_bodies)) (cstr_type x) _ [])
         idecl.(ind_ctors) (wt_cstrs (cs:=cs) X_ext Hcs)) ;;
     var <- (monad_All_All
@@ -2026,7 +2028,7 @@ End monad_Alli_nth_forall.
     apply iff_reflect. apply (abstract_env_compare_universe_correct _ H Cumul); eauto.
   Qed.
 
-  Program Definition do_check_ind_sorts X_ext (params : context)
+  Program Definition do_check_ind_sorts X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} (params : context)
     (wfparams : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ params ∥)
     (kelim : allowed_eliminations) (indices : context)
     (cs : list constructor_univs)
@@ -2164,7 +2166,7 @@ End monad_Alli_nth_forall.
     rewrite -eqvaru in e; discriminate.
   Qed.
 
-  Program Definition check_ind_types X_ext (mdecl : mutual_inductive_body)
+  Program Definition check_ind_types X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} (mdecl : mutual_inductive_body)
       : EnvCheck X_env_ext_type (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_ind_types Σ mdecl ∥) :=
     indtys <- monad_All (fun ind => wrap_error _ X_ext ind.(ind_name)
       (infer_type_wf_env X_ext [] (fun _ _ => sq_wfl_nil _) ind.(ind_type))) mdecl.(ind_bodies) ;;
@@ -2176,7 +2178,7 @@ End monad_Alli_nth_forall.
       solve_all. now exists y.
     Qed.
 
-  Program Definition check_one_ind_body X X_ext
+  Program Definition check_one_ind_body X X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ}
       (mind : kername) (mdecl : mutual_inductive_body)
       (pf : check_wf_env_ext_prop X X_ext (ind_universes mdecl))
       (wfpars : forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ mdecl.(ind_params) ∥)
@@ -2292,7 +2294,7 @@ End monad_Alli_nth_forall.
     Unshelve. eauto.
   Qed.
 
-  Program Definition check_wf_decl X X_ext
+  Program Definition check_wf_decl X X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ}
     kn (d : global_decl)
     (pf : check_wf_env_ext_prop X X_ext (universes_decl_of_decl d))
     : EnvCheck X_env_ext_type (forall Σ, abstract_env_ext_rel X_ext Σ -> ∥ on_global_decl cumulSpec0 (lift_typing typing) Σ kn d ∥) :=
@@ -2412,21 +2414,49 @@ End monad_Alli_nth_forall.
   Obligation Tactic := Tactics.program_simpl.
 
   Program Fixpoint check_wf_decls (univs : ContextSet.t) (retro : Retroknowledge.t)
-    (decls : global_declarations) : EnvCheck X_env_ext_type ({ X : X_env_type |
+    (decls : global_declarations) :
+    (* this is exactly what we need, I don't understand this function enough to know what the appropriate generalization is - JasonGross *)
+    forall {normalisation_in
+        : forall (d : kername × global_decl)
+               (decls' : global_declarations)
+               (Hdecls' : exists n, List.skipn n decls = decls')
+               (x : {X : X_env_type | forall Σ : global_env, Σ ∼ X -> Σ = {| universes := univs; declarations := decls'; retroknowledge := retro |}})
+               (X : X_env_type)
+               (wf_ : forall Σ : global_env, Σ ∼ X -> Σ = {| universes := univs; declarations := decls'; retroknowledge := retro |})
+               (isfresh : ∥ PCUICAst.fresh_global d.1 decls' ∥)
+               (udecl := universes_decl_of_decl d.2 : universes_decl)
+               (X' : {X_ext : X_env_ext_type | check_wf_env_ext_prop X X_ext udecl}),
+        forall Σ : global_env_ext, wf_ext Σ -> Σ ∼_ext ` X' -> NormalisationIn Σ},
+      EnvCheck X_env_ext_type ({ X : X_env_type |
     (forall Σ, abstract_env_rel X Σ -> Σ = {| universes := univs; declarations := decls; retroknowledge := retro |})})
     :=
     match decls with
-    [] =>
+    [] => fun _ =>
       X <- check_univs univs retro ;;
       ret (exist (proj1_sig X) _)
-    | d :: decls =>
-      '(exist X wf_) <- check_wf_decls univs retro decls ;;
+    | d :: decls => fun normalisation_in =>
+      '(exist X wf_) <- @check_wf_decls univs retro decls _ ;;
       isfresh <- check_fresh d.1 decls ;;
       let udecl := universes_decl_of_decl d.2 in
       X' <- make_abstract_env_ext X d.1 udecl ;;
-      check_wf_decl X (proj1_sig X') d.1 d.2 (proj2_sig X') ;;
+      @check_wf_decl X (proj1_sig X') _ d.1 d.2 (proj2_sig X') ;;
       ret (exist (abstract_env_add_decl X d.1 d.2 _) _)
     end.
+
+  Obligation Tactic := intros.
+  Next Obligation.
+    let H := match goal with H : @ex nat _ |- _ => H end in
+    destruct H as [n H];
+    eapply normalisation_in; try solve [ exists (S n); exact H ];
+    eassumption.
+  Qed.
+  Obligation Tactic := Tactics.program_simpl.
+
+  Next Obligation.
+    unshelve eapply normalisation_in; try ((idtac + unshelve econstructor); eassumption).
+    exists 1; reflexivity.
+  Qed.
+
   Next Obligation.
     cbn in *. destruct H0.
     specialize_Σ a. specialize_Σ H. rewrite wf_.  cbn in *.
@@ -2445,9 +2475,24 @@ End monad_Alli_nth_forall.
     unfold add_global_decl. now rewrite eq.
   Qed.
 
-  Program Definition check_wf_env (Σ : global_env) :
+  Program Definition check_wf_env (Σ : global_env)
+    (* this is the hypothesis we need, idk how to simplify it or appropriately generalize it *)
+    {normalisation_in
+      : forall (g : global_decl) (Hdecls' : nat) X,
+        (forall Σ0 : global_env,
+            Σ0 ∼ X ->
+            Σ0 =
+              {|
+                universes := Σ;
+                declarations := skipn Hdecls' (declarations Σ);
+                retroknowledge := retroknowledge Σ
+              |}) ->
+        forall X' : X_env_ext_type,
+          check_wf_env_ext_prop X X' (universes_decl_of_decl g) ->
+          forall Σ0 : global_env_ext, wf_ext Σ0 -> Σ0 ∼_ext X' -> NormalisationIn Σ0}
+    :
     EnvCheck X_env_ext_type ({ X : X_env_type | abstract_env_rel X Σ}) :=
-    X <- check_wf_decls Σ.(universes) Σ.(retroknowledge) Σ.(declarations) ;;
+    X <- @check_wf_decls Σ.(universes) Σ.(retroknowledge) Σ.(declarations) _ ;;
     ret (exist (proj1_sig X) _).
 
   Next Obligation.
@@ -2455,9 +2500,24 @@ End monad_Alli_nth_forall.
     specialize_Σ wfΣ. subst. now destruct Σ.
   Qed.
 
-  Program Definition check_wf_ext (Σ : global_env_ext) :
+  Program Definition check_wf_ext (Σ : global_env_ext)
+    (* this is the hypothesis we need, idk how to simplify it or appropriately generalize it, maybe use check_wf_env_ext_prop to simplify Σ0 ∼_ext X' into _ ∼ X so that we get an equality? *)
+    {normalisation_in
+      : forall (g : global_decl) (Hdecls' : nat) X,
+        (forall Σ0 : global_env,
+            Σ0 ∼ X ->
+            Σ0 =
+              {|
+                universes := Σ;
+                declarations := skipn Hdecls' (declarations Σ);
+                retroknowledge := retroknowledge Σ
+              |}) ->
+        forall X' : X_env_ext_type,
+          check_wf_env_ext_prop X X' (universes_decl_of_decl g) ->
+          forall Σ0 : global_env_ext, wf_ext Σ0 -> Σ0 ∼_ext X' -> NormalisationIn Σ0}
+    :
     EnvCheck X_env_ext_type ({ X : X_env_ext_type | abstract_env_ext_rel X Σ}) :=
-    X <- check_wf_env Σ.1 ;;
+    X <- @check_wf_env Σ.1 _ ;;
     X' <- make_abstract_env_ext (proj1_sig X) (MPfile [], "toplevel term") Σ.2 ;;
     ret (exist (proj1_sig X') _).
 
@@ -2465,14 +2525,14 @@ End monad_Alli_nth_forall.
     specialize_Σ a. now destruct H as [? ?], Σ.
   Qed.
 
-  Definition check_type_wf_env_bool X_ext Γ
+  Definition check_type_wf_env_bool X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ
     (wfΓ : forall Σ,  abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t T : bool :=
     match check_type_wf_env X_ext Γ wfΓ t T with
     | Checked _ => true
     | TypeError e => false
     end.
 
-  Definition check_wf_env_bool_spec X_ext Γ
+  Definition check_wf_env_bool_spec X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ
     (wfΓ : forall Σ,  abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t T :
     check_type_wf_env_bool X_ext Γ wfΓ t T = true ->
     forall Σ,  abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; Γ |- t : T ∥.
@@ -2482,7 +2542,7 @@ End monad_Alli_nth_forall.
     discriminate.
   Qed.
 
-  Definition check_wf_env_bool_spec2 X_ext Γ
+  Definition check_wf_env_bool_spec2 X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ
     (wfΓ : forall Σ,  abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t T :
     check_type_wf_env_bool X_ext Γ wfΓ t T = false -> type_error.
   Proof.
@@ -2494,7 +2554,7 @@ End monad_Alli_nth_forall.
   (* This function is appropriate for live evaluation inside Coq:
      it forgets about the derivation produced by typing and replaces it with an opaque constant. *)
 
-  Program Definition check_type_wf_env_fast X_ext Γ
+  Program Definition check_type_wf_env_fast X_ext {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X_ext -> NormalisationIn Σ} Γ
   (wfΓ : forall Σ,  abstract_env_ext_rel X_ext Σ -> ∥ wf_local Σ Γ ∥) t {T} :
   typing_result (forall Σ,  abstract_env_ext_rel X_ext Σ -> ∥ Σ ;;; Γ |- t : T ∥) :=
     (if check_type_wf_env_bool X_ext Γ wfΓ t T as x return (check_type_wf_env_bool X_ext Γ wfΓ t T = x -> typing_result _) then
@@ -2512,12 +2572,29 @@ End monad_Alli_nth_forall.
   Instance Monad_EnvCheck_X_env_ext_type {cf:checker_flags} : Monad EnvCheck_X_env_ext_type := _.
 
   Program Definition typecheck_program (p : program) φ
+    (* this is the hypothesis we need, idk how to simplify it or appropriately generalize it, maybe use check_wf_env_ext_prop to simplify Σ0 ∼_ext X' into _ ∼ X so that we get an equality? *)
+    {normalisation_in
+      : forall (g : global_decl) (Hdecls' : nat) X,
+        (forall Σ0 : global_env,
+            Σ0 ∼ X ->
+            Σ0 =
+              {|
+                universes := p.1;
+                declarations := skipn Hdecls' (declarations p.1);
+                retroknowledge := retroknowledge p.1
+              |}) ->
+        forall X' : X_env_ext_type,
+          check_wf_env_ext_prop X X' (universes_decl_of_decl g) ->
+          forall Σ0 : global_env_ext, wf_ext Σ0 -> Σ0 ∼_ext X' -> NormalisationIn Σ0}
+    {normalisation_in'
+      : forall x : X_env_ext_type,
+        (p.1, φ) ∼_ext x -> forall Σ : global_env_ext, wf_ext Σ -> Σ ∼_ext x -> NormalisationIn Σ}
     : EnvCheck_X_env_ext_type (∑ A, { X: X_env_ext_type | ∥ abstract_env_ext_rel X (p.1, φ) ×
                                                           wf_ext (p.1, φ) × (p.1, φ) ;;; [] |- p.2 ▹ A ∥}) :=
-    '(exist xx pf) <- check_wf_ext (p.1, φ) ;;
-    inft <- infer_term xx p.2 ;;
+    '(exist xx pf) <- @check_wf_ext (p.1, φ) _ ;;
+    inft <- @infer_term xx _ p.2 ;;
     ret (inft.π1; (exist xx _)).
-  Next Obligation.
+ Next Obligation.
     cbn in *. specialize_Σ pf. pose proof (abstract_env_ext_wf _ pf).
     sq. split; auto.
   Qed.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -64,6 +64,8 @@ Section Conversion.
 
   Context (X : X_type.π2.π1).
 
+  Context {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ}.
+
   Local Definition heΣ Σ (wfΣ : abstract_env_ext_rel X Σ) :
     ∥ wf_ext Σ ∥ :=  abstract_env_ext_wf _ wfΣ.
 
@@ -145,12 +147,12 @@ Section Conversion.
 
   Lemma wcored_wf :
     forall Γ, well_founded (wcored Γ).
-  Proof using Type.
+  Proof using normalisation_in.
     intros Γ [u hu].
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]];
-    pose proof (heΣ _ wfΣ) as heΣ.
+    pose proof (heΣ _ wfΣ) as [heΣ].
     pose proof (hu _ wfΣ) as h.
-    apply normalisation_upto in h. 2: exact heΣ.
+    apply normalisation_upto in h. 2: now apply normalisation_in.
     dependent induction h.
     constructor. intros [y hy] r.
     unfold wcored in r. cbn in r.
@@ -218,7 +220,7 @@ Section Conversion.
     forall Γ t p w q s,
       (forall Σ, abstract_env_ext_rel X Σ -> welltyped Σ Γ t) ->
       Acc (R_aux Γ) (t ; (p, (w ; (q, s)))).
-  Proof using Type.
+  Proof using normalisation_in.
     intros Γ t p w q s ht.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     rewrite R_aux_equation_1.
@@ -304,7 +306,7 @@ Section Conversion.
           -- left. unfold posR in *.
              simpl in *. assumption.
           -- right. assumption.
-    - pose proof (heΣ _ wfΣ).
+    - pose proof (heΣ _ wfΣ) as [?].
       eapply Acc_equiv; try eapply normalisation_upto; eauto.
       split; eauto; intros.
       erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
@@ -327,7 +329,7 @@ Section Conversion.
     forall Γ u,
       (forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ (zipc (tm1 u) (stk1 u))) ->
       Acc (R Γ) u.
-  Proof using Type.
+  Proof using normalisation_in.
     intros Γ u h.
     eapply Acc_fun with (f := fun x => obpack x).
     apply R_aux_Acc. assumption.
@@ -2734,7 +2736,7 @@ Qed.
   Qed.
 
   Lemma welltyped_zipc_inv Σ Γ t π : wf Σ -> welltyped Σ Γ (zipc t π) -> welltyped Σ (Γ,,, stack_context π) t.
-  Proof.
+  Proof using Type.
     intros ? Ht. apply welltyped_zipc_zipp in Ht; eauto.
     apply welltyped_zipp_inv in Ht; eauto.
   Defined.
@@ -5178,7 +5180,7 @@ Qed.
   Lemma whnf_mkApps_tPrim_inv :
     forall (f : RedFlags.t) (Σ : global_env) (Γ : context) p (args : list term),
       whnf f Σ Γ (mkApps (tPrim p) args) -> args = [].
-  Proof.
+  Proof using Type.
     intros * wh.
     inversion wh; solve_discr.
     clear -X0.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -194,6 +194,8 @@ Section Reduce.
 
   Context (X : X_type.π2.π1).
 
+  Context {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ}.
+
 (*  Local Definition gΣ := abstract_env_ext_rel Σ. *)
 
   Local Definition heΣ Σ (wfΣ : abstract_env_ext_rel X Σ) :
@@ -251,7 +253,7 @@ Definition R_singleton Abs A
   (R : Abs -> A -> A -> Prop) (Q : Abs -> Prop) x (q : Q x)
   (HQ : forall x x' , Q x -> Q x' -> x = x') (a a' : A) :
   R x a a' <-> (forall x, Q x -> R x a a').
-Proof.
+Proof using Type.
   split.
   - intros H x' q'.  specialize (HQ x x' q q'). subst; eauto.
   - eauto.
@@ -260,6 +262,7 @@ Defined.
 Fixpoint Acc_equiv A (R R' : A -> A -> Prop)
   (Heq : forall a a', R a a' <-> R' a a') a
   (HAcc : Acc R a) : Acc R' a.
+Proof using Type.
   econstructor. intros. apply Heq in H.
   destruct HAcc. eapply Acc_equiv; eauto.
 Defined.
@@ -268,7 +271,7 @@ Corollary R_Acc_aux :
     forall Γ t p,
     (forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ t) ->
     (Acc (fun t t' => forall Σ (wfΣ : abstract_env_ext_rel X Σ), R_aux Σ Γ t t') (t ; p)).
-  Proof.
+  Proof using normalisation_in.
     intros Γ t p h.
     eapply dlexprod_Acc_gen.
     - apply abstract_env_ext_exists.
@@ -278,7 +281,7 @@ Corollary R_Acc_aux :
     - destruct (abstract_env_ext_exists X) as [[Σ wfΣ]];
       destruct (heΣ _ wfΣ).
       eapply Acc_equiv; try
-      eapply normalisation; eauto.
+      eapply normalisation_in; eauto.
       eapply R_singleton with (Q := abstract_env_ext_rel X)
           (R := fun Σ a a' => cored Σ Γ a a'); eauto.
       intros; eapply abstract_env_ext_irr; eauto.
@@ -288,7 +291,7 @@ Corollary R_Acc_aux :
     forall Γ t,
       (forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ (zip t)) ->
       Acc (fun t t' => forall Σ (wfΣ : abstract_env_ext_rel X Σ), R Σ Γ t t') t.
-  Proof using Type.
+  Proof using normalisation_in.
     intros Γ t h.
     pose proof (R_Acc_aux _ _ (stack_pos (fst t) (snd t)) h) as h'.
     clear h. rename h' into h.
@@ -1074,7 +1077,7 @@ Corollary R_Acc_aux :
     intros x y H HR.
     pose proof (heΣ := heΣ _ wfΣ).
     pose proof (hΣ := hΣ _ wfΣ).
-    clear wfΣ X_type X.
+    clear wfΣ X_type X normalisation_in.
     sq.
     destruct x as [x πx], y as [y πy].
     dependent induction HR.
@@ -1091,7 +1094,7 @@ Corollary R_Acc_aux :
 
     Local Instance wf_proof : WellFounded (fun x y : sigmaarg =>
         forall Σ, abstract_env_ext_rel X Σ -> R Σ Γ (pr1 x, pr1 (pr2 x)) (pr1 y, pr1 (pr2 y))).
-    Proof.
+    Proof using normalisation_in.
       intros [t [π wt]].
       (* We fuel the accessibility proof to run reduction inside Coq. *)
       unshelve eapply (Acc_intro_generator
@@ -1820,7 +1823,7 @@ End Reduce.
 Section ReduceFns.
 
   Context {cf : checker_flags} {no : normalizing_flags}
-          {X_type : abstract_env_impl} {X : X_type.π2.π1}.
+          {X_type : abstract_env_impl} {X : X_type.π2.π1} {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ}.
 
   (* We get stack overflow on Qed after Equations definitions when this is transparent *)
   Opaque reduce_stack_full.
@@ -1828,7 +1831,7 @@ Section ReduceFns.
   Definition hnf := reduce_term RedFlags.default X_type X.
 
   Theorem hnf_sound {Γ t h} Σ (wfΣ : abstract_env_ext_rel X Σ) : ∥ Σ ;;; Γ ⊢ t ⇝ hnf Γ t h ∥.
-  Proof.
+  Proof using Type.
     unfold hnf.
     destruct (reduce_term_sound RedFlags.default _ X _ _ h Σ wfΣ).
     sq. eapply into_closed_red; fvs.
@@ -1850,7 +1853,7 @@ Section ReduceFns.
           | view_sort_other hnft r => TypeError_comp (NotASort hnft) _
         }
       }.
-  Proof.
+  Proof using Type.
     * destruct (h _ wfΣ) as [? hs].
       pose proof (hΣ := hΣ _ X _ wfΣ). sq.
       eapply (wt_closed_red_refl hs).
@@ -1894,7 +1897,7 @@ Section ReduceFns.
           | view_prod_other hnft _ => TypeError_comp (NotAProduct t hnft) _
         }
       }.
-  Proof.
+  Proof using Type.
     * destruct (h _ wfΣ) as [? hs].
       pose proof (hΣ := hΣ _ _ _ wfΣ). sq.
       now eapply wt_closed_red_refl.
@@ -1944,7 +1947,7 @@ Section ReduceFns.
           }
         }
       }.
-  Proof.
+  Proof using Type.
     - specialize (h _ wfΣ). destruct h  as [? h].
       assert (Xeq : mkApps (tInd i u) args = t).
       { etransitivity. 2: symmetry; eapply mkApps_decompose_app.
@@ -2098,7 +2101,7 @@ Section ReduceFns.
     eapply isArity_red; eauto. exact reda''.
   Qed.
 
-  Local Instance wellfounded Σ wfΣ : WellFounded (@hnf_subterm_rel _ Σ) :=
-    @wf_hnf_subterm _ _ (heΣ _ X Σ wfΣ).
+  Local Instance wellfounded Σ wfΣ {normalisation:NormalisationIn Σ} : WellFounded (@hnf_subterm_rel _ Σ) :=
+    @wf_hnf_subterm _ _ _ normalisation (heΣ _ X Σ wfΣ).
 
 End ReduceFns.

--- a/safechecker/theories/PCUICSafeRetyping.v
+++ b/safechecker/theories/PCUICSafeRetyping.v
@@ -142,6 +142,8 @@ Context {cf : checker_flags} {nor : normalizing_flags}.
 
   Context (X : X_type.π2.π1).
 
+  Context {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ}.
+
   Local Definition heΣ Σ (wfΣ : abstract_env_ext_rel X Σ) :
     ∥ wf_ext Σ ∥ :=  abstract_env_ext_wf _ wfΣ.
 
@@ -187,7 +189,7 @@ Qed.
     (wfΓ : forall Σ (wfΣ : abstract_env_ext_rel X Σ), ∥ wf_local Σ Γ ∥)
     (wf : forall Σ (wfΣ : abstract_env_ext_rel X Σ), well_sorted Σ Γ T)
     (tx : principal_type Γ T) : principal_sort Γ T :=
-    match @reduce_to_sort cf nor _ X Γ tx _ with
+    match @reduce_to_sort cf nor _ X _ Γ tx _ with
     | Checked_comp (u;_) => (u;_)
     | TypeError_comp e _ => !
     end.
@@ -227,7 +229,7 @@ Qed.
     (wf : forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ T)
     (isprod : forall Σ (wfΣ : abstract_env_ext_rel X Σ), ∥ ∑ na A B, red Σ Γ T (tProd na A B) ∥) :
     ∑ na' A' B', forall Σ (wfΣ : abstract_env_ext_rel X Σ), ∥ Σ ;;; Γ ⊢ T ⇝ tProd na' A' B' ∥ :=
-    match @reduce_to_prod cf nor _ X Γ T wf with
+    match @reduce_to_prod cf nor _ X _ Γ T wf with
     | Checked_comp p => p
     | TypeError_comp e _ => !
     end.
@@ -554,8 +556,6 @@ Qed.
     1: now symmetry.
     now do 2 eexists.
   Defined.
-  Next Obligation. exact X_type. Defined.
-  Next Obligation. exact X. Defined.
   Next Obligation.
     specialize_Σ wfΣ. inversion wt.
     inversion X0 ; subst.
@@ -574,7 +574,7 @@ Qed.
   Next Obligation.
     cbn in *. intros.
     set (H := λ (Σ0 : global_env_ext) (wfΣ0 : abstract_env_ext_rel X Σ0),
-    infer_obligations_obligation_26 Γ ci p c brs wt Σ0
+    infer_obligations_obligation_24 Γ ci p c brs wt Σ0
       wfΣ0) in indargs. cbn in *.
     set (infer _ wfΓ c H) in *. unfold H in *. clear H.
     pose proof p0.π2 as p02.
@@ -618,7 +618,7 @@ Qed.
   Next Obligation.
   cbn in *. intros.
   set (H := λ (Σ : global_env_ext) (wfΣ : abstract_env_ext_rel X Σ),
-  infer_obligations_obligation_26 Γ ci p c brs wt Σ wfΣ) in a0.
+  infer_obligations_obligation_24 Γ ci p c brs wt Σ wfΣ) in a0.
   cbn in *.
   set (infer _ wfΓ c H) in *.
   unfold H in *. clear H e.
@@ -634,8 +634,6 @@ Qed.
     do 3 eexists. intros. erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
     Unshelve. eauto.
   Defined.
-  Next Obligation. exact X_type. Defined.
-  Next Obligation. exact X. Defined.
   Next Obligation.
   specialize_Σ wfΣ. destruct wt.
     inversion X0. inversion X1.
@@ -653,7 +651,7 @@ Qed.
   Next Obligation.
   cbn in *. intros.
   set (H := λ (Σ0 : global_env_ext) (wfΣ0 : abstract_env_ext_rel X Σ0),
-  infer_obligations_obligation_32 Γ p c wt Σ0 wfΣ0) in indargs. cbn in *.
+  infer_obligations_obligation_28 Γ p c wt Σ0 wfΣ0) in indargs. cbn in *.
   set (infer _ wfΓ c H) in *. unfold H in *. clear H.
   pose proof p0.π2 as p02.
   destruct indargs as (?&?&?&?).
@@ -687,7 +685,7 @@ Qed.
     cbn in *.
     set (H := (λ (Σ0 : global_env_ext)
     (wfΣ0 : abstract_env_ext_rel X Σ0),
-    infer_obligations_obligation_32 Γ p c wt Σ0 wfΣ0)) in a0.
+    infer_obligations_obligation_28 Γ p c wt Σ0 wfΣ0)) in a0.
       cbn in *.
       set (infer _ wfΓ c H) in *.
       unfold H in *. clear H e1.
@@ -891,7 +889,7 @@ Qed.
 
   Theorem principal_types {Γ t} (wt : forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ t) :
     ∑ P, ∥ forall T Σ (wfΣ : abstract_env_ext_rel X Σ), Σ ;;; Γ |- t : T -> (Σ ;;; Γ |- t : P) * (Σ ;;; Γ ⊢ P ≤ T) ∥.
-  Proof using nor.
+  Proof using nor normalisation_in.
     unshelve eexists (infer Γ _ t _); intros.
     - destruct (wt _ wfΣ).
       pose (hΣ _ wfΣ); sq.

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -261,6 +261,8 @@ Section Typecheck.
 
   Context (X : X_type.π2.π1).
 
+  Context {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ}.
+
   Local Definition heΣ Σ (wfΣ : abstract_env_ext_rel X Σ) :
     ∥ wf_ext Σ ∥ :=  abstract_env_ext_wf _ wfΣ.
 
@@ -295,6 +297,7 @@ Section Typecheck.
   forall u u',
     conv_pb_relb_gen pb equ eqlu u u' =
     conv_pb_relb_gen pb equ' eqlu' u u'.
+  Proof using Type.
    now destruct pb.
   Qed.
 

--- a/safechecker/theories/PCUICWfReduction.v
+++ b/safechecker/theories/PCUICWfReduction.v
@@ -116,7 +116,7 @@ Qed.
 on (welltyped) terms and going under binders. *)
 Section fix_sigma.
   Context {cf : checker_flags} {no : normalizing_flags}.
-  Context {Σ : global_env_ext} {HΣ : ∥wf_ext Σ∥}.
+  Context {Σ : global_env_ext} {normalisation:NormalisationIn Σ} {HΣ : ∥wf_ext Σ∥}.
 
   Lemma term_subterm_red1 {Γ s s' t} {ts : term_subterm s t} :
     red1 Σ (Γ ,,, term_subterm_context ts) s s' ->
@@ -174,7 +174,7 @@ Section fix_sigma.
   Definition wf_hnf_subterm_rel : WellFounded hnf_subterm_rel.
   Proof.
     intros (Γ & s & H). sq'.
-    induction (normalisation Σ _ Γ s H) as [s _ IH].
+    induction (normalisation_in Γ s H) as [s _ IH].
     induction (term_subterm_wf s) as [s _ IH_sub] in Γ, H, IH |- *.
     econstructor.
     intros (Γ' & t2 & ?) [(t' & r & ts & eqctx)].
@@ -238,6 +238,8 @@ Section fix_sigma.
 
   Context (X : X_type.π2.π1).
 
+  Context {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ}.
+
   (* Reducing at least one step or taking a subterm is well-founded *)
   Definition redp_subterm_rel : Relation_Definitions.relation (∑ Γ t, forall Σ (wfΣ : abstract_env_ext_rel X Σ), welltyped Σ Γ t) :=
     fun '(Γ2; t2; H) '(Γ1; t1; H2) => forall Σ (wfΣ : abstract_env_ext_rel X Σ),
@@ -247,7 +249,7 @@ Section fix_sigma.
   Proof.
     intros (Γ & s & H). pose proof (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose (wf_extΣ := abstract_env_ext_wf _ wfΣ). sq.
-    induction (normalisation Σ wf_extΣ Γ s (H _ wfΣ)) as [s _ IH].
+    induction (normalisation_in Σ wf_extΣ wfΣ Γ s (H _ wfΣ)) as [s _ IH].
     induction (term_subterm_wf s) as [s _ IH_sub] in Γ, H, IH |- *.
     econstructor.
     intros (Γ' & t2 & ?). intro R. specialize (R _ wfΣ).

--- a/safechecker/theories/SafeTemplateChecker.v
+++ b/safechecker/theories/SafeTemplateChecker.v
@@ -18,9 +18,27 @@ Local Instance Monad_EnvCheck_wf_env_ext {cf:checker_flags} {guard : abstract_gu
 
 Program Definition infer_template_program {cf : checker_flags} {nor : normalizing_flags} {guard : abstract_guard_impl}
   (p : Ast.Env.program) φ
+  (* this is the hypothesis we need, idk how to simplify it or appropriately generalize it, maybe use check_wf_env_ext_prop to simplify Σ0 ∼_ext X' into _ ∼ X so that we get an equality? *)
+  {normalisation_in
+    : forall (g : global_decl) (Hdecls' : nat) (X : X_env_type optimized_abstract_env_impl),
+      (forall Σ0 : global_env,
+          Σ0 ∼ X ->
+          Σ0 =
+            {|
+              universes := (trans_program p).1;
+              declarations := skipn Hdecls' (declarations (trans_program p).1);
+              retroknowledge := retroknowledge (trans_program p).1
+            |}) ->
+      forall X' : X_env_ext_type optimized_abstract_env_impl,
+        check_wf_env_ext_prop optimized_abstract_env_impl X X' (universes_decl_of_decl g) ->
+        forall Σ0 : global_env_ext, wf_ext Σ0 -> Σ0 ∼_ext X' -> NormalisationIn Σ0}
+  {normalisation_in'
+    : forall x : X_env_ext_type optimized_abstract_env_impl,
+      ((trans_program p).1, φ) ∼_ext x ->
+      forall Σ : global_env_ext, wf_ext Σ -> Σ ∼_ext x -> NormalisationIn Σ}
   : EnvCheck_wf_env_ext (let p' := trans_program p in ∑ A, { X : wf_env_ext |
     ∥ (p'.1, φ) = X.(wf_env_ext_referenced).(referenced_impl_env_ext) × wf_ext (p'.1, φ) ×  (p'.1, φ) ;;; [] |- p'.2 : A ∥ }) :=
-  pp <- typecheck_program (cf := cf) optimized_abstract_env_impl (trans_program p) φ ;;
+  pp <- typecheck_program (cf := cf) (nor:=nor) optimized_abstract_env_impl (trans_program p) φ ;;
   ret (pp.π1 ; (exist (proj1_sig pp.π2) _)).
 Next Obligation.
   sq. destruct H; split; eauto. destruct p0; split; eauto.  eapply infering_typing; tea. eapply w. constructor.
@@ -28,7 +46,24 @@ Qed.
 
 Program Definition infer_and_print_template_program {cf : checker_flags} {nor : normalizing_flags} {guard : abstract_guard_impl}
   (p : Ast.Env.program) φ
-  : string + string :=
+(* this is the hypothesis we need, idk how to simplify it or appropriately generalize it, maybe use check_wf_env_ext_prop to simplify Σ0 ∼_ext X' into _ ∼ X so that we get an equality? *)
+  {normalisation_in
+    : forall (g : global_decl) (Hdecls' : nat) (X : X_env_type optimized_abstract_env_impl),
+      (forall Σ0 : global_env,
+          Σ0 ∼ X ->
+          Σ0 =
+            {|
+              universes := (trans_program p).1;
+              declarations := skipn Hdecls' (declarations (trans_program p).1);
+              retroknowledge := retroknowledge (trans_program p).1
+            |}) ->
+      forall X' : X_env_ext_type optimized_abstract_env_impl,
+        check_wf_env_ext_prop optimized_abstract_env_impl X X' (universes_decl_of_decl g) ->
+        forall Σ0 : global_env_ext, wf_ext Σ0 -> Σ0 ∼_ext X' -> NormalisationIn Σ0}
+  {normalisation_in'
+    : forall x : X_env_ext_type optimized_abstract_env_impl,
+      ((trans_program p).1, φ) ∼_ext x ->
+      forall Σ : global_env_ext, wf_ext Σ -> Σ ∼_ext x -> NormalisationIn Σ}  : string + string :=
   match infer_template_program (cf:=cf) p φ return string + string with
   | CorrectDecl t =>
     let Σ' := trans_global_env p.1 in

--- a/test-suite/reduction_test.v
+++ b/test-suite/reduction_test.v
@@ -21,7 +21,10 @@ From MetaCoq.SafeChecker Require Import PCUICEqualityDec PCUICWfReduction PCUICE
   {
     guard_impl := PCUICWfEnvImpl.fake_guard_impl
   }.
-Next Obligation. todo "this axiom is inconsitent, onlu used to make infer compute". Qed.
+Next Obligation. todo "this axiom is inconsitent, only used to make infer compute". Qed.
+#[local,program] Instance assume_normalisation {nor} : @PCUICSN.Normalisation default_checker_flags nor.
+Next Obligation. todo "we should write a Template Monad program to prove normalisation for the particular program being inferred, rather than axiomatizing it". Qed.
+#[local] Existing Instance PCUICSN.normalisation.
 
 Definition typecheck_template (cf := default_checker_flags)
   {nor : normalizing_flags} (p : Ast.Env.program)


### PR DESCRIPTION
We use two typeclasses: one for specifying that we can achieve normalisation within a particular environment, while the other posits normalisation for all well-formed environments.  This is useful because while the latter is expected to be unprovable, it may be possible to prove that specific concrete environments are normalising, which may allow us to prove particular programs well-typed more easily without axioms.

<strike>This PR is not yet complete (I've adapted template-coq, pcuic, and safechecker, but not yet erasure nor translations), but I'd be interested in getting feedback on what's already here, the direction, etc.</strike>
Edit: This PR should build now.

I've taken care to avoid overgeneralizing the normalization hypothesis, in the hopes that it might be useful to have access to definitions that don't require strong normalization of the full theory but only of the theory under a certain global environment.  However, my real motivation in making this change is that I want to adapt the definitions in safechecker in a way that allows me to bypass the normalization hypothesis entirely on concrete terms, by providing enough fuel, without needing to compute normal forms of typing derivations, and still get out typing derivations.  While this PR isn't necessary for that change, threading the normalization hypothesis through everything, as a hypothesis, makes this much easier and more principled.