### PR TITLE
Change specification of declared constant and co

### DIFF
--- a/erasure/theories/EArities.v
+++ b/erasure/theories/EArities.v
@@ -805,6 +805,8 @@ Proof.
   eapply subject_reduction in hr; tea; eauto.
   eapply inversion_Case in hc as [mdecl [idecl [isdecl [indices ?]]]]; eauto.
   eapply inversion_Case in hr as [mdecl' [idecl' [isdecl' [indices' ?]]]]; eauto.
+  pose proof (wfΣ' := wfΣ.1).
+  unshelve eapply declared_inductive_to_gen in isdecl, isdecl'; eauto.
   destruct (declared_inductive_inj isdecl isdecl'). subst mdecl' idecl'.
   intros hp.
   epose proof (Is_proof_ind _ _ _ wfΣ hp).
@@ -841,7 +843,9 @@ Proof.
   unfold isPropositional.
   eapply PCUICValidity.inversion_mkApps in HT as (? & ? & ?); auto.
   eapply inversion_Construct in t as (? & ? & ? & ? & ? & ? & ?); auto.
-  unfold lookup_inductive. rewrite (declared_inductive_lookup d.p1).
+  pose proof (wfΣ' := wfΣ.1).
+  unshelve epose proof (d_ := declared_constructor_to_gen d); eauto.
+  unfold lookup_inductive. rewrite (declared_inductive_lookup_gen d_.p1).
   destruct (on_declared_constructor d).
   destruct p as [onind oib].
   rewrite oib.(ind_arity_eq).
@@ -876,7 +880,10 @@ Proof.
   pose proof d as [decli ?].
   destruct (on_declared_constructor d).
   destruct p as [onind oib].
-  red. unfold lookup_inductive. rewrite (declared_inductive_lookup decli).
+  red. unfold lookup_inductive.
+  pose proof (wfΣ' := wfΣ.1).
+  unshelve epose proof (decli_ := declared_inductive_to_gen decli); eauto.
+  rewrite (declared_inductive_lookup_gen decli_).
   rewrite oib.(ind_arity_eq).
   rewrite /isPropositionalArity !destArity_it_mkProd_or_LetIn /=.
   destruct (is_propositional (ind_sort x0)) eqn:isp; auto.
@@ -912,7 +919,7 @@ Proof.
   specialize (sorts' isp). rewrite -sorts'. reflexivity.
 Qed.
 
-Lemma isPropositional_propositional Σ (Σ' : E.global_context) ind mdecl idecl mdecl' idecl' :
+Lemma isPropositional_propositional Σ {wfΣ: wf Σ} (Σ' : E.global_context) ind mdecl idecl mdecl' idecl' :
   PCUICAst.declared_inductive Σ ind mdecl idecl ->
   EGlobalEnv.declared_inductive Σ' ind mdecl' idecl' ->
   erases_mutual_inductive_body mdecl mdecl' ->
@@ -921,7 +928,9 @@ Lemma isPropositional_propositional Σ (Σ' : E.global_context) ind mdecl idecl 
 Proof.
   intros decli decli' [_ indp] [] b.
   unfold isPropositional, EGlobalEnv.inductive_isprop_and_pars.
-  unfold lookup_inductive. rewrite (declared_inductive_lookup decli).
+  unfold lookup_inductive.
+  unshelve epose proof (decli_ := declared_inductive_to_gen decli); eauto.
+  rewrite (declared_inductive_lookup_gen decli_).
   rewrite (EGlobalEnv.declared_inductive_lookup decli') /=
     /isPropositionalArity.
   destruct H0 as [_ [_ [_ isP]]]. red in isP.
@@ -993,9 +1002,11 @@ Proof.
   eapply subject_reduction in X0 as X2'; eauto.
   eapply inversion_Case in X2' as (? & ? & ? & ? & [] & ?); eauto.
   eapply inversion_Case in X0 as (? & ? & ? & ? & [] & ?); eauto.
+  pose (X' := X.1). unshelve eapply declared_inductive_to_gen in x8, x4, H; eauto.
   destruct (declared_inductive_inj x8 x4); subst.
   destruct (declared_inductive_inj x8 H); subst.
-  eapply H0; eauto. reflexivity.
+  eapply H0; eauto. apply declared_inductive_from_gen; eauto.
+  reflexivity.
   eapply Is_proof_ind; tea.
 Qed.
 

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -59,10 +59,10 @@ Proof.
 
   eapply weakening_env_declared_inductive in H; eauto; tc.
   destruct H, H1.
-  unfold PCUICAst.declared_minductive, declared_minductive_gen in *.
-
-  eapply PCUICWeakeningEnv.extends_lookup in H1; eauto; tc.
-  2:{ cbn. apply extends_refl. }
+  pose (X1' := X1.1). unshelve eapply declared_minductive_to_gen in H, H1; eauto.
+  eapply PCUICWeakeningEnv.extends_lookup in H1.
+  3:{ cbn. apply extends_refl. } 2:eauto.
+  unfold declared_minductive_gen in *.
   rewrite H1 in H. inversion H. subst. clear H.
   rewrite H3 in H4. inversion H4. subst. clear H4.
   split. eauto. econstructor. eauto.
@@ -80,11 +80,15 @@ Proof.
   all: try now (econstructor; eauto).
   all: try now (econstructor; eapply Is_type_extends; eauto; tc).
   - econstructor.
-    red. red in H4. unfold PCUICAst.lookup_inductive in H4. 
-    rewrite (PCUICAst.declared_inductive_lookup isdecl.p1) in H4.
+    red. red in H4. unfold PCUICAst.lookup_inductive in H4.
+    unshelve eapply declared_constructor_to_gen in isdecl; eauto.
+    rewrite (PCUICAst.declared_inductive_lookup_gen isdecl.p1) in H4.
     destruct isdecl as [decli declc].
+    eapply declared_inductive_from_gen in decli.
     eapply PCUICWeakeningEnv.weakening_env_declared_inductive in decli; tea; eauto; tc.
-    unfold PCUICAst.lookup_inductive. now rewrite (PCUICAst.declared_inductive_lookup decli).
+    unfold PCUICAst.lookup_inductive.
+    unshelve eapply declared_inductive_to_gen in decli; eauto.
+    now rewrite (PCUICAst.declared_inductive_lookup_gen decli).
   - econstructor. all:eauto.
     eapply Informative_extends; eauto.
     eapply All2i_All2_All2; tea. cbv beta.

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -1083,18 +1083,22 @@ Proof.
   - apply inversion_App in wt as (? & ? & ? & ? & ? & ?); eauto.
   - apply inversion_Const in wt as (? & ? & ? & ? & ?); eauto.
     eapply KernameSet.singleton_spec in hin; subst.
+    unshelve eapply declared_constant_to_gen in d; eauto.
     red in d. red. sq. rewrite d. intuition eauto.
   - apply inversion_Construct in wt as (? & ? & ? & ? & ? & ? & ?); eauto.
     destruct kn.
     eapply KernameSet.singleton_spec in hin; subst.
-    destruct d as [[H' _] _]. red in H'. simpl in *.
+    destruct d as [[H' _] _].
+    unshelve eapply declared_minductive_to_gen in H'; eauto.
+    red in H'. simpl in *.
     red. sq. rewrite H'. intuition eauto.
   - apply inversion_Case in wt as (? & ? & ? & ? & [] & ?); eauto.
     destruct ci as [kn i']; simpl in *.
     eapply KernameSet.singleton_spec in H1; subst.
-    destruct x1 as [d _]. red in d.
+    destruct x1 as [d _].
+    unshelve eapply declared_minductive_to_gen in d; eauto.
+    red in d.
     simpl in *. eexists; intuition eauto.
-
   - apply inversion_Case in wt as (? & ? & ? & ? & [] & ?); eauto.
     eapply knset_in_fold_left in H1.
     destruct H1. eapply IHer; eauto.
@@ -1112,7 +1116,9 @@ Proof.
 
   - eapply KernameSet.singleton_spec in H0; subst.
     apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?&?); eauto.
-    destruct d as [[[d _] _] _]. red in d. eexists; eauto.
+    unshelve eapply declared_projection_to_gen in d; eauto.
+    destruct d as [[[d _] _] _].
+    red in d. eexists; eauto.
 
   - apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?); eauto.
 
@@ -1163,37 +1169,56 @@ Proof.
   - apply inversion_Const in wt as (? & ? & ? & ? & ?); eauto.
     specialize (Σer kn).
     forward Σer. rewrite KernameSet.singleton_spec //.
+    pose proof (wf' := wf.1).
+    unshelve eapply declared_constant_to_gen in d; eauto.
     destruct Σer as [[c' [declc' (? & ? & ? & ?)]]|].
+    unshelve eapply declared_constant_to_gen in declc'; eauto.
     pose proof (declared_constant_inj _ _ d declc'). subst x.
-    now econstructor; eauto.
+    econstructor; eauto. eapply declared_constant_from_gen; eauto.
     destruct H as [mib [mib' [declm declm']]].
-    red in declm, d. unfold declared_minductive_gen in declm. rewrite d in declm. noconf declm.
+    unshelve eapply declared_minductive_to_gen in declm; eauto.
+    red in declm, d. unfold declared_minductive_gen in declm.
+    rewrite d in declm. noconf declm.
   - apply inversion_Construct in wt as (? & ? & ? & ? & ? & ?); eauto.
     red in Σer. destruct kn.
     setoid_rewrite KernameSetFact.singleton_iff in Σer.
+    pose (wf' := wf.1).
     destruct (Σer _ eq_refl) as [ (? & ? & ? & ? & ? & ?) | (? & ? & ? & ? & ?) ].
-    + red in H0. destruct d as [[]]. red in H4. cbn in *. unfold PCUICEnvironment.fst_ctx in *. congruence.
-    + pose proof H2 as H2'. destruct d. cbn in *. destruct H3. cbn in *. red in H3. red in H0. rewrite H0 in H3. invs H3.
+    + destruct d as [[]].
+      unshelve eapply declared_constant_to_gen in H0; eauto.
+      unshelve eapply declared_minductive_to_gen in H4; eauto.
+      red in H4, H. cbn in *. unfold PCUICEnvironment.fst_ctx in *. congruence.
+    + pose proof H2 as H2'. destruct d. cbn in *.
+      destruct H3. cbn in *. red in H3.
+      unshelve eapply declared_minductive_to_gen in H0, H3; eauto.
+      red in H0, H3. rewrite H0 in H3. invs H3.
       destruct H2.
       red in H1.
       eapply Forall2_nth_error_Some_l in H2 as (? & ? & ?); eauto. pose proof H6 as H6'. destruct H6 as (? & ? & ? & ? & ?); eauto.
       eapply Forall2_nth_error_Some_l in H6 as ([] & ? & ? & ?); subst; eauto.
-      econstructor. repeat eapply conj; eauto.
+      econstructor.
+      eapply declared_constructor_from_gen; eauto.  repeat eapply conj; eauto.
       repeat eapply conj; cbn; eauto. eauto. eauto.
   - apply inversion_Case in wt as (? & ? & ? & ? & [] & ?); eauto.
     destruct ci as [[kn i'] ? ?]; simpl in *.
     apply includes_deps_fold in H2 as [? ?].
-
+    pose proof (wf' := wf.1).
     specialize (H1 kn). forward H1.
     now rewrite KernameSet.singleton_spec. red in H1. destruct H1.
     elimtype False. destruct H1 as [cst [declc _]].
-    { red in declc. destruct x1 as [d _]. red in d. unfold declared_constant_gen in declc. rewrite d in declc. noconf declc. }
+    { destruct x1 as [d _].
+      unshelve eapply declared_minductive_to_gen in d; eauto.
+      unshelve eapply declared_constant_to_gen in declc; eauto.
+      red in d, declc.
+      unfold declared_constant_gen in declc. rewrite d in declc. noconf declc. }
     destruct H1 as [mib [mib' [declm [declm' em]]]].
     pose proof em as em'. destruct em'.
     destruct x1 as [x1 hnth].
+    unshelve eapply declared_minductive_to_gen in x1, declm; eauto.
     red in x1, declm. unfold declared_minductive_gen in declm. rewrite x1 in declm. noconf declm.
     eapply Forall2_nth_error_left in H1; eauto. destruct H1 as [? [? ?]].
     eapply erases_deps_tCase; eauto.
+    apply declared_inductive_from_gen; auto.
     split; eauto. split; eauto.
     destruct H1.
     eapply In_Forall in H3.
@@ -1208,14 +1233,20 @@ Proof.
 
   - apply inversion_Proj in wt as (?&?&?&?&?&?&?&?&?&?); eauto.
     destruct (proj1 d).
+    pose proof (wf' := wf.1).
     specialize (H0 (inductive_mind p.(proj_ind))). forward H0.
     now rewrite KernameSet.singleton_spec. red in H0. destruct H0.
     elimtype False. destruct H0 as [cst [declc _]].
-    { red in declc. destruct d as [[[d _] _] _]. red in d.
+    {
+      unshelve eapply declared_constant_to_gen in declc; eauto.
+      red in declc. destruct d as [[[d _] _] _].
+      unshelve eapply declared_minductive_to_gen in d; eauto.
+      red in d.
       unfold declared_constant_gen in declc.  rewrite d in declc. noconf declc. }
     destruct H0 as [mib [mib' [declm [declm' em]]]].
     assert (mib = x0).
     { destruct d as [[[]]].
+      unshelve eapply declared_minductive_to_gen in declm, H0; eauto.
       red in H0, declm. unfold declared_minductive_gen in declm. rewrite H0 in declm. now noconf declm. }
     subst x0.
     pose proof em as em'. destruct em'.
@@ -1267,36 +1298,45 @@ Lemma erases_deps_weaken kn d (Σ : global_env) (Σ' : EAst.global_declarations)
 Proof.
   intros wfΣ er.
   induction er using erases_deps_forall_ind; try solve [now constructor].
-  - assert (kn <> kn0).
-    { inv wfΣ. inv X. intros <-.
+  - inv wfΣ. inv X.
+    assert (wf Σ) by (inversion H4;econstructor; eauto).
+    pose proof (H_ := H). unshelve eapply declared_constant_to_gen in H; eauto.
+    assert (kn <> kn0).
+    { intros <-.
       eapply lookup_env_Some_fresh in H. destruct X1. contradiction. }
     eapply erases_deps_tConst with cb cb'; eauto.
+    eapply declared_constant_from_gen.
     red. rewrite /declared_constant_gen /lookup_env lookup_env_cons_fresh //.
     red.
     red in H1.
     destruct (cst_body cb) eqn:cbe;
     destruct (E.cst_body cb') eqn:cbe'; auto.
     specialize (H3 _ eq_refl).
-    eapply on_declared_constant in H; auto.
-    2:{ inv wfΣ. now inv X. }
-    red in H. rewrite cbe in H. simpl in H.
+    eapply on_declared_constant in H_; auto.
+    red in H_. rewrite cbe in H_. simpl in H_.
     eapply (erases_weakeninv_env (Σ := (Σ, cst_universes cb))
        (Σ' := (add_global_decl Σ (kn, d), cst_universes cb))); eauto.
-    simpl.
+    simpl. econstructor; eauto. econstructor; eauto.
     split => //; eexists [(kn, d)]; intuition eauto.
   - econstructor; eauto. eapply weakening_env_declared_constructor; eauto; tc.
     eapply extends_decls_extends. econstructor; try reflexivity. eexists [(_, _)]; reflexivity.
   - econstructor; eauto.
+    eapply declared_inductive_from_gen.
+    inv wfΣ. inv X.
+    assert (wf Σ) by (inversion H5;econstructor; eauto).
+    unshelve eapply declared_inductive_to_gen in H; eauto.
     red. destruct H. split; eauto.
     red in H. red.
-    inv wfΣ. inv X.
     rewrite -H. simpl. unfold lookup_env; simpl. destruct (eqb_spec (inductive_mind p.1) kn); try congruence.
     eapply lookup_env_Some_fresh in H. destruct X1. subst kn; contradiction.
   - econstructor; eauto.
-    red. destruct H. split; eauto.
-    destruct d0; split; eauto.
-    destruct d0; split; eauto.
     inv wfΣ. inv X.
+    assert (wf Σ) by (inversion H3;econstructor; eauto).
+    eapply declared_projection_from_gen.
+    unshelve eapply declared_projection_to_gen in H; eauto.
+    red. destruct H. split; eauto.
+    destruct H; split; eauto.
+    destruct H; split; eauto.
     red in H |- *.
     rewrite -H. simpl. unfold lookup_env; simpl; destruct (eqb_spec (inductive_mind p.(proj_ind)) kn); try congruence.
     eapply lookup_env_Some_fresh in H. subst kn. destruct X1. contradiction.
@@ -1335,13 +1375,19 @@ Lemma global_erases_with_deps_cons kn kn' d d' Σ Σ' :
   global_erased_with_deps (add_global_decl Σ (kn', d)) ((kn', d') :: Σ') kn.
 Proof.
   intros wf [[cst [declc [cst' [declc' [ebody IH]]]]]|].
-  red. inv wf. inv X. left.
+  red. inv wf. inv X.
+  assert (wf Σ) by (inversion H;econstructor; eauto).
+  left.
   exists cst. split.
+  eapply declared_constant_from_gen.
+  unshelve eapply declared_constant_to_gen in declc; eauto.
   red in declc |- *. unfold declared_constant_gen, lookup_env in *.
   rewrite lookup_env_cons_fresh //.
   { eapply lookup_env_Some_fresh in declc. destruct X1.
     intros <-; contradiction. }
   exists cst'.
+  pose proof (declc_ := declc).
+  unshelve eapply declared_constant_to_gen in declc; eauto.
   unfold EGlobalEnv.declared_constant. rewrite EGlobalEnv.elookup_env_cons_fresh //.
   { eapply lookup_env_Some_fresh in declc. destruct X1.
     intros <-; contradiction. }
@@ -1351,18 +1397,22 @@ Proof.
   eapply (erases_weakeninv_env (Σ  := (_, cst_universes cst)) (Σ' := (add_global_decl Σ (kn', d), cst_universes cst))); eauto.
   constructor; eauto. constructor; eauto.
   split => //. exists [(kn', d)]; intuition eauto.
-  eapply on_declared_constant in declc; auto.
-  red in declc. rewrite bod in declc. eapply declc.
-  split => //.
+  eapply on_declared_constant in declc_; auto.
+  red in declc_. rewrite bod in declc_. eapply declc_.
   noconf H0.
   eapply erases_deps_cons; eauto.
   constructor; auto.
 
-  right. destruct H as [mib [mib' [? [? ?]]]].
+  right.
+  pose proof (wf_ := wf). inv wf. inv X.
+  assert (wf Σ) by (inversion H0;econstructor; eauto).
+  destruct H as [mib [mib' [? [? ?]]]].
+  unshelve eapply declared_minductive_to_gen in H; eauto.
   exists mib, mib'. intuition eauto.
-  * red. red in H. pose proof (lookup_env_ext wf H). unfold declared_minductive_gen.
+  * eapply declared_minductive_from_gen.
+    red. red in H. pose proof (lookup_env_ext wf_ H). unfold declared_minductive_gen.
     now rewrite lookup_env_cons_disc.
-  * red. pose proof (lookup_env_ext wf H).
+  * red. pose proof (lookup_env_ext wf_ H).
     now rewrite elookup_env_cons_disc.
 Qed.
 
@@ -1373,7 +1423,11 @@ Lemma global_erases_with_deps_weaken kn kn' d Σ Σ' :
 Proof.
   intros wf [[cst [declc [cst' [declc' [ebody IH]]]]]|].
   red. inv wf. inv X. left.
+  assert (wf Σ) by (inversion H;econstructor; eauto).
+
   exists cst. split.
+  eapply declared_constant_from_gen.
+  unshelve eapply declared_constant_to_gen in declc; eauto.
   red in declc |- *.
   unfold declared_constant_gen, lookup_env in *.
   rewrite lookup_env_cons_fresh //.
@@ -1388,17 +1442,22 @@ Proof.
   split; auto. constructor; eauto.
   split; auto; exists [(kn', d)]; intuition eauto.
   eapply on_declared_constant in declc; auto.
-  red in declc. rewrite bod in declc. eapply declc. split => //.
+  red in declc. rewrite bod in declc. eapply declc.
   noconf H0.
   apply erases_deps_weaken.
   { split; auto. cbn. constructor; auto. }
   auto.
 
   right. destruct H as [mib [mib' [Hm [? ?]]]].
-  exists mib, mib'; intuition auto.
+  exists mib, mib'; intuition auto. pose proof (wf_ := wf).
+  inv wf. inv X.
+  assert (wf Σ) by (inversion H;econstructor; eauto).
+  eapply declared_minductive_from_gen.
+
+  unshelve eapply declared_minductive_to_gen in Hm; eauto.
   red. unfold declared_minductive_gen, lookup_env in *.
   rewrite lookup_env_cons_fresh //.
-  now epose proof (lookup_env_ext wf Hm).
+  now epose proof (lookup_env_ext wf_ Hm).
 Qed.
 
 Lemma erase_constant_body_correct X_type X {normalisation_in : forall Σ, wf_ext Σ -> Σ ∼_ext X -> NormalisationIn Σ} cb
@@ -1481,7 +1540,8 @@ Proof.
         set (Xmake :=  abstract_make_wf_env_ext Xpop (cst_universes c) _).
         epose proof (abstract_env_exists Xpop) as [[Σpop wfpop]].
         epose proof (abstract_env_ext_exists Xmake) as [[Σmake wfmake]].
-        exists c. split; auto. red.
+        exists c. split; auto.
+        eapply declared_constant_from_gen.
         unfold declared_constant_gen, lookup_env; simpl; rewrite (prf _ wfΣ). cbn.
         rewrite eq_kername_refl //.
         pose proof (sub _ hin) as indeps.
@@ -1529,6 +1589,7 @@ Proof.
           intros x hin'. eapply KernameSet.union_spec. right; auto.
           now rewrite -Heqdeps. } }
         { eexists m, _; intuition eauto.
+          eapply declared_minductive_from_gen.
           simpl. rewrite /declared_minductive /declared_minductive_gen /lookup_env prf; eauto.
           simpl. rewrite eq_kername_refl. reflexivity.
           specialize (sub _ hin).
@@ -1537,7 +1598,7 @@ Proof.
           red. cbn. rewrite eq_kername_refl.
           reflexivity.
           assert (declared_minductive Σ kn m).
-          { red. unfold declared_minductive_gen, lookup_env. rewrite prf; eauto. cbn. now rewrite eqb_refl. }
+          { eapply declared_minductive_from_gen. red. unfold declared_minductive_gen, lookup_env. rewrite prf; eauto. cbn. now rewrite eqb_refl. }
           eapply on_declared_minductive in H0; tea.
           now eapply erases_mutual. }
 
@@ -1791,9 +1852,11 @@ Lemma erase_global_declared_constructor X_type X ind c mind idecl cdecl deps dec
     (erase_mutual_inductive_body mind) (erase_one_inductive_body idecl)
     (EAst.mkConstructor cdecl.(cstr_name) cdecl.(cstr_arity)).
 Proof.
-  intros Σ wfΣ [[]] Hin.
+  intros Σ wfΣ [[]] Hin. pose (abstract_env_wf _ wfΣ). sq.
   cbn in *. split. split.
-  - red in H |- *. now eapply lookup_env_erase.
+  - unshelve eapply declared_minductive_to_gen in H; eauto.
+    red in H |- *. eapply lookup_env_erase; eauto.
+
   - cbn. now eapply map_nth_error.
   - cbn. erewrite map_nth_error; eauto.
 Qed.

--- a/pcuic/theories/Bidirectional/BDFromPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDFromPCUIC.v
@@ -239,7 +239,7 @@ Proof.
         erewrite PCUICGlobalMaps.onNpars.
         2: eapply on_declared_minductive ; eauto.
         rewrite firstn_app_left //.
-        now destruct wfpred.
+        now destruct wfpred. apply isdecl.
 
       * replace #|x1| with #|pparams p ++ indices|.
         1: assumption.
@@ -337,9 +337,9 @@ Proof.
         1: apply wf_local_closed_context ; auto.
         eapply projection_cumulative_indices ; eauto.
         2: now easy.
+        unshelve eapply declared_projection_to_gen in isdecl; eauto.
         eapply (weaken_lookup_on_global_env' _ _ (InductiveDecl _)); eauto.
         apply isdecl.
-
   - intros mfix n decl types ? ? ? Alltypes Allbodies.
     eexists.
     split.

--- a/pcuic/theories/Bidirectional/BDStrengthening.v
+++ b/pcuic/theories/Bidirectional/BDStrengthening.v
@@ -177,8 +177,10 @@ Proof.
   apply closedn_ctx_on_free_vars_shift.
   replace #|pparams p| with (context_assumptions (ind_params mdecl)).
   1: eapply closed_ind_predicate_context ; tea ; eapply declared_minductive_closed ; eauto.
+  apply H0.
   erewrite wf_predicate_length_pars ; tea.
   eapply onNpars, on_declared_minductive ; eauto.
+  apply H0.
 Qed.
 
 Lemma on_free_vars_case_branch_context `{checker_flags} {Σ : global_env_ext } {wfΣ : wf Σ} {P ci mdecl idecl p br cdecl} :
@@ -773,7 +775,7 @@ Proof using wfΣ.
       1:exact (declared_inductive_closed_params H).
       1:rewrite (wf_branch_length wfbr) //.
       1:rewrite (wf_predicate_length_pars H1).
-      1:erewrite declared_minductive_ind_npars ; eauto.
+      1:erewrite declared_minductive_ind_npars ; eauto; apply H.
       assert (on_free_vars_ctx P brctxty.1).
       { rewrite case_branch_type_fst.
         eapply (@on_free_vars_case_branch_context _ _ _ _ (ci.(ci_ind),i)).

--- a/pcuic/theories/Bidirectional/BDToPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDToPCUIC.v
@@ -263,7 +263,8 @@ Section BDToPCUICTyping.
       { apply ctx_inst_impl ; auto.
         rewrite rev_involutive.
         apply wf_rel_weak ; auto.
-        move: (H) => [? ?].
+        move: (H) => [decl ?].
+        unshelve epose proof (decl' := declared_minductive_to_gen decl); eauto.
         eapply wf_local_subst_instance_decl ; eauto.
         eapply wf_local_app_inv.
         now eapply on_minductive_wf_params_indices.

--- a/pcuic/theories/Bidirectional/BDUnique.v
+++ b/pcuic/theories/Bidirectional/BDUnique.v
@@ -108,28 +108,36 @@ Proof using wfΣ.
       eapply checking_typing ; tea.
       now eapply isType_tProd, validity, infering_prod_typing.
 
-  - replace decl0 with decl by (eapply declared_constant_inj ; eassumption).
+  - unshelve epose proof (declared_constant_to_gen isdecl); eauto.
+    unshelve epose proof (declared_constant_to_gen H); eauto.
+    replace decl0 with decl by (eapply declared_constant_inj ; eassumption).
     eexists ; split.
     all: eapply closed_red_refl.
     1,3: fvs.
     all: rewrite on_free_vars_subst_instance.
     all: now eapply closed_on_free_vars, declared_constant_closed_type.
 
-  - replace idecl0 with idecl by (eapply declared_inductive_inj ; eassumption).
+  - unshelve epose proof (declared_inductive_to_gen isdecl); eauto.
+    unshelve epose proof (declared_inductive_to_gen H); eauto.
+    replace idecl0 with idecl by (eapply declared_inductive_inj ; eassumption).
     eexists ; split.
     all: eapply closed_red_refl.
     1,3: fvs.
     all: rewrite on_free_vars_subst_instance.
     all: now eapply closed_on_free_vars, declared_inductive_closed_type.
 
-  - replace cdecl0 with cdecl by (eapply declared_constructor_inj ; eassumption).
+  - unshelve epose proof (declared_constructor_to_gen isdecl); eauto.
+    unshelve epose proof (declared_constructor_to_gen H); eauto.
+    replace cdecl0 with cdecl by (eapply declared_constructor_inj ; eassumption).
     replace mdecl0 with mdecl by (eapply declared_constructor_inj ; eassumption).
     eexists ; split.
     all: eapply closed_red_refl.
     1,3: fvs.
     all: now eapply closed_on_free_vars, declared_constructor_closed_type.
 
-  - eapply declared_projection_inj in H as (?&?&?&?); tea.
+  - unshelve epose proof (declared_projection_to_gen H1); eauto.
+    unshelve eapply declared_projection_to_gen in H; eauto.
+    eapply declared_projection_inj in H as (?&?&?&?); tea.
     subst.
     move: (X2) => tyc'.
     eapply X0 in X2 as [args'' []] ; tea.
@@ -193,6 +201,8 @@ Proof using wfΣ.
 
   - intros ? T' ty_T'.
     inversion ty_T' ; subst.
+    unshelve eapply declared_inductive_to_gen in H13; eauto.
+    unshelve eapply declared_inductive_to_gen in H; eauto.
     move: (H) => /declared_inductive_inj /(_ H13) [? ?].
     subst.
     assert (op' : is_open_term Γ (mkApps ptm0 (skipn (ci_npar ci) args0 ++ [c]))).
@@ -213,7 +223,7 @@ Proof using wfΣ.
         now apply r.
       * fvs.
       * eapply type_is_open_term, infering_typing ; tea.
-        now econstructor.
+        econstructor; eauto. apply declared_inductive_from_gen; eauto.
     + eapply into_closed_red.
       * eapply red_mkApps.
         1: reflexivity.
@@ -227,6 +237,7 @@ Proof using wfΣ.
 
   - inversion X1; subst.
     rewrite H in H2; noconf H2.
+    unshelve eapply declared_constant_to_gen in H0, H3; eauto.
     have eq := (declared_constant_inj _ _ H0 H3); subst cdecl0.
     exists (tConst prim_ty []).
     split; eapply closed_red_refl; fvs.

--- a/pcuic/theories/Conversion/PCUICClosedConv.v
+++ b/pcuic/theories/Conversion/PCUICClosedConv.v
@@ -115,6 +115,7 @@ Lemma declared_minductive_closed_inds {cf} {Σ ind mdecl u} {wfΣ : wf Σ} :
   forallb (closedn 0) (inds (inductive_mind ind) u (ind_bodies mdecl)).
 Proof.
   intros h.
+  eapply declared_minductive_to_gen in h.
   red in h.
   eapply lookup_on_global_env in h. 2: eauto.
   destruct h as [Σ' [ext wfΣ' decl']].
@@ -125,6 +126,7 @@ Proof.
   induction h in n, m |- *.
   - reflexivity.
   - simpl. eauto.
+  Unshelve. all:eauto.
 Qed.
 
 Lemma closed_cstr_branch_context_gen {cf : checker_flags} {Σ} {wfΣ : wf Σ} {c mdecl cdecl} :

--- a/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
+++ b/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
@@ -1713,9 +1713,10 @@ Section SubstIdentity.
     declared_minductive Σ mind mdecl ->
     wf_ext_wk (Σ, ind_universes mdecl).
   Proof using Type.
-    intros wfΣ decli.
+    intros wfΣ decli. eapply declared_minductive_to_gen in decli.
     epose proof (weaken_lookup_on_global_env' _ _ (InductiveDecl mdecl) wfΣ decli); eauto.
     red. simpl. split; auto.
+    Unshelve. all:eauto.
   Qed.
 
   Lemma declared_inductive_wf_global_ext Σ mdecl mind :
@@ -1723,9 +1724,10 @@ Section SubstIdentity.
     declared_minductive Σ mind mdecl ->
     wf_global_ext Σ (ind_universes mdecl).
   Proof using Type.
-    intros wfΣ decli.
+    intros wfΣ decli. eapply declared_minductive_to_gen in decli.
     split; auto.
     epose proof (weaken_lookup_on_global_env' _ _ (InductiveDecl mdecl) wfΣ decli); eauto.
+    Unshelve. all:eauto.
   Qed.
 
   Hint Resolve declared_inductive_wf_ext_wk declared_inductive_wf_global_ext : pcuic.

--- a/pcuic/theories/PCUICArities.v
+++ b/pcuic/theories/PCUICArities.v
@@ -78,12 +78,16 @@ Proof.
   { apply forall_nth_error_Alli. intros.
     eapply Alli_nth_error in oind; eauto. simpl in oind.
     destruct oind. destruct onArity as [s Hs].
+    unshelve eapply declared_inductive_to_gen in isdecl; eauto.
     eapply type_Cumul; eauto.
     econstructor; eauto. split; eauto with pcuic.
+    unshelve eapply declared_minductive_from_gen; eauto with pcuic.
     eapply consistent_instance_ext_abstract_instance; eauto.
     eapply declared_inductive_wf_global_ext; eauto with pcuic.
+    unshelve eapply declared_minductive_from_gen; eauto with pcuic.
     rewrite (subst_instance_ind_type_id Σ _ {| inductive_mind := inductive_mind ind; inductive_ind := i |}); eauto.
-    destruct isdecl. split; eauto. reflexivity. }
+    unshelve eapply declared_inductive_from_gen; eauto with pcuic.
+    reflexivity. }
   clear oind.
   revert X. clear onNpars.
   generalize (le_n #|ind_bodies mdecl|).
@@ -654,7 +658,9 @@ Section WfEnv.
     consistent_instance_ext Σ (ind_universes mdecl) u ->
     wf_local Σ (subst_instance u (ind_params mdecl)).
   Proof using wfΣ.
-    intros. eapply (wf_local_instantiate (decl := InductiveDecl mdecl)); eauto.
+    intros.
+    unshelve epose proof (declared_minductive_to_gen H); eauto with pcuic.
+    eapply (wf_local_instantiate (decl := InductiveDecl mdecl)); eauto.
     eapply on_declared_minductive in H; auto.
     now apply onParams in H.
   Qed.

--- a/pcuic/theories/PCUICCanonicity.v
+++ b/pcuic/theories/PCUICCanonicity.v
@@ -740,8 +740,8 @@ Section WeakNormalization.
     - now eapply typing_var in typed.
     - now eapply typing_evar in typed.
     - apply inversion_Const in typed as [decl' [wfd [declc [cu cum]]]]; eauto.
-      red in declc.
-      rewrite declc in e, axfree.
+      unshelve eapply declared_constant_to_gen in declc; eauto.
+      red in declc. rewrite declc in e, axfree.
       noconf e.
       destruct decl; cbn in *.
       rewrite e0 in axfree; congruence.
@@ -781,13 +781,16 @@ Section WeakNormalization.
     T = tConst cst u.
   Proof using wfΣ.
     intros hdecl hb.
+    unshelve eapply declared_constant_to_gen in hdecl; eauto.
     generalize_eq x (tConst cst u).
     move=> e [clΓ clt] red.
     revert cst u hdecl hb e.
     eapply clos_rt_rt1n_iff in red.
     induction red; simplify_dep_elim.
     - reflexivity.
-    - depelim r; solve_discr. congruence.
+    - depelim r; solve_discr.
+      unshelve eapply declared_constant_to_gen in isdecl; eauto.
+      congruence.
   Qed.
 
   Lemma ws_cumul_pb_Axiom_l_inv {pb Γ cst u cdecl T} :
@@ -971,12 +974,15 @@ Section WeakNormalization.
 
     - redt (subst_instance u body); auto.
       eapply red1_red. econstructor; eauto.
+      apply declared_constant_from_gen; eauto.
       eapply IHHe. eapply subject_reduction; eauto.
       eapply red1_red. econstructor; eauto.
+      apply declared_constant_from_gen; eauto.
 
     - epose proof (subject_reduction Σ [] _ _ _ wfΣ Ht).
       apply inversion_Case in Ht; auto. destruct_sigma Ht.
-      destruct (declared_inductive_inj d.p1 isdecl); subst mdecl0 idecl0.
+      unshelve epose proof (isdecl_ := declared_inductive_to_gen isdecl); eauto.
+      destruct (declared_inductive_inj d isdecl_); subst mdecl0 idecl0.
       destruct c0.
       specialize (IHHe1 _ scrut_ty).
       assert (red Σ [] (tCase ci p discr brs) (iota_red ci.(ci_npar) p args br)).

--- a/pcuic/theories/PCUICContexts.v
+++ b/pcuic/theories/PCUICContexts.v
@@ -150,6 +150,7 @@ Lemma instantiate_minductive {cf:checker_flags} Σ ind mdecl u Γ t T :
   Σ ;;; subst_instance u Γ |- subst_instance u t : subst_instance u T.
 Proof.
   intros wfΣ isdecl Hu Ht.
+  unshelve eapply declared_minductive_to_gen in isdecl; eauto.
   red in isdecl. eapply typing_subst_instance_decl in isdecl; eauto.
 Qed.
 

--- a/pcuic/theories/PCUICConvCumInversion.v
+++ b/pcuic/theories/PCUICConvCumInversion.v
@@ -340,7 +340,9 @@ Section fixed.
     set (pl := {| pparams := motivepars |}) in *.
     set (pr := {| pparams := motivepars0 |}) in *.
     specialize e as (?&?&?&?).
-    destruct (declared_inductive_inj decli decli') as [-> ->].
+    unshelve epose proof (decli_ := declared_inductive_to_gen decli); eauto.
+    unshelve epose proof (decli'_ := declared_inductive_to_gen decli'); eauto.
+    destruct (declared_inductive_inj decli_ decli'_) as [-> ->].
     repeat inv_on_free_vars.
     have clred : red_terms Σ Γ (pparams p) motivepars.
     { eapply into_red_terms; tea. }

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -1174,12 +1174,14 @@ Proof using Hcf Hcf'.
   - eapply inversion_Const in X1 as [decl' [wf [declc [cu cum]]]]; auto.
     eapply cumul_cumul_prop in cum; eauto.
     eapply cumul_prop_trans; eauto.
+    unshelve eapply declared_constant_to_gen in H, declc; eauto.
     pose proof (declared_constant_inj _ _ H declc); subst decl'.
     eapply cumul_prop_subst_instance; eauto. fvs.
     destruct (cumul_prop_is_open cum) as [].
     now rewrite on_free_vars_subst_instance in i0.
 
   - eapply inversion_Ind in X1 as [decl' [idecl' [wf [declc [cu cum]]]]]; auto.
+    unshelve eapply declared_inductive_to_gen in isdecl, declc; eauto.
     pose proof (declared_inductive_inj isdecl declc) as [-> ->].
     eapply cumul_cumul_prop in cum; eauto.
     eapply cumul_prop_trans; eauto.
@@ -1188,7 +1190,9 @@ Proof using Hcf Hcf'.
     now rewrite on_free_vars_subst_instance in i0.
 
   - eapply inversion_Construct in X1 as [decl' [idecl' [cdecl' [wf [declc [cu cum]]]]]]; auto.
-    pose proof (declared_constructor_inj isdecl declc) as [-> [-> ->]].
+    unshelve eapply declared_constructor_to_gen in declc; eauto.
+    unshelve epose proof (isdecl' := declared_constructor_to_gen isdecl); eauto.
+    pose proof (declared_constructor_inj isdecl' declc) as [-> [-> ->]].
     eapply cumul_cumul_prop in cum; eauto.
     eapply cumul_prop_trans; eauto.
     unfold type_of_constructor.
@@ -1226,6 +1230,7 @@ Proof using Hcf Hcf'.
     eapply cumul_cumul_prop in cum; eauto.
     eapply cumul_prop_trans; eauto. simpl.
     clear X8.
+    unshelve eapply declared_inductive_to_gen in isdecl, isdecl'; eauto.
     destruct (declared_inductive_inj isdecl isdecl'). subst.
     destruct data.
     specialize (X7 _ _ H5 scrut_ty _ (eq_term_upto_univ_napp_leq X10)).
@@ -1261,7 +1266,9 @@ Proof using Hcf Hcf'.
     eapply cumul_cumul_prop in b; eauto.
     eapply cumul_prop_trans; eauto.
     eapply cumul_prop_mkApps_Ind_inv in X2 => //.
-    destruct (declared_projection_inj a isdecl) as [<- [<- [<- <-]]].
+    unshelve epose proof (a' := declared_projection_to_gen a); eauto.
+    unshelve epose proof (isdecl' := declared_projection_to_gen isdecl); eauto.
+    destruct (declared_projection_inj a' isdecl') as [<- [<- [<- <-]]].
     destruct (isType_mkApps_Ind_inv _ isdecl X0 (validity X1)) as [ps [argss [_ cu]]]; eauto.
     destruct (isType_mkApps_Ind_inv _ isdecl X0 (validity a0)) as [? [? [_ cu']]]; eauto.
     epose proof (wf_projection_context _ _ isdecl c1).

--- a/pcuic/theories/PCUICElimination.v
+++ b/pcuic/theories/PCUICElimination.v
@@ -126,11 +126,13 @@ Lemma elim_restriction_works_kelim1 {cf : checker_flags} {Σ : global_env_ext}
   (Is_proof Σ Γ (tCase ci p c brs) -> False) ->
   ind_kelim idecl = IntoAny \/ ind_kelim idecl = IntoSetPropSProp.
 Proof.
-  intros cu wfΣ. intros.
+  intros cu wfΣ. pose wfΣ' := wfΣ.1. intros.
   assert (HT := X).
   eapply inversion_Case in X as [mdecl' [idecl' [isdecl' [indices [data cum]]]]]; eauto.
   destruct data.
-  eapply declared_inductive_inj in isdecl' as []. 2:exact H. subst.
+  unshelve epose proof (H_ := declared_inductive_to_gen H); eauto.
+  unshelve epose proof (isdecl'_ := declared_inductive_to_gen isdecl'); eauto.
+  eapply declared_inductive_inj in isdecl'_ as []. 2:exact H_. subst.
   enough (~ (Universe.is_prop ps \/ Universe.is_sprop ps)).
   { clear -cu wfΣ allowed_elim H1.
     apply wf_ext_consistent in wfΣ as (val&sat).
@@ -323,7 +325,7 @@ Lemma typing_spine_proofs {cf:checker_flags} Σ Γ Δ ind u args' args T' s :
         is_propositional (subst_instance_univ u idecl.(ind_sort)) ->
         s = subst_instance_univ u idecl.(ind_sort)))))%type.
 Proof.
-  intros checku wfΣ Ht.
+  intros checku wfΣ Ht. pose wfΣ' := wfΣ.1.
   induction Δ using PCUICInduction.ctx_length_rev_ind in Γ, args', args, T', Ht |- *; simpl; intros sp.
   - dependent elimination sp as [spnil _ _ e|spcons isty isty' e _ sp].
     split; [repeat constructor|].
@@ -333,7 +335,9 @@ Proof.
       eapply subject_reduction_closed in Ht; eauto.
       eapply inversion_mkApps in Ht as [A [tInd sp]]; auto.
       eapply inversion_Ind in tInd as [mdecl' [idecl' [wfΓ [decli' [cu' cum]]]]]; auto.
-      destruct (declared_inductive_inj decli decli'); subst mdecl' idecl'.
+      unshelve epose proof (decli_ := declared_inductive_to_gen decli); eauto.
+      unshelve epose proof (decli'_ := declared_inductive_to_gen decli'); eauto.
+      destruct (declared_inductive_inj decli_ decli'_); subst mdecl' idecl'.
       clear decli'.
       eapply typing_spine_strengthen in sp. 3:tea.
       rewrite (oib.(ind_arity_eq)) in sp.
@@ -519,7 +523,9 @@ Proof.
   set (onib := declared_inductive_inv _ _ _ _) in *.
   clearbody onib. clear oib.
   eapply typing_spine_strengthen in hsp; eauto.
-  pose proof (declared_inductive_inj decli (proj1 declc)) as [-> ->].
+  unshelve epose proof (decli_ := declared_inductive_to_gen decli); eauto.
+  unshelve epose proof (declc_ := declared_inductive_to_gen declc); eauto.
+pose proof (declared_inductive_inj decli_ declc_) as [-> ->].
   assert (isType Σ Γ (type_of_constructor mdecl cdecl' (ind, n) u)).
   { eapply PCUICInductiveInversion.declared_constructor_valid_ty in declc; eauto. }
   move: X hsp.
@@ -583,7 +589,7 @@ Proof.
     eapply In_map in H1 as [cs' [ins ->]].
     rewrite is_propositional_subst_instance.
     eapply All_In in X1; eauto.
-    sq. apply X1.
+    sq. apply X1. apply decli.
 
   * intros _ sp.
     rewrite List.skipn_all2. lia.
@@ -613,7 +619,9 @@ Proof.
   assert (wfΣ : wf Σ) by apply HΣ.
   destruct (on_declared_inductive H) as [[]]; eauto.
   intros ?. intros.
-  eapply declared_inductive_inj in H as []; eauto; subst idecl0 mind.
+  unshelve epose proof (H_ := declared_inductive_to_gen H); eauto.
+  unshelve epose proof (H0_ := declared_inductive_to_gen H0); eauto.
+  eapply declared_inductive_inj in H_ as []; eauto; subst idecl0 mind.
   eapply Is_proof_mkApps_tConstruct in X1; tea.
   assert (wf Σ') by auto.
   now eapply weakening_env_declared_inductive; tc.
@@ -650,7 +658,9 @@ Lemma elim_restriction_works_proj_kelim1 `{cf : checker_flags} (Σ : global_env_
 Proof.
   intros X H X0 H0.
   eapply inversion_Proj in X0 as (? & ? & ? & ? & ? & ? & ? & ? & ? & ?) ; auto.
-  destruct (declared_inductive_inj H d.p1) as [-> ->].
+  unshelve epose proof (H_ := declared_inductive_to_gen H); eauto.
+  unshelve epose proof (d_ := declared_inductive_to_gen d); eauto.
+  destruct (declared_inductive_inj H_ d_) as [-> ->].
   destruct x2. cbn in *.
   pose proof (declared_projection_projs_nonempty X d).
   pose proof (on_declared_projection d) as [_ onp].

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -4155,11 +4155,13 @@ Proof.
   induction 1 in p |- *.
   - intros ont.
     constructor; len. now eapply closedn_trans.
-  - rewrite on_free_vars_mkApps => /= /andP[] onk onl.
-    rewrite trans_mkApps. econstructor 2. now len. now len.
-    solve_all. len. now eapply closedn_trans. len.
-    cbn. rewrite rev_mapi. rewrite nth_error_mapi e /= //. len.
-    now rewrite -trans_ind_realargs.
+  - destruct m0 as [? [? ?]].
+    rewrite on_free_vars_mkApps => /= /andP[] onk onl.
+    rewrite trans_mkApps. econstructor 2.
+    2: {solve_all. len. now eapply closedn_trans. }
+    2: {repeat (econstructor; [now len|]).
+        len. cbn. rewrite rev_mapi. rewrite nth_error_mapi H1 /= //. }
+    len. now rewrite -trans_ind_realargs.
   - cbn. move/and3P => [] onb onty ont.
     constructor 3.
     rewrite (trans_subst (shiftnP 1 p) p) in IHX => /= //.
@@ -4178,7 +4180,7 @@ Lemma positive_cstr_trans m n acc p T :
 Proof.
   induction 1 in p |- *.
   - cbn. intros. rewrite trans_mkApps.
-    cbn. rewrite /headrel. relativize #|ctx|.
+    cbn. rewrite /headrel. relativize #|Γ|.
     relativize #|ind_bodies m|.
     constructor. solve_all.
     rewrite on_free_vars_closedn. eapply trans_on_free_vars. len.

--- a/pcuic/theories/PCUICGlobalEnv.v
+++ b/pcuic/theories/PCUICGlobalEnv.v
@@ -48,12 +48,13 @@ Qed.
 Lemma declared_inductive_minductive {Σ ind mdecl idecl} :
   declared_inductive_gen Σ ind mdecl idecl -> declared_minductive_gen Σ (inductive_mind ind) mdecl.
 Proof. now intros []. Qed.
+
+Lemma declared_inductive_minductive' {Σ ind mdecl idecl} :
+  declared_inductive Σ ind mdecl idecl -> declared_minductive Σ (inductive_mind ind) mdecl.
+Proof. now intros []. Qed.
+
 #[global]
 Hint Extern 0 => eapply declared_inductive_minductive : pcuic core.
-
-Definition declared_inductive_minductive' {Σ ind mdecl idecl} :
-  declared_inductive Σ ind mdecl idecl -> declared_minductive Σ (inductive_mind ind) mdecl :=
-  declared_inductive_minductive.
 
 Coercion declared_inductive_minductive : declared_inductive_gen >-> declared_minductive_gen.
 Coercion declared_inductive_minductive' : declared_inductive >-> declared_minductive.
@@ -65,7 +66,8 @@ Proof. now intros []. Qed.
 
 Definition declared_constructor_inductive' {Σ ind mdecl idecl cdecl} :
   declared_constructor Σ ind mdecl idecl cdecl ->
-  declared_inductive Σ ind.1 mdecl idecl := declared_constructor_inductive.
+  declared_inductive Σ ind.1 mdecl idecl.
+Proof. now intros []. Qed.
 
 Coercion declared_constructor_inductive : declared_constructor_gen >-> declared_inductive_gen.
 Coercion declared_constructor_inductive' : declared_constructor >-> declared_inductive.
@@ -74,10 +76,11 @@ Lemma declared_projection_constructor {Σ ind mdecl idecl cdecl pdecl} :
   declared_projection_gen Σ ind mdecl idecl cdecl pdecl ->
   declared_constructor_gen Σ (ind.(proj_ind), 0) mdecl idecl cdecl.
 Proof. now intros []. Qed.
+
 Definition declared_projection_constructor' {Σ ind mdecl idecl cdecl pdecl} :
   declared_projection Σ ind mdecl idecl cdecl pdecl ->
-  declared_constructor Σ (ind.(proj_ind), 0) mdecl idecl cdecl :=
-  declared_projection_constructor.
+  declared_constructor Σ (ind.(proj_ind), 0) mdecl idecl cdecl.
+Proof. now intros []. Qed.
 
 Coercion declared_projection_constructor : declared_projection_gen >-> declared_constructor_gen.
 Coercion declared_projection_constructor' : declared_projection >-> declared_constructor.
@@ -90,11 +93,13 @@ Section DeclaredInv.
     ind_npars mdecl = context_assumptions mdecl.(ind_params).
   Proof using wfΣ.
     intros h.
+    eapply declared_minductive_to_gen in h.
     unfold declared_minductive in h.
     eapply lookup_on_global_env in h; tea.
     destruct h as [Σ' [ext wfΣ' decl']].
     red in decl'. destruct decl' as [h ? ? ?].
     now rewrite onNpars.
+    Unshelve. all: eauto.
   Qed.
 
 End DeclaredInv.

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -1303,7 +1303,8 @@ Proof.
   induction 1.
   - constructor 1; len.
     now rewrite closedn_subst_instance.
-  - rewrite subst_instance_mkApps. econstructor 2; len => //; eauto.
+  - rewrite subst_instance_mkApps.
+    econstructor 2; unfold mdecl_at_i in *; len => //; eauto.
     eapply All_map; solve_all.
     now rewrite closedn_subst_instance.
   - simpl. constructor 3; len => //.
@@ -1486,11 +1487,12 @@ Proof.
   - epose proof (ws_cumul_pb_is_closed_context cum).
     rewrite !subst_instance_mkApps !subst_mkApps in cum |- *.
     simpl in cum. eapply ws_cumul_pb_mkApps_tRel in cum; eauto; cycle 1.
-    { rewrite nth_error_app_ge // subst_instance_length //
+    { destruct m as [? [? ?]].
+      rewrite nth_error_app_ge // subst_instance_length //
          nth_error_subst_instance.
       unfold ind_arities, arities_context.
       rewrite rev_map_spec -map_rev.
-      rewrite nth_error_map e /=. reflexivity. }
+      rewrite nth_error_map e0 /=. reflexivity. }
     1:trivial.
     rewrite -(app_context_nil_l (_ ,,, _)) app_context_assoc in cum.
     eapply ws_cumul_pb_terms_subst in cum.
@@ -1503,39 +1505,40 @@ Proof.
         cbn; intros. eapply ws_cumul_pb_refl; eauto. }
     rewrite app_context_nil_l // in cum. len in cum.
     rewrite /ind_subst.
-    eapply ws_cumul_pb_mkApps_eq => //.
+    eapply ws_cumul_pb_mkApps_eq => //; destruct m as [? [? ?]].
     * move: cl. rewrite -is_closed_ctx_closed => cl.
       apply (closedn_ctx_subst 0 0). cbn. len.
       rewrite !closedn_subst_instance_context. rewrite /ind_arities in cl.
       move: cl. rewrite closedn_subst_instance_context closedn_ctx_app. len. move/andP=> []//.
       eapply closed_inds.
-    * cbn. destruct (leb_spec_Set #|ctx| k); try lia.
+    * cbn. destruct (leb_spec_Set #|Γ| k); try lia.
       destruct (nth_error (inds _ _ _) _) eqn:hnth.
       eapply inds_nth_error in hnth as [n ->]. now cbn.
       eapply nth_error_None in hnth. len in hnth; lia.
-    * cbn. destruct (leb_spec_Set #|ctx| k); try lia.
+    * cbn. destruct (leb_spec_Set #|Γ| k); try lia.
       destruct (nth_error (inds _ _ _) _) eqn:hnth.
       eapply inds_nth_error in hnth as [n ->]. now cbn.
       eapply nth_error_None in hnth. len in hnth; lia.
     * rewrite !map_length.
-      simpl. destruct (Nat.leb #|ctx| k) eqn:eqle.
+      simpl. destruct (Nat.leb #|Γ| k) eqn:eqle.
       eapply Nat.leb_le in eqle.
       rewrite /ind_subst !inds_spec !rev_mapi !nth_error_mapi.
       unshelve epose proof (declm' := declared_minductive_to_gen declm); eauto.
-      rewrite e /=. simpl. constructor. simpl.
+      rewrite H2 /=. simpl. constructor. simpl.
       unfold R_global_instance, R_global_instance_gen. simpl.
       assert(declared_inductive Σ {|
       inductive_mind := inductive_mind ind;
-      inductive_ind := Nat.pred #|ind_bodies mdecl| - (k - #|ctx|) |} mdecl i).
-      { split; auto. simpl. rewrite -e nth_error_rev; lia_f_equal. }
+      inductive_ind := Nat.pred #|ind_bodies mdecl| - (k - #|Γ|) |} mdecl i).
+      { split; auto. simpl. rewrite -H2 nth_error_rev; lia_f_equal. }
       unfold lookup_inductive.
-      unshelve epose proof (H0' := declared_inductive_to_gen H0); eauto.
+      unshelve epose proof (H0' := declared_inductive_to_gen H3); eauto.
       rewrite (declared_inductive_lookup_gen H0') //.
-      destruct (on_declared_inductive H0) as [onmind onind] => //. simpl in *.
-      rewrite e0 /ind_realargs.
+      destruct (on_declared_inductive H3) as [onmind onind] => //. simpl in *.
+      rewrite e /ind_realargs.
       rewrite !onind.(ind_arity_eq).
-      rewrite !destArity_it_mkProd_or_LetIn /=; len; simpl.
-      rewrite (Nat.leb_refl) //. eapply Nat.leb_nle in eqle. lia.
+      rewrite !destArity_it_mkProd_or_LetIn /=. len; simpl.
+      rewrite (Nat.leb_refl) //.
+      eapply Nat.leb_nle in eqle. lia.
     * do 2 eapply All2_map. do 2 eapply All2_map_inv in cum.
       eapply All2_All in cum. apply All_All2_refl.
       solve_all.

--- a/pcuic/theories/PCUICInductives.v
+++ b/pcuic/theories/PCUICInductives.v
@@ -192,9 +192,12 @@ Lemma wf_arities_context_inst {cf} {Σ : global_env_ext} {wfΣ : wf Σ} {mind md
   wf_local Σ (arities_context mdecl.(ind_bodies))@[u].
 Proof.
   intros decli cu.
+  unshelve eapply declared_minductive_to_gen in decli; eauto.
   eapply wf_local_instantiate; tea. cbn.
   eapply wf_arities_context; tea.
+  unshelve eapply declared_minductive_from_gen; eauto.
 Qed.
+
 
 Lemma instantiate_inds {cf:checker_flags} {Σ} {wfΣ : wf Σ.1} {u mind mdecl} :
   declared_minductive Σ.1 mind mdecl ->
@@ -268,8 +271,10 @@ Section OnInductives.
     wf_local Σ (subst_instance u (ind_params mdecl ,,, ind_indices idecl)).
   Proof using decli wfΣ.
     intros.
+    unshelve eapply declared_inductive_to_gen in decli; eauto.
     eapply (wf_local_instantiate _ (proj1 decli)); eauto.
-    now eapply on_minductive_wf_params_indices.
+    eapply on_minductive_wf_params_indices.
+    unshelve eapply declared_inductive_from_gen; eauto.
   Qed.
 
   Lemma on_inductive_inst Γ u :
@@ -288,6 +293,7 @@ Section OnInductives.
     rewrite -it_mkProd_or_LetIn_app in ar.
     eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u wfΣ) in ar.
     all:pcuic.
+    unshelve eapply declared_inductive_to_gen in decli; eauto.
   Qed.
 
   Lemma declared_inductive_valid_type Γ u :
@@ -301,7 +307,8 @@ Section OnInductives.
     destruct ar as [s ar].
     eapply isType_weaken => //.
     eapply (typing_subst_instance_decl Σ [] _ _ _ (InductiveDecl mdecl) u wfΣ) in ar.
-    all:pcuic. 
+    all:pcuic.
+    unshelve eapply declared_inductive_to_gen in decli; eauto.
   Qed.
 
   Local Definition oi := (on_declared_inductive decli).1.
@@ -707,6 +714,7 @@ Proof.
   eapply consistent_instance_ext_abstract_instance; eauto with pcuic.
   eapply declared_inductive_wf_global_ext; eauto with pcuic.
   set (u := abstract_instance (ind_universes mdecl)).
+  destruct hdecl; eauto.
   assert (isType (Σ.1, ind_universes mdecl) [] (ind_type idecl)).
   { pose proof (onArity oib). exact X. }
   rewrite (subst_instance_ind_type_id _ _ _ _ _ hdecl).
@@ -1080,7 +1088,8 @@ Proof.
         rewrite context_assumptions_smash_context /= //.
         assert(subst_instance (abstract_instance (ind_universes mdecl)) pdecl.(proj_type) = pdecl.(proj_type)) as ->.
         { eapply (isType_subst_instance_id (Σ.1, ind_universes mdecl)); eauto with pcuic.
-          eapply declared_inductive_wf_ext_wk; eauto with pcuic. }
+          eapply declared_inductive_wf_ext_wk; eauto with pcuic.
+          destruct Hdecl; eauto.    }
         destruct IH as [isTy [decl [nthdecl _ _ eqpdecl ptyeq]]].
         move ptyeq at bottom.
         rewrite nthdecl in Hnth. noconf Hnth. simpl in ptyeq.
@@ -1181,7 +1190,8 @@ Proof.
   simpl.
   assert (wfarities : wf_local (Σ.1, ind_universes mdecl)
       (arities_context (ind_bodies mdecl))).
-  { eapply wf_arities_context; eauto. }
+  { eapply wf_arities_context; eauto.
+    destruct isdecl as [[[] ?] ?]; eauto. }
   destruct (ind_cunivs oib) as [|? []] eqn:hequ => //.
   eapply PCUICClosedConv.sorts_local_ctx_All_local_env in wfargs.
   2:{ eapply All_local_env_app. split; auto.
@@ -1200,7 +1210,8 @@ Proof.
   red in onpars. eapply closed_wf_local; [|eauto]. auto.
   assert (parsu : subst_instance u (ind_params mdecl) = ind_params mdecl).
   { red in onpars. eapply (subst_instance_id (Σ.1, ind_universes mdecl)). eauto.
-    eapply declared_inductive_wf_ext_wk; eauto with pcuic. auto. }
+    eapply declared_inductive_wf_ext_wk; eauto with pcuic.
+    destruct decli; eauto. auto. }
   assert (typeu : subst_instance u (ind_type idecl) = ind_type idecl).
   { eapply (subst_instance_ind_type_id Σ.1); eauto. }
   assert (sortu : subst_instance u (ind_sort idecl) = ind_sort idecl).
@@ -1220,6 +1231,7 @@ Proof.
     destruct isdecl as []; eauto. subst u.
     eapply consistent_instance_ext_abstract_instance; eauto with pcuic.
     eapply declared_inductive_wf_global_ext; eauto with pcuic.
+    destruct decli; eauto.
     assert (isType (Σ.1, ind_universes mdecl) [] (ind_type idecl)@[u]).
     { rewrite typeu. pose proof (onArity oib). exact X1. }
     rewrite (ind_arity_eq oib).
@@ -1281,7 +1293,8 @@ Proof.
     eapply (closedn_ctx_subst 0 #|ind_params mdecl|).
     now unfold indsubst; rewrite inds_length.
     unfold indsubst.
-    eapply declared_minductive_closed_inds. eauto. }
+    eapply declared_minductive_closed_inds. eauto.
+    destruct isdecl as [[[] ?] ?]; eauto.  }
   rewrite -app_assoc in wfl.
   apply All_local_env_app_inv in wfl as [wfctx wfsargs].
   rewrite smash_context_app in Heq'.
@@ -1652,7 +1665,10 @@ Proof.
       split; auto.
     destruct (on_declared_inductive decli) as [onmind oib].
     eapply typing_spine_app; eauto.
-  - invs H0. destruct (declared_inductive_inj d decli) as [-> ->].
+  - invs H0.
+    unshelve epose proof (d' := declared_inductive_to_gen d);
+    unshelve epose proof (decli' := declared_inductive_to_gen decli); eauto.
+    destruct (declared_inductive_inj d' decli') as [-> ->].
     clear decli. split; auto.
     destruct (on_declared_inductive d) as [onmind oib].
     pose proof (oib.(onArity)) as ar.
@@ -2594,8 +2610,9 @@ Lemma inductive_ind_ind_bodies_length `{cf:checker_flags}
   (inddecl: declared_inductive Σ ind mib oib) :
   inductive_ind ind < #|ind_bodies mib|.
 Proof.
-  move: (declared_inductive_lookup inddecl).
-  rewrite /lookup_inductive /lookup_inductive_gen (PCUICLookup.declared_minductive_lookup (PCUICGlobalEnv.declared_inductive_minductive inddecl)).
+  unshelve eapply declared_inductive_to_gen in inddecl; eauto.
+  move: (declared_inductive_lookup_gen inddecl).
+  rewrite /lookup_inductive /lookup_inductive_gen (PCUICLookup.declared_minductive_lookup_gen (PCUICGlobalEnv.declared_inductive_minductive inddecl)).
   remember (nth_error _ _) as o eqn:eo; symmetry in eo.
   move: o eo=> [io|] // /nth_error_Some_length //.
 Qed.

--- a/pcuic/theories/PCUICNormal.v
+++ b/pcuic/theories/PCUICNormal.v
@@ -639,7 +639,7 @@ Context (Σ : global_env).
 Context (Γ : context).
 Context (P : term -> term -> Type).
 
-Lemma whne_red1_ind
+Lemma whne_red1_ind {cf:checker_flags} {wfΣ : wf Σ}
       (Hrel : forall i body,
           RedFlags.zeta flags = false ->
           option_map decl_body (nth_error Γ i) = Some (Some body) ->
@@ -778,6 +778,7 @@ Proof using Type.
   - depelim r; solve_discr; eauto.
   - eauto.
   - depelim r; solve_discr.
+    unshelve eapply declared_constant_to_gen in isdecl; try exact wfΣ.
     unfold declared_constant, declared_constant_gen in isdecl.
     rewrite e in isdecl.
     inv isdecl.
@@ -842,7 +843,7 @@ Proof using Type.
 Qed.
 End whne_red1_ind.
 
-Lemma whne_pres1 Σ Γ t t' :
+Lemma whne_pres1 {cf:checker_flags} Σ {wfΣ : wf Σ} Γ t t' :
   red1 Σ Γ t t' ->
   whne RedFlags.default Σ Γ t ->
   whne RedFlags.default Σ Γ t'.
@@ -887,14 +888,14 @@ Proof.
       reflexivity.
 Qed.
 
-Lemma whne_pres Σ Γ t t' :
+Lemma whne_pres {cf:checker_flags} Σ {wfΣ : wf Σ} Γ t t' :
   red Σ Γ t t' ->
   whne RedFlags.default Σ Γ t -> whne RedFlags.default Σ Γ t'.
 Proof.
   induction 1 using red_rect_n1; eauto using whne_pres1.
 Qed.
 
-Lemma whnf_pres1 Σ Γ t t' :
+Lemma whnf_pres1 {cf:checker_flags} Σ {wfΣ : wf Σ} Γ t t' :
   red1 Σ Γ t t' ->
   whnf RedFlags.default Σ Γ t ->
   whnf RedFlags.default Σ Γ t'.
@@ -944,7 +945,7 @@ Proof.
   - depelim r. solve_discr.
 Qed.
 
-Lemma whnf_pres Σ Γ t t' :
+Lemma whnf_pres {cf:checker_flags} Σ {wfΣ : wf Σ} Γ t t' :
   red Σ Γ t t' ->
   whnf RedFlags.default Σ Γ t -> whnf RedFlags.default Σ Γ t'.
 Proof.
@@ -1413,7 +1414,7 @@ Proof.
     now apply All2_length in a.
 Qed.
 
-Lemma whne_red1_inv Σ Γ t t' :
+Lemma whne_red1_inv {cf:checker_flags} Σ {wfΣ : wf Σ} Γ t t' :
   whne RedFlags.default Σ Γ t ->
   red1 Σ Γ t t' ->
   whnf_red Σ Γ t t'.
@@ -1458,7 +1459,7 @@ Proof.
       intuition eauto; try reflexivity.
 Qed.
 
-Lemma whnf_red1_inv Σ Γ t t' :
+Lemma whnf_red1_inv {cf:checker_flags} Σ {wfΣ : wf Σ} Γ t t' :
   whnf RedFlags.default Σ Γ t ->
   red1 Σ Γ t t' ->
   whnf_red Σ Γ t t'.
@@ -1529,7 +1530,7 @@ Proof.
   intros wf wh [clΓ clt r].
   induction r using red_rect_n1.
   - apply whnf_red_refl; auto.
-  - eapply whnf_red1_inv in X.
+  - eapply whnf_red1_inv in X; eauto.
     + eapply whnf_red_trans; tea.
     + eapply whnf_pres; eauto.
 Qed.

--- a/pcuic/theories/PCUICParallelReductionConfluence.v
+++ b/pcuic/theories/PCUICParallelReductionConfluence.v
@@ -179,7 +179,8 @@ Section Pred1_inversion.
         eapply All2_app; auto.
   Qed.
 
-  Lemma pred1_mkApps_tConst_axiom (Σ : global_env) (Γ Δ : context)
+  Lemma pred1_mkApps_tConst_axiom {cf : checker_flags}
+      (Σ : global_env) {wfΣ : wf Σ} (Γ Δ : context)
         cst u (args : list term) cb c :
     declared_constant Σ cst cb -> cst_body cb = None ->
     pred1 Σ Γ Δ (mkApps (tConst cst u) args) c ->
@@ -187,7 +188,8 @@ Section Pred1_inversion.
   Proof with solve_discr.
     revert c. induction args using rev_ind; intros; simpl in *.
     depelim X...
-    - red in H, isdecl. unfold declared_constant_gen in *. 
+    - unshelve eapply declared_constant_to_gen in H, isdecl; eauto.
+      red in H, isdecl. unfold declared_constant_gen in *.
       rewrite isdecl in H; noconf H.
       congruence.
     - exists []. intuition auto.
@@ -3615,16 +3617,17 @@ Section Rho.
       + eapply forallb_All in b;eapply All2_All_mix_left in X4; tea.
         eapply All2_sym, All2_map_left; solve_all.
 
-    - simpl; simp rho; simpl.
+    - unshelve eapply declared_constant_to_gen in H; eauto.
+      simpl; simp rho; simpl.
       simpl in X0. red in H. rewrite H /= heq_cst_body /=.
       now eapply pred1_refl_gen.
 
     - simpl in *. simp rho; simpl.
       destruct (lookup_env Σ c) eqn:Heq. 2:{ constructor; auto. }
       destruct g. 2:{ constructor; auto. }
-      destruct c0. destruct cst_body0 eqn:Heq'. pcuic.
+      destruct c0. destruct cst_body0 eqn:Heq'.
+      econstructor; try  unshelve eapply declared_constant_from_gen; eauto.
       constructor; auto.
-
     - simpl in *. inv_on_free_vars. rewrite rho_app_proj.
       rewrite decompose_app_mkApps; auto.
       change eq_inductive with (@eqb inductive _).

--- a/pcuic/theories/PCUICProgress.v
+++ b/pcuic/theories/PCUICProgress.v
@@ -510,7 +510,9 @@ Proof.
   pose proof (validity hc).
   eapply PCUICSpine.inversion_mkApps_direct in hc as [A' [u' [s' [hs hsp]]]]; eauto.
   eapply inversion_Construct in s' as [mdecl' [idecl' [cdecl' [wf [declc' [cu cum]]]]]]; tea.
-  destruct (PCUICGlobalEnv.declared_constructor_inj declc declc') as [? []]. subst mdecl' idecl' cdecl'.
+  unshelve epose proof (declc_ := declared_constructor_to_gen declc); eauto.
+  unshelve epose proof (declc'_ := declared_constructor_to_gen declc'); eauto.
+  destruct (PCUICGlobalEnv.declared_constructor_inj declc_ declc'_) as [? []]. subst mdecl' idecl' cdecl'.
   clear declc'.
   eapply typing_spine_strengthen in hsp. 3:exact cum.
   2:{ eapply validity. econstructor; tea. }
@@ -598,7 +600,7 @@ Proof.
     pose proof hfn as hfn'.
     eapply inversion_Construct in hfn' as [mdecl [idecl [cdecl [wf [declc _]]]]]; tea.
     eapply (typing_constructor_arity declc) in ht.
-    econstructor; tea.
+    econstructor; tea. unshelve eapply declared_constructor_to_gen; eauto.
   * (* fix *)
     destruct (isStuckFix (tFix mfix idx) (args ++ [hd])) eqn:E.
     + right. eapply value_stuck_fix; eauto with pcuic.
@@ -696,7 +698,9 @@ Proof with eauto with wcbv; try congruence.
       { destruct H_ as [? []]; auto. now noconf H0. }
       clear H_. eapply Construct_Ind_ind_eq' in Hc as (? & ? & ? & ? & _); eauto.
       eexists.
-      destruct (declared_inductive_inj d.p1 Hidecl); subst x x0.
+      unshelve epose proof (d_ := declared_constructor_to_gen d); eauto.
+      unshelve epose proof (Hidecl_ := declared_inductive_to_gen Hidecl); eauto.
+      destruct (declared_inductive_inj d_ Hidecl_); subst x x0.
       eapply All2i_nth_error in Hall as [eqctx _]; tea; [|eapply d].
       eapply PCUICCasesContexts.alpha_eq_context_assumptions in eqctx.
       rewrite cstr_branch_context_assumptions in eqctx.
@@ -723,6 +727,7 @@ Proof with eauto with wcbv; try congruence.
       left. eapply nth_error_Some' in Hl as [x Hx].
       eexists.
       eapply red_proj; eauto.
+      unshelve eapply declared_projection_to_gen; eauto.
       now eapply (typing_constructor_arity_exact Hcon) in Hc.
       eapply value_mkApps_inv in Hval as [[-> Hval] | [? ? Hval]]; eauto.
     + left. eapply inversion_Proj in H as (? & ? & ? & ? & ? & ? & ? & ? & ? & ?); eauto.
@@ -795,11 +800,16 @@ Proof.
   - inversion Heval; subst; clear Heval. all:cbn in Hty; solve_all. 1-3,6: now econstructor; eauto with wcbv.
     eapply eval_construct; tea. eauto. eapply eval_app_cong; eauto with wcbv.
   - inversion Heval; subst; clear Heval. all:cbn in Hty; solve_all. all: now econstructor; eauto with wcbv.
-  - inversion Heval; subst; clear Heval. all:cbn in Hty; solve_all. all: try now econstructor; eauto with wcbv.
-  - eapply eval_iota. eapply eval_mkApps_Construct; tea. now econstructor. unfold cstr_arity. rewrite e0.
+  - unshelve eapply declared_constant_to_gen in isdecl; eauto.
+    inversion Heval; subst. all:cbn in Hty; solve_all. all: try now econstructor; eauto with wcbv.
+  - inversion Heval; subst. all:cbn in Hty; solve_all. all: try now econstructor; eauto with wcbv.
+  - eapply eval_iota. eapply eval_mkApps_Construct; tea.
+    unshelve eapply declared_constructor_to_gen; eauto.
+    now econstructor. unfold cstr_arity. rewrite e0.
     rewrite (PCUICGlobalEnv.declared_minductive_ind_npars d).
     now rewrite -(declared_minductive_ind_npars d) /cstr_arity.
     all:tea. eapply All_All2_refl. solve_all. now eapply value_final.
+    unshelve eapply declared_constructor_to_gen; eauto.
   - inversion Heval; subst; clear Heval. all:cbn in Hty; solve_all. all: now econstructor; eauto with wcbv.
   - all:cbn in Hty; solve_all. eapply eval_proj; tea.
     eapply value_final. eapply value_app; auto. econstructor; tea. eapply d.

--- a/pcuic/theories/PCUICSafeLemmata.v
+++ b/pcuic/theories/PCUICSafeLemmata.v
@@ -661,7 +661,7 @@ Section Lemmata.
   Proof using Type.
     intros Γ c u cty cb cu rel e.
     econstructor. econstructor.
-    - symmetry in e. exact e.
+    - apply declared_constant_from_gen. symmetry in e. exact e.
     - reflexivity.
   Qed.
 
@@ -676,7 +676,7 @@ Section Lemmata.
     symmetry in e.
     econstructor.
     econstructor.
-    - exact e.
+    - apply declared_constant_from_gen. exact e.
     - reflexivity.
   Qed.
 

--- a/pcuic/theories/PCUICSubstitution.v
+++ b/pcuic/theories/PCUICSubstitution.v
@@ -361,7 +361,7 @@ Lemma subst_declared_constant `{H:checker_flags} Σ cst decl n k u :
   map_constant_body (subst n k) (map_constant_body (subst_instance u) decl) =
   map_constant_body (subst_instance u) decl.
 Proof.
-  intros.
+  intros. unshelve eapply declared_constant_to_gen in H0; eauto.
   eapply declared_decl_closed in H0; eauto.
   unfold map_constant_body.
   do 2 red in H0. destruct decl as [ty [body|] univs]; simpl in *.

--- a/pcuic/theories/PCUICTransform.v
+++ b/pcuic/theories/PCUICTransform.v
@@ -92,7 +92,8 @@ Next Obligation.
   red. intros cf K [Σ t] v [[]].
   unfold eval_pcuic_program.
   cbn. intros [ev]. destruct X.
-  eapply (PCUICExpandLetsCorrectness.trans_wcbveval (Σ:=global_env_ext_map_global_env_ext Σ)) in ev.
+  unshelve eapply (PCUICExpandLetsCorrectness.trans_wcbveval (Σ:=global_env_ext_map_global_env_ext Σ)) in ev; eauto.
+  apply trans_wf; eauto.
   eexists; split; split; eauto.
   destruct s as [T HT]. now apply PCUICClosedTyp.subject_closed in HT.
 Qed.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -282,12 +282,14 @@ Section Validity.
       * eapply declared_constant_inv in X; eauto.
         red in X. simpl in X.
         eapply isType_weakening; eauto.
+        unshelve eapply declared_constant_to_gen in H; eauto.
         eapply (isType_subst_instance_decl (Γ:=[])); eauto. simpl.
         eapply weaken_env_prop_isType.
       * have ond := on_declared_constant wf H.
         do 2 red in ond. simpl in ond.
         simpl in ond.
         eapply isType_weakening; eauto.
+        unshelve eapply declared_constant_to_gen in H; eauto.
         eapply (isType_subst_instance_decl (Γ:=[])); eauto.
 
      - (* Inductive type *)
@@ -295,6 +297,7 @@ Section Validity.
       destruct isdecl.
       apply onArity in o0.
       eapply isType_weakening; eauto.
+      unshelve eapply declared_minductive_to_gen in H; eauto.
       eapply (isType_subst_instance_decl (Γ:=[])); eauto.
 
     - (* Constructor type *)
@@ -366,7 +369,8 @@ Section Validity.
         lenpars lenargs cu]]]; eauto.
       2:eapply isdecl.p1.
       eapply infer_typing_sort_impl with _ isdecl'; intros Hs.
-      eapply (typing_subst_instance_decl _ _ _ _ _ _ _ wf isdecl.p1.p1.p1) in Hs; eauto.
+      unshelve epose proof (isdecl_ := declared_projection_to_gen isdecl); eauto.
+      eapply (typing_subst_instance_decl _ _ _ _ _ _ _ wf isdecl_.p1.p1.p1) in Hs; eauto.
       simpl in Hs.
       eapply (weaken_ctx Γ) in Hs; eauto.
       rewrite -heq_length in sppar. rewrite firstn_all in sppar.

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -1,6 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From MetaCoq.Template Require Import config utils.
-From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping.
 From Equations Require Import Equations.
 From MetaCoq Require Import LibHypsNaming.
 
@@ -195,8 +195,6 @@ Proof.
 Qed.
 
 
-
-
 Definition on_udecl_prop (Σ : global_env) (udecl : universes_decl)
   := let levels := levels_of_udecl udecl in
      let global_levels := global_levels Σ.(universes) in
@@ -264,7 +262,7 @@ Section ExtendsWf.
 
   Let wf := on_global_env Pcmp P.
 
-Lemma extends_lookup Σ Σ' c decl :
+  Lemma extends_lookup Σ Σ' c decl :
   wf Σ' ->
   extends Σ Σ' ->
   lookup_env Σ c = Some decl ->
@@ -288,8 +286,11 @@ Lemma weakening_env_declared_constant :
     forall Σ' : global_env, wf Σ' -> extends Σ Σ' -> declared_constant Σ' cst decl.
 Proof using P Pcmp cf.
   intros Σ cst decl H0 Σ' X2 H2.
-  eapply extends_lookup; eauto.
+  unfold declared_constant in *.
+  destruct H2 as [? []]. rewrite e.
+  apply in_or_app. now right.
 Qed.
+
 Hint Resolve weakening_env_declared_constant : extends.
 
 Lemma weakening_env_declared_minductive `{CF:checker_flags}:
@@ -298,8 +299,10 @@ Lemma weakening_env_declared_minductive `{CF:checker_flags}:
     forall Σ' : global_env, wf Σ' -> extends Σ Σ' -> declared_minductive Σ' ind decl.
 Proof using P Pcmp cf.
   intros Σ cst decl H0 Σ' X2 H2.
-  eapply extends_lookup; eauto.
-Qed.
+  unfold declared_minductive in *.
+  destruct H2 as [? []]. rewrite e.
+  apply in_or_app. now right.
+  Qed.
 
 Hint Extern 0 => eapply weakening_env_declared_minductive : extends.
 

--- a/pcuic/theories/PCUICWfUniverses.v
+++ b/pcuic/theories/PCUICWfUniverses.v
@@ -1058,6 +1058,7 @@ Qed.
         eapply consistent_instance_ext_wf; eauto. }
       pose proof (declared_constant_inv _ _ _ _ wf_universes_weaken wf X H).
       red in X1; cbn in X1.
+      unshelve eapply declared_constant_to_gen in H; eauto.
       destruct (cst_body decl).
       * to_prop.
         epose proof (weaken_lookup_on_global_env' Σ.1 _ _ wf H).
@@ -1077,6 +1078,7 @@ Qed.
       pose proof (declared_inductive_inv wf_universes_weaken wf X isdecl).
       cbn in X1. eapply onArity in X1. cbn in X1.
       move: X1 => [s /andP[Hind ?]].
+      unshelve eapply declared_inductive_to_gen in isdecl; eauto.
       eapply wf_universes_inst; eauto.
       exact (weaken_lookup_on_global_env' Σ.1 _ _ wf (proj1 isdecl)).
       now eapply consistent_instance_ext_wf.
@@ -1092,6 +1094,7 @@ Qed.
         now eapply consistent_instance_ext_wf. }
       eapply on_ctype in onc. cbn in onc.
       move: onc=> [_ /andP[onc _]].
+      clear nthe. unshelve eapply declared_constructor_to_gen in isdecl; eauto.
       eapply wf_universes_inst; eauto.
       exact (weaken_lookup_on_global_env' Σ.1 _ _ wf (proj1 (proj1 isdecl))).
       now eapply consistent_instance_ext_wf.
@@ -1110,7 +1113,8 @@ Qed.
       move/and3P: hty => [] wfp wfindis wfisort.
       have ond : on_udecl_prop Σ (ind_universes mdecl).
       { eapply (weaken_lookup_on_global_env' _ _ (InductiveDecl mdecl)); eauto.
-        }
+      unshelve eapply declared_inductive_to_gen in isdecl; eauto.
+      }
       eapply wf_ctx_universes_closed in wfp => //.
       eapply wf_ctx_universes_closed in wfindis => //.
       rewrite (consistent_instance_length H1).
@@ -1158,7 +1162,7 @@ Qed.
       rewrite wf_universes_mkApps {1}/wf_universes /= -!/(wf_universes _ _)
         wf_universeb_instance_forall in H1.
       move/andP: H1 => [/wf_universe_instanceP wfu wfargs].
-
+      unshelve eapply declared_projection_to_gen in isdecl; eauto.
       eapply (wf_universes_inst (ind_universes mdecl)); eauto.
       exact (weaken_lookup_on_global_env' Σ.1 _ _ wf (proj1 (proj1 (proj1 isdecl)))).
       rewrite wf_universes_subst.

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -3167,9 +3167,9 @@ Proof.
               subst headrel.
               assert (#|PCUICEnvironment.ind_bodies (trans_minductive_body Σ' m)| = #|Ast.Env.ind_bodies m|) as <-.
               now rewrite /trans_minductive_body /= map_length.
-              assert (#|ctx| = #|map (trans_decl Σ') ctx|) as ->. now rewrite map_length.
+              assert (#|Γ| = #|map (trans_decl Σ') Γ|) as ->. now rewrite map_length.
               move/WfAst.wf_mkApps_inv => wfindices.
-              eapply positive_cstr_concl.
+              eapply pos_concl.
               rewrite map_length.
               eapply All_map. solve_all. now eapply trans_closedn.
               move/WfAst.wf_inv => /= [[wfb wfty] wft].
@@ -3180,14 +3180,14 @@ Proof.
               constructor. clear -onI X0 wfΣg onu IHond p wfty.
               induction p.
               { constructor; rewrite map_length; eapply trans_closedn => //. }
-              { rewrite trans_mkApps /=.
+              { destruct m0 as [? [? ?]]. rewrite trans_mkApps /=.
                 move/WfAst.wf_mkApps_inv: wfty => wfl.
-                econstructor 2; tea; rewrite ?map_length //.
-                solve_all. eapply trans_closedn => //.
-                rewrite -map_rev nth_error_map e //.
-                rewrite e0.
+                econstructor 2; tea; repeat econstructor; rewrite ?map_length //.
+                2: solve_all; eapply trans_closedn => //.
+                2: rewrite -map_rev nth_error_map H2//.
+                rewrite e.
                 have wfty : WfAst.wf Σg (Ast.Env.ind_type i).
-                { rewrite nth_error_rev in e. len. rewrite List.rev_involutive in e.
+                { rewrite nth_error_rev in H2. len. rewrite List.rev_involutive in H2.
                   eapply nth_error_alli in onI; tea. cbn in onI.
                   destruct onI as [onI _]. eapply Typing.onArity in onI as [s Hs].
                   now eapply typing_wf in Hs. }

--- a/pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/pcuic/theories/TemplateToPCUICCorrectness.v
@@ -224,7 +224,9 @@ Proof.
   rewrite !trans_lookup_inductive.
   unshelve epose proof (trans_lookup_inductive (Σ := trans_global_env Σ) ci _); tc.
   eapply extends_decls_wf; tea. rewrite {}H2.
-  destruct H as [H hnth]. red in H.
+  destruct H as [H hnth].
+  unshelve eapply Typing.TemplateDeclarationTyping.declared_minductive_to_gen in H; eauto.
+  red in H.
   generalize (trans_lookup_env (inductive_mind ci)).
   move: H.
   rewrite /lookup_inductive /lookup_minductive. intros ->.
@@ -669,7 +671,10 @@ Section Trans_Global.
     Ast.declared_constant Σ cst decl ->
     declared_constant Σ' cst (trans_constant_body Σ' decl).
   Proof.
-    unfold declared_constant, Ast.declared_constant, 
+    intro H.
+    unshelve eapply Typing.TemplateDeclarationTyping.declared_constant_to_gen in H; eauto.
+    unshelve eapply declared_constant_from_gen; eauto. move:H.
+    unfold declared_constant, Ast.declared_constant,
       declared_constant_gen, Ast.declared_constant_gen.
     now rewrite trans_lookup => -> /=.
   Qed.
@@ -678,6 +683,9 @@ Section Trans_Global.
     Ast.declared_minductive Σ cst decl ->
     declared_minductive (trans_global_env Σ) cst (trans_minductive_body Σ' decl).
   Proof.
+    intro H.
+    unshelve eapply Typing.TemplateDeclarationTyping.declared_minductive_to_gen in H; eauto.
+    unshelve eapply declared_minductive_from_gen; eauto. move:H.
     unfold declared_minductive, Ast.declared_minductive.
     unfold declared_minductive_gen, Ast.declared_minductive_gen.
     now rewrite trans_lookup => -> /=.
@@ -737,25 +745,28 @@ Proof.
   now eapply typing_wf.
 Qed.
 
-Lemma declared_inductive_inj {Σ mdecl mdecl' ind idecl idecl'} :
+Lemma declared_inductive_inj {cf Σ mdecl mdecl' ind idecl idecl'}
+  {wfΣ : Typing.wf Σ}:
   Ast.declared_inductive Σ ind mdecl' idecl' ->
   Ast.declared_inductive Σ ind mdecl idecl ->
   mdecl = mdecl' /\ idecl = idecl'.
 Proof.
-  intros [] []. unfold Ast.declared_minductive in *.
-  unfold Ast.declared_minductive_gen in H1. 
+  intros [] [].
+  unshelve eapply Typing.TemplateDeclarationTyping.declared_minductive_to_gen in H, H1; eauto.
+  unfold Ast.declared_minductive_gen in H1.
   rewrite H in H1. inversion H1. subst. rewrite H2 in H0. inversion H0. eauto.
 Qed.
 
-Lemma lookup_inductive_None Σ ind : lookup_inductive Σ ind = None ->
+Lemma lookup_inductive_None {cf} Σ {wfΣ : wf Σ} ind : lookup_inductive Σ ind = None ->
     ~ (exists mdecl idecl, declared_inductive Σ ind mdecl idecl).
 Proof.
   intros hl [mdecl [idecl [decli hnth]]].
+  unshelve eapply declared_minductive_to_gen in decli; eauto.
   unfold declared_inductive, declared_minductive in decli.
-  unfold lookup_inductive, lookup_inductive_gen, 
+  unfold lookup_inductive, lookup_inductive_gen,
     lookup_minductive, lookup_minductive_gen in hl.
-  unfold declared_minductive_gen in decli. 
-  destruct lookup_env eqn:heq. 
+  unfold declared_minductive_gen in decli.
+  destruct lookup_env eqn:heq.
   noconf decli. cbn in hl.
   destruct nth_error; congruence. congruence.
 Qed.
@@ -774,14 +785,15 @@ Section Trans_Global.
     unfold SEq.R_global_instance, SEq.global_variance.
     destruct gref; simpl; auto.
     - unfold R_global_instance_gen, R_opt_variance; cbn.
-      unfold Ast.lookup_inductive_gen, lookup_inductive_gen, 
+      unfold Ast.lookup_inductive_gen, lookup_inductive_gen,
         Ast.lookup_minductive_gen, lookup_minductive_gen.
       rewrite trans_lookup. destruct Ast.Env.lookup_env eqn:look => //; simpl.
       destruct g => /= //.
       rewrite nth_error_map.
       destruct nth_error eqn:hnth => /= //.
       assert (wfty : WfAst.wf Σ (Ast.Env.ind_type o)).
-      { eapply declared_inductive_wf; eauto. eapply typing_wf_sigma; eauto. split; eauto. }
+      { eapply declared_inductive_wf; eauto. eapply typing_wf_sigma; eauto. split; eauto.
+        unshelve eapply Typing.TemplateDeclarationTyping.declared_minductive_from_gen; eauto. }
       generalize (trans_destArity Σ [] (Ast.Env.ind_type o) wfty wfΣ').
       destruct Ast.destArity as [[ctx ps]|] eqn:eq' => /= // -> //.
       now rewrite context_assumptions_map.
@@ -867,9 +879,10 @@ Section Trans_Global.
       eapply forall_decls_declared_inductive in decli; tea.
       rewrite trans_lookup_inductive.
       destruct lookup_inductive as [[mdecl idecl]|] eqn:hl => //.
-      2:{ eapply lookup_inductive_None in hl. elim hl. eauto. }
+      2:{ eapply lookup_inductive_None in hl; tea. elim hl. eauto. }
       apply lookup_inductive_declared in hl.
-      destruct (PCUICGlobalEnv.declared_inductive_inj decli hl). subst.
+      unshelve epose proof (decli'' := declared_inductive_to_gen decli); eauto.
+      destruct (PCUICGlobalEnv.declared_inductive_inj decli'' hl). subst.
       destruct X.
       constructor. all: try solve [
         match goal with
@@ -1282,12 +1295,14 @@ Section Trans_Global.
     rewrite map2_set_binder_name_context_assumptions; len.
   Qed.
 
-  Lemma declared_inductive_lookup {ind mdecl idecl} :
+  Lemma declared_inductive_lookup {wfΣ' : wf Σ'} {ind mdecl idecl} :
     declared_inductive Σ' ind mdecl idecl ->
     lookup_inductive Σ' ind = Some (mdecl, idecl).
   Proof.
-    intros []. unfold lookup_inductive, lookup_minductive.
-    unfold lookup_inductive_gen, lookup_minductive_gen. 
+    intros [].
+    unshelve eapply declared_minductive_to_gen in H; eauto.
+    unfold lookup_inductive, lookup_minductive.
+    unfold lookup_inductive_gen, lookup_minductive_gen.
     now rewrite H H0.
   Qed.
 

--- a/pcuic/theories/TemplateToPCUICExpanded.v
+++ b/pcuic/theories/TemplateToPCUICExpanded.v
@@ -43,36 +43,37 @@ Proof.
   congruence.
 Qed.
 
-Lemma declared_minductive_expanded Σ c mdecl :
+Lemma declared_minductive_expanded {cf:checker_flags} Σ {wfΣ : wf Σ} c mdecl :
   expanded_global_env Σ ->
   declared_minductive Σ c mdecl ->
   exists Σ', ∥ extends_decls Σ' Σ ∥ /\ expanded_minductive_decl Σ' mdecl.
 Proof.
-  unfold expanded_global_env, declared_minductive, lookup_env.
-  destruct Σ as [univs Σ]; cbn. unfold declared_minductive_gen.
-  intros exp; induction exp; cbn => //.
+  unfold expanded_global_env.
+  intros decl H. unshelve eapply declared_minductive_to_gen in H; eauto.
+  clear wfΣ. move:decl H. unfold declared_minductive_gen, lookup_env.
+  destruct Σ as [univs Σ]; cbn.
+  intros exp; induction exp; cbn in * => //.
   destruct decl as [kn d]; cbn.
   destruct (eqb_spec c kn). intros [= ->].
   subst c. eexists. split ; [|exact H]. sq. red. split => //. cbn.
   eexists. cbn. instantiate (1:= [_]); reflexivity.
-  intros hl; destruct (IHexp hl). exists x. intuition auto.
+  intros hl; destruct (IHexp  hl). exists x. intuition auto.
   sq. eapply extends_decls_trans; tea.
   split => //. now exists [(kn, d)].
 Qed.
 
-Lemma declared_constructor_expanded {Σ c mdecl idecl cdecl} :
+Lemma declared_constructor_expanded {cf:checker_flags} {Σ} {wfΣ : wf Σ} {c mdecl idecl cdecl} :
   expanded_global_env Σ ->
   declared_constructor Σ c mdecl idecl cdecl ->
   exists Σ', ∥ extends_decls Σ' Σ ∥ /\ expanded_minductive_decl Σ' mdecl /\ expanded_constructor_decl Σ' mdecl cdecl.
 Proof.
   intros exp [[decli hnth] hnth'].
-  eapply declared_minductive_expanded in decli.
+  eapply declared_minductive_expanded in decli; eauto.
   destruct decli as [Σ' [ext exp']]. exists Σ'; split => //. split => //.
   destruct exp' as [hp hb]. solve_all.
   eapply nth_error_all in hb; tea.
   destruct hb as [hb]. solve_all.
   eapply nth_error_all in hb; tea.
-  auto.
 Qed.
 
 Lemma expanded_extended_subst {Σ Γ Δ} :
@@ -226,6 +227,7 @@ Proof with eauto using expanded.
         - cbn. tea. rewrite context_assumptions_map. now rewrite e0. }
       * cbn. rewrite map2_bias_left_length. now eapply e1.
     + eapply template_to_pcuic_env; eauto.
+    + apply template_to_pcuic_env; eauto.
   - now (wf_inv wf [[]]; eauto using expanded).
   - wf_inv wf [[]]. wf_inv w ?. eapply expanded_tFix.
     + solve_all.

--- a/pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -614,7 +614,7 @@ Proof.
     rewrite trans_csubst in IHev2; tea.
     econstructor; tea.
 
-  - econstructor.
+  - econstructor. unshelve eapply declared_constant_to_gen; eauto.
     eapply forall_decls_declared_constant; tea.
     rewrite /trans_constant_body H0 /=. reflexivity.
     rewrite -trans_subst_instance.
@@ -636,19 +636,21 @@ Proof.
     erewrite (nth_error_map2 _ _ _ _ _ _ (proj2 decl')).
     reflexivity.
     rewrite nth_error_map H /=. reflexivity.
+    unshelve eapply declared_constructor_to_gen; eauto.
     len. rewrite H1.
     { rewrite /cstr_arity e. cbn.
       eapply All2_length in a1. len in a1.
       rewrite /bctx case_branch_context_assumptions //.
       rewrite /trans_branch /=.
       rewrite context_assumptions_map //. }
+    { eapply All2_length in a1. len in a1. }
     { eapply All2_length in a1. len in a1.
       rewrite /bctx.
-      rewrite /trans_branch /=.
-      rewrite context_assumptions_map. f_equal.
-      rewrite map2_map2_bias_left. len.
-      rewrite PCUICCases.map2_set_binder_name_context_assumptions. len.
-      len. now rewrite context_assumptions_map. }
+    rewrite /trans_branch /=.
+    rewrite context_assumptions_map. f_equal.
+    rewrite map2_map2_bias_left. len.
+    rewrite PCUICCases.map2_set_binder_name_context_assumptions. len.
+    len. now rewrite context_assumptions_map. }
     forward IHev2.
     { rewrite /Typing.iota_red.
       eapply WfAst.wf_subst.
@@ -669,6 +671,7 @@ Proof.
   - wf_inv wf hdiscr.
     cbn in *; eapply eval_proj; tea.
     * eapply forall_decls_declared_projection in H; tea.
+      unshelve eapply declared_projection_to_gen in H; eauto.
     * rewrite trans_mkApps in IHev1.
       now eapply IHev1.
     * cbn. len. rewrite H0 /WcbvEval.cstr_arity. f_equal.
@@ -758,6 +761,7 @@ Proof.
   - wf_inv wf [wff wfa].
     rewrite !trans_mkApps.
     eapply forall_decls_declared_constructor in H; tea.
+    unshelve eapply declared_constructor_to_gen in H; eauto.
     eapply eval_mkApps_Construct; tea. now eapply IHev. len.
     { move: H2; unfold WcbvEval.cstr_arity, cstr_arity. cbn.
       rewrite context_assumptions_map //. }

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -92,7 +92,8 @@ Lemma declared_minductive_closed_ind {cf:checker_flags} {Σ : global_env} {wfΣ 
   declared_minductive Σ mind mdecl ->
   closed_inductive_decl mdecl.
 Proof.
-  intros HΣ decl.
+  intros HΣ decl. pose proof (decl_ := decl).
+  eapply declared_minductive_to_gen in decl.
   pose proof (declared_decl_closed_ind decl) as decl'.
   specialize (decl' HΣ).
   red in decl'.
@@ -105,7 +106,7 @@ Proof.
   assert (Alli (fun i =>  declared_inductive Σ {| inductive_mind := mind; inductive_ind := i |} mdecl)
     0 (ind_bodies mdecl)).
   { eapply forall_nth_error_Alli. intros.
-    split; auto. }
+    split; auto.  }
   eapply Alli_mix in decl'; eauto. clear X.
   clear decl.
   eapply Alli_All; eauto.
@@ -148,6 +149,7 @@ Proof.
       intros. split; auto. split; auto. cbn. now rewrite hcdecl. }
     eapply (Alli_All X0). intros.
     now eapply declared_projection_closed_ind in H.
+  Unshelve. all:eauto.
 Qed.
 
 
@@ -188,7 +190,8 @@ Proof.
     move=> Hs. apply: Hs => /=. simpl. rewrite H1 => //.
     rewrite Nat.add_1_r. auto.
 
-  - rewrite closedn_subst_instance.
+  - eapply declared_constant_to_gen in H0.
+    rewrite closedn_subst_instance.
     eapply lookup_on_global_env in X0; eauto.
     destruct X0 as [Σ' [hext [onu HΣ'] IH]].
     repeat red in IH. destruct decl, cst_body0. simpl in *.
@@ -290,6 +293,7 @@ Proof.
     eapply nth_error_all in X0; eauto.
     destruct X0 as [s [Hs cl]].
     now rewrite andb_true_r in cl.
+    Unshelve. all:eauto.
 Qed.
 
 Lemma declared_minductive_closed {cf:checker_flags} {Σ : global_env} {wfΣ : wf Σ} {mdecl mind} :
@@ -489,8 +493,7 @@ Lemma declared_constant_closed_type {cf:checker_flags} {Σ : global_env} {wfΣ :
   declared_constant Σ cst decl ->
   closed decl.(cst_type).
 Proof.
-  intros h.
-  unfold declared_constant in h.
+  intros h. eapply declared_constant_to_gen in h.
   eapply lookup_on_global_env in h. 2: eauto.
   destruct h as [Σ' [ext wfΣ' decl']].
   red in decl'. red in decl'.
@@ -510,7 +513,7 @@ Lemma declared_constant_closed_body {cf : checker_flags} :
     closed body.
 Proof.
   intros Σ cst decl body hΣ h e.
-  unfold declared_constant in h.
+  eapply declared_constant_to_gen in h.
   eapply lookup_on_global_env in h. 2: eauto.
   destruct h as [Σ' [ext wfΣ' decl']].
   red in decl'. red in decl'.
@@ -530,7 +533,7 @@ Proof.
   intros Σ mdecl ind idecl hΣ h.
   unfold declared_inductive in h.
   destruct h as [h1 h2].
-  unfold declared_minductive in h1.
+  eapply declared_minductive_to_gen in h1.
   eapply lookup_on_global_env in h1. 2: eauto.
   destruct h1 as [Σ' [ext wfΣ' decl']].
   red in decl'. destruct decl' as [h ? ? ?].
@@ -538,6 +541,7 @@ Proof.
   simpl in h. destruct h as [? [? h] ? ? ?].
   eapply typecheck_closed in h as [? e]. 2: auto.
   now move: e => [_ /andP []].
+  Unshelve. all:eauto.
 Qed.
 
 
@@ -622,7 +626,8 @@ Proof.
   eapply All_nth_error in h. 2: eassumption.
   move/andP: h => [/andP [hargs hindices]] hty.
   eapply closedn_subst0.
-  - eapply declared_minductive_closed_inds. all: eauto.
+  - eapply declared_minductive_closed_inds.
+    now destruct hidecl.
   - simpl. rewrite inds_length.
     rewrite closedn_subst_instance. assumption.
 Qed.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -2,8 +2,7 @@
 From MetaCoq.Template Require Import config utils.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
   PCUICEquality PCUICContextSubst PCUICUnivSubst PCUICCases
-  PCUICReduction PCUICCumulativity PCUICTyping
-  PCUICGuardCondition PCUICGlobalEnv
+  PCUICReduction PCUICCumulativity PCUICTyping PCUICGuardCondition
   PCUICWeakeningEnv PCUICWeakeningEnvConv.
 From Equations Require Import Equations.
 
@@ -357,7 +356,9 @@ Lemma declared_constant_inv `{checker_flags} Σ P cst decl :
   on_constant_decl (lift_typing P) (Σ, cst_universes decl) decl.
 Proof.
   intros.
+  eapply declared_constant_to_gen in H0.
   eapply weaken_lookup_on_global_env in X1; eauto. apply X1.
+  Unshelve. all:eauto.
 Qed.
 
 Lemma declared_minductive_inv `{checker_flags} {Σ P ind mdecl} :
@@ -367,7 +368,9 @@ Lemma declared_minductive_inv `{checker_flags} {Σ P ind mdecl} :
   on_inductive cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) ind mdecl.
 Proof.
   intros.
+  eapply declared_minductive_to_gen in H0.
   eapply weaken_lookup_on_global_env in X1; eauto. apply X1.
+  Unshelve. all:eauto.
 Qed.
 
 Lemma declared_inductive_inv `{checker_flags} {Σ P ind mdecl idecl} :
@@ -409,7 +412,9 @@ Lemma declared_minductive_inv_decls `{checker_flags} {Σ P ind mdecl} :
   on_inductive cumulSpec0 (lift_typing P) (Σ, ind_universes mdecl) ind mdecl.
 Proof.
   intros.
+  eapply declared_minductive_to_gen in H0.
   eapply weaken_decls_lookup_on_global_env in X1; eauto. apply X1.
+  Unshelve. all:eauto.
 Qed.
 
 Lemma declared_inductive_inv_decls `{checker_flags} {Σ P ind mdecl idecl} :
@@ -562,7 +567,7 @@ Lemma on_declared_constructor `{checker_flags} {Σ ref mdecl idecl cdecl}
                  idecl idecl.(ind_indices) cdecl ind_ctor_sort.
 Proof.
   split.
-  - apply (on_declared_inductive Hdecl).
+  - destruct Hdecl; now apply on_declared_inductive.
   - apply (declared_constructor_inv weaken_env_prop_typing wfΣ wfΣ Hdecl).
 Defined.
 
@@ -586,8 +591,7 @@ Proof.
     move: e. destruct (ind_ctors idecl) as [|? []] => //.
     intros [= ->] => //. }
   split.
-  - split => //.
-    apply (on_declared_inductive Hdecl).
+  - split => //. destruct Hdecl as [[] ?]. now eapply on_declared_inductive.
   - pose proof (declared_projection_inv weaken_env_prop_typing wfΣ wfΣ Hdecl).
     destruct Hdecl. cbn in *. destruct d; cbn in *.
     now rewrite hctors in X.

--- a/safechecker/theories/PCUICConsistency.v
+++ b/safechecker/theories/PCUICConsistency.v
@@ -71,6 +71,13 @@ Proof.
   lia.
 Qed.
 
+Lemma notInFresh Σ decl : ~In (make_fresh_name Σ, decl) (declarations Σ).
+Proof.
+  pose proof (max_name_length_ge Σ.(declarations)) as all.
+  intro H. eapply Forall_forall in all; eauto.
+  cbn in all. rewrite string_repeat_length in all. lia.
+Qed.
+
 Definition Prop_univ := Universe.of_levels (inl PropLevel.lProp).
 
 Definition False_oib : one_inductive_body :=
@@ -105,6 +112,7 @@ Proof.
   - destruct lookup_env eqn:find; auto.
     destruct g; auto.
     destruct c; auto.
+    apply declared_constant_from_gen in find.
     apply axfree in find; cbn in *.
     now destruct cst_body0.
   - destruct nth_error; auto.
@@ -112,6 +120,7 @@ Proof.
     destruct nth_error eqn:nth; auto.
     eapply nth_error_forall in nth; eauto.
 Qed.
+
 
 Definition binder := {| binder_name := nNamed "P"; binder_relevance := Relevant |}.
 
@@ -179,9 +188,8 @@ Proof.
     destruct typ_prod.
     eapply type_App with (B := tRel 0) (u := False_ty); eauto.
     eapply type_Ind with (u := []) (mdecl := False_mib) (idecl := False_oib); eauto.
-    - hnf. cbn.
-      unfold declared_minductive, declared_minductive_gen.
-      cbn. now rewrite eq_kername_refl. 
+    - apply declared_inductive_from_gen. hnf. cbn.
+      unfold declared_minductive_gen. cbn. now rewrite eq_kername_refl.
     - now cbn. }
   pose proof (iswelltyped typ_false) as wt.
   set (_Σ' := Build_referenced_impl_ext cf _ Σext (sq wf')). cbn in *.
@@ -206,23 +214,21 @@ Proof.
     destruct s.
     destruct p.
     destruct typ_false as (((((->&_)&_)&_)&_)&_).
-    clear -d.
+    clear -d wfΣ. destruct wfΣ. cbn in *.
+    (*unshelve eapply declared_constructor_to_gen in d; eauto.*)
     destruct d as ((?&?)&?).
-    cbn in *.
-    red in H.
-    cbn in *.
-    rewrite eq_kername_refl in H.
+    cbn in *. destruct H.
     noconf H.
     noconf H0.
     cbn in H1.
     rewrite nth_error_nil in H1.
     discriminate.
+    eapply notInFresh; eauto.
   - eapply axiom_free_axiom_free_value.
     intros kn decl isdecl.
-    hnf in isdecl.
-    cbn in isdecl.
-    destruct eq_kername; [noconf isdecl|].
-    eapply axfree; eauto.
+    destruct isdecl.
+    + inversion H.
+    + eapply axfree; eauto.
   - unfold check_recursivity_kind.
     cbn.
     rewrite eq_kername_refl; auto.

--- a/safechecker/theories/PCUICRetypingEnvIrrelevance.v
+++ b/safechecker/theories/PCUICRetypingEnvIrrelevance.v
@@ -153,7 +153,9 @@ Section infer_irrel.
         destruct H0, H3.
         eapply inversion_Const in X0 as [decl [_ [Hdecl _]]]; eauto.
         eapply inversion_Const in X1 as [decl' [_ [Hdecl' _]]]; eauto.
-        now eapply hl. }
+        sq. eapply hl; eauto;
+        unshelve eapply declared_constant_to_gen in Hdecl, Hdecl'; eauto.
+        }
       destruct PCUICSafeReduce.inspect => //.
       destruct PCUICSafeReduce.inspect => //.
       destruct x as [[]|] => //; simp _reduce_stack. 2-3:bang.
@@ -510,7 +512,9 @@ Proof.
       specialize (wi' _ wfΣ').
       depelim wt. inv X0.
       depelim wi'. inv X0.
-      eapply hl; tea. }
+      destruct hwfΣ, hwfΣ'. eapply hl; eauto;
+      unshelve eapply declared_constant_to_gen in isdecl, isdecl0; eauto.
+    }
     move: e Heq.
     cbn -[infer].
     rewrite H. unfold infer.
@@ -525,9 +529,10 @@ Proof.
       epose proof (abstract_env_ext_wf X' wfΣ') as [hwfΣ'].
       destruct (wi' _ wfΣ'). inv X0.
       pose proof (hd _ wfΣ).
-      destruct isdecl, H0.
-      unfold declared_minductive in *.
-      now eapply (hl Σ wfΣ Σ' wfΣ').  }
+      destruct isdecl, H0. destruct hwfΣ, hwfΣ'.
+      eapply hl; eauto;
+      unshelve eapply declared_minductive_to_gen in H1, H0; eauto.
+      }
     destruct (PCUICSafeReduce.inspect (lookup_ind_decl _ X' ind)).
     generalize (same_lookup_ind_decl ind H). rewrite -{1}e0 -{1}e.
     destruct x => //. cbn. cbn.
@@ -544,8 +549,10 @@ Proof.
       pose proof (wt _ wfΣ).
       destruct isdecl, H0. inv X0.
       destruct H1. destruct isdecl as [[] ?].
-      unfold declared_minductive in *.
-      now eapply (hl Σ wfΣ Σ' wfΣ'). }
+      destruct hwfΣ, hwfΣ'.
+      eapply hl; eauto;
+      unshelve eapply declared_minductive_to_gen in H1, H4; eauto.
+      }
     destruct (PCUICSafeReduce.inspect (lookup_ind_decl _ X' ind)).
     generalize (same_lookup_ind_decl _ H). rewrite -{1}e1 -{1}e.
     destruct x => //.
@@ -586,13 +593,15 @@ Proof.
       destruct (wi' _ wfΣ'). inv X0.
       pose proof (wt _ wfΣ).
       inv H1. inv X0. destruct H1 as [[[]]]. destruct H as [[[]]].
-      unfold declared_minductive in *.
-      now eapply (hl Σ wfΣ Σ' wfΣ'). }
+      destruct hwfΣ, hwfΣ'.
+      eapply hl; eauto;
+      unshelve eapply declared_minductive_to_gen in H1, H; eauto.
+      }
     generalize (same_lookup_ind_decl _ H). rewrite -{1}eq -{1}e.
     destruct y => //.
     destruct a as [decl [body ?]], d as [decl' [body' ?]].
-    intros h. cbn in h. noconf h.
     simp infer.
+    intros h. cbn in h. noconf h.
     eapply elim_inspect => nth eq'.
     cbn in eq', e0. destruct nth as [[]|] => //.
     simp infer.

--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1284,7 +1284,7 @@ Section CheckEnv.
         move/andP: isind => [/Nat.leb_le le /Nat.ltb_lt lt].
         eapply forallb_All in check_closed. sq.
         symmetry in Heq_anonymous2; eapply decompose_app_inv in Heq_anonymous2.
-        subst t0. econstructor 2; eauto.
+        subst t0. econstructor 2; repeat constructor; eauto.
         match goal with [ H : is_true (eqb _ _) |- _ ] => now apply eqb_eq in H end.
       Qed.
 

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -593,7 +593,7 @@ Corollary R_Acc_aux :
     left. econstructor. eapply red1_context.
     econstructor.
     - unfold declared_constant, declared_constant_gen.
-      rewrite (abstract_env_lookup_correct' _ _ wfΣ). rewrite <- eq. reflexivity.
+      rewrite (abstract_env_lookup_correct _ _ _ wfΣ). rewrite <- eq. reflexivity.
     - cbn. reflexivity.
   Qed.
 
@@ -605,7 +605,7 @@ Corollary R_Acc_aux :
     destruct h as [T h].
     apply inversion_Const in h as [decl [? [d [? ?]]]] ; auto.
     unfold declared_constant, declared_constant_gen in d.
-    rewrite (abstract_env_lookup_correct' _ _ wfΣ), <- eq in d.
+    rewrite (abstract_env_lookup_correct _ _ _ wfΣ), <- eq in d.
     discriminate.
   Qed.
   Next Obligation.
@@ -616,7 +616,7 @@ Corollary R_Acc_aux :
     destruct h as [T h].
     apply inversion_Const in h as [decl [? [d [? ?]]]] ; auto.
     unfold declared_constant, declared_constant_gen in d.
-    rewrite (abstract_env_lookup_correct' _ _ wfΣ), <- eq in d.
+    rewrite (abstract_env_lookup_correct _ _ _ wfΣ), <- eq in d.
     discriminate.
   Qed.
 
@@ -1406,6 +1406,7 @@ Corollary R_Acc_aux :
     - unfold isCoFinite in not_cofinite.
       unfold check_recursivity_kind.
       cbn.
+      unshelve eapply declared_inductive_to_gen in isdecl; eauto.
       unfold declared_inductive, declared_minductive in isdecl.
       cbn in isdecl.
       rewrite (proj1 isdecl).

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -944,26 +944,31 @@ Section Typecheck.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]]; specialize_Σ wfΣ.
     erewrite <- abstract_env_lookup_correct' in e0; eauto.
-    depelim X2.
-    unfold declared_minductive, declared_minductive_gen in H. erewrite <- e0 in H.
+    depelim X2. destruct (hΣ _ wfΣ).
+    unshelve eapply declared_minductive_to_gen in H; eauto.
+    unfold declared_minductive_gen in H.
+    erewrite <- e0 in H.
     congruence.
   Qed.
   Next Obligation.
     erewrite <- abstract_env_lookup_correct' in e; eauto.
+    eapply declared_inductive_from_gen.
     now split.
   Qed.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]]; specialize_Σ wfΣ.
     erewrite <- abstract_env_lookup_correct' in e1; eauto.
-    depelim X2.
-    unfold declared_minductive, declared_minductive_gen in H. erewrite <- e1 in H.
+    depelim X2.  destruct (hΣ _ wfΣ).
+    unshelve eapply declared_minductive_to_gen in H; eauto.
+    unfold declared_minductive_gen in H. erewrite <- e1 in H.
     congruence.
   Qed.
   Next Obligation.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]]; specialize_Σ wfΣ.
     erewrite <- abstract_env_lookup_correct' in e0; eauto.
-    depelim X2.
-    unfold declared_minductive, declared_minductive_gen in H. erewrite <- e0 in H.
+    depelim X2. destruct (hΣ _ wfΣ).
+    unshelve eapply declared_minductive_to_gen in H; eauto.
+    unfold declared_minductive_gen in H. erewrite <- e0 in H.
     congruence.
   Qed.
 
@@ -1658,11 +1663,14 @@ Section Typecheck.
     pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     constructor; try assumption.
     symmetry in HH. erewrite <- abstract_env_lookup_correct' in HH; eauto.
+    eapply declared_constant_from_gen; eauto.
   Qed.
   Next Obligation.
     apply absurd; intros. pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     erewrite <- abstract_env_lookup_correct' in HH; eauto.
-    inversion X1. unfold declared_constant, declared_constant_gen in isdecl.
+    inversion X1. destruct (hΣ _ wfΣ).
+    unshelve eapply declared_constant_to_gen in isdecl; eauto.
+    unfold declared_constant_gen in isdecl.
     rewrite <- HH in isdecl. inversion isdecl. now subst.
   Qed.
   Next Obligation.
@@ -1670,6 +1678,7 @@ Section Typecheck.
     cbn in *.
     pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     inversion X1 ; subst. erewrite <- abstract_env_lookup_correct' in e0; eauto.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in isdecl; eauto.
     rewrite isdecl in e0.
     congruence.
   Qed.
@@ -1678,6 +1687,7 @@ Section Typecheck.
     cbn in *.
     pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     inversion X1 ; subst. erewrite <- abstract_env_lookup_correct' in e0; eauto.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in isdecl; eauto.
     rewrite isdecl in e0.
     congruence.
   Qed.
@@ -1686,6 +1696,7 @@ Section Typecheck.
   Next Obligation.
     cbn in *. pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     eapply global_uctx_invariants_ext.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in X1; eauto.
     eapply (weaken_lookup_on_global_env' _ _ _ (heΣ : wf _) (proj1 X1)).
   Qed.
   Next Obligation.
@@ -1694,6 +1705,7 @@ Section Typecheck.
   Next Obligation.
     apply absurd. intros. cbn in *. specialize_Σ wfΣ ; sq.
     inversion X1 ; subst.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, X3; eauto.
     epose proof (H := declared_inductive_unique_sig isdecl X3).
     now injection H.
   Qed.
@@ -1709,6 +1721,7 @@ Section Typecheck.
   Next Obligation.
     cbn in *. pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     eapply global_uctx_invariants_ext.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in decl; eauto.
     eapply (weaken_lookup_on_global_env' _ _ _ (heΣ : wf _) (proj1 decl)).
   Qed.
   Next Obligation.
@@ -1719,6 +1732,8 @@ Section Typecheck.
   Next Obligation.
     apply absurd. intros; cbn in *. specialize_Σ wfΣ ; sq.
     inversion X1 ; subst.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in decl; eauto.
+    unshelve eapply declared_constructor_to_gen in isdecl; eauto.
     epose proof (H := declared_inductive_unique_sig isdecl decl).
     now injection H.
   Qed.
@@ -1726,6 +1741,8 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     cbn in *. specialize_Σ wfΣ ; sq.
     inversion X1 ; subst.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constructor_to_gen in isdecl; eauto.
+    unshelve eapply declared_inductive_to_gen in decl; eauto.
     epose proof (H := declared_inductive_unique_sig isdecl decl).
     injection H.
     intros ; subst.
@@ -1751,6 +1768,7 @@ Section Typecheck.
   Next Obligation.
     cbn in *. pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     eapply global_uctx_invariants_ext.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in X1; eauto.
     eapply (weaken_lookup_on_global_env' _ _ _ (heΣ : wf _) (proj1 X1)).
   Qed.
   Next Obligation.
@@ -1758,7 +1776,8 @@ Section Typecheck.
     cbn in *. pose proof (heΣ _ wfΣ) as [heΣ]. specialize_Σ wfΣ ; sq.
     eapply wf_rel_weak ; eauto.
     rewrite subst_instance_smash ; eapply wf_local_smash_context.
-    now eapply on_minductive_wf_params.
+    eapply on_minductive_wf_params; eauto.
+    now destruct X1.
   Qed.
   Next Obligation.
     eapply assumption_context_rev.
@@ -1793,7 +1812,8 @@ Section Typecheck.
     rewrite subst_instance_smash /= in wt_params.
     eapply ctx_inst_smash in wt_params.
     unshelve epose proof (ctx_inst_spine_subst _ wt_params).
-    { eapply weaken_wf_local; eauto. eapply on_minductive_wf_params; eauto. }
+    { eapply weaken_wf_local; eauto. eapply on_minductive_wf_params; eauto.
+      now destruct X1. }
     eexists; eapply isType_mkApps_Ind_smash; tea.
     rewrite subst_instance_app List.rev_app_distr smash_context_app_expand.
     have wf_ctx : wf_local Σ
@@ -1989,7 +2009,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst. sq.
     eapply infering_ind_ind in X0 as [args'' []].
     2-3: now auto.
@@ -2012,10 +2033,12 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst. sq.
     eapply infering_sort_sort in s as <- ; eauto.
-    now eapply wf_case_predicate_context.
+    eapply wf_case_predicate_context; eauto.
+    eapply declared_inductive_from_gen; eauto.
   Qed.
 
   Next Obligation.
@@ -2029,7 +2052,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ ; sq.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     apply absurd.
 
@@ -2048,7 +2072,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ ; sq.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     apply absurd.
     sq.
@@ -2066,7 +2091,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     sq.
     rewrite /params /chop_args chop_firstn_skipn /=.
@@ -2098,12 +2124,14 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     sq.
     apply ctx_inst_bd_typing, ctx_inst_smash in X4 ; eauto.
     2: eapply weaken_wf_local, on_minductive_wf_params ; eauto.
-    now rewrite subst_instance_smash.
+    rewrite subst_instance_smash; eauto.
+    eapply declared_minductive_from_gen; eauto.
   Qed.
 
   Next Obligation.
@@ -2118,7 +2146,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ ; sq.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     apply absurd.
     erewrite <- compare_global_instance_correct; eauto.
@@ -2145,8 +2174,8 @@ Section Typecheck.
       now move: tyu => /andP [].
     - apply infering_typing, typing_wf_universes in ty ; auto.
       move: ty => /andP [].
-      now rewrite {1}/wf_universes /= wf_universeb_instance_forall =>
-        /andP [] /wf_universe_instanceP.
+      rewrite {1}/wf_universes /= wf_universeb_instance_forall =>
+        /andP [] /wf_universe_instanceP; eauto.
   Qed.
 
   Next Obligation.
@@ -2160,7 +2189,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ ; sq.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     now subst.
   Qed.
 
@@ -2176,7 +2206,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ ; sq.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     apply absurd.
     now apply/eqb_specT.
@@ -2194,7 +2225,8 @@ Section Typecheck.
     cbn in *. specialize_Σ wfΣ ; sq.
     destruct X0 as [? [ty]]; eauto.
     inversion ty ; subst.
-    eapply declared_inductive_inj in isdecl as []; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
+    eapply declared_inductive_inj in isdecl as []. 2: exact H3.
     subst.
     apply absurd.
     now apply/negPf.
@@ -2324,7 +2356,8 @@ Section Typecheck.
     subst.
     destruct H1 as [[] []].
     cbn in * ; subst.
-    eapply declared_inductive_inj in decl as [-> ->] ; tea.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in decl, H; eauto.
+    eapply declared_inductive_inj in decl as [-> ->]. 2: exact H.
     now eapply Nat.eqb_eq.
   Qed.
   Next Obligation.
@@ -2375,6 +2408,8 @@ Section Typecheck.
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
     inversion X1 ; subst.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in decl; eauto.
+    unshelve eapply declared_projection_to_gen in H1; eauto.
     eapply declared_inductive_inj in decl as [].
     2: exact H1.p1.
     subst.
@@ -2530,6 +2565,7 @@ Section Typecheck.
     rewrite -(abstract_env_lookup_correct' _ (Σ := Σ)) // in HH.
     split. econstructor. rewrite eqp.
     erewrite abstract_primitive_constant_correct; try reflexivity. eassumption.  red.
+    apply declared_constant_from_gen.
     unfold declared_constant_gen. now rewrite -HH.
     destruct (cst_type d) eqn:hty => //.
     exists u. split => //.
@@ -2542,7 +2578,8 @@ Section Typecheck.
     rewrite -(abstract_env_lookup_correct' _ (Σ := Σ)) // in HH.
     rewrite (abstract_primitive_constant_correct _ _ _ wfΣ) in eqp.
     rewrite e1 in eqp. noconf eqp.
-    symmetry in HH. rewrite /declared_constant in d0.
+    symmetry in HH.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in d0; eauto.
     rewrite d0 in HH; noconf HH.
     destruct p1 as [s' []]. rewrite H in absurd. now apply absurd.
   Qed.
@@ -2554,8 +2591,8 @@ Section Typecheck.
     rewrite -(abstract_env_lookup_correct' _ (Σ := Σ)) // in HH.
     rewrite (abstract_primitive_constant_correct _ _ _ wfΣ) in eqp.
     rewrite e1 in eqp. noconf eqp.
-    symmetry in HH. rewrite /declared_constant in d0.
-    rewrite d0 in HH; noconf HH.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in d0; eauto.
+    symmetry in HH. rewrite d0 in HH; noconf HH.
     destruct p1 as [s' []]. apply absurd. case: eqb_spec => //.
   Qed.
 
@@ -2567,8 +2604,8 @@ Section Typecheck.
     rewrite -(abstract_env_lookup_correct' _ (Σ := Σ)) // in HH.
     rewrite (abstract_primitive_constant_correct _ _ _ wfΣ) in eqp.
     rewrite e1 in eqp. noconf eqp.
-    symmetry in HH. rewrite /declared_constant in d0.
-    rewrite d0 in HH; noconf HH.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in d0; eauto.
+    symmetry in HH. rewrite d0 in HH; noconf HH.
     destruct p1 as [s' []]. apply absurd. case: eqb_spec => //.
   Qed.
 
@@ -2579,8 +2616,8 @@ Section Typecheck.
     rewrite -(abstract_env_lookup_correct' _ (Σ := Σ)) // in e0.
     rewrite (abstract_primitive_constant_correct _ _ _ wfΣ) in eqp.
     rewrite e1 in eqp. noconf eqp.
-    symmetry in e0. rewrite /declared_constant in d.
-    rewrite d in e0; noconf e0.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in d; eauto.
+    symmetry in e0. rewrite d in e0; noconf e0.
   Qed.
 
   Next Obligation.
@@ -2590,7 +2627,8 @@ Section Typecheck.
     rewrite -(abstract_env_lookup_correct' _ (Σ := Σ)) // in e0.
     rewrite (abstract_primitive_constant_correct _ _ _ wfΣ) in eqp.
     rewrite e1 in eqp. noconf eqp.
-    symmetry in e0. rewrite /declared_constant /declared_constant_gen in d.
+    destruct (hΣ _ wfΣ). unshelve eapply declared_constant_to_gen in d; eauto.
+    symmetry in e0. rewrite /declared_constant_gen in d.
     rewrite e0 in d; noconf d.
   Qed.
 

--- a/template-coq/theories/Environment.v
+++ b/template-coq/theories/Environment.v
@@ -380,6 +380,14 @@ Module Environment (T : Term).
     move => ??; case: eqb_spec; intuition congruence.
   Qed.
 
+  Lemma lookup_global_Some_if_In Σ kn decl
+  : lookup_global Σ kn = Some decl -> In (kn, decl) Σ.
+  Proof.
+    move: Σ; elim => //=; try tauto.
+    move => [??]?; case: eqb_spec => ? IH; inversion 1; subst; try rewrite <- IH by assumption.
+    all: intuition try congruence; subst.
+  Qed.
+
   Lemma lookup_global_Some_iff_In_NoDup Σ kn decl (H : NoDup (List.map fst Σ))
     : In (kn, decl) Σ <-> lookup_global Σ kn = Some decl.
   Proof.

--- a/template-coq/theories/EnvironmentTyping.v
+++ b/template-coq/theories/EnvironmentTyping.v
@@ -12,24 +12,28 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
   Definition declared_constant_gen (lookup : kername -> option global_decl) (id : kername) decl : Prop :=
     lookup id = Some (ConstantDecl decl).
 
-  Definition declared_constant (Σ : global_env) := declared_constant_gen (lookup_env Σ).
+  Definition declared_constant (Σ : global_env) id decl := In (id,ConstantDecl decl) (declarations Σ).
 
   Definition declared_minductive_gen (lookup : kername -> option global_decl) mind decl :=
     lookup mind = Some (InductiveDecl decl).
 
-  Definition declared_minductive Σ := declared_minductive_gen (lookup_env Σ).
+  Definition declared_minductive Σ mind decl := In (mind,InductiveDecl decl) (declarations Σ).
 
   Definition declared_inductive_gen lookup ind mdecl decl :=
     declared_minductive_gen lookup (inductive_mind ind) mdecl /\
     List.nth_error mdecl.(ind_bodies) (inductive_ind ind) = Some decl.
 
-  Definition declared_inductive Σ := declared_inductive_gen (lookup_env Σ).
+  Definition declared_inductive Σ ind mdecl decl :=
+    declared_minductive Σ (inductive_mind ind) mdecl /\
+    List.nth_error mdecl.(ind_bodies) (inductive_ind ind) = Some decl.
 
   Definition declared_constructor_gen lookup cstr mdecl idecl cdecl : Prop :=
     declared_inductive_gen lookup (fst cstr) mdecl idecl /\
     List.nth_error idecl.(ind_ctors) (snd cstr) = Some cdecl.
 
-  Definition declared_constructor Σ := declared_constructor_gen (lookup_env Σ).
+  Definition declared_constructor Σ cstr mdecl idecl cdecl :=
+    declared_inductive Σ (fst cstr) mdecl idecl /\
+    List.nth_error idecl.(ind_ctors) (snd cstr) = Some cdecl.
 
   Definition declared_projection_gen lookup (proj : projection) mdecl idecl cdecl pdecl
   : Prop :=
@@ -37,7 +41,11 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     List.nth_error idecl.(ind_projs) proj.(proj_arg) = Some pdecl /\
     mdecl.(ind_npars) = proj.(proj_npars).
 
-  Definition declared_projection Σ := declared_projection_gen (lookup_env Σ).
+  Definition declared_projection Σ (proj : projection) mdecl idecl cdecl pdecl
+  : Prop :=
+    declared_constructor Σ (proj.(proj_ind), 0) mdecl idecl cdecl /\
+    List.nth_error idecl.(ind_projs) proj.(proj_arg) = Some pdecl /\
+    mdecl.(ind_npars) = proj.(proj_npars).
 
   Definition lookup_constant_gen (lookup : kername -> option global_decl) kn :=
     match lookup kn with
@@ -90,24 +98,24 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     end.
 
   Definition lookup_projection Σ := lookup_projection_gen (lookup_env Σ).
-  
-  Lemma declared_constant_lookup {lookup kn cdecl} :
+
+  Lemma declared_constant_lookup_gen {lookup kn cdecl} :
     declared_constant_gen lookup kn cdecl ->
     lookup_constant_gen lookup kn = Some cdecl.
   Proof.
-    unfold declared_constant_gen, lookup_constant_gen. 
+    unfold declared_constant_gen, lookup_constant_gen.
     now intros ->.
   Qed.
 
-  Lemma lookup_constant_declared {lookup kn cdecl} :
+  Lemma lookup_constant_declared_gen {lookup kn cdecl} :
     lookup_constant_gen lookup kn = Some cdecl ->
     declared_constant_gen lookup kn cdecl.
   Proof.
-    unfold declared_constant_gen, lookup_constant_gen. 
+    unfold declared_constant_gen, lookup_constant_gen.
     destruct lookup as [[]|] => //. congruence.
   Qed.
 
-  Lemma declared_minductive_lookup {lookup ind mdecl} :
+  Lemma declared_minductive_lookup_gen {lookup ind mdecl} :
     declared_minductive_gen lookup ind mdecl ->
     lookup_minductive_gen lookup ind = Some mdecl.
   Proof.
@@ -115,7 +123,7 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     now intros ->.
   Qed.
 
-  Lemma lookup_minductive_declared {lookup ind mdecl} :
+  Lemma lookup_minductive_declared_gen {lookup ind mdecl} :
     lookup_minductive_gen lookup ind = Some mdecl ->
     declared_minductive_gen lookup ind mdecl.
   Proof.
@@ -123,15 +131,15 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     destruct lookup as [[]|] => //. congruence.
   Qed.
 
-  Lemma declared_inductive_lookup {lookup ind mdecl idecl} :
+  Lemma declared_inductive_lookup_gen {lookup ind mdecl idecl} :
     declared_inductive_gen lookup ind mdecl idecl ->
     lookup_inductive_gen lookup ind = Some (mdecl, idecl).
   Proof.
     rewrite /declared_inductive_gen /lookup_inductive_gen.
-    intros []. now rewrite (declared_minductive_lookup H) H0.
+    intros []. now rewrite (declared_minductive_lookup_gen H) H0.
   Qed.
 
-  Lemma lookup_inductive_declared {lookup ind mdecl idecl} :
+  Lemma lookup_inductive_declared_gen {lookup ind mdecl idecl} :
     lookup_inductive_gen lookup ind = Some (mdecl, idecl) ->
     declared_inductive_gen lookup ind mdecl idecl.
   Proof.
@@ -139,18 +147,18 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     destruct lookup_minductive_gen as [[]|] eqn:hl => //=.
     destruct nth_error eqn:hnth => //. intros [= <- <-].
     split => //.
-    apply (lookup_minductive_declared hl).
+    apply (lookup_minductive_declared_gen hl).
   Qed.
 
-  Lemma declared_constructor_lookup {lookup id mdecl idecl cdecl} :
+  Lemma declared_constructor_lookup_gen {lookup id mdecl idecl cdecl} :
     declared_constructor_gen lookup id mdecl idecl cdecl ->
     lookup_constructor_gen lookup id.1 id.2 = Some (mdecl, idecl, cdecl).
   Proof.
     intros []. unfold lookup_constructor_gen.
-    rewrite (declared_inductive_lookup (lookup := lookup) H) /= H0 //.
+    rewrite (declared_inductive_lookup_gen (lookup := lookup) H) /= H0 //.
   Qed.
 
-  Lemma lookup_constructor_declared {lookup id mdecl idecl cdecl} :
+  Lemma lookup_constructor_declared_gen {lookup id mdecl idecl cdecl} :
     lookup_constructor_gen lookup id.1 id.2 = Some (mdecl, idecl, cdecl) ->
     declared_constructor_gen lookup id mdecl idecl cdecl.
   Proof.
@@ -158,18 +166,18 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     destruct lookup_inductive_gen as [[]|] eqn:hl => //=.
     destruct nth_error eqn:hnth => //. intros [= <- <-].
     split => //.
-    apply (lookup_inductive_declared hl). congruence.
+    apply (lookup_inductive_declared_gen hl). congruence.
   Qed.
 
-  Lemma declared_projection_lookup {lookup p mdecl idecl cdecl pdecl} :
+  Lemma declared_projection_lookup_gen {lookup p mdecl idecl cdecl pdecl} :
     declared_projection_gen lookup p mdecl idecl cdecl pdecl ->
     lookup_projection_gen lookup p = Some (mdecl, idecl, cdecl, pdecl).
   Proof.
     intros [? []]. unfold lookup_projection_gen.
-    rewrite (declared_constructor_lookup (lookup := lookup) H) /= H0 //.
+    rewrite (declared_constructor_lookup_gen (lookup := lookup) H) /= H0 //.
   Qed.
 
-  Lemma lookup_projection_declared {lookup p mdecl idecl cdecl pdecl} :
+  Lemma lookup_projection_declared_gen {lookup p mdecl idecl cdecl pdecl} :
     ind_npars mdecl = p.(proj_npars) ->
     lookup_projection_gen lookup p = Some (mdecl, idecl, cdecl, pdecl) ->
     declared_projection_gen lookup p mdecl idecl cdecl pdecl.
@@ -178,7 +186,7 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     destruct lookup_constructor_gen as [[[] ?]|] eqn:hl => //=.
     destruct nth_error eqn:hnth => //. intros [= <- <-]. subst c p0.
     split => //.
-    apply (lookup_constructor_declared (id:=(proj_ind p, 0)) hl).
+    apply (lookup_constructor_declared_gen (id:=(proj_ind p, 0)) hl).
   Qed.
 
   Definition on_udecl_decl {A} (F : universes_decl -> A) d : A :=
@@ -280,9 +288,7 @@ Module Lookup (T : Term) (E : EnvironmentSig T).
     Alli (fun i => declared_constructor Σ (ind, i) mib oib) 0 (ind_ctors oib).
   Proof using.
     move=> inddecl.
-    apply: forall_nth_error_Alli=> /= i x eq.
-    apply: lookup_constructor_declared=> /=.
-    rewrite /lookup_constructor_gen (declared_inductive_lookup inddecl) eq //.
+    apply: forall_nth_error_Alli=> /= i x eq => //.
   Qed.
 
 End Lookup.
@@ -1446,11 +1452,111 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E)
         eapply All_local_env_impl; tea.
   Qed.
 
-End DeclarationTyping.
 
-Module Type DeclarationTypingSig (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E)
-       (ET : EnvTypingSig T E TU) (CT : ConversionSig T E TU ET)
-       (CS : ConversionParSig T E TU ET) (Ty : Typing T E TU ET CT CS)
-       (L : LookupSig T E) (GM : GlobalMapsSig T E TU ET CT L).
-  Include DeclarationTyping T E TU ET CT CS Ty L GM.
-End DeclarationTypingSig.
+  Section Properties.
+    Context {cf : checker_flags}.
+    Context {Pcmp: global_env_ext -> context -> conv_pb -> term -> term -> Type}.
+    Context {P: global_env_ext -> context -> term -> typ_or_sort -> Type}.
+
+  Let wf := on_global_env Pcmp P.
+
+  Lemma declared_constant_from_gen {Σ kn cdecl} :
+    declared_constant_gen (lookup_env Σ) kn cdecl ->
+    declared_constant Σ kn cdecl.
+  Proof.
+    intro H. eapply lookup_global_Some_if_In.
+    red in H. unfold lookup_env in H.
+    apply lookup_constant_declared_gen => //.
+    unfold lookup_constant_gen. now rewrite H.
+  Qed.
+
+  Lemma declared_constant_to_gen {Σ kn cdecl}
+  {wfΣ : wf Σ} :
+  declared_constant Σ kn cdecl ->
+  declared_constant_gen (lookup_env Σ) kn cdecl.
+  Proof.
+    intro H; eapply lookup_global_Some_iff_In_NoDup in H.
+    - apply lookup_constant_declared_gen => //.
+      unfold lookup_constant_gen, lookup_env.
+      destruct (lookup_global _ _) => //.
+      destruct g => //. now inversion H.
+    - destruct wfΣ; now eapply NoDup_on_global_decls.
+  Qed.
+
+  Lemma declared_minductive_to_gen {Σ ind mdecl}
+   {wfΣ : wf Σ} :
+    declared_minductive Σ ind mdecl ->
+    declared_minductive_gen (lookup_env Σ) ind mdecl.
+  Proof.
+    intro H; eapply lookup_global_Some_iff_In_NoDup in H.
+    - apply lookup_minductive_declared_gen => //.
+      unfold lookup_minductive_gen, lookup_env.
+      destruct (lookup_global _ _) => //.
+      destruct g => //. now inversion H.
+    - destruct wfΣ; now eapply NoDup_on_global_decls.
+  Qed.
+
+  Lemma declared_minductive_from_gen {Σ ind mdecl} :
+    declared_minductive_gen (lookup_env Σ) ind mdecl ->
+    declared_minductive Σ ind mdecl.
+  Proof.
+    intro H; eapply lookup_global_Some_if_In.
+    apply lookup_minductive_declared_gen => //.
+    apply declared_minductive_lookup_gen in H => //.
+  Qed.
+
+  Lemma declared_inductive_to_gen {Σ ind mdecl idecl}
+  {wfΣ : wf Σ} :
+    declared_inductive Σ ind mdecl idecl ->
+    declared_inductive_gen (lookup_env Σ) ind mdecl idecl.
+  Proof.
+    intros []; split => //.
+    eapply declared_minductive_to_gen; eauto.
+    Unshelve. all:eauto.
+  Qed.
+
+  Lemma declared_inductive_from_gen {Σ ind mdecl idecl}:
+    declared_inductive_gen (lookup_env Σ) ind mdecl idecl ->
+    declared_inductive Σ ind mdecl idecl.
+  Proof.
+    intros []; split => //.
+    eapply declared_minductive_from_gen; eauto.
+  Qed.
+
+  Lemma declared_constructor_to_gen {Σ id mdecl idecl cdecl}
+    {wfΣ : wf Σ} :
+    declared_constructor Σ id mdecl idecl cdecl ->
+    declared_constructor_gen (lookup_env Σ) id mdecl idecl cdecl.
+  Proof.
+    intros []; split => //.
+    eapply declared_inductive_to_gen; eauto.
+    Unshelve. all:eauto.
+  Qed.
+
+  Lemma declared_constructor_from_gen {Σ id mdecl idecl cdecl} :
+    declared_constructor_gen (lookup_env Σ) id mdecl idecl cdecl ->
+    declared_constructor Σ id mdecl idecl cdecl.
+  Proof.
+    intros []; split => //.
+    eapply declared_inductive_from_gen; eauto.
+  Qed.
+
+  Lemma declared_projection_to_gen {Σ p mdecl idecl cdecl pdecl}
+    {wfΣ : wf Σ} :
+    declared_projection Σ p mdecl idecl cdecl pdecl ->
+    declared_projection_gen (lookup_env Σ) p mdecl idecl cdecl pdecl.
+  Proof.
+    intros [? []]. split => //.
+    eapply declared_constructor_to_gen; eauto.
+    Unshelve. all:eauto.
+  Qed.
+
+  Lemma declared_projection_from_gen {Σ p mdecl idecl cdecl pdecl} :
+    declared_projection_gen (lookup_env Σ) p mdecl idecl cdecl pdecl ->
+    declared_projection Σ p mdecl idecl cdecl pdecl.
+  Proof.
+    intros [? []]. split => //.
+    eapply declared_constructor_from_gen; eauto.
+  Qed.
+  End Properties.
+End DeclarationTyping.


### PR DESCRIPTION
This PR changes the definition of declared_constant and declared_minductive
to make us of `In` instead of the more operational `lookup_env` approach.