### PR TITLE
Allow environment weakening to reorder declarations

### DIFF
--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -491,7 +491,7 @@ Proof.
         easy. }
       inversion wfΣ; subst. destruct X0.
       eapply declared_constant_inv in H4; eauto.
-      2:eapply weaken_env_prop_typing.
+      2:exact weaken_env_prop_typing.
       red in H4.
       rewrite body in *.
       cbn in *.
@@ -499,7 +499,7 @@ Proof.
       1,3,5,6:constructor; auto.
       2:{ split; auto. eexists [_]; reflexivity. }
       eapply declared_constant_inv in H.
-      2:eapply weaken_env_prop_typing.
+      2:exact weaken_env_prop_typing.
       2: easy.
       2: easy.
       unfold on_constant_decl in H.
@@ -508,7 +508,7 @@ Proof.
     + now destruct E.cst_body.
   - easy.
   - econstructor; eauto. eapply weakening_env_declared_constructor; eauto with pcuic; tc.
-    { eapply extends_decls_extends. econstructor; try reflexivity. eexists [(_, _)]; reflexivity. }
+    { eapply extends_decls_extends, strictly_extends_decls_extends_decls. econstructor; try reflexivity. eexists [(_, _)]; reflexivity. }
     invs wfΣ.
     destruct H0. split. 2: eauto.
     destruct d. split; eauto.
@@ -795,4 +795,3 @@ Proof.
   eapply erases_deps_single; eauto.
   now eapply erases_global_all_deps.
 Qed.
-

--- a/erasure/theories/ETransform.v
+++ b/erasure/theories/ETransform.v
@@ -131,7 +131,7 @@ Proof.
     revert normalisation_in.
     apply PCUICWeakeningEnvSN.weakening_env_normalisation_in; eauto;
       try match goal with H : PCUICTyping.wf_ext _ |- _ => refine (@PCUICTyping.wf_ext_wf _ _ H) end.
-    apply PCUICAst.PCUICEnvironment.extends_decls_extends; split; cbn; try reflexivity.
+    apply PCUICAst.PCUICEnvironment.extends_decls_extends, PCUICAst.PCUICEnvironment.strictly_extends_decls_extends_decls; split; cbn; try reflexivity.
     eauto using firstn_skipn. }
 Qed.
 

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -6,7 +6,7 @@ From MetaCoq.Erasure Require Import ELiftSubst EGlobalEnv EWcbvEval Extract Prel
 From MetaCoq.PCUIC Require Import PCUICTyping PCUICGlobalEnv PCUICAst
   PCUICAstUtils PCUICConversion PCUICSigmaCalculus
   PCUICClosed PCUICClosedTyp
-  PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
+  PCUICWeakeningEnv PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
   PCUICWeakeningConv PCUICWeakeningTyp PCUICSubstitution PCUICArities
   PCUICWcbvEval PCUICSR PCUICInversion
   PCUICLiftSubst
