### PR TITLE
Add `hd_error_skipn_iff_In`

### DIFF
--- a/template-coq/theories/utils/MCList.v
+++ b/template-coq/theories/utils/MCList.v
@@ -1454,3 +1454,17 @@ Proof.
   case=> [|l' z];
   [exact: (snoc_view_snoc nil) | exact: (snoc_view_snoc (a :: l'))].
 Qed.
+
+Lemma hd_error_skipn_iff_In {A v ls}
+  : (exists n, hd_error (@skipn A n ls) = Some v) <-> In v ls.
+Proof.
+  move: ls; elim => //=.
+  1: setoid_rewrite skipn_nil; cbn; firstorder congruence.
+  move => ?? <-.
+  split.
+  { move => [[|?]]; rewrite ?skipn_0 ?skipn_S => //=.
+    1: move => [->].
+    all: eauto. }
+  { move => [->|[n H]]; [ exists 0 | exists (S n) ];
+            rewrite ?skipn_0 ?skipn_S => //=. }
+Qed.


### PR DESCRIPTION
I need something like this in a refinement of #792 that doesn't use full-blown normalisation in erasure.  I figured I'd split off this PR to get feedback on naming, etc, earlier on.