### PR TITLE
notation <# _ #> for quoting programs (global_env + term)

### DIFF
--- a/template-coq/theories/Loader.v
+++ b/template-coq/theories/Loader.v
@@ -6,3 +6,6 @@ Declare ML Module "coq-metacoq-template-coq.plugin".
 
 Notation "<% x %>" := (ltac:(let p y := exact y in quote_term x p))
   (only parsing).
+
+Notation "<# x #>" := (ltac:(let p y := exact y in run_template_program (TemplateMonad.Core.tmQuoteRec x) p))
+  (only parsing).

--- a/template-coq/theories/Loader.v
+++ b/template-coq/theories/Loader.v
@@ -7,5 +7,6 @@ Declare ML Module "coq-metacoq-template-coq.plugin".
 Notation "<% x %>" := (ltac:(let p y := exact y in quote_term x p))
   (only parsing).
 
-Notation "<# x #>" := (ltac:(let p y := exact y in run_template_program (TemplateMonad.Core.tmQuoteRec x) p))
-  (only parsing).
+(* Work around COQBUG(https://github.com/coq/coq/issues/16715) with [match] *)
+(* Use [return _] to avoid running the program twice on failure *)
+Notation "<# x #>" := (match TemplateMonad.Core.tmQuoteRec x return _ with qx => ltac:(let p y := exact y in run_template_program qx p) end).


### PR DESCRIPTION
This notation is useful when using the translation functions to pcuic terms that take a global-environment translation table as argument.