### PR TITLE
Allow weakening of typing across different checker configs

### DIFF
--- a/common/theories/EnvironmentTyping.v
+++ b/common/theories/EnvironmentTyping.v
@@ -1,5 +1,6 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import ssreflect ssrbool.
+From Coq Require CMorphisms CRelationClasses.
 From MetaCoq.Utils Require Import utils.
 From MetaCoq.Common Require Import config BasicAst Universes Environment Primitive.
 From Equations Require Import Equations.
@@ -563,6 +564,21 @@ Module EnvTyping (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E).
     Derive Signature NoConfusion for ctx_inst.
   End TypeCtxInst.
 
+  Lemma ctx_inst_impl_gen Σ Γ inst Δ args P :
+    { P' & ctx_inst P' Σ Γ inst Δ } ->
+    (forall t T,
+        All (fun P' => P' Σ Γ t T) args ->
+        P Σ Γ t T) ->
+    All (fun P' => ctx_inst P' Σ Γ inst Δ) args ->
+    ctx_inst P Σ Γ inst Δ.
+  Proof.
+    intros [? Hexists] HPQ H.
+    induction Hexists; constructor; tea.
+    all: first [ apply IHHexists; clear IHHexists
+               | apply HPQ ].
+    all: eapply All_impl; tea; cbn; intros *; inversion 1; subst; eauto.
+  Qed.
+
   Lemma ctx_inst_impl P Q Σ Γ inst Δ :
     ctx_inst P Σ Γ inst Δ ->
     (forall t T, P Σ Γ t T -> Q Σ Γ t T) ->
