### PR TITLE
Fix #777 (eager forced values in async mode) 

### DIFF
--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -323,14 +323,14 @@ struct
 
 
   let sprop_level =
-    constr_mkApp (cInl, [|Lazy.force tproplevel;Lazy.force tlevel;Lazy.force tlevelSProp |])
+    lazy (constr_mkApp (cInl, [|Lazy.force tproplevel;Lazy.force tlevel;Lazy.force tlevelSProp |]))
   let prop_level =
-    constr_mkApp (cInl, [|Lazy.force tproplevel;Lazy.force tlevel;Lazy.force tlevelProp |])
+    lazy (constr_mkApp (cInl, [|Lazy.force tproplevel;Lazy.force tlevel;Lazy.force tlevelProp |]))
 
   let quote_sort s = match s with
   | Sorts.Set -> quote_universe Universe.type0
-  | Sorts.Prop -> constr_mkApp (tof_levels, [| prop_level |])
-  | Sorts.SProp -> constr_mkApp (tof_levels, [| sprop_level |])
+  | Sorts.Prop -> constr_mkApp (tof_levels, [| Lazy.force prop_level |])
+  | Sorts.SProp -> constr_mkApp (tof_levels, [| Lazy.force sprop_level |])
   | Sorts.Type u -> quote_universe u
 
   let quote_sort_family = function


### PR DESCRIPTION
Fixes #777 by thunking prop_level and sprop_level

Tested with the following file

```coq
From MetaCoq.Template Require Import All.

(* Before the PR all the following lemmas report an error in async mode *)
Lemma foo0 : nat. Proof. exact 0. Qed.
Lemma foo1 : nat. Proof. exact 0. Qed.
Lemma foo2 : nat. Proof. exact 0. Qed.
Lemma foo3 : nat. Proof. exact 0. Qed.
Lemma foo4 : nat. Proof. exact 0. Qed.
Lemma foo5 : nat. Proof. exact 0. Qed.
Lemma foo6 : nat. Proof. exact 0. Qed.

Definition foo7 := 0.

(* And this Print kills coq before the PR*)
Print foo0.
```