### PR TITLE
Add `(only parsing)` to `<# x #>` notation

### DIFF
--- a/template-coq/theories/Loader.v
+++ b/template-coq/theories/Loader.v
@@ -9,4 +9,5 @@ Notation "<% x %>" := (ltac:(let p y := exact y in quote_term x p))
 
 (* Work around COQBUG(https://github.com/coq/coq/issues/16715) with [match] *)
 (* Use [return _] to avoid running the program twice on failure *)
-Notation "<# x #>" := (match TemplateMonad.Core.tmQuoteRec x return _ with qx => ltac:(let p y := exact y in run_template_program qx p) end).
+Notation "<# x #>" := (match TemplateMonad.Core.tmQuoteRec x return _ with qx => ltac:(let p y := exact y in run_template_program qx p) end)
+  (only parsing).


### PR DESCRIPTION
It's not printable anyway, as it contains `ltac:(...)`