@@ -696,6 +712,10 @@ Module Conversion (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E) (ET : E
   Notation conv_context cumul_gen Σ := (cumul_pb_context cumul_gen Conv Σ).
   Notation cumul_context cumul_gen Σ := (cumul_pb_context cumul_gen Cumul Σ).
 
+  Lemma All_decls_alpha_pb_impl {pb} {P Q : conv_pb -> term -> term -> Type} {t t'} :
+    (forall pb t t', P pb t t' -> Q pb t t') ->
+    All_decls_alpha_pb pb P t t' -> All_decls_alpha_pb pb Q t t'.
+  Proof. induction 2; constructor; eauto. Qed.
 End Conversion.
 
 Module Type ConversionSig (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E) (ET : EnvTypingSig T E TU).
@@ -1279,6 +1299,31 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
   Arguments onVariance {_ Pcmp P Σ mind mdecl}.
 
 
+  Local Ltac destr_prod :=
+    repeat match goal with H : _ × _ |- _ => destruct H end.
+  Lemma type_local_ctx_impl_gen Σ Γ Δ u args P :
+    { P' & type_local_ctx P' Σ Γ Δ u } ->
+    (forall Γ t T,
+        All (fun P' => P' Σ Γ t T) args ->
+        P Σ Γ t T) ->
+    All (fun P' => type_local_ctx P' Σ Γ Δ u) args ->
+    type_local_ctx P Σ Γ Δ u.
+  Proof.
+    intros Hexists HP HPQ. revert HP Hexists; induction Δ in Γ, HPQ |- *; simpl; auto.
+    { intros ? [? ?]; auto. }
+    { intros HP Hexists; cbn in *.
+      specialize (fun H1 Γ P' H2 H => IHΔ Γ H H1 (P'; H2)).
+      forward IHΔ => //=; [].
+      destruct Hexists as [? Hexists].
+      all: destruct a as [na [b|] ty].
+      all: repeat match goal with H : _ × _ |- _ => destruct H end.
+      all: repeat split; eauto.
+      all: simpl in *.
+      all: first [ eapply IHΔ; clear IHΔ | apply HP; clear HP ]; tea.
+      all: eapply All_impl; tea => //=; intros.
+      all: repeat match goal with H : _ × _ |- _ => destruct H end => //=. }
+  Qed.
+
   Lemma type_local_ctx_impl (P Q : global_env_ext -> context -> term -> typ_or_sort -> Type) Σ Γ Δ u :
     type_local_ctx P Σ Γ Δ u ->
     (forall Γ t T, P Σ Γ t T -> Q Σ Γ t T) ->
@@ -1287,6 +1332,29 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
     intros HP HPQ. revert HP; induction Δ in Γ, HPQ |- *; simpl; auto.
     destruct a as [na [b|] ty]; simpl; auto.
     intros. intuition auto. intuition auto.
+  Qed.
+
+  Lemma sorts_local_ctx_impl_gen Σ Γ Δ u args P :
+    { P' & sorts_local_ctx P' Σ Γ Δ u } ->
+    (forall Γ t T,
+        All (fun P' => P' Σ Γ t T) args ->
+        P Σ Γ t T) ->
+    All (fun P' => sorts_local_ctx P' Σ Γ Δ u) args ->
+    sorts_local_ctx P Σ Γ Δ u.
+  Proof.
+    intros Hexists HP HPQ. revert HP Hexists; induction Δ in Γ, HPQ, u |- *; simpl; auto.
+    { intros ? [? ?]; auto. }
+    { intros HP Hexists; cbn in *.
+      specialize (fun H1 Γ u P' H2 H => IHΔ Γ u H H1 (P'; H2)).
+      forward IHΔ => //=; []; cbn in *.
+      destruct Hexists as [? Hexists].
+      destruct a as [na [b|] ty]; [ | destruct u ].
+      all: repeat match goal with H : _ × _ |- _ => destruct H end.
+      all: repeat split; eauto.
+      all: simpl in *.
+      all: first [ eapply IHΔ; clear IHΔ | apply HP; clear HP ]; tea.
+      all: eapply All_impl; tea => //=; intros.
+      all: repeat match goal with H : _ × _ |- _ => destruct H end => //=. }
   Qed.
 
   Lemma sorts_local_ctx_impl (P Q : global_env_ext -> context -> term -> typ_or_sort -> Type) Σ Γ Δ u :
@@ -1300,14 +1368,184 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
     destruct u; auto. intuition eauto.
   Qed.
 
-  Lemma on_global_env_impl {cf : checker_flags} Pcmp P Q :
-    (forall Σ Γ t T,
-        on_global_env Pcmp P Σ.1 ->
-        on_global_env Pcmp Q Σ.1 ->
-        P Σ Γ t T -> Q Σ Γ t T) ->
-    forall Σ, on_global_env Pcmp P Σ -> on_global_env Pcmp Q Σ.
+  Lemma cstr_respects_variance_impl_gen Σ mdecl v cs args Pcmp :
+    { Pcmp' & @cstr_respects_variance Pcmp' Σ mdecl v cs } ->
+    (match variance_universes (ind_universes mdecl) v with
+     | Some (univs, u, u')
+       => forall Γ t T pb,
+         All (fun Pcmp' => Pcmp' (Σ, univs) Γ pb t T) args ->
+         Pcmp (Σ, univs) Γ pb t T
+     | None => True
+     end) ->
+    All (fun Pcmp' => @cstr_respects_variance Pcmp' Σ mdecl v cs) args ->
+    @cstr_respects_variance Pcmp Σ mdecl v cs.
   Proof.
-    intros X Σ [cu IH]. split; auto.
+    rewrite /cstr_respects_variance/cumul_ctx_rel/cumul_pb_decls.
+    destruct variance_universes; destr_prod; try now case.
+    move => Hexists HPQ HP.
+    apply All_prod_inv in HP.
+    destruct HP as [HP1 HP2].
+    apply All_All2_fold_swap_sum in HP1.
+    apply All_All2_swap_sum in HP2.
+    destruct args.
+    { specialize (fun Γ t T pb => HPQ Γ t T pb ltac:(constructor)).
+      destruct Hexists as [? [? ?]];
+        split; first [ eapply All2_fold_impl | eapply All2_impl ]; tea; intros *; cbn; eauto.
+      eapply All_decls_alpha_pb_impl; eauto. }
+    { destruct HP1 as [HP1|HP1], HP2 as [HP2|HP2]; subst; try congruence.
+      split; first [ eapply All2_fold_impl | eapply All2_impl ]; tea; intros *; cbn; eauto.
+      inversion 1; subst.
+      let H := match goal with X : All_decls_alpha_pb _ _ _ _ |- _ => X end in
+      inversion H; clear H; subst; constructor => //.
+      all: apply HPQ; constructor; tea.
+      all: eapply All_impl; tea; intros *; cbn.
+      all: inversion 1; subst => //=. }
+  Qed.
+
+  Lemma cstr_respects_variance_impl Σ mdecl v cs Pcmp Pcmp' :
+    (match variance_universes (ind_universes mdecl) v with
+     | Some (univs, u, u')
+       => forall Γ t T pb,
+         Pcmp' (Σ, univs) Γ pb t T ->
+         Pcmp (Σ, univs) Γ pb t T
+     | None => True
+     end) ->
+    @cstr_respects_variance Pcmp' Σ mdecl v cs ->
+    @cstr_respects_variance Pcmp Σ mdecl v cs.
+  Proof.
+    rewrite /cstr_respects_variance/cumul_ctx_rel/cumul_pb_decls.
+    destruct variance_universes; destr_prod; try now case.
+    move => HPQ [HP1 HP2].
+    split; first [ eapply All2_fold_impl | eapply All2_impl ]; tea; intros *; cbn; eauto.
+    eapply All_decls_alpha_pb_impl; eauto.
+  Qed.
+
+  Lemma on_constructor_impl_config_gen Σ mdecl i idecl ind_indices cdecl cunivs args cf Pcmp P :
+    { '(cf', Pcmp', P') & config.impl cf' cf × @on_constructor cf' Pcmp' P' Σ mdecl i idecl ind_indices cdecl cunivs } ->
+    (forall Γ t T,
+        All (fun '(cf', Pcmp', P') => P' Σ Γ t T) args ->
+        P Σ Γ t T) ->
+    (forall u Γ t T pb,
+        All (fun '(cf', Pcmp', P') => Pcmp' (Σ.1, u) Γ pb t T) args ->
+        Pcmp (Σ.1, u) Γ pb t T) ->
+    All (fun '(cf', Pcmp', P') => @on_constructor cf' Pcmp' P' Σ mdecl i idecl ind_indices cdecl cunivs) args
+    -> @on_constructor cf Pcmp P Σ mdecl i idecl ind_indices cdecl cunivs.
+  Proof.
+    intros Hexists H1 H2 Hargs.
+    destruct Hexists as [[[??]?] [? Hexists]].
+    destruct Hexists; split; tea.
+    all: unfold on_type, config.impl in *; eauto.
+    { apply H1; clear H1.
+      eapply All_impl; tea; intros *; destr_prod; destruct 1; tea. }
+    { eapply sorts_local_ctx_impl_gen; tea.
+      { eexists; tea. }
+      { intros; eapply H1, All_eta3; cbn; apply All_map_inv with (P:=fun P => P _ _ _ _) (f:=snd); tea. }
+      { eapply All_map, All_impl; tea; intros *; destr_prod; destruct 1; cbn; tea. } }
+    { eapply ctx_inst_impl_gen; tea.
+      { eexists; tea. }
+      { intros; eapply H1, All_eta3; cbn; apply All_map_inv with (P:=fun P => P _ _ _ _) (f:=fun P Σ Γ t T => snd P Σ Γ t (Typ T)); tea. }
+      { eapply All_map, All_impl; tea; intros *; destr_prod; destruct 1; cbn; tea. } }
+    { move => ? H'.
+      match goal with H : _ |- _ => specialize (H _ H'); revert H end => H''.
+      eapply cstr_respects_variance_impl_gen; revgoals.
+      { eapply All_map, All_impl; tea; intros *; destr_prod; destruct 1; cbn.
+        instantiate (1:=ltac:(intros [[??]?])); cbn.
+        match goal with H : _ |- _ => refine (H _ H') end. }
+      { repeat match goal with |- context[match ?x with _ => _ end] => destruct x eqn:?; subst end => //.
+        intros; eapply H2, All_eta3; cbn; apply All_map_inv with (P:=fun P => P _ _ _ _ _) (f:=fun x => x.1.2).
+        erewrite map_ext; tea; intros; destr_prod; cbn => //. }
+      { eexists; tea. } }
+    { unfold config.impl in *.
+      do 2 destruct lets_in_constructor_types; cbn in *; rewrite -> ?andb_false_r in * => //. }
+  Qed.
+
+  Lemma on_constructors_impl_config_gen Σ mdecl i idecl ind_indices cdecl cunivs args cf Pcmp P :
+    { '(cf', Pcmp', P') & config.impl cf' cf × @on_constructors cf' Pcmp' P' Σ mdecl i idecl ind_indices cdecl cunivs } ->
+    All (fun '(cf', Pcmp', P') => config.impl cf' cf) args ->
+    (forall Γ t T,
+        All (fun '(cf', Pcmp', P') => P' Σ Γ t T) args ->
+        P Σ Γ t T) ->
+    (forall u Γ t T pb,
+        All (fun '(cf', Pcmp', P') => Pcmp' (Σ.1, u) Γ pb t T) args ->
+        Pcmp (Σ.1, u) Γ pb t T) ->
+    All (fun '(cf', Pcmp', P') => @on_constructors cf' Pcmp' P' Σ mdecl i idecl ind_indices cdecl cunivs) args
+    -> @on_constructors cf Pcmp P Σ mdecl i idecl ind_indices cdecl cunivs.
+  Proof.
+    intros Hexists Hargsconfig H1 H2 Hargs.
+    destruct Hexists as [[[??]?] [? Hexists]].
+    unfold on_constructors in *.
+    destruct args.
+    { eapply All2_impl; tea; intros.
+      eapply on_constructor_impl_config_gen; tea; try eexists (_, _, _); eauto. }
+    apply All_eta3, All_All2_swap in Hargs; [ | constructor; congruence ].
+    eapply All2_impl; try exact Hargs; cbv beta => ?? Hargs'.
+    eapply on_constructor_impl_config_gen; tea.
+    all: repeat first [ progress destr_prod
+                      | match goal with
+                        | [ H : All _ (_ :: _) |- _ ] => inversion H; clear H; subst
+                        end ].
+    { eexists; instantiate (1:=ltac:(repeat eapply pair)); cbn in *.
+      eauto. }
+    constructor; eauto.
+    now eapply All_impl; [ multimatch goal with H : _ |- _ => exact H end | ]; intros; destr_prod; eauto.
+  Qed.
+
+  Lemma ind_respects_variance_impl Σ mdecl v cs Pcmp' Pcmp :
+    match variance_universes (ind_universes mdecl) v with
+     | Some (univs, u, u')
+       => forall Γ t T pb,
+         Pcmp' (Σ, univs) Γ pb t T ->
+         Pcmp (Σ, univs) Γ pb t T
+     | None => True
+     end ->
+    @ind_respects_variance Pcmp' Σ mdecl v cs ->
+    @ind_respects_variance Pcmp Σ mdecl v cs.
+  Proof.
+    rewrite /ind_respects_variance/cumul_ctx_rel/cumul_pb_decls.
+    destruct variance_universes; destr_prod; try now case.
+    move => HPQ HP.
+    eapply All2_fold_impl; tea; intros *; cbn; eauto.
+    inversion 1; subst; subst; constructor => //; auto.
+  Qed.
+
+  Lemma on_variance_impl Σ univs variances cf' cf :
+    config.impl cf' cf ->
+    @on_variance cf' Σ univs variances ->
+    @on_variance cf Σ univs variances.
+  Proof.
+    rewrite /on_variance; case: univs; case: variances => //; intros.
+    repeat first [ match goal with
+                   | [ H : sigT _ |- _ ] => destruct H
+                   | [ H : and4 _ _ _ _ |- _ ] => destruct H
+                   | [ H : ssrbool.and4 _ _ _ _ |- _ ] => destruct H
+                   | [ H : prod _ _ |- _ ] => destruct H
+                   | [ H : and _ _ |- _ ] => destruct H
+                   | [ |- and _ _ ] => split
+                   | [ |- sigT _ ]
+                     => repeat match goal with |- sigT _ => eexists end;
+                        split; tea
+                   end
+                 | progress unfold config.impl, consistent_instance_ext, consistent_instance, valid_constraints in *
+                 | progress cbn in * => //=
+                 | match goal with
+                   | [ |- context[match ?x with _ => _ end] ] => destruct x eqn:?; subst
+                   | [ H : context[match ?x with _ => _ end] |- _ ] => destruct x eqn:?; subst
+                   end ].
+  Qed.
+
+  Lemma on_global_env_impl_config {cf1 cf2 : checker_flags} Pcmp Pcmp' P Q :
+    config.impl cf1 cf2 ->
+    (forall Σ Γ t T,
+        @on_global_env cf1 Pcmp P Σ.1 ->
+        @on_global_env cf2 Pcmp' Q Σ.1 ->
+        P Σ Γ t T -> Q Σ Γ t T) ->
+    (forall Σ Γ t T pb,
+        @on_global_env cf1 Pcmp P Σ.1 ->
+        @on_global_env cf2 Pcmp' Q Σ.1 ->
+        Pcmp Σ Γ pb t T -> Pcmp' Σ Γ pb t T) ->
+    forall Σ, @on_global_env cf1 Pcmp P Σ -> @on_global_env cf2 Pcmp' Q Σ.
+  Proof.
+    intros Hcf X Y Σ [cu IH]. split; auto.
     revert cu IH; generalize (universes Σ) as univs, (retroknowledge Σ) as retro, (declarations Σ). clear Σ.
     induction g; intros; auto. constructor; auto.
     depelim IH. specialize (IHg cu IH). constructor; auto.
@@ -1316,6 +1554,9 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
     assert (X' := fun Γ t T => X ({| universes := univs; declarations := _ |}, udecl0) Γ t T
       (cu, IH) (cu, IHg)); clear X.
     rename X' into X.
+    assert (Y' := fun udecl0 Γ t T pb => Y ({| universes := univs; declarations := _ |}, udecl0) Γ t T pb
+      (cu, IH) (cu, IHg)); clear Y.
+    rename Y' into Y.
     clear IH IHg. destruct d; simpl.
     - destruct c; simpl. destruct cst_body0; cbn in *; now eapply X.
     - destruct on_global_decl_d0 as [onI onP onNP].
@@ -1339,19 +1580,41 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
               generalize (List.rev (lift_context #|cstr_args x0| 0 (ind_indices x))).
               generalize (cstr_indices x0).
               induction 1; simpl; constructor; auto.
+            * intros; eapply cstr_respects_variance_impl; [ | now eauto ].
+              repeat destruct ?; subst; eauto.
+            * move: Hcf; unfold config.impl.
+              do 2 destruct lets_in_constructor_types => //=; rewrite ?andb_false_r => //.
         --- simpl; intros. pose (onProjections X1) as X2. simpl in *; auto.
         --- destruct X1. simpl. unfold check_ind_sorts in *.
             destruct Universe.is_prop; auto.
             destruct Universe.is_sprop; auto.
             split.
-            * apply ind_sorts0.
-            * destruct indices_matter; auto.
+            * unfold check_constructors_smaller in *.
+              eapply Forall_impl; [ apply ind_sorts0 | ]; cbv beta; intros *.
+              move => H'; eapply Forall_impl; [ exact H' | ]; cbv beta; intros *.
+              unfold leq_universe, leq_universe_n, leq_universe_n_, leq_levelalg_n, config.impl in *.
+              repeat match goal with |- context[match ?x with _ => _ end] => destruct x eqn:?; subst end => //=.
+              move: Hcf; do 2 destruct prop_sub_type => //=; rewrite ?andb_false_r => //=.
+            * move: Hcf; unfold config.impl.
+              destr_prod.
+              do 2 destruct indices_matter => //=; rewrite ?andb_false_r => //= Hcf; auto.
               eapply type_local_ctx_impl; eauto.
-              eapply ind_sorts0.
-        --- eapply X1.(onIndices).
+        --- generalize X1.(onIndices).
+            destruct ind_variance eqn:? => //.
+            eapply ind_respects_variance_impl; eauto.
+            repeat destruct ?; eauto.
       -- red in onP. red.
         eapply All_local_env_impl; tea.
+      -- move: onVariance0; eapply on_variance_impl; eauto.
   Qed.
+
+  Lemma on_global_env_impl {cf : checker_flags} Pcmp P Q :
+    (forall Σ Γ t T,
+        on_global_env Pcmp P Σ.1 ->
+        on_global_env Pcmp Q Σ.1 ->
+        P Σ Γ t T -> Q Σ Γ t T) ->
+    forall Σ, on_global_env Pcmp P Σ -> on_global_env Pcmp Q Σ.
+  Proof. intros; eapply on_global_env_impl_config; eauto; reflexivity. Qed.
 
 End GlobalMaps.
 
@@ -1414,15 +1677,17 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E)
 
   (** Functoriality of global environment typing derivations + folding of the well-formed
     environment assumption. *)
-  Lemma on_wf_global_env_impl `{checker_flags} {Σ : global_env} {wfΣ : on_global_env cumul_gen (lift_typing typing) Σ} P Q :
-    (forall Σ Γ t T, on_global_env cumul_gen (lift_typing typing) Σ.1 ->
-        on_global_env cumul_gen P Σ.1 ->
-        on_global_env cumul_gen Q Σ.1 ->
+  Lemma on_wf_global_env_impl_config {cf1 cf2 cf3 : checker_flags} {Σ : global_env} {wfΣ : @on_global_env cf1 (@cumul_gen cf1) (lift_typing (@typing cf1)) Σ} P Q :
+    config.impl cf2 cf3 ->
+    (forall Σ Γ pb t T, @cumul_gen cf2 Σ Γ pb t T -> @cumul_gen cf3 Σ Γ pb t T) ->
+    (forall Σ Γ t T, @on_global_env cf1 (@cumul_gen cf1) (lift_typing (@typing cf1)) Σ.1 ->
+        @on_global_env cf2 (@cumul_gen cf2) P Σ.1 ->
+        @on_global_env cf3 (@cumul_gen cf3) Q Σ.1 ->
         P Σ Γ t T -> Q Σ Γ t T) ->
-    on_global_env cumul_gen P Σ -> on_global_env cumul_gen Q Σ.
+    @on_global_env cf2 (@cumul_gen cf2) P Σ -> @on_global_env cf3 (@cumul_gen cf3) Q Σ.
   Proof.
     unfold on_global_env in *.
-    intros X [hu X0]. split; auto.
+    intros Hcf Hcumul X [hu X0]. split; auto.
     simpl in *. destruct wfΣ as [cu wfΣ]. revert cu wfΣ.
     revert X0. generalize (universes Σ) as univs, (retroknowledge Σ) as retro, (declarations Σ). clear hu Σ.
     induction 1; constructor; try destruct o; try constructor; auto.
@@ -1454,20 +1719,57 @@ Module DeclarationTyping (T : Term) (E : EnvironmentSig T) (TU : TermUtils T E)
               generalize (List.rev (lift_context #|cstr_args x0| 0 (ind_indices x))).
               generalize (cstr_indices x0).
               induction 1; simpl; constructor; auto.
+            * move => v H.
+              move: Hcf (on_ctype_variance0 v H).
+              rewrite /config.impl/cstr_respects_variance/cumul_ctx_rel/cumul_pb_decls.
+              repeat match goal with
+                     | [ |- context[match ?x with _ => _ end] ] => destruct x eqn:?; subst
+                     end => //=.
+              move => Hcf [H1 H2]; split.
+              all: [ > eapply All2_fold_impl; try eapply H1 | eapply All2_impl; try eapply H2 ]; intros *; cbn; try eapply All_decls_alpha_pb_impl; intros *.
+              all: auto.
+            * move: on_lets_in_type0.
+              move: Hcf.
+              rewrite /config.impl.
+              do 3 destruct lets_in_constructor_types => //=.
+              all: rewrite ?andb_false_r //=.
         --- simpl; intros. pose (onProjections X1). simpl in *; auto.
         --- destruct X1. simpl. unfold check_ind_sorts in *.
             destruct Universe.is_prop; auto.
             destruct Universe.is_sprop; auto.
             split.
-            * apply ind_sorts0.
-            * destruct indices_matter; auto.
+            * eapply Forall_impl; [ apply ind_sorts0 | cbn ]; intros.
+              eapply Forall_impl; [ eassumption | cbn ] => ?.
+              move: Hcf.
+              rewrite /leq_universe/leq_universe_n/leq_universe_n_/leq_levelalg_n/config.impl.
+              do 2 destruct check_univs => //=.
+              all: do 2 destruct prop_sub_type => //=.
+              all: repeat match goal with
+                     | [ |- context[match ?x with _ => _ end] ] => destruct x eqn:?; subst
+                     end => //=.
+            * move: Hcf; unfold config.impl.
+              repeat match goal with H : _ × _ |- _ => destruct H end.
+              do 2 destruct indices_matter; cbn [implb andb]; rewrite ?andb_false_r => //= Hcf.
               eapply type_local_ctx_impl; eauto.
-              eapply ind_sorts0.
-        --- eapply X1.(onIndices).
+        --- move: X1.(onIndices).
+            destruct ind_variance eqn:Heq => //.
+            eapply ind_respects_variance_impl.
+            repeat match goal with |- context[match ?x with _ => _ end] => destruct x eqn:?; subst end; eauto.
       -- red in onP. red.
         eapply All_local_env_impl; tea.
+      -- move: onVariance0.
+         eapply on_variance_impl; eauto.
   Qed.
 
+  Lemma on_wf_global_env_impl `{checker_flags} {Σ : global_env} {wfΣ : on_global_env cumul_gen (lift_typing typing) Σ} P Q :
+    (forall Σ Γ t T, on_global_env cumul_gen (lift_typing typing) Σ.1 ->
+        on_global_env cumul_gen P Σ.1 ->
+        on_global_env cumul_gen Q Σ.1 ->
+        P Σ Γ t T -> Q Σ Γ t T) ->
+    on_global_env cumul_gen P Σ -> on_global_env cumul_gen Q Σ.
+  Proof.
+    unshelve eapply on_wf_global_env_impl_config; eauto; reflexivity.
+  Qed.
 
   Section Properties.
     Context {cf : checker_flags}.

--- a/common/theories/EnvironmentTyping.v
+++ b/common/theories/EnvironmentTyping.v
@@ -1155,7 +1155,7 @@ Module GlobalMaps (T: Term) (E: EnvironmentSig T) (TU : TermUtils T E) (ET: EnvT
         | None => unit
         | Some v =>
           ∑ univs' i i',
-            [× (variance_universes univs v = Some (univs', i, i')),
+            [/\ (variance_universes univs v = Some (univs', i, i')),
               consistent_instance_ext (Σ, univs') univs i,
               consistent_instance_ext (Σ, univs') univs i' &
               List.length v = #|UContext.instance (AUContext.repr auctx)|]

--- a/common/theories/Universes.v
+++ b/common/theories/Universes.v
@@ -2042,6 +2042,49 @@ Section Univ.
 
 End Univ.
 
+Section UnivCF2.
+  Context {cf1 cf2 : checker_flags}.
+
+  Lemma valid_config_impl φ ctrs
+    : config.impl cf1 cf2 -> @valid_constraints cf1 φ ctrs
+      -> @valid_constraints cf2 φ ctrs.
+  Proof using Type.
+    unfold valid_constraints, config.impl, is_true.
+    do 2 destruct check_univs; trivial; cbn => //.
+  Qed.
+
+  Lemma cmp_universe_config_impl ctrs pb t u
+    : config.impl cf1 cf2
+      -> @compare_universe cf1 pb ctrs t u -> @compare_universe cf2 pb ctrs t u.
+  Proof using Type.
+    destruct pb, t, u; cbnr; trivial.
+    all: unfold config.impl, eq_levelalg, leq_levelalg_n, is_true.
+    all: do 2 destruct check_univs, prop_sub_type; cbn => //.
+  Qed.
+
+  Lemma eq_universe_config_impl ctrs t u
+    : config.impl cf1 cf2
+      -> @eq_universe cf1 ctrs t u -> @eq_universe cf2 ctrs t u.
+  Proof using Type. apply cmp_universe_config_impl with (pb := Conv). Qed.
+
+  Lemma leq_universe_config_impl ctrs t u
+    : config.impl cf1 cf2
+      -> @leq_universe cf1 ctrs t u -> @leq_universe cf2 ctrs t u.
+  Proof using Type. apply cmp_universe_config_impl with (pb := Cumul). Qed.
+
+  (** Elimination restriction *)
+
+  Lemma allowed_eliminations_config_impl φ a s
+    : config.impl cf1 cf2 ->
+      @is_allowed_elimination cf1 φ a s -> @is_allowed_elimination cf2 φ a s.
+  Proof using Type.
+    destruct a, s; cbnr; trivial.
+    unfold eq_levelalg, config.impl, is_true.
+    do 2 destruct check_univs; cbnr; auto => //.
+  Qed.
+
+End UnivCF2.
+
 Ltac unfold_univ_rel0 :=
   unfold eq0_levelalg, leq0_levelalg_n in *;
   intros v Hv; cbnr.

--- a/common/theories/config.v
+++ b/common/theories/config.v
@@ -1,5 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
-
+From Coq Require CRelationClasses.
+From Coq Require Import Bool RelationClasses Btauto.
+From Coq.ssr Require Import ssreflect ssrbool.
 
 Class checker_flags := {
   (* check_guard : bool ; *)
@@ -38,3 +40,34 @@ Local Instance extraction_checker_flags : checker_flags := {|
   indices_matter := false;
   lets_in_constructor_types := false
 |}.
+
+(** [cf1 -> cf2] means that typing under [cf1] implies typing under [cf2] *)
+#[local] Definition impl (cf1 cf2 : checker_flags) : bool
+  := implb cf2.(@check_univs) cf1.(@check_univs)
+     && implb cf1.(@prop_sub_type) cf2.(@prop_sub_type)
+     && implb cf2.(@indices_matter) cf1.(@indices_matter)
+     && implb cf1.(@lets_in_constructor_types) cf2.(@lets_in_constructor_types).
+
+#[local] Definition impl_reflb cf : impl cf cf = true.
+Proof. rewrite /impl !implb_same ?orb_true_r //. Qed.
+#[local] Definition impl_refl : Reflexive impl := impl_reflb.
+#[local] Definition impl_crefl : CRelationClasses.Reflexive impl := impl_reflb.
+#[local] Definition impl_trans : Transitive impl.
+Proof.
+  rewrite /impl => x y z; destruct x, y, z; cbn.
+  rewrite !implb_orb.
+  repeat match goal with
+         | [ |- is_true (andb _ _) -> _ ] => move => /andP[]
+         | [ |- is_true (orb _ _) -> _ ] => move => /orP[]
+         | [ |- is_true (negb _) -> _ ] => let H := fresh in intro H; apply negbTE in H; subst => //=
+         | [ |- is_true true -> _ ] => move => _
+         | [ |- is_true false -> _ ] => move => //=
+         | [ |- is_true ?x -> _ ] => is_var x; let H := fresh in intro H; cbv [is_true] in H; subst
+         end.
+  all: rewrite ?orb_true_l ?orb_true_r ?andb_false_l ?andb_false_r //.
+Qed.
+#[local] Definition impl_ctrans : CRelationClasses.Transitive impl := impl_trans.
+#[global] Existing Instances
+  impl_refl impl_crefl
+  impl_trans impl_ctrans
+| 100.

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -616,7 +616,7 @@ Proof.
     (try eapply forallb_Forall);
     eauto).
   - eapply isEtaExp_mkApps_intro; eauto. solve_all.
-  - solve_all. now rewrite b H.
+  - solve_all.
   - rewrite isEtaExp_Constructor. rtoProp; repeat split.
     2: eapply forallb_Forall.
     2: solve_all. eapply expanded_isEtaExp_app_; eauto.
@@ -708,4 +708,3 @@ Proof.
   destruct (cst_body c) => // /=.
   eapply isEtaExpFix_isEtaExp.
 Qed.
-

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -734,7 +734,6 @@ Proof.
     split; intros; rtoProp; intuition auto; solve_all.
   - red. intros. simpl in H0. simpl. rtoProp; intuition auto.
   - red. move=> hasproj n p discr. simpl; rtoProp; intuition auto.
-    rtoProp; intuition auto.
   - red. move=> t args clt cll.
     eapply wellformed_substl. solve_all. now rewrite Nat.add_0_r.
   - red. move=> n mfix idx. cbn. unfold EWellformed.wf_fix.

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -248,7 +248,6 @@ Section EEnvFlags.
         now eapply nth_error_all in Heq; simpl; eauto; simpl in *.
       -- simpl. elim (Nat.ltb_spec); auto. rtoProp; intuition auto.
         apply nth_error_None in Heq. intros.
-        rewrite H.
         apply Nat.ltb_lt in H0. lia.
       -- simpl. f_equal. rewrite H /=.
         elim: Nat.ltb_spec => //. intros. apply Nat.ltb_lt in H0. lia.

--- a/pcuic/_CoqProject.in
+++ b/pcuic/_CoqProject.in
@@ -28,6 +28,7 @@ theories/Conversion/PCUICNamelessConv.v
 theories/Conversion/PCUICRenameConv.v
 theories/Conversion/PCUICInstConv.v
 theories/Conversion/PCUICWeakeningEnvConv.v
+theories/Conversion/PCUICWeakeningConfigConv.v
 theories/Conversion/PCUICUnivSubstitutionConv.v
 theories/Conversion/PCUICWeakeningConv.v
 theories/Conversion/PCUICClosedConv.v
@@ -37,6 +38,7 @@ theories/Typing/PCUICNamelessTyp.v
 theories/Typing/PCUICRenameTyp.v
 theories/Typing/PCUICInstTyp.v
 theories/Typing/PCUICWeakeningEnvTyp.v
+theories/Typing/PCUICWeakeningConfigTyp.v
 theories/Typing/PCUICWeakeningTyp.v
 theories/Typing/PCUICUnivSubstitutionTyp.v
 theories/Typing/PCUICClosedTyp.v
@@ -82,6 +84,7 @@ theories/PCUICCumulProp.v
 theories/PCUICElimination.v
 theories/PCUICSN.v
 theories/PCUICWeakeningEnvSN.v
+theories/PCUICWeakeningConfigSN.v
 theories/PCUICPrincipality.v
 theories/PCUICSigmaCalculus.v
 theories/PCUICFirstorder.v
@@ -104,6 +107,7 @@ theories/Bidirectional/BDUnique.v
 theories/Bidirectional/BDStrengthening.v
 
 theories/PCUICWeakeningEnv.v
+theories/PCUICWeakeningConfig.v
 
 theories/PCUICCasesHelper.v
 

--- a/pcuic/theories/Conversion/PCUICWeakeningConfigConv.v
+++ b/pcuic/theories/Conversion/PCUICWeakeningConfigConv.v
@@ -1,0 +1,213 @@
+(* Distributed under the terms of the MIT license. *)
+From MetaCoq.Utils Require Import MCUtils utils.
+From MetaCoq.Common Require Import config.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+  PCUICWeakeningConfig PCUICEquality PCUICReduction PCUICCumulativity PCUICCumulativitySpec
+  (* PCUICContextSubst *) (* PCUICUnivSubst *) (* PCUICCases *) (* PCUICTyping *)
+  (* PCUICGuardCondition *) (* PCUICGlobalEnv *).
+From Equations Require Import Equations.
+
+Require Import ssreflect.
+
+Set Default Goal Selector "!".
+Implicit Types (cf : checker_flags).
+
+Lemma compare_term_config_impl {cf1 cf2} pb Σ φ t t'
+  : config.impl cf1 cf2
+    -> @compare_term cf1 pb Σ φ t t' -> @compare_term cf2 pb Σ φ t t'.
+Proof.
+  intro H. apply eq_term_upto_univ_impl; auto.
+  all: repeat change (@eq_universe ?cf) with (@compare_universe cf Conv).
+  all: repeat change (@leq_universe ?cf) with (@compare_universe cf Cumul).
+  3: destruct pb.
+  4: transitivity (@compare_universe cf1 Cumul φ); tc.
+  all: intros ??; now eapply cmp_universe_config_impl.
+Qed.
+
+Lemma eq_term_config_impl {cf1 cf2} Σ φ t t'
+  : config.impl cf1 cf2 -> @compare_term cf1 Conv Σ φ t t' -> @compare_term cf2 Conv Σ φ t t'.
+Proof. eapply compare_term_config_impl with (pb := Conv). Qed.
+
+Lemma leq_term_config_impl {cf1 cf2} Σ ctrs t u
+  : config.impl cf1 cf2 -> @compare_term cf1 Cumul Σ ctrs t u -> @compare_term cf2 Cumul Σ ctrs t u.
+Proof. apply compare_term_config_impl with (pb := Cumul). Qed.
+
+Lemma compare_decl_config_impl {cf1 cf2} pb Σ φ d d'
+  : config.impl cf1 cf2
+    -> @compare_decl cf1 pb Σ φ d d' -> @compare_decl cf2 pb Σ φ d d'.
+Proof.
+  intros Hcf []; constructor; eauto using (@compare_term_config_impl cf1 cf2).
+Qed.
+
+Lemma compare_context_config_impl {cf1 cf2} pb Σ φ Γ Γ'
+  : config.impl cf1 cf2
+    -> @compare_context cf1 pb Σ φ Γ Γ' -> @compare_context cf2 pb Σ φ Γ Γ'.
+Proof.
+  intros Hcf. induction 1; constructor; auto; eapply (@compare_decl_config_impl cf1 cf2); eassumption.
+Qed.
+
+(* TODO: Factor with PCUICWeakeningEnvConv.R_global_instance_weaken_env *)
+Lemma R_global_instance_weaken_subrel Σ Re Re' Rle Rle' gr napp :
+  RelationClasses.subrelation Re Re' ->
+  RelationClasses.subrelation Rle Rle' ->
+  RelationClasses.subrelation Re Rle' ->
+  subrelation (R_global_instance Σ Re Rle gr napp) (R_global_instance Σ Re' Rle' gr napp).
+Proof.
+  intros he hle hele t t'.
+  rewrite /R_global_instance_gen /R_opt_variance.
+  destruct global_variance_gen as [v|] eqn:look.
+  - induction t in v, t' |- *; destruct v, t'; simpl; auto.
+    intros []; split; auto.
+    destruct t0; simpl; auto.
+  - eauto using R_universe_instance_impl'.
+Qed.
+
+(* TODO: Factor with PCUICWeakeningEnvConv.eq_term_upto_univ_weaken_env *)
+#[global]
+Instance eq_term_upto_univ_weaken_subrel Σ Re Re' Rle Rle' napp :
+  RelationClasses.subrelation Re Re' ->
+  RelationClasses.subrelation Rle Rle' ->
+  RelationClasses.subrelation Re Rle' ->
+  CRelationClasses.subrelation (eq_term_upto_univ_napp Σ Re Rle napp)
+    (eq_term_upto_univ_napp Σ Re' Rle' napp).
+Proof.
+  intros he hele hle t t'.
+  induction t in napp, t', Rle, Rle', hle, hele |- * using PCUICInduction.term_forall_list_ind;
+    try (inversion 1; subst; constructor;
+         eauto using R_universe_instance_impl'; fail).
+  - inversion 1; subst; constructor.
+    eapply All2_impl'; tea.
+    eapply All_impl; eauto.
+  - inversion 1; subst; constructor.
+    eapply R_global_instance_weaken_subrel; [ .. | eassumption ]. all:eauto.
+  - inversion 1; subst; constructor.
+    eapply R_global_instance_weaken_subrel; [ .. | eassumption ]. all:eauto.
+  - inversion 1; subst; destruct X as [? [? ?]]; constructor; eauto.
+    * destruct X2 as [? [? ?]].
+      constructor; intuition auto; solve_all.
+      + eauto using R_universe_instance_impl'.
+    * eapply All2_impl'; tea.
+      eapply All_impl; eauto.
+      cbn. intros x [? ?] y [? ?]. split; eauto.
+  - inversion 1; subst; constructor.
+    eapply All2_impl'; tea.
+    eapply All_impl; eauto.
+    cbn. intros x [? ?] y [[[? ?] ?] ?]. repeat split; eauto.
+  - inversion 1; subst; constructor.
+    eapply All2_impl'; tea.
+    eapply All_impl; eauto.
+    cbn. intros x [? ?] y [[[? ?] ?] ?]. repeat split; eauto.
+Qed.
+
+Lemma weakening_config_cumul_gen {cf1 cf2} pb Σ Γ M N :
+  config.impl cf1 cf2 ->
+  @cumulAlgo_gen cf1 Σ Γ pb M N ->
+  @cumulAlgo_gen cf2 Σ Γ pb M N.
+Proof.
+  intro Hcf; induction 1; simpl; trivial.
+  all: now econstructor; try eassumption; eapply (@compare_term_config_impl cf1 cf2); eassumption.
+Qed.
+
+Lemma weakening_config_conv {cf1 cf2} Σ Γ M N :
+  config.impl cf1 cf2 ->
+  @cumulAlgo_gen cf1 Σ Γ Conv M N ->
+  @cumulAlgo_gen cf2 Σ Γ Conv M N.
+Proof. apply weakening_config_cumul_gen with (pb := Conv). Qed.
+
+Lemma weakening_config_cumul {cf1 cf2} Σ Γ M N :
+  config.impl cf1 cf2 ->
+  @cumulAlgo_gen cf1 Σ Γ Cumul M N ->
+  @cumulAlgo_gen cf2 Σ Γ Cumul M N.
+Proof. apply weakening_config_cumul_gen with (pb := Cumul). Qed.
+
+Lemma weakening_config_cumulSpec0 {cf1 cf2} Σ Γ pb M N :
+  config.impl cf1 cf2 ->
+  @cumulSpec0 cf1 Σ Γ pb M N ->
+  @cumulSpec0 cf2 Σ Γ pb M N.
+Proof.
+  intros Hcf.
+  revert pb Γ M N.
+  apply: (@cumulSpec0_ind_all cf1 Σ).
+  all:intros; try solve [econstructor; try eassumption; intuition auto].
+  - eapply cumul_Evar. solve_all.
+  - eapply cumul_Case.
+    * destruct X as (Hparams & Hinst & Hctx & Hret & IHret). repeat split; tas.
+      + solve_all.
+      + eapply R_universe_instance_impl'; eauto.
+        hnf; intros *; eapply (@cmp_universe_config_impl cf1 cf2); assumption.
+    * solve_all.
+    * solve_all.
+  - eapply cumul_Fix; solve_all.
+  - eapply cumul_CoFix; solve_all.
+  - eapply cumul_Ind; eauto. 2:solve_all.
+    eapply @R_global_instance_weaken_subrel; [ .. | eassumption ].
+    all: repeat change (@eq_universe ?cf) with (@compare_universe cf Conv).
+    all: repeat change (@leq_universe ?cf) with (@compare_universe cf Cumul).
+    3: destruct pb.
+    all: try (hnf; intros *; eapply (@cmp_universe_config_impl cf1 cf2); eassumption).
+    all: now etransitivity; [ | hnf; intros *; eapply (@cmp_universe_config_impl cf1 cf2); eassumption ]; tc.
+  - eapply cumul_Construct; eauto. 2:solve_all.
+    eapply @R_global_instance_weaken_subrel; [ .. | eassumption ].
+    all: repeat change (@eq_universe ?cf) with (@compare_universe cf Conv).
+    all: repeat change (@leq_universe ?cf) with (@compare_universe cf Cumul).
+    3: destruct pb.
+    all: try (hnf; intros *; eapply (@cmp_universe_config_impl cf1 cf2); eassumption).
+    all: now etransitivity; [ | hnf; intros *; eapply (@cmp_universe_config_impl cf1 cf2); eassumption ]; tc.
+  - eapply cumul_Sort. eapply (@cmp_universe_config_impl cf1 cf2); eassumption.
+  - eapply cumul_Const. eapply R_universe_instance_impl'; eauto; tc.
+    hnf; intros *; eapply (@cmp_universe_config_impl cf1 cf2); eassumption.
+Defined.
+
+Lemma weakening_config_convSpec {cf1 cf2} Σ Γ M N :
+  config.impl cf1 cf2 ->
+  @convSpec cf1 Σ Γ M N ->
+  @convSpec cf2 Σ Γ M N.
+Proof. apply weakening_config_cumulSpec0 with (pb := Conv). Qed.
+
+Lemma weakening_config_cumulSpec {cf1 cf2} Σ Γ M N :
+  config.impl cf1 cf2 ->
+  @cumulSpec cf1 Σ Γ M N ->
+  @cumulSpec cf2 Σ Γ M N.
+Proof. apply weakening_config_cumulSpec0 with (pb := Cumul). Qed.
+
+Lemma weakening_config_conv_decls {cf1 cf2 Σ Γ Γ'} :
+  config.impl cf1 cf2 ->
+  CRelationClasses.subrelation (conv_decls (@cumulSpec0 cf1) Σ Γ Γ') (conv_decls (@cumulSpec0 cf2) Σ Γ Γ').
+Proof.
+  intros Hcf d d' Hd; depelim Hd; constructor; tas;
+    eapply (@weakening_config_convSpec cf1 cf2); tea.
+Qed.
+
+Lemma weakening_config_cumul_decls {cf1 cf2 Σ Γ Γ'} :
+  config.impl cf1 cf2 ->
+  CRelationClasses.subrelation (cumul_decls (@cumulSpec0 cf1) Σ Γ Γ') (cumul_decls (@cumulSpec0 cf2) Σ Γ Γ').
+Proof.
+  intros Hcf d d' Hd; depelim Hd; constructor; tas;
+    (eapply (@weakening_config_convSpec cf1 cf2) || eapply (@weakening_config_cumulSpec cf1 cf2)); tea.
+Qed.
+
+Lemma weakening_config_conv_ctx {cf1 cf2 Σ Γ Δ} :
+  config.impl cf1 cf2 ->
+  conv_context (@cumulSpec0 cf1) Σ Γ Δ ->
+  conv_context (@cumulSpec0 cf2) Σ Γ Δ.
+Proof.
+  intros Hcf.
+  intros; eapply All2_fold_impl; tea => Γ0 Γ' d d'.
+  now eapply weakening_config_conv_decls.
+Qed.
+
+
+Lemma weakening_config_cumul_ctx {cf1 cf2 Σ Γ Δ} :
+  config.impl cf1 cf2 ->
+  cumul_context (@cumulSpec0 cf1) Σ Γ Δ ->
+  cumul_context (@cumulSpec0 cf2) Σ Γ Δ.
+Proof.
+  intros Hcf.
+  intros; eapply All2_fold_impl; tea => Γ0 Γ' d d'.
+  now eapply weakening_config_cumul_decls.
+Qed.
+
+(*
+#[global] Hint Resolve weakening_config_conv_ctx : config.
+#[global] Hint Resolve weakening_config_cumul_ctx : config.
+*)

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -1809,7 +1809,7 @@ Hint Rewrite lift_instance_length : len.
 Lemma variance_universes_insts {cf} {Σ mdecl l} :
   on_variance Σ (ind_universes mdecl) (Some l) ->
   ∑ v i i',
-  [/\ variance_universes (PCUICEnvironment.ind_universes mdecl) l = Some (v, i, i'),
+  [× variance_universes (PCUICEnvironment.ind_universes mdecl) l = Some (v, i, i'),
     match ind_universes mdecl with
     | Monomorphic_ctx => False
     | Polymorphic_ctx (inst, cstrs) =>

--- a/pcuic/theories/PCUICInductiveInversion.v
+++ b/pcuic/theories/PCUICInductiveInversion.v
@@ -1809,7 +1809,7 @@ Hint Rewrite lift_instance_length : len.
 Lemma variance_universes_insts {cf} {Σ mdecl l} :
   on_variance Σ (ind_universes mdecl) (Some l) ->
   ∑ v i i',
-  [× variance_universes (PCUICEnvironment.ind_universes mdecl) l = Some (v, i, i'),
+  [/\ variance_universes (PCUICEnvironment.ind_universes mdecl) l = Some (v, i, i'),
     match ind_universes mdecl with
     | Monomorphic_ctx => False
     | Polymorphic_ctx (inst, cstrs) =>
@@ -1827,9 +1827,11 @@ Proof.
   destruct (ind_universes mdecl); simpl => //.
   destruct cst as [inst cstrs].
   intros [univs' [i [i' []]]].
+  let e := match goal with H : Some _ = Some _ |- _ => H end in
   noconf e.
   do 3 eexists; split. trea. all:eauto. 1-3:len.
-  len in e0. len.
+  repeat match goal with H : _ |- _ => progress len in H end.
+  len.
   rewrite /closedu_instance /level_var_instance forallb_mapi //.
   intros i hi. simpl. now eapply Nat.ltb_lt.
   now len.
@@ -4536,4 +4538,3 @@ Proof.
     rewrite -eqsubst. apply: red_betas_typed; last eassumption.
     rewrite (ctx_inst_length instl) context_assumptions_rev //.
 Qed.
-

--- a/pcuic/theories/PCUICSN.v
+++ b/pcuic/theories/PCUICSN.v
@@ -29,6 +29,17 @@ Proof.
   now constructor.
 Qed.
 
+#[local] Instance weakening_config_normalizing {cf1 cf2} :
+  config.impl cf2 cf1 -> @normalizing_flags cf1 -> @normalizing_flags cf2.
+Proof.
+  intros Hcf no.
+  destruct cf1, cf2, no; constructor; cbv -[andb] in *.
+  subst; simpl in *.
+  revert Hcf; cbv [andb].
+  repeat match goal with |- context[if ?b then _ else _] => is_var b; destruct b end.
+  all: trivial.
+Qed.
+
 Class NormalisationIn {cf : checker_flags} {no : normalizing_flags} (Σ : global_env_ext) :=
   normalisation_in :
     forall Γ t,

--- a/pcuic/theories/PCUICWcbvEval.v
+++ b/pcuic/theories/PCUICWcbvEval.v
@@ -698,7 +698,7 @@ Section Wcbv.
     unfold unfold_fix. destruct (nth_error mfix idx) eqn:Heq.
     move=> /= Hf Heq'; noconf Heq'.
     eapply closedn_subst0. unfold fix_subst. clear -Hf. generalize #|mfix|.
-    induction n; simpl; auto. apply/andP; split; auto.
+    induction n; simpl; auto.
     simpl. rewrite fix_subst_length. solve_all.
     eapply All_nth_error in Hf; eauto. unfold test_def in Hf.
     rewrite PeanoNat.Nat.add_0_r in Hf. now move/andP: Hf.
@@ -797,7 +797,7 @@ Section Wcbv.
     unfold unfold_cofix. destruct (nth_error mfix idx) eqn:Heq.
     move=> /= Hf Heq'; noconf Heq'.
     eapply closedn_subst0. unfold cofix_subst. clear -Hf. generalize #|mfix|.
-    induction n; simpl; auto. apply/andP; split; auto.
+    induction n; simpl; auto.
     simpl. rewrite cofix_subst_length. solve_all.
     eapply All_nth_error in Hf; eauto. unfold test_def in Hf.
     rewrite PeanoNat.Nat.add_0_r in Hf. now move/andP: Hf.
@@ -1209,4 +1209,3 @@ Proof.
   - eapply eval_cofix_case; tea.
     eapply value_final, value_app. now constructor. auto.
 Qed.
-

--- a/pcuic/theories/PCUICWeakeningConfig.v
+++ b/pcuic/theories/PCUICWeakeningConfig.v
@@ -1,0 +1,75 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq.ssr Require Import ssreflect ssrbool.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import config.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping.
+From Equations Require Import Equations.
+From MetaCoq Require Import LibHypsNaming.
+
+Require Import ssreflect.
+
+Set Default Goal Selector "!".
+
+(** * Weakening lemmas w.r.t. the checker configuration *)
+
+(** ** Constraints *)
+
+#[global] Instance subrel_config_impl_cmp cf1 cf2 pb cs :
+  config.impl cf1 cf2 ->
+  RelationClasses.subrelation (@compare_universe cf1 pb cs) (@compare_universe cf2 pb cs).
+Proof.
+  cbv [compare_universe eq_universe leq_universe leq_universe_n leq_universe_n_ eq_levelalg leq_levelalg_n eq_universe_ config.impl].
+  destruct cf1, cf2; cbn.
+  move => H u1 u2; move: H.
+  repeat match goal with
+         | [ |- context[match ?x with _ => _ end] ] => is_var x; destruct x
+         end; cbn => //=; try reflexivity.
+  repeat move => /andP[]; cbv [is_true]; intros; repeat (cbn in *; subst).
+  reflexivity.
+Qed.
+
+#[global] Instance subrel_config_impl_eq_pb cf1 cf2 pb cs :
+  config.impl cf1 cf2 ->
+  RelationClasses.subrelation (@eq_universe cf1 cs) (@compare_universe cf2 pb cs).
+Proof.
+  change (@eq_universe ?cf) with (@compare_universe cf Conv).
+  etransitivity; [ now eapply (@subrel_config_impl_cmp cf1 cf2) | ].
+  tc.
+Qed.
+
+#[global] Instance subrel_config_impl_eq cf1 cf2 u :
+  config.impl cf1 cf2 ->
+  RelationClasses.subrelation (@eq_universe cf1 u) (@eq_universe cf2 u).
+Proof. change (@eq_universe ?cf) with (@compare_universe cf Conv). tc. Qed.
+
+#[global] Instance subrel_config_impl_le cf1 cf2 u :
+  config.impl cf1 cf2 ->
+  RelationClasses.subrelation (@leq_universe cf1 u) (@leq_universe cf2 u).
+Proof. change (@leq_universe ?cf) with (@compare_universe cf Cumul). tc. Qed.
+
+#[global] Instance subrel_config_impl_eq_le cf1 cf2 u :
+  config.impl cf1 cf2 ->
+  RelationClasses.subrelation (@eq_universe cf1 u) (@leq_universe cf2 u).
+Proof. change (@leq_universe ?cf) with (@compare_universe cf Cumul). tc. Qed.
+
+Lemma weakening_config_is_allowed_elimination cf1 cf2 cs u allowed :
+  config.impl cf1 cf2 ->
+  @is_allowed_elimination cf1 cs allowed u ->
+  @is_allowed_elimination cf2 cs allowed u.
+Proof.
+  destruct allowed; cbnr; trivial; cbv [is_lSet].
+  move => ? [?|H]; [ left | right ] => //; move: H.
+  now apply subrel_config_impl_eq.
+Qed.
+(*#[global] Hint Resolve weakening_config_is_allowed_elimination : extends.*)
+
+Lemma weakening_config_consistent_instance cf1 cf2 Σ ctrs u :
+  config.impl cf1 cf2 ->
+  @consistent_instance_ext cf1 Σ ctrs u ->
+  @consistent_instance_ext cf2 Σ ctrs u.
+Proof.
+  rewrite /consistent_instance_ext/consistent_instance/valid_constraints/config.impl.
+  do 2 case: check_univs; cbn => //=.
+  case: ctrs => //=; intuition auto.
+Qed.
+(*#[global] Hint Resolve weakening_config_consistent_instance : extends.*)

--- a/pcuic/theories/PCUICWeakeningConfigSN.v
+++ b/pcuic/theories/PCUICWeakeningConfigSN.v
@@ -1,0 +1,16 @@
+From Coq Require Import ssreflect Wellfounded.Inclusion.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICSN PCUICTyping PCUICSafeLemmata PCUICWeakeningConfigTyp.
+Import PCUICEnvironment.
+
+Lemma weakening_config_normalisation_in {cf1 cf2} {no1 no2}
+  Σ
+  (Hcf : config.impl cf2 cf1)
+  : @PCUICSN.NormalisationIn cf1 no1 Σ -> @PCUICSN.NormalisationIn cf2 no2 Σ.
+Proof.
+  cbv [PCUICSN.NormalisationIn].
+  intros normalisation_in Γ t1 [T Hwt]; specialize (normalisation_in Γ t1).
+  eapply Acc_incl; [ | eapply normalisation_in; econstructor; instantiate (1:=T); revert Hwt ].
+  { hnf; trivial. }
+  eapply (@weakening_config cf2 cf1); assumption.
+Qed.

--- a/pcuic/theories/PCUICWfUniverses.v
+++ b/pcuic/theories/PCUICWfUniverses.v
@@ -517,7 +517,6 @@ Qed.
 
   - solve_all.
   - now eapply weaken_wf_universe.
-  - apply /andP; to_wfu; intuition eauto 4.
   - eapply forallb_impl ; tea.
     now move => ? _ /wf_universe_reflect /weaken_wf_universe /wf_universe_reflect.
   - eapply forallb_impl ; tea.
@@ -1036,7 +1035,6 @@ Qed.
         now simpl in Hs.
       * induction X; simpl; auto.
         rewrite IHX /= /test_decl /=. now move/andP: Hs.
-        rewrite IHX /= /test_decl /=. now move/andP: Hc => [] -> ->.
 
     - rewrite wf_universes_lift.
       destruct X as [X _].

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -752,7 +752,6 @@ Proof.
   - move: h4; rewrite !on_free_vars_mkApps.
     move=> /andP [] hcofix ->.
     eapply on_free_vars_unfold_cofix in hcofix; eauto.
-    now rewrite hcofix.
   - move: hav; rewrite !on_free_vars_mkApps => /andP [] hcofix ->.
     eapply on_free_vars_unfold_cofix in H as ->; eauto.
   - eapply closed_on_free_vars. rewrite closedn_subst_instance.

--- a/pcuic/theories/Typing/PCUICWeakeningConfigTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningConfigTyp.v
@@ -1,0 +1,148 @@
+(* Distributed under the terms of the MIT license. *)
+From MetaCoq.Utils Require Import utils MCUtils.
+From MetaCoq.Common Require Import config.
+From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
+  PCUICEquality PCUICContextSubst PCUICUnivSubst PCUICCases
+  PCUICReduction PCUICCumulativity PCUICTyping PCUICGuardCondition
+  PCUICWeakeningConfig PCUICWeakeningConfigConv.
+From Equations Require Import Equations.
+
+Require Import ssreflect.
+
+Set Default Goal Selector "!".
+Implicit Types (cf : checker_flags).
+
+Local Ltac constructor_per_goal' _ :=
+  let n := numgoals in
+  [ > .. | econstructor n; shelve ];
+  gtry (constructor_per_goal' ()).
+Local Ltac constructor_per_goal _ :=
+  unshelve constructor_per_goal' (); shelve_unifiable.
+
+Lemma weakening_config_wf_local_sized {cf1 cf2 : checker_flags} Σ Γ
+  (Hwf : match cf1 with _ => wf_local Σ Γ end)
+  (IH : forall Γ0 t0 T0 (H0 : @typing cf1 Σ Γ0 t0 T0),
+      typing_size H0 < S (All_local_env_size (fun _ _ _ _ H => typing_size H) Σ Γ Hwf)
+      -> @typing cf2 Σ Γ0 t0 T0)
+  : match cf2 with _ => wf_local Σ Γ end.
+Proof.
+  simpl in *.
+  induction Hwf; [ constructor 1 | constructor 2 | constructor 3 ].
+  all: try assumption.
+  all: unfold lift_typing, lift_judgment, infer_sort in *.
+  all: rdest.
+  all: simpl in *.
+  all: try (unshelve eapply IH; [ eassumption | ];
+            try solve [ constructor; simpl in *; cbn in *; lia ]).
+  all: repeat (exactly_once (idtac; multimatch goal with H : _ |- _ => unshelve eapply H; [ try eassumption .. | intros; simpl in * ]; clear H end)).
+  all: try (cbn; lia).
+Qed.
+
+Lemma weakening_config {cf1 cf2} Σ Γ t T :
+  config.impl cf1 cf2 ->
+  @typing cf1 Σ Γ t T ->
+  @typing cf2 Σ Γ t T.
+Proof.
+  intros Hcf H.
+  pose proof (@Fix_F { Σ & { Γ & { t & { T & @typing cf1 Σ Γ t T }}}}) as p0.
+  specialize (p0 (PCUICUtils.dlexprod (precompose lt (fun Σ => globenv_size (fst Σ)))
+                    (fun Σ => precompose lt (fun x => typing_size x.π2.π2.π2)))) as p.
+  try clear p0.
+  set (foo := (Σ; Γ; t; _; H) : { Σ & { Γ & { t & { T & Σ ;;; Γ |- t : T }}}}).
+  change Σ with foo.π1.
+  change Γ with foo.π2.π1.
+  change t with foo.π2.π2.π1.
+  change T with foo.π2.π2.π2.π1.
+  change H with foo.π2.π2.π2.π2.
+  revert foo.
+  match goal with
+    |- let foo := _ in @?P foo => specialize (p (fun x => P x))
+  end.
+  forward p; [ | apply p; apply PCUICUtils.wf_dlexprod; intros; apply wf_precompose; apply lt_wf].
+  clear p.
+  clear Σ Γ t T H.
+  intros (Σ & Γ & t & T & H). simpl.
+  intros IH. specialize (fun Σ Γ t T H => IH (Σ; Γ; t; T; H)). simpl in IH.
+  destruct H; constructor_per_goal (); try eassumption.
+  all: try (unshelve eapply IH; [ eassumption .. | ];
+            try solve [ constructor; simpl; lia ]).
+  all: try (eapply (@weakening_config_cumulSpec cf1 cf2); eassumption).
+  all: try now constructor; simpl; repeat destruct ?; simpl; lia.
+  all: specialize (fun Γ t T H H' => IH _ Γ t T H ltac:(right; exact H')).
+  all: simpl in IH.
+  all: try (set (k := fix_context _) in *; clearbody k).
+  all: match goal with
+       | [ H : All (fun d => ∑ s : ?S, _) ?l |- All (fun d => ∑ s' : ?S, _) ?l ]
+         => is_var l; clear -H IH; induction H as [|???? IH']; constructor
+       | [ H : All (fun d => _ ;;; _ |- _ : _) ?l |- All (fun d => _ ;;; _ |- _ : _) ?l ]
+         => is_var l; clear -H IH; induction H as [|???? IH']; constructor
+       | [ H : case_side_conditions _ _ _ _ _ _ _ _ _ _ _ |- case_side_conditions _ _ _ _ _ _ _ _ _ _ _ ] => destruct H; constructor
+       | [ H : case_branch_typing _ _ _ _ _ _ _ _ _ _ _ |- case_branch_typing _ _ _ _ _ _ _ _ _ _ _ ] => destruct H; constructor
+       | _ => idtac
+       end.
+  all: unfold wf_branches in *.
+  all: repeat match goal with H : All _ (_ :: _) |- _ => depelim H end.
+  all: rdest.
+  all: try (unshelve eapply IH'; clear IH'; auto; [];
+            intros;
+            unshelve eapply IH; [ eassumption .. | simpl; lia ]).
+  all: try (unshelve eapply IH; [ eassumption .. | simpl; lia ]).
+  all: try now eapply (@weakening_config_consistent_instance cf1 cf2); eassumption.
+  all: try now eapply (@weakening_config_is_allowed_elimination cf1 cf2); eassumption.
+  all: try now repeat destruct ?; subst; simpl in *; assumption.
+  all: repeat destruct ?; subst.
+  all: lazymatch goal with
+       | [ H : ctx_inst _ _ _ _ _ |- ctx_inst _ _ _ _ _ ]
+         => revert dependent H;
+            repeat match goal with
+              | [ |- context[typing_size ?x] ]
+                => generalize (typing_size x); clear x; intro
+              end;
+            intro H; intros;
+            induction H; constructor_per_goal ()
+       | [ H : All2i _ _ ?x ?y |- All2i _ _ ?x ?y ]
+         => induction H; constructor_per_goal (); cbv zeta in *
+       | _ => idtac
+       end.
+  all: repeat rdest; try assumption.
+  all: repeat (exactly_once (idtac; multimatch goal with H : _ |- _ => unshelve eapply H; [ try eassumption .. | intros; simpl ctx_inst_size in *; simpl branches_size in * ]; clear H end)).
+  all: lazymatch goal with
+       | [ |- _ < _ ] => lia || (simpl; lia)
+       | _ => idtac
+       end.
+  all: repeat match goal with H : Forall2 _ (_ :: _) (_ :: _) |- _ => depelim H end.
+  all: try assumption.
+  all: [ > unshelve eapply (@weakening_config_wf_local_sized cf1 cf2); [ eassumption | ] .. ].
+  all: intros; unshelve eapply IH; [ eassumption | ].
+  all: simpl in *; try lia.
+  all: cbn in *; try lia.
+  all: try assumption.
+  all: repeat match goal with
+         | [ |- context[All_local_env_size ?x ?y ?z ?w] ]
+           => let v := fresh in
+              set (v := All_local_env_size _ y z w) in *
+         end.
+  all: try lia.
+Qed.
+
+Lemma weakening_config_wf_local {cf1 cf2 : checker_flags} Σ Γ :
+  config.impl cf1 cf2
+  -> match cf1 with _ => wf_local Σ Γ end
+  -> match cf2 with _ => wf_local Σ Γ end.
+Proof.
+  intros Hcf H; eapply All_local_env_impl; [ eassumption | ].
+  intros * H'; eapply lift_typing_impl; [ eassumption | ].
+  intros *; eapply (@weakening_config cf1 cf2); assumption.
+Qed.
+
+Lemma weakening_config_wf {cf1 cf2 : checker_flags} Σ :
+  config.impl cf1 cf2
+  -> @wf cf1 Σ
+  -> @wf cf2 Σ.
+Proof.
+  rewrite /wf/Forall_decls_typing.
+  intros; eapply (@on_global_env_impl_config cf1 cf2); try eassumption.
+  { intros; eapply @lift_typing_impl; [ eassumption | ].
+    intros; eapply (@weakening_config cf1 cf2); eassumption. }
+  { intros; eapply (@weakening_config_cumulSpec0 cf1 cf2); eassumption. }
+Qed.

--- a/safechecker/theories/PCUICEqualityDec.v
+++ b/safechecker/theories/PCUICEqualityDec.v
@@ -223,7 +223,6 @@ Lemma Forall2_forallb2:
   Forall2 (fun x y : A => p x y) l l' -> forallb2 p l l'.
 Proof.
   induction 1; simpl; auto.
-  now rewrite H IHForall2.
 Qed.
 
 Lemma eqb_annot_spec {A} na na' : eqb_binder_annot na na' <-> @eq_binder_annot A A na na'.

--- a/utils/theories/MCUtils.v
+++ b/utils/theories/MCUtils.v
@@ -193,3 +193,15 @@ Ltac todo s := exact (todo s).
 
 From Coq Require Import Extraction.
 Extract Constant todo => "fun s -> failwith (Caml_bytestring.caml_string_of_bytestring s)".
+
+From Ltac2 Require Import Init.
+From Ltac2 Require Control Ltac1.
+
+Ltac2 gtry (tac : unit -> unit) :=
+  Control.plus tac (fun _ => ()).
+
+Ltac gtry tac :=
+  let f := ltac2:(tac |- gtry (fun () => Ltac1.run tac)) in
+  f tac.
+
+Tactic Notation "gtry" tactic3(tac) := gtry tac.


### PR DESCRIPTION
The motivation for this PR is related to having Gallina quotation functions.  In theory, we want to prove that the quoted terms we get out are well-typed under the most restrictive checker configuration possible, and then be able to weaken the typing theorem to less restrictive checker configurations without having to redo the work of proving well-typedness.  This PR will allow us to do this weakening systematically, in the same way that the PR allowing environment reordering allows us to systematically merge and weaken typing derivations across different environments.

On top of #836