@@ -150,14 +150,14 @@ Proof.
       * cbn in *.
         assert (isdecl'' := isdecl').
         eapply declared_constant_inv in isdecl'; [| |now eauto|now apply wfΣ].
-        2:eapply weaken_env_prop_typing.
+        2:exact weaken_env_prop_typing.
         unfold on_constant_decl in isdecl'. rewrite e in isdecl'. red in isdecl'.
         unfold declared_constant in isdecl''.
         now eapply @typing_subst_instance_decl with (Σ := Σ) (Γ := []); eauto.
       * assert (isdecl'' := isdecl').
         eapply declared_constant_inv in isdecl'; [| |now eauto|now apply wfΣ].
         unfold on_constant_decl in isdecl'. rewrite e in isdecl'. cbn in *.
-        2:eapply weaken_env_prop_typing.
+        2:exact weaken_env_prop_typing.
         now eapply erases_subst_instance_decl with (Σ := Σ) (Γ := []); eauto.
       * now eauto.
       * exists x0. split; eauto. constructor; econstructor; eauto.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -763,26 +763,6 @@ Proof.
     destruct x => //.
 Qed.
 
-  Lemma extends_lookup_env {cf Σ Σ' kn d} : wf Σ' -> extends_decls Σ Σ' ->
-    lookup_env Σ kn = Some d -> lookup_env Σ' kn = Some d.
-  Proof.
-    destruct Σ as [univs Σ].
-    destruct Σ' as [univs' Σ'].
-    intros wf [Σ'' []]. cbn in *. subst univs'.
-    induction x in Σ, Σ', e, wf |- *. cbn in e. now subst Σ'.
-    intros hl.
-    rewrite e; cbn.
-    case: eqb_spec.
-    intros ->.
-    eapply lookup_global_Some_fresh in hl.
-    rewrite e in wf. destruct wf as [_ ond]; depelim ond. destruct o as [f ? ? ? ].
-    cbn in *. eapply Forall_app in f as []. contradiction.
-    intros _.
-    eapply IHx; trea.
-    rewrite e in wf. destruct wf as [onu ond]; depelim ond.
-    split => //.
-  Qed.
-
 Lemma is_erasableb_irrel_global_env {X_type X} {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ} {X_type' X'} {normalisation_in' : forall Σ, wf_ext Σ -> Σ ∼_ext X' -> NormalisationIn Σ} {Γ t wt wt'} :
   (forall Σ Σ' : global_env_ext, abstract_env_ext_rel X Σ ->
       abstract_env_ext_rel X' Σ' -> ∥ extends_decls Σ' Σ ∥ /\ (Σ.2 = Σ'.2)) ->
@@ -791,12 +771,12 @@ Proof.
   intro ext.
   (* ext eqext. *)
   assert (hl : Hlookup X_type X X_type' X').
-  { red. intros. specialize (ext _ _ H H0) as [[?] ?].
-    split. intros.
+  { red. intros Σ H Σ' H0. specialize (ext _ _ H H0) as [[X0] H1].
+    split. intros kn decl decl' H2 H3.
     rewrite -(abstract_env_lookup_correct' _ _ H).
     rewrite -(abstract_env_lookup_correct' _ _ H0).
-    rewrite H2 H3. pose proof (abstract_env_ext_wf _ H) as [?].
-    eapply extends_lookup_env in H3; try apply e; eauto. clear -H2 H3. congruence.
+    rewrite H2 H3. pose proof (abstract_env_ext_wf _ H) as [X1].
+    eapply lookup_env_extends_NoDup in H3; try eapply NoDup_on_global_decls; try eapply X1; eauto; tc. cbv [PCUICEnvironment.fst_ctx] in *. congruence.
     destruct X0. intros tag.
     rewrite (abstract_primitive_constant_correct _ _ _ H).
     rewrite (abstract_primitive_constant_correct _ _ _ H0).
@@ -1250,14 +1230,14 @@ Proof.
     ELiftSubst.solve_all. Unshelve.
 Qed.
 
+(* TODO: Figure out if this (and [erases]) should use [strictly_extends_decls] or [extends] -Jason Gross *)
 Lemma erases_weakeninv_env {Σ Σ' : global_env_ext} {Γ t t' T} :
-  wf Σ' -> extends_decls Σ Σ' ->
+  wf Σ -> wf Σ' -> strictly_extends_decls Σ Σ' ->
   Σ ;;; Γ |- t : T ->
   erases Σ Γ t t' -> erases (Σ'.1, Σ.2) Γ t t'.
 Proof.
-  intros wfΣ' ext Hty.
+  intros wfΣ wfΣ' ext Hty.
   eapply (env_prop_typing ESubstitution.erases_extends); tea.
-  eapply extends_decls_wf; tea.
 Qed.
 
 Lemma erases_deps_weaken kn d (Σ : global_env) (Σ' : EAst.global_declarations) t :
@@ -1266,6 +1246,8 @@ Lemma erases_deps_weaken kn d (Σ : global_env) (Σ' : EAst.global_declarations)
   erases_deps (add_global_decl Σ (kn, d)) Σ' t.
 Proof.
   intros wfΣ er.
+  assert (wfΣ' : wf Σ)
+    by now eapply strictly_extends_decls_wf; tea; split => //; eexists [_].
   induction er using erases_deps_forall_ind; try solve [now constructor].
   - assert (kn <> kn0).
     { inv wfΣ. inv X. intros <-.
@@ -1278,14 +1260,13 @@ Proof.
     destruct (E.cst_body cb') eqn:cbe'; auto.
     specialize (H3 _ eq_refl).
     eapply on_declared_constant in H; auto.
-    2:{ inv wfΣ. now inv X. }
     red in H. rewrite cbe in H. simpl in H.
     eapply (erases_weakeninv_env (Σ := (Σ, cst_universes cb))
        (Σ' := (add_global_decl Σ (kn, d), cst_universes cb))); eauto.
     simpl.
     split => //; eexists [(kn, d)]; intuition eauto.
   - econstructor; eauto. eapply weakening_env_declared_constructor; eauto; tc.
-    eapply extends_decls_extends. econstructor; try reflexivity. eexists [(_, _)]; reflexivity.
+    eapply extends_decls_extends, strictly_extends_decls_extends_decls. econstructor; try reflexivity. eexists [(_, _)]; reflexivity.
   - econstructor; eauto.
     red. destruct H. split; eauto.
     red in H. red.
@@ -1335,6 +1316,8 @@ Lemma global_erases_with_deps_cons kn kn' d d' Σ Σ' :
   global_erased_with_deps (add_global_decl Σ (kn', d)) ((kn', d') :: Σ') kn.
 Proof.
   intros wf [[cst [declc [cst' [declc' [ebody IH]]]]]|].
+  assert (wfΣ : PCUICTyping.wf Σ)
+    by now eapply strictly_extends_decls_wf; tea; split => //; eexists [_].
   red. inv wf. inv X. left.
   exists cst. split.
   red in declc |- *. unfold declared_constant_gen, lookup_env in *.
@@ -1353,7 +1336,6 @@ Proof.
   split => //. exists [(kn', d)]; intuition eauto.
   eapply on_declared_constant in declc; auto.
   red in declc. rewrite bod in declc. eapply declc.
-  split => //.
   noconf H0.
   eapply erases_deps_cons; eauto.
   constructor; auto.
@@ -1372,7 +1354,9 @@ Lemma global_erases_with_deps_weaken kn kn' d Σ Σ' :
   global_erased_with_deps (add_global_decl Σ (kn', d)) Σ' kn.
 Proof.
   intros wf [[cst [declc [cst' [declc' [ebody IH]]]]]|].
-  red. inv wf. inv X. left.
+  assert (wfΣ : PCUICTyping.wf Σ)
+    by now eapply strictly_extends_decls_wf; tea; split => //; eexists [_].
+  red. inversion wf. inversion X. subst. left.
   exists cst. split.
   red in declc |- *.
   unfold declared_constant_gen, lookup_env in *.
@@ -1384,15 +1368,13 @@ Proof.
   red in ebody. unfold erases_constant_body.
   destruct (cst_body cst) eqn:bod; destruct (E.cst_body cst') eqn:bod' => //.
   intuition auto.
-  eapply (erases_weakeninv_env (Σ  := (Σ, cst_universes cst)) (Σ' := (add_global_decl Σ (kn', d), cst_universes cst))). 4:eauto.
+  eapply (erases_weakeninv_env (Σ  := (Σ, cst_universes cst)) (Σ' := (add_global_decl Σ (kn', d), cst_universes cst))). 5:eauto.
   split; auto. constructor; eauto.
   split; auto; exists [(kn', d)]; intuition eauto.
   eapply on_declared_constant in declc; auto.
-  red in declc. rewrite bod in declc. eapply declc. split => //.
+  red in declc. rewrite bod in declc. eapply declc.
   noconf H0.
-  apply erases_deps_weaken.
-  { split; auto. cbn. constructor; auto. }
-  auto.
+  apply erases_deps_weaken; auto.
 
   right. destruct H as [mib [mib' [Hm [? ?]]]].
   exists mib, mib'; intuition auto.
@@ -1401,10 +1383,11 @@ Proof.
   now epose proof (lookup_env_ext wf Hm).
 Qed.
 
+(* TODO: Figure out if this (and [erases]) should use [strictly_extends_decls] or [extends] -Jason Gross *)
 Lemma erase_constant_body_correct X_type X {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ} cb
   (onc : forall Σ : global_env_ext, abstract_env_ext_rel X Σ -> ∥ on_constant_decl (lift_typing typing) Σ cb ∥) :
   forall Σ Σ', abstract_env_ext_rel X Σ ->
-  wf Σ' -> extends_decls Σ Σ' ->
+  wf Σ -> wf Σ' -> strictly_extends_decls Σ Σ' ->
   erases_constant_body (Σ', Σ.2) cb (fst (erase_constant_body X_type X cb onc)).
 Proof.
   red. destruct cb as [name [bod|] univs]; simpl; eauto. intros.
@@ -1491,8 +1474,10 @@ Proof.
         eexists; intuition eauto.
         rewrite indeps. cbn.
         rewrite eq_kername_refl. reflexivity.
+        cut (strictly_extends_decls Σpop Σ) => [?|].
         eapply (erase_constant_body_correct _ _ _ _ (Σpop , _)); eauto.
         rewrite <- (abstract_make_wf_env_ext_correct Xpop (cst_universes c) _ Σpop Σmake wfpop wfmake); eauto.
+        { now eapply strictly_extends_decls_wf. }
         red. simpl. unshelve epose (abstract_pop_decls_correct X decls _ Σ Σpop wfΣ wfpop).
         { intros. now eexists. }
         split => //. intuition eauto.
@@ -2585,9 +2570,8 @@ Proof using Type.
   intros prefix wfΣ.
   have wfdecls := decls_prefix_wf prefix wfΣ.
   epose proof (weakening_env_lookup_on_global_env (lift_typing typing) _ Σ kn decl
-    weaken_env_prop_typing wfdecls wfΣ).
-  forward X. red; split => //. cbn. apply incl_cs_refl. cbn.
-  apply Retroknowledge.extends_refl.
+    weaken_env_prop_typing wfΣ wfdecls).
+  forward X. apply extends_strictly_on_decls_extends, strictly_extends_decls_extends_strictly_on_decls. red; split => //.
   now apply (X wfdecls).
 Qed.
 
@@ -2715,23 +2699,20 @@ Qed.
 
 Lemma isErasable_irrel_global_env {Σ Σ' : global_env_ext} {Γ t} :
   wf Σ ->
-  extends_decls Σ' Σ ->
+  wf Σ' ->
+  extends Σ' Σ ->
   Σ.2 = Σ'.2 ->
   isErasable Σ' Γ t -> isErasable Σ Γ t.
 Proof using Type.
   unfold isErasable.
-  intros wfΣ ext eqext [T [ht isar]].
+  intros wfΣ wfΣ' ext eqext [T [ht isar]].
   destruct Σ as [Σ decl], Σ' as [Σ' decl']. cbn in eqext; subst decl'.
   exists T; split.
   eapply (env_prop_typing weakening_env (Σ', decl)) => //=.
-  eapply extends_decls_wf; tea.
-  now eapply extends_decls_extends.
   destruct isar as [|s]; [left|right] => //.
   destruct s as [u [Hu isp]].
   exists u; split => //.
   eapply (env_prop_typing weakening_env (Σ', decl)) => //=.
-  eapply extends_decls_wf; tea.
-  now eapply extends_decls_extends.
 Qed.
 
 Definition reduce_stack_eq {cf} {fl} {no:normalizing_flags} {X_type : abstract_env_impl} {X : X_type.π2.π1} {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ} Γ t π wi : reduce_stack fl X_type X Γ t π wi = ` (reduce_stack_full fl X_type X Γ t π wi).
@@ -2832,7 +2813,7 @@ Proof using Type.
       epose proof (abstract_make_wf_env_ext_correct X (cst_universes c) _ _ _ wfΣ H2).
       epose proof (abstract_make_wf_env_ext_correct (abstract_pop_decls X') (cst_universes c) _ _ _ wfpop H3).
       subst. split => //.
-      sq; red. cbn.
+      sq. apply strictly_extends_decls_extends_decls. red. cbn.
       rewrite eq. rewrite <- H0, <- H1. split. symmetry. apply equ; eauto.
       eexists (Σ'' ++ [(kn, ConstantDecl c)]). subst. now rewrite -app_assoc. subst.
       symmetry. now apply equ.

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -21,12 +21,13 @@ Implicit Types (cf : checker_flags) (Σ : global_env_ext).
 Definition Is_proof `{cf : checker_flags} Σ Γ t := ∑ T u, Σ ;;; Γ |- t : T × Σ ;;; Γ |- T : tSort u ×
   (Universe.is_prop u || Universe.is_sprop u).
 
+(* TODO: Figure out whether [SingletonProp], [Computational], and [Informative] should use [strictly_extends_decls] or [extends]. -Jason Gross *)
 Definition SingletonProp `{cf : checker_flags} (Σ : global_env_ext) (ind : inductive) :=
   forall mdecl idecl,
     declared_inductive (fst Σ) ind mdecl idecl ->
     forall Γ args u n (Σ' : global_env_ext),
       wf Σ' ->
-      extends_decls Σ Σ' ->
+      strictly_extends_decls Σ Σ' ->
       welltyped Σ' Γ (mkApps (tConstruct ind n u) args) ->
       ∥Is_proof Σ' Γ (mkApps (tConstruct ind n u) args)∥ /\
        #|ind_ctors idecl| <= 1 /\
@@ -37,7 +38,7 @@ Definition Computational `{cf : checker_flags} (Σ : global_env_ext) (ind : indu
     declared_inductive (fst Σ) ind mdecl idecl ->
     forall Γ args u n (Σ' : global_env_ext),
       wf Σ' ->
-      extends_decls Σ Σ' ->
+      strictly_extends_decls Σ Σ' ->
       welltyped Σ' Γ (mkApps (tConstruct ind n u) args) ->
       Is_proof Σ' Γ (mkApps (tConstruct ind n u) args) -> False.
 
@@ -46,7 +47,7 @@ Definition Informative `{cf : checker_flags} (Σ : global_env_ext) (ind : induct
     declared_inductive (fst Σ) ind mdecl idecl ->
     forall Γ args u n (Σ' : global_env_ext),
       wf_ext Σ' ->
-      extends_decls Σ Σ' ->
+      strictly_extends_decls Σ Σ' ->
       Is_proof Σ' Γ (mkApps (tConstruct ind n u) args) ->
        #|ind_ctors idecl| <= 1 /\
        squash (All (Is_proof Σ' Γ) (skipn (ind_npars mdecl) args)).

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -3326,39 +3326,85 @@ Proof.
   now apply trans_eq_annots.
 Qed.
 
-Lemma extends_trans {Σ Σ' : global_env} : extends Σ Σ' -> extends (trans_global_env Σ) (trans_global_env Σ').
+Lemma lookup_globals_trans decls c : lookup_globals (trans_global_decls decls) c = List.map trans_global_decl (lookup_globals decls c).
+Proof.
+  move: decls. elim => //= => [[kn d]] decls //=.
+  elim: eqb_spec => //= -> -> //=.
+Qed.
+
+Lemma extends_strictly_on_decls_trans {Σ Σ' : global_env} : extends_strictly_on_decls Σ Σ' -> extends_strictly_on_decls (trans_global_env Σ) (trans_global_env Σ').
 Proof.
   intros [onu [Σ'' eq]].
   split => //. exists (trans_global_decls Σ'').
   rewrite /= eq /trans_global_decls /= map_app //.
+Qed.
+
+Lemma strictly_extends_decls_trans {Σ Σ' : global_env} : strictly_extends_decls Σ Σ' ->
+  strictly_extends_decls (trans_global_env Σ) (trans_global_env Σ').
+Proof.
+  intros [onu [Σ'' eq]].
+  split => //. exists (trans_global_decls Σ'').
+  rewrite /= eq /trans_global_decls /= map_app //.
+Qed.
+
+Lemma extends_trans {Σ Σ' : global_env} : extends Σ Σ' -> extends (trans_global_env Σ) (trans_global_env Σ').
+Proof.
+  intros [onu eq].
+  split => // c. specialize (eq c). move: eq => [Σ'' eq].
+  exists (List.map trans_global_decl Σ'').
+  cbv [lookup_envs] in *.
+  rewrite /trans_global_env /= !lookup_globals_trans eq map_app //.
 Qed.
 
 Lemma extends_decls_trans {Σ Σ' : global_env} : extends_decls Σ Σ' ->
   extends_decls (trans_global_env Σ) (trans_global_env Σ').
 Proof.
-  intros [onu [Σ'' eq]].
-  split => //. exists (trans_global_decls Σ'').
-  rewrite /= eq /trans_global_decls /= map_app //.
+  intros [onu eq].
+  split => // c. specialize (eq c). move: eq => [Σ'' eq].
+  exists (List.map trans_global_decl Σ'').
+  cbv [lookup_envs] in *.
+  rewrite /trans_global_env /= !lookup_globals_trans eq map_app //.
 Qed.
 
-Lemma weaken_prop {cf} : weaken_env_decls_prop cumulSpec0 (lift_typing typing)
+(* we make this transparent so we can make use of the fact that the sort is the same in the next proof *)
+Lemma weaken_prop_gen {cf} : weaken_env_prop_gen cumulSpec0 (lift_typing typing) (fun Σ Σ' => wf_trans Σ × wf_trans Σ' × extends Σ Σ')
+  (lift_typing
+   (λ (Σ : global_env_ext) (Γ : context) (t T : term),
+      typing (H:=cf' cf) (trans_global Σ) (trans_local Γ) (trans t) (trans T))).
+Proof.
+  intros Σ Σ' u wf wf' ext Γ t T.
+  destruct T.
+  - intros Ht.
+    eapply (weakening_env (trans_global (Σ, u))), extends_trans; eauto; destruct ext as (wfΣ&wfΣ'&ext); eauto.
+
+  - intros [s Hs]. exists s.
+    eapply (weakening_env (trans_global (Σ, u))), extends_trans; eauto; destruct ext as (wfΣ&wfΣ'&ext); eauto.
+Defined.
+
+(* to get a version that fits in one of the non-_gen lemmas, we need a strict enough version of extension to imply [wf_trans] from extension. *)
+Lemma weaken_prop {cf} : weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing)
   (lift_typing
    (λ (Σ : global_env_ext) (Γ : context) (t T : term),
       wf_trans Σ →
       typing (H:=cf' cf) (trans_global Σ) (trans_local Γ) (trans t) (trans T))).
 Proof.
-  intros Σ Σ' u wf' ext Γ t T.
-  destruct T.
-  - intros Ht Hw.
-    pose proof (extends_decls_trans ext).
-    assert (wfΣ := extends_decls_wf _ _ Hw X).
-    eapply (weakening_env (trans_global (Σ, u))); eauto. tc.
-
-  - intros [s Hs]. exists s. intros Hw.
-    pose proof (extends_decls_trans ext).
-    pose proof (extends_decls_wf _ _ Hw X).
-    specialize (Hs X0).
-    eapply (weakening_env (trans_global (Σ, u))); eauto. tc.
+  pose weaken_prop_gen as H.
+  cbv [lift_typing lift_judgment infer_sort weaken_env_strictly_on_decls_prop weaken_env_prop_gen] in *.
+  repeat (intro; let x := lazymatch goal with x : _ |- _ => x end in pose (H x) as H'; subst H; rename H' into H).
+  move => Hext Γ t T.
+  pose (fun v wfΣ' wfΣ => H (wfΣ, (wfΣ', ltac:(tc))) Γ t T v) as H'; subst H; rename H' into H.
+  destruct T; eauto.
+  { move => H' Ht.
+    pose proof (strictly_extends_decls_trans Hext).
+    pose proof (strictly_extends_decls_wf _ _ Ht _).
+    eauto using strictly_extends_decls_trans, strictly_extends_decls_wf. }
+  { move => [s Hs]. exists s.
+    move => Ht.
+    pose proof (fun pf wfΣ wfΣ' => (H (s; pf) wfΣ wfΣ').π2) as H'; subst H; rename H' into H.
+    cbv [weaken_prop_gen] in *; cbn [projT1] in *.
+    pose proof (strictly_extends_decls_trans Hext).
+    pose proof (strictly_extends_decls_wf _ _ Ht _).
+    eauto. }
 Qed.
 
 Lemma trans_arities_context mdecl :
@@ -3575,7 +3621,7 @@ Proof.
     eapply TT.type_Construct. eauto.
     + eapply trans_declared_constructor in isdecl; tea.
     + now apply trans_consistent_instance_ext.
-    + red in X. epose proof (declared_constructor_inv_decls weaken_prop _ X isdecl) as [cs [hnth onc]].
+    + red in X. epose proof (declared_constructor_inv weaken_prop _ X isdecl) as [cs [hnth onc]].
       destruct onc. red in on_ctype.
       destruct on_ctype as [s Hs].
       rewrite /type_of_constructor. forward Hs. eauto.

--- a/pcuic/theories/PCUICFirstorder.v
+++ b/pcuic/theories/PCUICFirstorder.v
@@ -4,7 +4,7 @@ From MetaCoq.Template Require Import config utils Kernames MCRelations.
 
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICPrimitive
   PCUICReduction
-  PCUICReflect PCUICWeakeningEnvConv PCUICWeakeningEnvTyp PCUICCasesContexts
+  PCUICReflect PCUICWeakeningEnv PCUICWeakeningEnvConv PCUICWeakeningEnvTyp PCUICCasesContexts
   PCUICWeakeningConv PCUICWeakeningTyp
   PCUICContextConversionTyp
   PCUICTyping PCUICGlobalEnv PCUICInversion PCUICGeneration
@@ -267,7 +267,7 @@ Arguments firstorder_mutind : clear implicits.
 Lemma plookup_env_lookup_env {Σ : global_env_ext} kn b :
   plookup_env (firstorder_env Σ) kn = Some b ->
   ∑ Σ' decl, lookup_env Σ kn = Some decl ×
-    extends_decls Σ' Σ ×
+    strictly_extends_decls Σ' Σ ×
     match decl with
     | ConstantDecl _ => b = false
     | InductiveDecl mind =>
@@ -351,7 +351,7 @@ Import PCUICGlobalMaps.
 Lemma fresh_global_app decls decls' kn :
   fresh_global kn (decls ++ decls') ->
   fresh_global kn decls /\ fresh_global kn decls'.
-Proof.
+Proof using Type.
   induction decls => /= //.
   - intros f; split => //.
   - intros f; depelim f.
@@ -362,7 +362,7 @@ Qed.
 Lemma plookup_env_Some_not_fresh g kn b :
   plookup_env (firstorder_env' g) kn = Some b ->
   ~ PCUICGlobalMaps.fresh_global kn g.
-Proof.
+Proof using Type.
   induction g; cbn => //.
   destruct a => //. destruct g0 => //.
   - cbn.
@@ -380,11 +380,11 @@ Proof.
 Qed.
 
 Lemma plookup_env_extends {Σ Σ' : global_env} kn b :
-  extends_decls Σ' Σ ->
+  strictly_extends_decls Σ' Σ ->
   wf Σ ->
   plookup_env (firstorder_env' (declarations Σ')) kn = Some b ->
   plookup_env (firstorder_env' (declarations Σ)) kn = Some b.
-Proof.
+Proof using Type.
   intros [equ [Σ'' eq] eqr]. rewrite eq.
   clear equ eqr. intros []. clear o.
   rewrite eq in o0. clear eq. move: o0.
@@ -410,11 +410,11 @@ Proof.
 Qed.
 
 Lemma firstorder_mutind_ext {Σ Σ' : global_env_ext} m :
-  extends_decls Σ' Σ ->
+  strictly_extends_decls Σ' Σ ->
   wf Σ ->
   firstorder_mutind (firstorder_env' (declarations Σ')) m ->
   firstorder_mutind (firstorder_env Σ) m.
-Proof.
+Proof using Type.
   intros [equ [Σ'' eq]] wf.
   unfold firstorder_env. rewrite eq.
   unfold firstorder_mutind.
@@ -439,7 +439,7 @@ Lemma firstorder_args {Σ : global_env_ext} {wfΣ : wf Σ} { mind cbody i n ui a
   firstorder_spine Σ [] (type_of_constructor mind cbody (i, n) ui) args (mkApps (tInd i u) pandi).
 Proof using Type.
   intros Hdecl Hspine Hind. revert Hspine.
-  unshelve edestruct @declared_constructor_inv with (Hdecl := Hdecl); eauto. eapply weaken_env_prop_typing.
+  unshelve edestruct @declared_constructor_inv with (Hdecl := Hdecl); eauto. exact weaken_env_prop_typing.
 
   (* revert Hspine. *) unfold type_of_constructor.
   erewrite cstr_eq. 2: eapply p.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTactics PCUICInduction
-     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
+     PCUICLiftSubst PCUICUnivSubst PCUICTyping PCUICWeakeningEnv PCUICWeakeningEnvConv PCUICWeakeningEnvTyp
      PCUICWeakeningConv PCUICWeakeningTyp
      PCUICSigmaCalculus PCUICInstDef PCUICInstConv PCUICContextSubst
      PCUICRenameDef PCUICRenameConv PCUICRenameTyp
@@ -301,7 +301,7 @@ Section OnInductives.
     destruct ar as [s ar].
     eapply isType_weaken => //.
     eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u wfΣ) in ar.
-    all:pcuic. 
+    all:pcuic.
   Qed.
 
   Local Definition oi := (on_declared_inductive decli).1.

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -3,7 +3,7 @@ From MetaCoq.Template Require Import utils config.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTactics PCUICInduction
      PCUICLiftSubst PCUICEquality PCUICPosition PCUICCases PCUICSigmaCalculus
      PCUICUnivSubst PCUICContextSubst PCUICTyping
-     PCUICWeakeningEnvConv PCUICWeakeningEnvTyp PCUICClosed PCUICClosedConv PCUICClosedTyp
+     PCUICWeakeningEnvConv PCUICWeakeningEnv PCUICWeakeningEnvTyp PCUICClosed PCUICClosedConv PCUICClosedTyp
      PCUICReduction PCUICWeakeningConv PCUICWeakeningTyp PCUICCumulativity PCUICUnivSubstitutionConv
      PCUICRenameDef PCUICRenameConv PCUICInstDef PCUICInstConv PCUICInstTyp PCUICOnFreeVars.
 
@@ -602,7 +602,7 @@ Lemma wf_arities_context {cf:checker_flags} {Σ : global_env} {wfΣ : wf Σ} {mi
   declared_minductive Σ mind mdecl -> wf_local (Σ, ind_universes mdecl) (arities_context mdecl.(ind_bodies)).
 Proof.
   intros Hdecl.
-  eapply declared_minductive_inv in Hdecl. 2:apply weaken_env_prop_typing. all:eauto.
+  eapply declared_minductive_inv in Hdecl. 2:exact weaken_env_prop_typing. all:eauto.
   eapply wf_arities_context'; eauto.
 Qed.
 

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -1240,7 +1240,7 @@ Section All_local_env.
   Lemma lookup_on_global_env P (Σ : global_env) c decl :
     on_global_env cumulSpec0 P Σ ->
     lookup_env Σ c = Some decl ->
-    { Σ' : global_env & [× extends Σ' Σ, on_global_env cumulSpec0 P Σ' &
+    { Σ' : global_env & [× extends_strictly_on_decls Σ' Σ, on_global_env cumulSpec0 P Σ' &
        on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl] }.
   Proof using Type.
     destruct Σ as [univs Σ retro]; rewrite /on_global_env /lookup_env; cbn.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -26,7 +26,7 @@ Section Validity.
 
   Lemma isType_weaken_full : weaken_env_prop_full cumulSpec0 (lift_typing typing) (fun Σ Γ t T => isType Σ Γ T).
   Proof using Type.
-    red. intros.
+    do 2 red. intros.
     apply infer_typing_sort_impl with id X2; intros Hs.
     unshelve eapply (weaken_env_prop_typing _ _ _ _ _ X1 _ _ (Typ (tSort _))); eauto with pcuic.
     red. simpl. destruct Σ. eapply Hs.
@@ -38,7 +38,7 @@ Section Validity.
     weaken_env_prop cumulSpec0 (lift_typing typing)
       (lift_typing (fun Σ Γ (_ T : term) => isType Σ Γ T)).
   Proof using Type.
-    red. intros.
+    do 2 red. intros.
     apply lift_typing_impl with (1 := X2); intros ? Hs.
     now eapply (isType_weaken_full (Σ, _)).
   Qed.
@@ -283,7 +283,7 @@ Section Validity.
         red in X. simpl in X.
         eapply isType_weakening; eauto.
         eapply (isType_subst_instance_decl (Γ:=[])); eauto. simpl.
-        eapply weaken_env_prop_isType.
+        exact weaken_env_prop_isType.
       * have ond := on_declared_constant wf H.
         do 2 red in ond. simpl in ond.
         simpl in ond.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -44,7 +44,7 @@ Proof.
   intros Hl. apply LevelSet.union_spec in Hl.
   apply LevelSet.union_spec.
   destruct Hl as [Hl|Hl]; [now left|right]. clear φ.
-  destruct H as [[lsub csub] [Σ'' eq]]; subst.
+  destruct H as [[lsub csub] _].
   apply LevelSet.union_spec in Hl.
   apply LevelSet.union_spec; intuition auto.
 Qed.
@@ -62,7 +62,7 @@ Lemma weakening_env_global_ext_constraints Σ Σ' φ (H : extends Σ Σ')
   : ConstraintSet.Subset (global_ext_constraints (Σ, φ))
                          (global_ext_constraints (Σ', φ)).
 Proof.
-  destruct H as [sub [Σ'' eq]]. subst.
+  destruct H as [sub _].
   apply global_ext_constraints_app, sub.
 Qed.
 
@@ -182,7 +182,7 @@ Lemma extends_wf_universe {Σ : global_env_ext} Σ' u : extends Σ Σ' ->
   wf_universe Σ u -> wf_universe (Σ', Σ.2) u.
 Proof.
   destruct Σ as [Σ univ]; cbn.
-  intros [sub [Σ'' eq]].
+  intros [sub _].
   destruct u; simpl; auto.
   intros Hl.
   intros l inl; specialize (Hl l inl).
@@ -270,15 +270,10 @@ Lemma extends_lookup Σ Σ' c decl :
   lookup_env Σ c = Some decl ->
   lookup_env Σ' c = Some decl.
 Proof using P Pcmp cf.
-  destruct Σ as [univs Σ], Σ' as [univs' Σ']; cbn.
-  intros [hu hΣ].
-  rewrite /lookup_env; intros [sub [Σ'' eq]]; cbn in *. subst Σ'.
-  induction Σ'' in hΣ, c, decl |- *.
-  - simpl. auto.
-  - intros hl. depelim hΣ. specialize (IHΣ'' c decl hΣ hl).
-    simpl in *.
-    destruct (eqb_spec c kn); subst; auto. destruct o.
-    apply lookup_global_Some_fresh in IHΣ''; contradiction.
+  cbv [wf on_global_env].
+  intros; eapply lookup_env_extends_NoDup; tea.
+  repeat match goal with H : _ × _ |- _ => destruct H end.
+  eapply NoDup_on_global_decls; tea.
 Qed.
 Hint Resolve extends_lookup : extends.
 
@@ -337,7 +332,7 @@ Hint Extern 0 => eapply weakening_env_declared_projection : extends.
 
 (* Lemma wf_extends {Σ Σ'} : wf Σ' -> extends Σ Σ' -> wf Σ.
 Proof.
-  intros HΣ' [univs [Σ'' eq]]. simpl in *.
+  intros HΣ' [univs H]. simpl in *.
   split => //.
   - red.
   induction Σ''; auto.
@@ -417,22 +412,69 @@ Qed.
 
 
 
-Definition weaken_env_prop_full
-  (P : global_env_ext -> context -> term -> term -> Type) :=
+Definition weaken_env_prop_full_gen
+             (R : global_env_ext -> global_env_ext -> Type)
+             (P : global_env_ext -> context -> term -> term -> Type) :=
   forall (Σ : global_env_ext) (Σ' : global_env),
-    wf Σ -> wf Σ' -> extends Σ.1 Σ' ->
+    wf Σ -> wf Σ' -> R Σ (Σ', Σ.2) ->
     forall Γ t T, P Σ Γ t T -> P (Σ', Σ.2) Γ t T.
 
-Definition weaken_env_prop
+Definition weaken_env_prop_gen
+           (R : global_env_ext -> global_env_ext -> Type)
            (P : global_env_ext -> context -> term -> typ_or_sort -> Type) :=
-  forall Σ Σ' φ, wf Σ -> wf Σ' -> extends Σ Σ' -> forall Γ t T, P (Σ, φ) Γ t T -> P (Σ', φ) Γ t T.
+  forall Σ Σ' φ, wf Σ -> wf Σ' -> R (Σ, φ) (Σ', φ) -> forall Γ t T, P (Σ, φ) Γ t T -> P (Σ', φ) Γ t T.
 
-Definition weaken_env_decls_prop
-  (P : global_env_ext -> context -> term -> typ_or_sort -> Type) :=
-  forall Σ Σ' φ, wf Σ' -> extends_decls Σ Σ' -> forall Γ t T, P (Σ, φ) Γ t T -> P (Σ', φ) Γ t T.
+Definition weaken_env_prop_full := weaken_env_prop_full_gen extends.
+Definition weaken_env_decls_prop_full := weaken_env_prop_full_gen extends_decls.
+Definition weaken_env_strictly_decls_prop_full := weaken_env_prop_full_gen strictly_extends_decls.
+Definition weaken_env_strictly_on_decls_prop_full := weaken_env_prop_full_gen extends_strictly_on_decls.
 
-Lemma extends_decls_wf Σ Σ' :
-  wf Σ' -> extends_decls Σ Σ' -> wf Σ.
+Definition weaken_env_prop := weaken_env_prop_gen extends.
+Definition weaken_env_decls_prop := weaken_env_prop_gen extends_decls.
+Definition weaken_env_strictly_decls_prop := weaken_env_prop_gen strictly_extends_decls.
+Definition weaken_env_strictly_on_decls_prop := weaken_env_prop_gen extends_strictly_on_decls.
+
+Import CMorphisms CRelationClasses.
+#[global] Instance weaken_env_prop_gen_impl
+  : Proper (flip subrelation ==> (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ iffT)))) ==> arrow)%signatureT weaken_env_prop_gen | 10.
+Proof using Type.
+  cbv -[weaken_env_prop_gen iffT]; cbv [weaken_env_prop_gen]; intros * H1 * H2 H3.
+  unshelve
+    (repeat (let x := fresh in
+             intro x;
+             first [ specialize (H3 x)
+                   | let x := open_constr:(_) in specialize (H3 x) ]));
+    eauto.
+  all: rewrite -> H2 in *; assumption.
+Qed.
+
+#[global] Instance Proper_weaken_env_prop_gen_respectful
+  : Proper (flip subrelation ==> (eq ==> eq ==> eq ==> eq ==> iffT) ==> arrow)%signatureT weaken_env_prop_gen | 10.
+Proof using Type.
+  generalize weaken_env_prop_gen_impl; cbv -[weaken_env_prop_gen]; eauto.
+Qed.
+
+#[global] Instance weaken_env_prop_full_gen_impl
+  : Proper (flip subrelation ==> (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ iffT)))) ==> arrow)%signatureT weaken_env_prop_full_gen | 10.
+Proof using Type.
+  cbv -[weaken_env_prop_full_gen iffT]; cbv [weaken_env_prop_full_gen]; intros * H1 * H2 H3.
+  unshelve
+    (repeat (let x := fresh in
+             intro x;
+             first [ specialize (H3 x)
+                   | let x := open_constr:(_) in specialize (H3 x) ]));
+    eauto.
+  all: rewrite -> H2 in *; assumption.
+Qed.
+
+#[global] Instance Proper_weaken_env_prop_full_gen_respectful
+  : Proper (flip subrelation ==> (eq ==> eq ==> eq ==> eq ==> iffT) ==> arrow)%signatureT weaken_env_prop_full_gen | 10.
+Proof using Type.
+  generalize weaken_env_prop_full_gen_impl; cbv -[weaken_env_prop_full_gen]; eauto.
+Qed.
+
+Lemma strictly_extends_decls_wf Σ Σ' :
+  wf Σ' -> strictly_extends_decls Σ Σ' -> wf Σ.
 Proof using P Pcmp cf.
   intros [onu ond] [eq [Σ'' eq']].
   split => //.
@@ -447,9 +489,16 @@ Qed.
 
 End ExtendsWf.
 
+Arguments weaken_env_prop_full_gen {cf} (Pcmp P R)%function_scope _%function_scope.
+Arguments weaken_env_prop_gen {cf} (Pcmp P R)%function_scope _%function_scope.
 Arguments weaken_env_prop_full {cf} (Pcmp P)%function_scope _%function_scope.
-Arguments weaken_env_decls_prop {cf} (Pcmp P)%function_scope _%function_scope.
+Arguments weaken_env_decls_prop_full {cf} (Pcmp P)%function_scope _%function_scope.
+Arguments weaken_env_strictly_on_decls_prop_full {cf} (Pcmp P)%function_scope _%function_scope.
+Arguments weaken_env_strictly_decls_prop_full {cf} (Pcmp P)%function_scope _%function_scope.
 Arguments weaken_env_prop {cf} (Pcmp P)%function_scope _%function_scope.
+Arguments weaken_env_decls_prop {cf} (Pcmp P)%function_scope _%function_scope.
+Arguments weaken_env_strictly_on_decls_prop {cf} (Pcmp P)%function_scope _%function_scope.
+Arguments weaken_env_strictly_decls_prop {cf} (Pcmp P)%function_scope _%function_scope.
 
 #[global] Hint Resolve extends_lookup : extends.
 #[global] Hint Resolve weakening_env_declared_constant : extends.
@@ -457,3 +506,36 @@ Arguments weaken_env_prop {cf} (Pcmp P)%function_scope _%function_scope.
 #[global] Hint Resolve weakening_env_declared_inductive : extends.
 #[global] Hint Resolve weakening_env_declared_constructor : extends.
 #[global] Hint Resolve weakening_env_declared_projection : extends.
+
+(* diamond dependency, but the proofs should never matter *)
+(* we export disabling this warning here so these coercions don't result in warnings, and then we re-enable it later to not suppress other warnings *)
+#[export] Set Warnings Append "-ambiguous-paths".
+Import CMorphisms CRelationClasses.
+Global Coercion weaken_env_prop_full_to_decls {cf Pcmp P P0} : @weaken_env_prop_full cf Pcmp P P0 -> @weaken_env_decls_prop_full cf Pcmp P P0.
+Proof. eapply weaken_env_prop_full_gen_impl; repeat intro; tc; reflexivity. Qed.
+Global Coercion weaken_env_prop_full_to_strictly_on_decls {cf Pcmp P P0} : @weaken_env_prop_full cf Pcmp P P0 -> @weaken_env_strictly_on_decls_prop_full cf Pcmp P P0.
+Proof. eapply weaken_env_prop_full_gen_impl; repeat intro; tc; reflexivity. Qed.
+Global Coercion weaken_env_prop_full_decls_to_strictly_decls {cf Pcmp P P0} : @weaken_env_decls_prop_full cf Pcmp P P0 -> @weaken_env_strictly_decls_prop_full cf Pcmp P P0.
+Proof. eapply weaken_env_prop_full_gen_impl; repeat intro; tc; reflexivity. Qed.
+Global Coercion weaken_env_prop_full_strictly_on_decls_to_strictly_decls {cf Pcmp P P0} : @weaken_env_strictly_on_decls_prop_full cf Pcmp P P0 -> @weaken_env_strictly_decls_prop_full cf Pcmp P P0.
+Proof. eapply weaken_env_prop_full_gen_impl; repeat intro; tc; reflexivity. Qed.
+
+Global Coercion weaken_env_prop_to_decls {cf Pcmp P P0} : @weaken_env_prop cf Pcmp P P0 -> @weaken_env_decls_prop cf Pcmp P P0.
+Proof. eapply weaken_env_prop_gen_impl; repeat intro; tc; reflexivity. Qed.
+Global Coercion weaken_env_prop_to_strictly_on_decls {cf Pcmp P P0} : @weaken_env_prop cf Pcmp P P0 -> @weaken_env_strictly_on_decls_prop cf Pcmp P P0.
+Proof. eapply weaken_env_prop_gen_impl; repeat intro; tc; reflexivity. Qed.
+Global Coercion weaken_env_prop_decls_to_strictly_decls {cf Pcmp P P0} : @weaken_env_decls_prop cf Pcmp P P0 -> @weaken_env_strictly_decls_prop cf Pcmp P P0.
+Proof. eapply weaken_env_prop_gen_impl; repeat intro; tc; reflexivity. Qed.
+Global Coercion weaken_env_prop_strictly_on_decls_to_strictly_decls {cf Pcmp P P0} : @weaken_env_strictly_on_decls_prop cf Pcmp P P0 -> @weaken_env_strictly_decls_prop cf Pcmp P P0.
+Proof. eapply weaken_env_prop_gen_impl; repeat intro; tc; reflexivity. Qed.
+#[export] Set Warnings Append "ambiguous-paths".
+
+#[global] Hint Resolve weaken_env_prop_full_to_decls : extends.
+#[global] Hint Resolve weaken_env_prop_full_to_strictly_on_decls : extends.
+#[global] Hint Resolve weaken_env_prop_full_decls_to_strictly_decls : extends.
+#[global] Hint Resolve weaken_env_prop_full_strictly_on_decls_to_strictly_decls : extends.
+
+#[global] Hint Resolve weaken_env_prop_to_decls : extends.
+#[global] Hint Resolve weaken_env_prop_to_strictly_on_decls : extends.
+#[global] Hint Resolve weaken_env_prop_decls_to_strictly_decls : extends.
+#[global] Hint Resolve weaken_env_prop_strictly_on_decls_to_strictly_decls : extends.

--- a/pcuic/theories/PCUICWfUniverses.v
+++ b/pcuic/theories/PCUICWfUniverses.v
@@ -537,7 +537,7 @@ Qed.
   Lemma wf_universes_weaken_full : weaken_env_prop_full cumulSpec0 (lift_typing typing) (fun Σ Γ t T =>
       wf_universes Σ t && wf_universes Σ T).
   Proof using Type.
-    red. intros.
+    do 2 red. intros.
     to_prop; apply /andP; split; now apply weaken_wf_universes.
   Qed.
 

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -149,7 +149,7 @@ Proof.
 Qed.
 
 Lemma extends_trans_global_decls_acc (Σ' : global_env_map) (Σ : Ast.Env.global_declarations) :
-  extends_decls Σ' (trans_global_decls Σ' Σ).
+  strictly_extends_decls Σ' (trans_global_decls Σ' Σ).
 Proof.
   induction Σ.
   * split; cbn; now try exists [].
@@ -171,10 +171,10 @@ Lemma trans_lookup_env {cf} {Σ : Ast.Env.global_env} cst {wfΣ : Typing.wf Σ} 
   | None => lookup_env (trans_global_env Σ) cst = None
   | Some d =>
     ∑ Σ' : Ast.Env.global_env,
-      [× Ast.Env.extends_decls Σ' Σ,
+      [× Ast.Env.strictly_extends_decls Σ' Σ,
         Typing.wf Σ',
         wf_global_decl (Σ', Ast.universes_decl_of_decl d) cst d,
-        extends_decls (trans_global_env Σ') (trans_global_env Σ) &
+        strictly_extends_decls (trans_global_env Σ') (trans_global_env Σ) &
         lookup_env (trans_global_env Σ) cst = Some (trans_global_decl (trans_global_env Σ') d)]
   end.
 Proof.
@@ -215,15 +215,13 @@ Proof.
 Qed.
 
 Lemma trans_weakening {cf} Σ {Σ' : global_env_map} t :
-  Typing.wf Σ -> extends_decls (trans_global_env Σ) Σ' -> wf Σ' ->
+  Typing.wf Σ -> extends (trans_global_env Σ) Σ' -> wf (trans_global_env Σ) -> wf Σ' ->
   WfAst.wf Σ t ->
   trans (trans_global_env Σ) t = trans Σ' t.
 Proof.
-  intros wfΣ ext wfΣ' wft.
+  intros wfΣ ext wftΣ wfΣ' wft.
   induction wft using WfAst.term_wf_forall_list_ind; cbn; auto; try solve [f_equal; solve_all].
   rewrite !trans_lookup_inductive.
-  unshelve epose proof (trans_lookup_inductive (Σ := trans_global_env Σ) ci _); tc.
-  eapply extends_decls_wf; tea. rewrite {}H2.
   destruct H as [H hnth]. red in H.
   generalize (trans_lookup_env (inductive_mind ci)).
   move: H.
@@ -232,7 +230,7 @@ Proof.
   unfold lookup_inductive_gen, lookup_minductive_gen.
   rewrite hl => /= //. cbn.
   rewrite nth_error_map hnth /=.
-  rewrite (extends_lookup _ _ _ _ wfΣ' (extends_decls_extends _ _ ext) hl) /=.
+  rewrite (extends_lookup _ _ _ _ wfΣ' ext hl) /=.
   rewrite nth_error_map hnth /=.
   red in X0.
   f_equal => //. rewrite /id. unfold trans_predicate. f_equal; solve_all.
@@ -240,11 +238,11 @@ Proof.
 Qed.
 
 Lemma trans_decl_weakening {cf} Σ {Σ' : global_env_map} t :
-  Typing.wf Σ -> extends_decls (trans_global_env Σ) Σ' -> wf Σ' ->
+  Typing.wf Σ -> extends (trans_global_env Σ) Σ' -> wf (trans_global_env Σ) -> wf Σ' ->
   WfAst.wf_decl Σ t ->
   trans_decl (trans_global_env Σ) t = trans_decl Σ' t.
 Proof.
-  intros wfΣ ext wfΣ' wft.
+  intros wfΣ ext wftΣ wfΣ' wft.
   rewrite /trans_decl; destruct t as [na [b|] ty] => /=; f_equal;
   rewrite trans_weakening => //; apply wft.
 Qed.
@@ -256,11 +254,11 @@ Proof. now rewrite map_length. Qed.
 Hint Rewrite @trans_local_length : len.
 
 Lemma trans_local_weakening {cf} Σ {Σ' : global_env_map} t :
-  Typing.wf Σ -> extends_decls (trans_global_env Σ) Σ' -> wf Σ' ->
+  Typing.wf Σ -> extends (trans_global_env Σ) Σ' -> wf (trans_global_env Σ) -> wf Σ' ->
   All (WfAst.wf_decl Σ) t ->
   trans_local (trans_global_env Σ) t = trans_local Σ' t.
 Proof.
-  intros wfΣ ext wfΣ' a.
+  intros wfΣ ext wftΣ wfΣ' a.
   induction a; cbn; auto.
   f_equal. 2:apply IHa.
   rewrite /trans_decl; destruct x as [na [b|] ty] => /=; f_equal;
@@ -268,11 +266,11 @@ Proof.
 Qed.
 
 Lemma trans_ind_body_weakening {cf} Σ {Σ' : global_env_map} b :
-  Typing.wf Σ -> extends_decls (trans_global_env Σ) Σ' -> wf Σ' ->
+  Typing.wf Σ -> extends (trans_global_env Σ) Σ' -> wf (trans_global_env Σ) -> wf Σ' ->
   TypingWf.wf_inductive_body Σ b ->
   trans_one_ind_body (trans_global_env Σ) b = trans_one_ind_body Σ' b.
 Proof.
-  intros wfΣ ext wfΣ' H.
+  intros wfΣ ext wftΣ wfΣ' H.
   destruct H. rewrite /trans_one_ind_body; destruct b; cbn in *.
   f_equal; solve_all.
   - rewrite trans_decl_weakening //.
@@ -286,31 +284,31 @@ Proof.
 Qed.
 
 Lemma trans_global_decl_weaken {cf} (Σ : Ast.Env.global_env_ext) {Σ' : global_env_map} kn d :
-  Typing.wf Σ -> extends_decls (trans_global_env Σ) Σ' -> wf Σ' ->
+  Typing.wf Σ -> extends (trans_global_env Σ) Σ' -> wf (trans_global_env Σ) -> wf Σ' ->
   wf_global_decl Σ kn d ->
   trans_global_decl (trans_global_env Σ) d = trans_global_decl Σ' d.
 Proof.
-  intros.
+  intros wfΣ ext wftΣ wfΣ' wfd.
   destruct d; cbn; f_equal.
   - rewrite /trans_constant_body /=.
-    do 3 red in X2.
+    do 3 red in wfd.
     destruct (Ast.Env.cst_body c) => /=. cbn.
     f_equal.
-    erewrite trans_weakening; tea. reflexivity. apply X2.
-    erewrite trans_weakening; tea. reflexivity. apply X2.
+    erewrite trans_weakening; tea. reflexivity. apply wfd.
+    erewrite trans_weakening; tea. reflexivity. apply wfd.
     f_equal.
-    erewrite trans_weakening; tea. reflexivity. apply X2.
+    erewrite trans_weakening; tea. reflexivity. apply wfd.
   - rewrite /trans_minductive_body. f_equal.
     * erewrite trans_local_weakening; trea.
-      eapply TypingWf.on_global_inductive_wf_params in X2. solve_all.
-    * eapply TypingWf.on_global_inductive_wf_bodies in X2. solve_all.
+      eapply TypingWf.on_global_inductive_wf_params in wfd. solve_all.
+    * eapply TypingWf.on_global_inductive_wf_bodies in wfd. solve_all.
       rewrite trans_ind_body_weakening //.
 Qed.
 
 Import TypingWf.
 
 Lemma weaken_wf_decl_pred {cf} (Σ Σ' : Ast.Env.global_env) Γ t T :
-  Typing.wf Σ -> Ast.Env.extends_decls Σ Σ' -> Typing.wf Σ' ->
+  Typing.wf Σ -> Ast.Env.extends Σ Σ' -> Typing.wf Σ' ->
   WfAst.wf_decl_pred Σ Γ t T -> WfAst.wf_decl_pred Σ' Γ t T.
 Proof.
   intros wf ext wf' ong.
@@ -329,7 +327,8 @@ Proof.
   destruct Ast.Env.lookup_env eqn:heq => //.
   intros [Σ' [ext wfΣ' wfdecl ext' hl]].
   rewrite hl. cbn. f_equal.
-  eapply (trans_global_decl_weaken (Σ', Ast.universes_decl_of_decl g)); tea.
+  eapply (trans_global_decl_weaken (Σ', Ast.universes_decl_of_decl g)); tea; tc.
+  eapply strictly_extends_decls_wf; tea.
 Qed.
 
 Section Translation.
@@ -340,7 +339,7 @@ Section Translation.
 
   Ltac dest_lookup :=
     destruct TransLookup.lookup_inductive as [[mdecl idecl]|].
-    Lemma map_map2 {A B C D} (f : A -> B) (g : C -> D -> A) l l' :
+  Lemma map_map2 {A B C D} (f : A -> B) (g : C -> D -> A) l l' :
     map f (map2 g l l') = map2 (fun x y => f (g x y)) l l'.
   Proof.
     induction l in l' |- *; destruct l'; simpl; auto. f_equal.
@@ -669,7 +668,7 @@ Section Trans_Global.
     Ast.declared_constant Σ cst decl ->
     declared_constant Σ' cst (trans_constant_body Σ' decl).
   Proof.
-    unfold declared_constant, Ast.declared_constant, 
+    unfold declared_constant, Ast.declared_constant,
       declared_constant_gen, Ast.declared_constant_gen.
     now rewrite trans_lookup => -> /=.
   Qed.
@@ -743,7 +742,7 @@ Lemma declared_inductive_inj {Σ mdecl mdecl' ind idecl idecl'} :
   mdecl = mdecl' /\ idecl = idecl'.
 Proof.
   intros [] []. unfold Ast.declared_minductive in *.
-  unfold Ast.declared_minductive_gen in H1. 
+  unfold Ast.declared_minductive_gen in H1.
   rewrite H in H1. inversion H1. subst. rewrite H2 in H0. inversion H0. eauto.
 Qed.
 
@@ -752,10 +751,10 @@ Lemma lookup_inductive_None Σ ind : lookup_inductive Σ ind = None ->
 Proof.
   intros hl [mdecl [idecl [decli hnth]]].
   unfold declared_inductive, declared_minductive in decli.
-  unfold lookup_inductive, lookup_inductive_gen, 
+  unfold lookup_inductive, lookup_inductive_gen,
     lookup_minductive, lookup_minductive_gen in hl.
-  unfold declared_minductive_gen in decli. 
-  destruct lookup_env eqn:heq. 
+  unfold declared_minductive_gen in decli.
+  destruct lookup_env eqn:heq.
   noconf decli. cbn in hl.
   destruct nth_error; congruence. congruence.
 Qed.
@@ -774,7 +773,7 @@ Section Trans_Global.
     unfold SEq.R_global_instance, SEq.global_variance.
     destruct gref; simpl; auto.
     - unfold R_global_instance_gen, R_opt_variance; cbn.
-      unfold Ast.lookup_inductive_gen, lookup_inductive_gen, 
+      unfold Ast.lookup_inductive_gen, lookup_inductive_gen,
         Ast.lookup_minductive_gen, lookup_minductive_gen.
       rewrite trans_lookup. destruct Ast.Env.lookup_env eqn:look => //; simpl.
       destruct g => /= //.
@@ -1287,7 +1286,7 @@ Section Trans_Global.
     lookup_inductive Σ' ind = Some (mdecl, idecl).
   Proof.
     intros []. unfold lookup_inductive, lookup_minductive.
-    unfold lookup_inductive_gen, lookup_minductive_gen. 
+    unfold lookup_inductive_gen, lookup_minductive_gen.
     now rewrite H H0.
   Qed.
 

--- a/pcuic/theories/TemplateToPCUICExpanded.v
+++ b/pcuic/theories/TemplateToPCUICExpanded.v
@@ -35,18 +35,11 @@ Proof.
 Qed.
 
 Import PCUICWeakeningEnv.
-(* TODO move *)
-Lemma extends_decls_trans Σ Σ' Σ'' : extends_decls Σ Σ' -> extends_decls Σ' Σ'' -> extends_decls Σ Σ''.
-Proof.
-  intros [e [ext e'] er] [e0 [ext' e0'] er']. subst. split. now transitivity Σ'.
-  exists (ext' ++ ext). now rewrite -app_assoc.
-  congruence.
-Qed.
 
 Lemma declared_minductive_expanded Σ c mdecl :
   expanded_global_env Σ ->
   declared_minductive Σ c mdecl ->
-  exists Σ', ∥ extends_decls Σ' Σ ∥ /\ expanded_minductive_decl Σ' mdecl.
+  exists Σ', ∥ strictly_extends_decls Σ' Σ ∥ /\ expanded_minductive_decl Σ' mdecl.
 Proof.
   unfold expanded_global_env, declared_minductive, lookup_env.
   destruct Σ as [univs Σ]; cbn. unfold declared_minductive_gen.
@@ -56,14 +49,14 @@ Proof.
   subst c. eexists. split ; [|exact H]. sq. red. split => //. cbn.
   eexists. cbn. instantiate (1:= [_]); reflexivity.
   intros hl; destruct (IHexp hl). exists x. intuition auto.
-  sq. eapply extends_decls_trans; tea.
+  sq. etransitivity; tea.
   split => //. now exists [(kn, d)].
 Qed.
 
 Lemma declared_constructor_expanded {Σ c mdecl idecl cdecl} :
   expanded_global_env Σ ->
   declared_constructor Σ c mdecl idecl cdecl ->
-  exists Σ', ∥ extends_decls Σ' Σ ∥ /\ expanded_minductive_decl Σ' mdecl /\ expanded_constructor_decl Σ' mdecl cdecl.
+  exists Σ', ∥ strictly_extends_decls Σ' Σ ∥ /\ expanded_minductive_decl Σ' mdecl /\ expanded_constructor_decl Σ' mdecl cdecl.
 Proof.
   intros exp [[decli hnth] hnth'].
   eapply declared_minductive_expanded in decli.
@@ -139,7 +132,7 @@ Qed.
 Implicit Types (cf : checker_flags).
 
 Lemma expanded_weakening {cf} {Σ Σ' Γ t} :
-  wf Σ' -> extends_decls Σ Σ' -> expanded Σ Γ t -> expanded Σ' Γ t.
+  wf Σ' -> extends Σ Σ' -> expanded Σ Γ t -> expanded Σ' Γ t.
 Proof.
   intros wfΣ ext.
   eapply expanded_ind; intros.
@@ -148,11 +141,11 @@ Proof.
     intros ? ? []; constructor; auto. now rewrite <- repeat_app.
   - eapply expanded_tFix; tea; eauto. solve_all.
   - eapply expanded_tConstruct_app; tea.
-    eapply weakening_env_declared_constructor; tea. now eapply extends_decls_extends.
+    eapply weakening_env_declared_constructor; tea.
 Qed.
 
 Lemma expanded_context_weakening {cf} {Σ Σ' Γ t} :
-  wf Σ' -> extends_decls Σ Σ' -> expanded_context Σ Γ t -> expanded_context Σ' Γ t.
+  wf Σ' -> extends Σ Σ' -> expanded_context Σ Γ t -> expanded_context Σ' Γ t.
 Proof.
   intros wfΣ ext.
   intros [a]; sq.
@@ -181,7 +174,7 @@ Proof.
   epose proof (expanded_context_subst (Γ := []) (Δ' := repeat 0 #|ind_bodies mdecl|)).
   rewrite !app_nil_r in H0. eapply H0; rewrite ?repeat_length //. len. apply expanded_inds.
   rewrite -repeat_app. exact hargs.
-  destruct ext. eapply expanded_context_weakening; tea.
+  destruct ext. eapply expanded_context_weakening; tea; tc.
 Qed.
 
 Lemma trans_expanded {cf : checker_flags} {Σ} {wfΣ : Template.Typing.wf Σ} Γ T  :

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -4,7 +4,7 @@ From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICCases PCUICInduction
      PCUICLiftSubst PCUICUnivSubst PCUICSigmaCalculus PCUICClosed
      PCUICOnFreeVars PCUICTyping PCUICReduction PCUICGlobalEnv PCUICWeakeningEnvConv PCUICClosedConv
-     PCUICWeakeningEnvTyp.
+     PCUICWeakeningEnv PCUICWeakeningEnvTyp.
 
 Require Import ssreflect ssrbool.
 From Equations Require Import Equations.
@@ -79,7 +79,7 @@ Lemma declared_decl_closed_ind {cf : checker_flags} {Σ : global_env} {wfΣ : wf
                  (Σ, universes_decl_of_decl decl) cst decl.
 Proof.
   intros.
-  eapply weaken_lookup_on_global_env; eauto. red; eauto.
+  eapply weaken_lookup_on_global_env; eauto. do 2 red; eauto.
   eapply @on_global_env_impl with (Σ := (empty_ext Σ)); cycle 1. tea.
   red; intros. destruct T; intuition auto with wf.
   destruct X2 as [s0 Hs0]. simpl. rtoProp; intuition.
@@ -200,7 +200,7 @@ Proof.
     eauto using closed_upwards with arith.
 
   - rewrite closedn_subst_instance.
-    eapply declared_inductive_inv in X0; eauto.
+    eapply declared_inductive_inv in X0; eauto with extends.
     apply onArity in X0. repeat red in X0.
     destruct X0 as [s Hs]. rewrite -> andb_and in Hs.
     intuition eauto using closed_upwards with arith.
@@ -211,7 +211,7 @@ Proof.
       simpl. now rewrite IHn.
     + rewrite inds_length.
       rewrite closedn_subst_instance.
-      eapply declared_inductive_inv in X0; eauto.
+      eapply declared_inductive_inv in X0; eauto with extends.
       pose proof X0.(onConstructors) as XX.
       eapply All2_nth_error_Some in Hcdecl; eauto.
       destruct Hcdecl as [? [? ?]]. cbn in *.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -23,23 +23,28 @@ Ltac my_rename_hyp h th :=
 
 Ltac rename_hyp h ht ::= my_rename_hyp h ht.
 
-Lemma extends_wf_local `{cf : checker_flags} Σ Γ (wfΓ : wf_local Σ Γ) :
+Lemma extends_wf_local_gen `{cf : checker_flags} R Σ Γ (wfΓ : wf_local Σ Γ) :
   All_local_env_over typing
       (fun Σ0 Γ0 wfΓ (t T : term) ty =>
          forall Σ' : global_env,
            wf Σ' ->
-           extends Σ0 Σ' ->
+           R Σ0 Σ' ->
            (Σ', Σ0.2);;; Γ0 |- t : T
       ) Σ Γ wfΓ ->
-    forall Σ' : global_env, wf Σ' -> extends Σ Σ' -> wf_local (Σ', Σ.2) Γ.
+    forall Σ' : global_env, wf Σ' -> R Σ Σ' -> wf_local (Σ', Σ.2) Γ.
 Proof.
   intros X0 Σ' H0.
   induction X0 in H0 |- *; try econstructor; simpl in *; intuition auto.
   - apply infer_typing_sort_impl with id tu. intro; eauto.
   - apply infer_typing_sort_impl with id tu. intro; eauto.
 Qed.
+
+Definition extends_wf_local `{cf : checker_flags} := extends_wf_local_gen extends.
+Definition extends_decls_wf_local `{cf : checker_flags} := extends_wf_local_gen extends_decls.
+Definition extends_strictly_on_decls_wf_local `{cf : checker_flags} := extends_wf_local_gen extends_strictly_on_decls.
+Definition strictly_extends_decls_wf_local `{cf : checker_flags} := extends_wf_local_gen strictly_extends_decls.
 #[global]
-Hint Resolve extends_wf_local : extends.
+Hint Resolve extends_wf_local extends_decls_wf_local extends_strictly_on_decls_wf_local strictly_extends_decls_wf_local : extends.
 
 Lemma extends_check_recursivity_kind `{cf : checker_flags} Σ ind k Σ' : extends Σ Σ' -> wf Σ' ->
   check_recursivity_kind (lookup_env Σ) ind k -> check_recursivity_kind (lookup_env Σ') ind k.
@@ -91,9 +96,9 @@ Local Hint Resolve extends_primitive_constant : extends.
 
 Lemma weakening_env `{checker_flags} :
   env_prop (fun Σ Γ t T =>
-              forall Σ', wf Σ' -> extends Σ.1 Σ' -> (Σ', Σ.2) ;;; Γ |- t : T)
+              forall Σ', wf Σ -> wf Σ' -> extends Σ.1 Σ' -> (Σ', Σ.2) ;;; Γ |- t : T)
            (fun Σ Γ =>
-             forall Σ', wf Σ' -> extends Σ.1 Σ' -> wf_local (Σ', Σ.2) Γ).
+             forall Σ', wf Σ -> wf Σ' -> extends Σ.1 Σ' -> wf_local (Σ', Σ.2) Γ).
 Proof.
   apply typing_ind_env; intros;
     rename_all_hyps; try solve [econstructor; eauto 2 with extends].
@@ -105,11 +110,11 @@ Proof.
   - econstructor; eauto 2 with extends.
     now apply extends_wf_universe.
   - econstructor; eauto 2 with extends. all: econstructor; eauto 2 with extends.
-    * revert X5. clear -Σ' wfΣ' extΣ.
+    * revert X5. clear -Σ' wf0 wfΣ' extΣ.
       induction 1; constructor; try destruct t0; eauto with extends.
     * close_Forall. intros; intuition eauto with extends.
   - econstructor; eauto with extends.
-    + specialize (forall_Σ' _ wfΣ' extΣ).
+    + specialize (forall_Σ' _ wf0 wfΣ' extΣ).
       now apply wf_local_app_inv in forall_Σ'.
     + eapply fix_guard_extends; eauto.
     + eapply (All_impl X0); intros d X.
@@ -117,7 +122,7 @@ Proof.
     + eapply (All_impl X1); intros d X.
       apply (lift_typing_impl X); now intros ? [].
   - econstructor; eauto with extends.
-    + specialize (forall_Σ' _ wfΣ' extΣ).
+    + specialize (forall_Σ' _ wf0 wfΣ' extΣ).
       now apply wf_local_app_inv in forall_Σ'.
     + eapply cofix_guard_extends; eauto.
     + eapply (All_impl X0); intros d X.
@@ -129,14 +134,15 @@ Proof.
     + destruct Σ as [Σ φ]. eapply weakening_env_cumulSpec in cumulA; eauto.
 Qed.
 
-Lemma weakening_on_global_decl `{checker_flags} P Σ Σ' φ kn decl :
-  weaken_env_prop cumulSpec0 (lift_typing typing) P ->
-  wf Σ -> wf Σ' -> extends Σ Σ' ->
+Lemma weakening_on_global_decl_gen `{checker_flags} R P Σ Σ' φ kn decl :
+  CRelationClasses.subrelation R extends ->
+  weaken_env_prop_gen cumulSpec0 (lift_typing typing) R P ->
+  wf Σ -> wf Σ' -> R Σ Σ' ->
   on_global_decl cumulSpec0 P (Σ, φ) kn decl ->
   on_global_decl cumulSpec0 P (Σ', φ) kn decl.
 Proof.
-  unfold weaken_env_prop.
-  intros HPΣ wfΣ wfΣ' Hext Hdecl.
+  unfold weaken_env_prop_gen.
+  intros HRext HPΣ wfΣ wfΣ' Hext Hdecl.
   destruct decl.
   1:{
     destruct c. destruct cst_body0.
@@ -183,8 +189,8 @@ Proof.
       * eapply Forall_impl; tea; cbn.
         intros. eapply Forall_impl; tea; simpl; intros.
         eapply leq_universe_subset; tea.
-        apply weakening_env_global_ext_constraints; tea.
-      * destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ wfΣ' Hext.
+        apply weakening_env_global_ext_constraints; tea; eauto.
+      * destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ wfΣ' HRext Hext.
         induction ind_indices; simpl in *; auto.
         -- eapply (extends_wf_universe (Σ:=(Σ,φ)) Σ'); auto.
         -- destruct a as [na [b|] ty]; simpl in *; intuition eauto.
@@ -202,156 +208,98 @@ Proof.
     rewrite /on_variance. destruct ind_universes => //.
     destruct ind_variance => //.
     intros [univs' [i [i' []]]]. exists univs', i, i'. split => //.
-    all:eapply weakening_env_consistent_instance; tea.
+    all:eapply weakening_env_consistent_instance; tea; eauto.
 Qed.
 
-Lemma weakening_on_global_decl_ext `{checker_flags} P Σ Σ' φ kn decl :
-  weaken_env_decls_prop cumulSpec0 (lift_typing typing) P ->
-  wf Σ' -> extends_decls Σ Σ' ->
+Definition weakening_on_global_decl `{checker_flags} P Σ Σ' φ kn decl :
+  weaken_env_prop cumulSpec0 (lift_typing typing) P ->
+  wf Σ -> wf Σ' -> extends Σ Σ' ->
   on_global_decl cumulSpec0 P (Σ, φ) kn decl ->
   on_global_decl cumulSpec0 P (Σ', φ) kn decl.
-Proof.
-  unfold weaken_env_prop.
-  intros HPΣ wfΣ' Hext Hdecl.
-  pose proof (wfΣ := extends_decls_wf _ _ wfΣ' Hext).
-  destruct decl.
-  1:{
-    destruct c. destruct cst_body0.
-    - simpl in *.
-      red in Hdecl |- *. simpl in *.
-      eapply (HPΣ Σ Σ'); eauto.
-    - eapply (HPΣ Σ Σ'); eauto.
-  }
-  simpl in *.
-  destruct Hdecl as [onI onP onnP]; constructor; eauto.
-  - eapply Alli_impl; eauto. intros.
-    destruct X. unshelve econstructor; eauto.
-    + unfold on_type in *; intuition eauto.
-    + unfold on_constructors in *. eapply All2_impl; eauto.
-      intros.
-      destruct X as [? ? ? ?]. unshelve econstructor; eauto.
-      * unfold on_type in *; eauto.
-      * clear on_cindices cstr_eq cstr_args_length.
-        revert on_cargs.
-        induction (cstr_args x0) in y |- *; destruct y; simpl in *; eauto.
-        ** destruct a as [na [b|] ty]; simpl in *; intuition eauto.
-        ** destruct a as [na [b|] ty]; simpl in *; intuition eauto.
-      * clear on_ctype on_cargs.
-        revert on_cindices.
-        generalize (List.rev (lift_context #|cstr_args x0| 0 (ind_indices x))).
-        generalize (cstr_indices x0).
-        induction 1; constructor; eauto.
-      * simpl.
-        intros v indv. specialize (on_ctype_variance v indv).
-        simpl in *. move: on_ctype_variance.
-        unfold cstr_respects_variance. destruct variance_universes as [[[univs u] u']|]; auto.
-        intros [args idxs]. split.
-        ** eapply (All2_fold_impl args); intros.
-           inversion X; constructor; auto.
-           ++ eapply weakening_env_cumulSpec; eauto. tc.
-           ++ eapply weakening_env_convSpec; eauto. tc.
-           ++ eapply weakening_env_cumulSpec; eauto. tc.
-        ** eapply (All2_impl idxs); intros.
-          eapply weakening_env_convSpec; eauto. tc.
-    + unfold check_ind_sorts in *.
-      destruct Universe.is_prop; auto.
-      destruct Universe.is_sprop; auto.
-      split; [apply fst in ind_sorts|apply snd in ind_sorts].
-      * eapply Forall_impl; tea; cbn.
-        intros. eapply Forall_impl; tea; simpl; intros.
-        eapply leq_universe_subset; tea.
-        apply weakening_env_global_ext_constraints; tea. tc.
-      * destruct indices_matter; [|trivial]. clear -ind_sorts HPΣ wfΣ wfΣ' Hext.
-        induction ind_indices; simpl in *; auto.
-        -- eapply (extends_wf_universe (Σ:=(Σ,φ)) Σ'); auto. tc.
-        -- destruct a as [na [b|] ty]; simpl in *; intuition eauto.
-    + destruct ind_variance => //.
-      move: onIndices. unfold ind_respects_variance.
-      destruct variance_universes as [[[univs u] u']|] => //.
-      intros idx; eapply (All2_fold_impl idx); simpl.
-      intros par par' t t' d.
-      inv d; constructor; auto.
-      ++ eapply weakening_env_cumulSpec; eauto; tc.
-      ++ eapply weakening_env_convSpec; eauto; tc.
-      ++ eapply weakening_env_cumulSpec; eauto; tc.
-  - red in onP |- *. eapply All_local_env_impl; eauto.
-  - move: onVariance.
-    rewrite /on_variance. destruct ind_universes => //.
-    destruct ind_variance => //.
-    intros [univs' [i [i' []]]]. exists univs', i, i'. split => //.
-    all:eapply weakening_env_consistent_instance; tea; tc.
-Qed.
-
-Lemma weakening_env_decls_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
+Proof. intro; eapply weakening_on_global_decl_gen; [ | eassumption ]; tc. Qed.
+Lemma weakening_on_global_decl_ext `{checker_flags} P Σ Σ' φ kn decl :
   weaken_env_decls_prop cumulSpec0 (lift_typing typing) P ->
-  wf Σ' -> extends_decls Σ Σ' -> on_global_env cumulSpec0 P Σ ->
+  wf Σ -> wf Σ' -> extends_decls Σ Σ' ->
+  on_global_decl cumulSpec0 P (Σ, φ) kn decl ->
+  on_global_decl cumulSpec0 P (Σ', φ) kn decl.
+Proof. intro; eapply weakening_on_global_decl_gen; [ | eassumption ]; tc. Qed.
+Lemma weakening_on_global_decl_strictly `{checker_flags} P Σ Σ' φ kn decl :
+  weaken_env_strictly_on_decls_prop cumulSpec0 (lift_typing typing) P ->
+  wf Σ -> wf Σ' -> extends_strictly_on_decls Σ Σ' ->
+  on_global_decl cumulSpec0 P (Σ, φ) kn decl ->
+  on_global_decl cumulSpec0 P (Σ', φ) kn decl.
+Proof. intro; eapply weakening_on_global_decl_gen; [ | eassumption ]; tc. Qed.
+Lemma weakening_on_global_decl_strictly_ext `{checker_flags} P Σ Σ' φ kn decl :
+  weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) P ->
+  wf Σ -> wf Σ' -> strictly_extends_decls Σ Σ' ->
+  on_global_decl cumulSpec0 P (Σ, φ) kn decl ->
+  on_global_decl cumulSpec0 P (Σ', φ) kn decl.
+Proof. intro; eapply weakening_on_global_decl_gen; [ | eassumption ]; tc. Qed.
+
+Import CRelationClasses CMorphisms.
+Lemma weakening_env_gen_lookup_on_global_env `{checker_flags} R P Σ Σ' c decl :
+  subrelation R extends ->
+  subrelation strictly_extends_decls R ->
+  Transitive R ->
+  weaken_env_prop_gen cumulSpec0 (lift_typing typing) R P ->
+  wf Σ' -> wf Σ -> R Σ Σ' -> on_global_env cumulSpec0 P Σ ->
   lookup_env Σ c = Some decl ->
   on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl.
 Proof.
-  intros HP wfΣ' Hext HΣ.
-  assert (wfΣ := extends_decls_wf _ _ wfΣ' Hext).
+  intros HRext1 HRext2 HTR HP wfΣ' wfΣ Hext HΣ.
   destruct HΣ as [onu onΣ].
   destruct Σ as [univs Σ retro]; cbn in *.
   induction onΣ; simpl. 1: congruence.
-  assert (HH: extends_decls {| universes := univs; declarations := Σ; retroknowledge := retro |} Σ'). {
-    destruct Hext as [univs' [Σ'' HΣ'']]. split; eauto.
-    exists (Σ'' ++ [(kn, d)]). now rewrite <- app_assoc.
+  assert (HH: R {| universes := univs; declarations := Σ; retroknowledge := retro |} Σ'). {
+    etransitivity; [ eapply HRext2 | exact Hext ].
+    split; cbv [snoc]; cbn; auto.
+    eexists [_]; cbn; reflexivity.
   }
   case: eqb_specT; intro eq; subst.
   - intros [= ->]. subst. destruct o.
-    clear Hext; eapply weakening_on_global_decl_ext. 3:tea. all:eauto.
+    clear Hext; eapply weakening_on_global_decl_gen; [ .. | eassumption ]; eauto; [].
+    destruct wfΣ as [? wfΣ]; inversion wfΣ; subst; split; tea.
   - destruct o. apply IHonΣ; auto.
     destruct wfΣ. split => //. now depelim o0.
 Qed.
 
 Lemma weakening_env_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
   weaken_env_prop cumulSpec0 (lift_typing typing) P ->
-  wf Σ -> wf Σ' -> extends Σ Σ' -> on_global_env cumulSpec0 P Σ ->
+  wf Σ' -> wf Σ -> extends Σ Σ' -> on_global_env cumulSpec0 P Σ ->
   lookup_env Σ c = Some decl ->
   on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl.
-Proof.
-  intros HP wfΣ wfΣ' Hext HΣ.
-  destruct HΣ as [onu onΣ].
-  destruct Σ as [univs Σ retro]; cbn in *.
-  induction onΣ; simpl. 1: congruence.
-  assert (HH: extends {| universes := univs; declarations := Σ; retroknowledge := retro |} Σ'). {
-    destruct Hext as [univs' [Σ'' HΣ'']]. split; eauto.
-    exists (Σ'' ++ [(kn, d)]). now rewrite <- app_assoc.
-  }
-  destruct o. case: eqb_specT; intro e; subst.
-  - intros [= ->]. subst.
-    clear Hext; eapply weakening_on_global_decl. 5:tea. all:eauto.
-    destruct wfΣ. split => //. now depelim o0.
-  - apply IHonΣ; auto.
-    destruct wfΣ. split => //. now depelim o0.
-Qed.
-
-Lemma weaken_lookup_on_global_env `{checker_flags} P Σ c decl :
-  weaken_env_prop cumulSpec0 (lift_typing typing) P ->
-  wf Σ -> on_global_env cumulSpec0 P Σ ->
-  lookup_env Σ c = Some decl ->
-  on_global_decl cumulSpec0 P (Σ, universes_decl_of_decl decl) c decl.
-Proof.
-  intros. eapply weakening_env_lookup_on_global_env; eauto.
-  split => //.
-  - split; [lsets|csets].
-  - exists []; simpl; destruct Σ; eauto.
-  - apply Retroknowledge.extends_refl.
-Qed.
-
-Lemma weaken_decls_lookup_on_global_env `{checker_flags} P Σ c decl :
+Proof. eapply weakening_env_gen_lookup_on_global_env; tc. Qed.
+Lemma weakening_env_decls_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
   weaken_env_decls_prop cumulSpec0 (lift_typing typing) P ->
+  wf Σ' -> wf Σ -> extends_decls Σ Σ' -> on_global_env cumulSpec0 P Σ ->
+  lookup_env Σ c = Some decl ->
+  on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl.
+Proof. eapply weakening_env_gen_lookup_on_global_env; tc. Qed.
+Lemma weakening_env_strictly_decls_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
+  weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) P ->
+  wf Σ' -> wf Σ -> strictly_extends_decls Σ Σ' -> on_global_env cumulSpec0 P Σ ->
+  lookup_env Σ c = Some decl ->
+  on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl.
+Proof. eapply weakening_env_gen_lookup_on_global_env; tc. Qed.
+Lemma weakening_env_strictly_on_decls_lookup_on_global_env `{checker_flags} P Σ Σ' c decl :
+  weaken_env_strictly_on_decls_prop cumulSpec0 (lift_typing typing) P ->
+  wf Σ' -> wf Σ -> extends_strictly_on_decls Σ Σ' -> on_global_env cumulSpec0 P Σ ->
+  lookup_env Σ c = Some decl ->
+  on_global_decl cumulSpec0 P (Σ', universes_decl_of_decl decl) c decl.
+Proof. eapply weakening_env_gen_lookup_on_global_env; tc. Qed.
+
+(* we can fill weaken_env_strictly_decls_prop with any other weaken_env_*_prop, so we only include this version *)
+Lemma weaken_lookup_on_global_env `{checker_flags} P Σ c decl :
+  weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) P ->
   wf Σ -> on_global_env cumulSpec0 P Σ ->
   lookup_env Σ c = Some decl ->
   on_global_decl cumulSpec0 P (Σ, universes_decl_of_decl decl) c decl.
 Proof.
-  intros. eapply weakening_env_decls_lookup_on_global_env; eauto.
-  split => //.
-  - exists []; simpl; destruct Σ; eauto.
+  intros. eapply weakening_env_strictly_decls_lookup_on_global_env; tea; tc; reflexivity.
 Qed.
 
 Lemma declared_constant_inv `{checker_flags} Σ P cst decl :
-  weaken_env_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
+  weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
   wf Σ -> Forall_decls_typing P Σ ->
   declared_constant Σ cst decl ->
   on_constant_decl (lift_typing P) (Σ, cst_universes decl) decl.
@@ -361,7 +309,7 @@ Proof.
 Qed.
 
 Lemma declared_minductive_inv `{checker_flags} {Σ P ind mdecl} :
-  weaken_env_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
+  weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
   wf Σ -> Forall_decls_typing P Σ ->
   declared_minductive Σ ind mdecl ->
   on_inductive cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) ind mdecl.
@@ -371,7 +319,7 @@ Proof.
 Qed.
 
 Lemma declared_inductive_inv `{checker_flags} {Σ P ind mdecl idecl} :
-  weaken_env_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
+  weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
   wf Σ -> Forall_decls_typing P Σ ->
   declared_inductive Σ ind mdecl idecl ->
   on_ind_body cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl (inductive_ind ind) idecl.
@@ -385,7 +333,7 @@ Proof.
 Qed.
 
 Lemma declared_constructor_inv `{checker_flags} {Σ P mdecl idecl ref cdecl}
-  (HP : weaken_env_prop cumulSpec0 (lift_typing typing) (lift_typing P))
+  (HP : weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P))
   (wfΣ : wf Σ)
   (HΣ : Forall_decls_typing P Σ)
   (Hdecl : declared_constructor Σ ref mdecl idecl cdecl) :
@@ -402,50 +350,8 @@ Proof.
   eapply All2_nth_error_Some in Hcdecl; tea.
 Defined.
 
-Lemma declared_minductive_inv_decls `{checker_flags} {Σ P ind mdecl} :
-  weaken_env_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
-  wf Σ -> Forall_decls_typing P Σ ->
-  declared_minductive Σ ind mdecl ->
-  on_inductive cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) ind mdecl.
-Proof.
-  intros.
-  eapply weaken_decls_lookup_on_global_env in X1; eauto. apply X1.
-Qed.
-
-Lemma declared_inductive_inv_decls `{checker_flags} {Σ P ind mdecl idecl} :
-  weaken_env_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P) ->
-  wf Σ -> Forall_decls_typing P Σ ->
-  declared_inductive Σ ind mdecl idecl ->
-  on_ind_body cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) (inductive_mind ind) mdecl (inductive_ind ind) idecl.
-Proof.
-  intros.
-  destruct H0 as [Hmdecl Hidecl].
-  eapply declared_minductive_inv_decls in Hmdecl; cbn in X; eauto.
-  apply onInductives in Hmdecl.
-  eapply nth_error_alli in Hidecl; eauto.
-  apply Hidecl.
-Qed.
-
-Lemma declared_constructor_inv_decls `{checker_flags} {Σ P mdecl idecl ref cdecl}
-  (HP : weaken_env_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P))
-  (wfΣ : wf Σ)
-  (HΣ : Forall_decls_typing P Σ)
-  (Hdecl : declared_constructor Σ ref mdecl idecl cdecl) :
-  ∑ cs,
-  let onib := declared_inductive_inv_decls HP wfΣ HΣ (let (x, _) := Hdecl in x) in
-  nth_error onib.(ind_cunivs) ref.2 = Some cs
-  × on_constructor cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) mdecl
-                   (inductive_ind ref.1) idecl idecl.(ind_indices) cdecl cs.
-Proof.
-  intros.
-  destruct Hdecl as [Hidecl Hcdecl].
-  set (declared_inductive_inv_decls HP wfΣ HΣ Hidecl) as HH.
-  clearbody HH. pose proof HH.(onConstructors) as HH'.
-  eapply All2_nth_error_Some in Hcdecl; tea.
-Defined.
-
 Lemma declared_projection_inv `{checker_flags} {Σ P mdecl idecl cdecl ref pdecl} :
-  forall (HP : weaken_env_prop cumulSpec0 (lift_typing typing) (lift_typing P))
+  forall (HP : weaken_env_strictly_decls_prop cumulSpec0 (lift_typing typing) (lift_typing P))
   (wfΣ : wf Σ)
   (HΣ : Forall_decls_typing P Σ)
   (Hdecl : declared_projection Σ ref mdecl idecl cdecl pdecl),
@@ -485,25 +391,15 @@ Qed.
 
 Lemma weaken_env_prop_typing `{checker_flags} : weaken_env_prop cumulSpec0 (lift_typing typing) (lift_typing typing).
 Proof.
-  red. intros * wfΣ wfΣ' Hext Γ t T HT.
+  do 2 red. intros * wfΣ wfΣ' Hext Γ t T HT.
   apply lift_typing_impl with (1 := HT); intros ? Hty.
   eapply (weakening_env (_, _)).
   2: eauto.
   all: auto.
 Qed.
 
-Lemma weaken_env_decls_prop_typing `{checker_flags} : weaken_env_decls_prop cumulSpec0 (lift_typing typing) (lift_typing typing).
-Proof.
-  red. intros * wfΣ' Hext Γ t T HT.
-  apply lift_typing_impl with (1 := HT); intros ? Hty.
-  eapply (weakening_env (_, _)).
-  2-4: eauto.
-  * cbn; now eapply extends_decls_wf.
-  * tc.
-Qed.
-
 #[global]
- Hint Unfold weaken_env_prop : pcuic.
+ Hint Unfold weaken_env_prop weaken_env_prop_gen : pcuic.
 
 Lemma on_declared_constant `{checker_flags} {Σ cst decl} :
   wf Σ -> declared_constant Σ cst decl ->
@@ -511,9 +407,8 @@ Lemma on_declared_constant `{checker_flags} {Σ cst decl} :
 Proof.
   intros.
   eapply declared_constant_inv; tea.
-  apply weaken_env_prop_typing.
+  exact weaken_env_prop_typing.
 Qed.
-
 
 
 Lemma weaken_wf_local `{checker_flags} (Σ : global_env_ext) Σ' Γ :

--- a/safechecker/theories/PCUICConsistency.v
+++ b/safechecker/theories/PCUICConsistency.v
@@ -18,6 +18,7 @@ From MetaCoq.PCUIC Require Import PCUICSafeLemmata.
 From MetaCoq.PCUIC Require Import PCUICTyping.
 From MetaCoq.PCUIC Require Import PCUICUnivSubst.
 From MetaCoq.PCUIC Require Import PCUICValidity.
+From MetaCoq.PCUIC Require Import PCUICWeakeningEnv.
 From MetaCoq.PCUIC Require Import PCUICWeakeningEnvConv.
 From MetaCoq.PCUIC Require Import PCUICWeakeningEnvTyp.
 From MetaCoq.PCUIC Require Import PCUICWellScopedCumulativity.
@@ -165,11 +166,12 @@ Proof.
       + reflexivity.
       + reflexivity.
   }
+  assert (strictly_extends_decls Σ Σext.1).
+  { split; auto.
+    exists [(make_fresh_name Σ.1, InductiveDecl False_mib)]; reflexivity. }
   eapply (env_prop_typing weakening_env) in cons; auto.
   2:instantiate (1:=Σext.1).
-  3:{ split; auto; cbn. split; [lsets|csets].
-      exists [(make_fresh_name Σ.1, InductiveDecl False_mib)]; reflexivity.
-      apply Retroknowledge.extends_refl. }
+  3:tc.
   2: now destruct wf'.
 
   set (Σ' := Σext.1) in cons.
@@ -181,7 +183,7 @@ Proof.
     eapply type_Ind with (u := []) (mdecl := False_mib) (idecl := False_oib); eauto.
     - hnf. cbn.
       unfold declared_minductive, declared_minductive_gen.
-      cbn. now rewrite eq_kername_refl. 
+      cbn. now rewrite eq_kername_refl.
     - now cbn. }
   pose proof (iswelltyped typ_false) as wt.
   set (_Σ' := Build_referenced_impl_ext cf _ Σext (sq wf')). cbn in *.

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -1210,6 +1210,10 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
       : fresh_global kn Σ <-> lookup_global Σ kn = None.
     Proof using Type. rewrite fresh_global_iff_not_In lookup_global_None //. Qed.
 
+    Lemma fresh_global_iff_lookup_globals_nil kn Σ
+      : fresh_global kn Σ <-> lookup_globals Σ kn = [].
+    Proof using Type. rewrite fresh_global_iff_not_In lookup_globals_nil //. Qed.
+
     Lemma NoDup_on_global_decls univs retro decls
       : on_global_decls univs retro decls -> NoDup (List.map fst decls).
     Proof using Type.

--- a/template-coq/theories/EtaExpand.v
+++ b/template-coq/theories/EtaExpand.v
@@ -1537,19 +1537,12 @@ Qed.
 
 Lemma lookup_global_extends Σ Σ' kn d :
   lookup_env Σ kn = Some d ->
-  extends_decls Σ Σ' ->
+  extends Σ Σ' ->
   EnvMap.fresh_globals Σ'.(declarations) ->
   lookup_env Σ' kn = Some d.
 Proof.
-  destruct Σ as [univs Σ retro].
-  destruct Σ' as [univs' Σ' retro'].
-  cbn. move=> hl [] /=; intros <- [Σ'' ->] extretro.
-  induction Σ''; cbn; auto.
-  case: eqb_spec.
-  - intros ->. intros fr.
-    depelim fr. eapply lookup_global_Some_fresh in hl. cbn in hl.
-    red in H. eapply Forall_app in H as [frl frr]. contradiction.
-  - move=> _ hf. now depelim hf.
+  setoid_rewrite EnvMap.fresh_globals_iff_NoDup.
+  intros; eapply lookup_env_extends_NoDup; tea.
 Qed.
 
 Lemma eta_expand_global_env_expanded {cf : checker_flags} (Σ : global_env_ext_map) :
@@ -1561,7 +1554,7 @@ Proof.
   unfold Typing.wf, Typing.on_global_env. intros [onu ond].
   cbn in *.
   destruct Σ as []. cbn in *.
-  assert (extends_decls env env). red; split => //. now exists [].
+  assert (strictly_extends_decls env env) by reflexivity.
   revert X.
   move: map repr wf.
   generalize env at 1 2 4 6 7.
@@ -1582,6 +1575,7 @@ Proof.
     rewrite GlobalEnvMap.lookup_env_spec /=.
     cbn. unfold snoc.
     eapply (lookup_global_extends Σ' (set_declarations Σ' (Σ'' ++ (kn, d) :: Σ)%list)); eauto.
+    apply extends_decls_extends, strictly_extends_decls_extends_decls.
     split => //. cbn. now exists (Σ'' ++ [(kn, d)])%list; rewrite -app_assoc. }
   forward H. split. cbn. split => //. now cbn.
   specialize (H o0).

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -1569,7 +1569,7 @@ Arguments on_global_env {cf} Pcmp P !g.
 Lemma lookup_on_global_env `{checker_flags} {Pcmp P} {Σ : global_env} {c decl} :
   on_global_env Pcmp P Σ ->
   lookup_env Σ c = Some decl ->
-  { Σ' : global_env_ext & on_global_env Pcmp P Σ' × extends_decls Σ' Σ × on_global_decl Pcmp P Σ' c decl }.
+  { Σ' : global_env_ext & on_global_env Pcmp P Σ' × strictly_extends_decls Σ' Σ × on_global_decl Pcmp P Σ' c decl }.
 Proof.
   unfold on_global_env.
   destruct Σ as [univs Σ retro]; cbn. intros [cu ond].


### PR DESCRIPTION
This is a significant reorganization of the handling of declaration extension, with the goal of allowing environment weakening across reordering of independent declarations.  This will be useful for using the safechecker to concretely prove different constructions well-typed in minimal global environments, and then combine the well-typedness proofs in a union of the global environments without having to care about strict extension.

We define four notions of environment extension.  The two configurable bits are: is universe and retroknowledge extension strict (`Logic.eq`) or loose (`⊂_cs` / `Retroknowledge.extends`); and is declaration extension strict (fully order-preserving, i.e., new declarations are added only at the front) or lax (declarations may be reordered and added freely, as long as all new declarations with existing names come before the old ones with the same names, and the relative order of declarations with identical names is preserved).

In most cases, we are actually interested only in duplicate-free environments, where the lax construction is equivalent to merely requiring that the lookup function agrees on all existing delcarations. However, we formulate the property in a way that makes sense for duplicative environments so that strict declaration extension will always imply lax declaration extension.  (The lookup function prefers earlier / newer declarations over older ones.)

We thus have the following implication structure:
```
┌-----------------------------┬------------------------┬---------------------------┐
|    univ/retro extension is: |        strict          |  lax                      |
├ declaration exension is ----┼------------------------┼---------------------------┤
|    lax                      |     extends_decls      →         extends           |
|                             |            ↑           ↗            ↑              |
|   strict                    | strictly_extends_decls → extends_strictly_on_decls |
└-----------------------------┴------------------------┴---------------------------┘
```

In general, theorems use the strictest version permissible in the conclusion (more generally in covariant positions), and the laxest version permissible in their hypotheses (more generally in contravariant positions).  Some theorems are parameterized over their notion of context extension, when the version in the conclusion and the hypotheses (more generally: isovariant positions) must match.

The exception to this rule is `SingletonProp`, `Computational`, `Informative`, `erases`, and their dependents.  These definitions and theorems uniformly use `strictly_extends_decls`, because I wasn't sure if it was worth the effort to generalize these definitions over their notion of extension, and the definitions seem to be used in both co- and contra-variant positions.

This is on top of #802