### PR TITLE
Minor reorganization around `extends`, `fresh_global`

### DIFF
--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -149,10 +149,10 @@ Proof.
 Qed.
 
 Lemma extends_trans_global_decls_acc (Σ' : global_env_map) (Σ : Ast.Env.global_declarations) :
-  extends Σ' (trans_global_decls Σ' Σ).
+  extends_decls Σ' (trans_global_decls Σ' Σ).
 Proof.
   induction Σ.
-  * split; cbn. apply incl_cs_refl. now exists []. apply Retroknowledge.extends_refl.
+  * split; cbn; now try exists [].
   * rewrite /=.
     destruct IHΣ as [univs [Σ'' eq]]. cbn in *.
     split; cbn; auto.
@@ -212,21 +212,6 @@ Proof.
       cbn. rewrite -eq'. reflexivity.
       cbn. rewrite eqk /=. apply e.
       cbn. now rewrite eqk.
-Qed.
-
-Lemma cs_subset_trans cs cs' cs'' :
-  cs ⊂_cs cs' -> cs' ⊂_cs cs'' -> cs ⊂_cs cs''.
-Proof.
-  intros [] []; split; [lsets|csets].
-Qed.
-
-Lemma extends_trans {Σ Σ' Σ'' : global_env} : extends Σ Σ' -> extends Σ' Σ'' -> extends Σ Σ''.
-Proof.
-  intros [u [s eq]] [u' [s' eq']]; subst.
-  split.
-  - eapply cs_subset_trans; tea.
-  - eexists (s' ++ s); cbn. rewrite eq' eq. now rewrite app_assoc.
-  - now etransitivity; tea.
 Qed.
 
 Lemma trans_weakening {cf} Σ {Σ' : global_env_map} t :

--- a/template-coq/theories/EnvMap.v
+++ b/template-coq/theories/EnvMap.v
@@ -94,7 +94,20 @@ Module EnvMap.
       fresh_globals ((kn, d) :: g).
   Derive Signature for fresh_globals.
 
+  Lemma fresh_global_iff_not_In kn Σ
+    : fresh_global kn Σ <-> ~ In kn (map fst Σ).
+  Proof using Type.
+    rewrite /fresh_global; split; [ induction 1 | induction Σ; constructor ]; cbn in *.
+    all: tauto.
+  Qed.
 
+  Lemma fresh_globals_iff_NoDup : forall Σ, fresh_globals Σ <-> NoDup (List.map fst Σ).
+  Proof using Type.
+    elim; [ | case ]; split; cbn; inversion 1; subst; constructor.
+    all: repeat match goal with H : iff _ _ |- _ => destruct H end.
+    all: repeat match goal with H : ?T |- _ => match type of T with Prop => revert H end end.
+    all: rewrite -?fresh_global_iff_not_In; auto.
+  Qed.
 
   Lemma fold_left_cons d g acc :
     fold_left (fun (genv : t) (decl : kername × A) => add decl.1 decl.2 genv) (d :: g) acc =

--- a/template-coq/theories/Environment.v
+++ b/template-coq/theories/Environment.v
@@ -380,6 +380,19 @@ Module Environment (T : Term).
     move => ??; case: eqb_spec; intuition congruence.
   Qed.
 
+  Lemma lookup_global_Some_iff_In_NoDup Σ kn decl (H : NoDup (List.map fst Σ))
+    : In (kn, decl) Σ <-> lookup_global Σ kn = Some decl.
+  Proof.
+    move: Σ H; elim => //=; try tauto.
+    move => [??]?; case: eqb_spec => ? IH; inversion 1; subst; try rewrite <- IH by assumption.
+    all: intuition try congruence; subst.
+    all: cbn in *.
+    all: repeat match goal with H : (_, _) = (_, _) |- _ => inversion H; clear H end.
+    all: repeat match goal with H : Some _ = Some _ |- _ => inversion H; clear H end.
+    all: subst => //=; auto.
+    all: try now epose proof (@in_map _ _ fst _ (_, _)); cbn in *; exfalso; eauto.
+  Qed.
+
   #[global] Instance extends_decls_extends Σ Σ' : extends_decls Σ Σ' -> extends Σ Σ'.
   Proof.
     destruct Σ, Σ'; intros []. cbn in *; subst. split => //=.

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -1199,6 +1199,27 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
 
     Derive Signature for on_global_decls.
 
+    Lemma fresh_global_iff_not_In kn Σ
+      : fresh_global kn Σ <-> ~ In kn (map fst Σ).
+    Proof using Type.
+      rewrite /fresh_global; split; [ induction 1 | induction Σ; constructor ]; cbn in *.
+      all: tauto.
+    Qed.
+
+    Lemma fresh_global_iff_lookup_global_None kn Σ
+      : fresh_global kn Σ <-> lookup_global Σ kn = None.
+    Proof using Type. rewrite fresh_global_iff_not_In lookup_global_None //. Qed.
+
+    Lemma NoDup_on_global_decls univs retro decls
+      : on_global_decls univs retro decls -> NoDup (List.map fst decls).
+    Proof using Type.
+      induction 1; cbn in *; constructor => //.
+      let H := match goal with H : on_global_decls_data _ _ _ _ _ |- _ => H end in
+      move: H.
+      case.
+      rewrite fresh_global_iff_not_In; auto.
+    Qed.
+
     Definition on_global_univs (c : ContextSet.t) :=
       let levels := global_levels c in
       let cstrs := ContextSet.constraints c in

--- a/template-coq/theories/Universes.v
+++ b/template-coq/theories/Universes.v
@@ -1562,6 +1562,11 @@ Proof.
   split; [lsets|csets].
 Qed.
 
+Lemma incl_cs_trans cs1 cs2 cs3 : cs1 ⊂_cs cs2 -> cs2 ⊂_cs cs3 -> cs1 ⊂_cs cs3.
+Proof.
+  intros [? ?] [? ?]; split; [lsets|csets].
+Qed.
+
 Lemma empty_contextset_subset u : ContextSet.empty ⊂_cs u.
 Proof.
   red. split; cbn; [lsets|csets].


### PR DESCRIPTION
- Move `cs_subset_trans`, `extends_trans` to more central places
- Add lemmas relating `fresh_global`/`fresh_globals` to `NoDup` and `In`.
- Characterize when `lookup_global` is `None` in terms of `In`
- Characterize `lookup_global` `Some` vs `None` behavior in terms of `fresh_global`
- Show that `on_global_decls` implies `NoDup`
- Strengthen the conclusion of `extends_trans_global_decls_acc` in passing.
- Avoid autogenerated names in `extends_decls_extends`

I need some of these to prove some properties about normalisation, and this is also part of the reorganization that I'm working on for allowing permutation of global environments.