### PR TITLE
Add `tmLocateModule` and `tmLocateModType`

### DIFF
--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -144,10 +144,25 @@ let tmLocate (qualid : qualid) : global_reference list tm =
   fun ~st env evd success _fail ->
   let grs = Nametab.locate_all qualid in success ~st env evd grs
 
+let tmLocateModule (qualid : qualid) : Names.ModPath.t list tm =
+  fun ~st env evd success _fail ->
+  let mps = Nametab.locate_extended_all_module qualid in success ~st env evd mps
+
+let tmLocateModType (qualid : qualid) : Names.ModPath.t list tm =
+  fun ~st env evd success _fail ->
+  let mps = Nametab.locate_extended_all_modtype qualid in success ~st env evd mps
 
 let tmLocateString (s : string) : global_reference list tm =
   let id = Libnames.qualid_of_string s in
   tmLocate id
+
+let tmLocateModuleString (s : string) : Names.ModPath.t list tm =
+  let id = Libnames.qualid_of_string s in
+  tmLocateModule id
+
+let tmLocateModTypeString (s : string) : Names.ModPath.t list tm =
+  let id = Libnames.qualid_of_string s in
+  tmLocateModType id
 
 let tmCurrentModPath : Names.ModPath.t tm =
   fun ~st env evd success _fail ->

--- a/template-coq/src/plugin_core.mli
+++ b/template-coq/src/plugin_core.mli
@@ -54,7 +54,11 @@ val tmLemma : ident -> ?poly:bool -> term -> kername tm
 val tmFreshName : ident -> ident tm
 
 val tmLocate : qualid -> global_reference list tm
+val tmLocateModule : qualid -> Names.ModPath.t list tm
+val tmLocateModType : qualid -> Names.ModPath.t list tm
 val tmLocateString : string -> global_reference list tm
+val tmLocateModuleString : string -> Names.ModPath.t list tm
+val tmLocateModTypeString : string -> Names.ModPath.t list tm
 val tmCurrentModPath : Names.ModPath.t tm
 
 val tmQuoteInductive : kername -> (Names.MutInd.t * mutual_inductive_body) option tm

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -176,6 +176,8 @@ let dbg = function
   | Coq_tmLemma (nm, typ) -> "tmLemma"
   | Coq_tmFreshName nm -> "tmFreshName"
   | Coq_tmLocate id -> "tmLocate"
+  | Coq_tmLocateModule id -> "tmLocateModule"
+  | Coq_tmLocateModType id -> "tmLocateModType"
   | Coq_tmCurrentModPath -> "tmCurrentModPath"
   | Coq_tmQuoteInductive kn -> "tmQuoteInductive"
   | Coq_tmQuoteUniverses -> "tmQuoteUniverses"
@@ -216,8 +218,14 @@ let rec interp_tm (t : 'a coq_TM) : 'a tm =
   | Coq_tmLocate id ->
     tmMap (fun x -> Obj.magic (List.map quote_global_reference x))
           (tmLocate (to_qualid id))
+  | Coq_tmLocateModule id ->
+    tmMap (fun mp -> Obj.magic (List.map quote_modpath mp))
+          (tmLocateModule (to_qualid id))
+  | Coq_tmLocateModType id ->
+    tmMap (fun mp -> Obj.magic (List.map quote_modpath mp))
+          (tmLocateModType (to_qualid id))
   | Coq_tmCurrentModPath ->
-    tmMap (fun mp -> Obj.magic (quote_string (Names.ModPath.to_string mp)))
+    tmMap (fun mp -> Obj.magic (quote_modpath mp))
           tmCurrentModPath
   | Coq_tmQuoteInductive kn ->
     tmBind (tmQuoteInductive (unquote_kn kn))

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -482,6 +482,20 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
          let l = List.map quote_global_reference l in
          let l = to_coq_listl tglobal_reference l in
          k ~st env evm l)
+  | TmLocateModule id ->
+    let id = unquote_string (reduce_all env evm id) in
+    Plugin_core.run ~st (Plugin_core.tmLocateModuleString id) env evm
+      (fun ~st env evm l ->
+         let l = List.map quote_modpath l in
+         let l = to_coq_listl tmodpath l in
+         k ~st env evm l)
+  | TmLocateModType id ->
+    let id = unquote_string (reduce_all env evm id) in
+    Plugin_core.run ~st (Plugin_core.tmLocateModTypeString id) env evm
+      (fun ~st env evm l ->
+         let l = List.map quote_modpath l in
+         let l = to_coq_listl tmodpath l in
+         k ~st env evm l)
   | TmCurrentModPath ->
     let mp = Lib.current_mp () in
     let s = quote_modpath mp in

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -29,6 +29,8 @@ let (ptmReturn,
      ptmFreshName,
 
      ptmLocate,
+     ptmLocateModule,
+     ptmLocateModType,
      ptmCurrentModPath,
 
      ptmQuote,
@@ -68,6 +70,8 @@ let (ptmReturn,
    r_template_monad_prop_p "tmFreshName",
 
    r_template_monad_prop_p "tmLocate",
+   r_template_monad_prop_p "tmLocateModule",
+   r_template_monad_prop_p "tmLocateModType",
    r_template_monad_prop_p "tmCurrentModPath",
 
    r_template_monad_prop_p "tmQuote",
@@ -102,6 +106,8 @@ let (ttmReturn,
      ttmLemma,
      ttmFreshName,
      ttmLocate,
+     ttmLocateModule,
+     ttmLocateModType,
      ttmCurrentModPath,
      ttmQuoteInductive,
      ttmQuoteUniverses,
@@ -125,6 +131,8 @@ let (ttmReturn,
    r_template_monad_type_p "tmFreshName",
 
    r_template_monad_type_p "tmLocate",
+   r_template_monad_type_p "tmLocateModule",
+   r_template_monad_type_p "tmLocateModType",
    r_template_monad_type_p "tmCurrentModPath",
 
    r_template_monad_type_p "tmQuoteInductive",
@@ -166,6 +174,8 @@ type template_monad =
   | TmFreshName of Constr.t
 
   | TmLocate of Constr.t
+  | TmLocateModule of Constr.t
+  | TmLocateModType of Constr.t
   | TmCurrentModPath
 
     (* quoting *)
@@ -294,6 +304,16 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     | id::[] ->
        (TmLocate id, universes)
     | _ -> monad_failure "tmLocate" 1
+  else if eq_gr ptmLocateModule || eq_gr ttmLocateModule then
+    match args with
+    | id::[] ->
+       (TmLocateModule id, universes)
+    | _ -> monad_failure "tmLocateModule" 1
+  else if eq_gr ptmLocateModType || eq_gr ttmLocateModType then
+    match args with
+    | id::[] ->
+       (TmLocateModType id, universes)
+    | _ -> monad_failure "tmLocateModType" 1
   else if eq_gr ptmCurrentModPath then
     match args with
     | _::[] -> (TmCurrentModPath, universes)

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -34,6 +34,8 @@ type template_monad =
   | TmFreshName of Constr.t
 
   | TmLocate of Constr.t
+  | TmLocateModule of Constr.t
+  | TmLocateModType of Constr.t
   | TmCurrentModPath
 
     (* quoting *)

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -245,6 +245,8 @@ Register MetaCoq.Template.TemplateMonad.Core.tmMkDefinition as metacoq.templatem
 Register MetaCoq.Template.TemplateMonad.Core.tmMkInductive as metacoq.templatemonad.prop.tmMkInductive.
 Register MetaCoq.Template.TemplateMonad.Core.tmFreshName as metacoq.templatemonad.prop.tmFreshName.
 Register MetaCoq.Template.TemplateMonad.Core.tmLocate as metacoq.templatemonad.prop.tmLocate.
+Register MetaCoq.Template.TemplateMonad.Core.tmLocateModule as metacoq.templatemonad.prop.tmLocateModule.
+Register MetaCoq.Template.TemplateMonad.Core.tmLocateModType as metacoq.templatemonad.prop.tmLocateModType.
 Register MetaCoq.Template.TemplateMonad.Core.tmCurrentModPath as metacoq.templatemonad.prop.tmCurrentModPath.
 
 Register MetaCoq.Template.TemplateMonad.Core.tmQuote as metacoq.templatemonad.prop.tmQuote.
@@ -280,6 +282,8 @@ Register MetaCoq.Template.TemplateMonad.Extractable.tmAxiom as metacoq.templatem
 Register MetaCoq.Template.TemplateMonad.Extractable.tmLemma as metacoq.templatemonad.type.tmLemma.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmFreshName as metacoq.templatemonad.type.tmFreshName.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmLocate as metacoq.templatemonad.type.tmLocate.
+Register MetaCoq.Template.TemplateMonad.Extractable.tmLocateModule as metacoq.templatemonad.type.tmLocateModule.
+Register MetaCoq.Template.TemplateMonad.Extractable.tmLocateModType as metacoq.templatemonad.type.tmLocateModType.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmCurrentModPath as metacoq.templatemonad.type.tmCurrentModPath.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteInductive as metacoq.templatemonad.type.tmQuoteInductive.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteUniverses as metacoq.templatemonad.type.tmQuoteUniverses.

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -33,6 +33,8 @@ Record TMInstance@{t u r} :=
 ; tmFreshName : ident -> TemplateMonad ident
 
 ; tmLocate : qualid -> TemplateMonad (list global_reference)
+; tmLocateModule : qualid -> TemplateMonad (list modpath)
+; tmLocateModType : qualid -> TemplateMonad (list modpath)
 ; tmCurrentModPath : unit -> TemplateMonad modpath
 
 (* Quote the body of a definition or inductive. Its name need not be fully quaified *)

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -39,6 +39,8 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 (* Returns the list of globrefs corresponding to a qualid,
    the head is the default one if any. *)
 | tmLocate : qualid -> TemplateMonad (list global_reference)
+| tmLocateModule : qualid -> TemplateMonad (list modpath)
+| tmLocateModType : qualid -> TemplateMonad (list modpath)
 | tmCurrentModPath : unit -> TemplateMonad modpath
 
 (* Quoting and unquoting commands *)
@@ -98,6 +100,20 @@ Definition tmLocate1 (q : qualid) : TemplateMonad global_reference :=
   | x :: _ => tmReturn x
   end.
 
+Definition tmLocateModule1 (q : qualid) : TemplateMonad modpath :=
+  l <- tmLocateModule q ;;
+  match l with
+  | [] => tmFail ("Module [" ^ q ^ "] not found")
+  | x :: _ => tmReturn x
+  end.
+
+Definition tmLocateModType1 (q : qualid) : TemplateMonad modpath :=
+  l <- tmLocateModType q ;;
+  match l with
+  | [] => tmFail ("ModType [" ^ q ^ "] not found")
+  | x :: _ => tmReturn x
+  end.
+
 (** Don't remove. Constants used in the implem of the plugin *)
 Definition tmTestQuote {A} (t : A) := tmQuote t >>= tmPrint.
 
@@ -127,6 +143,8 @@ Definition TypeInstance : Common.TMInstance :=
    ; Common.tmFail:=@tmFail
    ; Common.tmFreshName:=@tmFreshName
    ; Common.tmLocate:=@tmLocate
+   ; Common.tmLocateModule:=@tmLocateModule
+   ; Common.tmLocateModType:=@tmLocateModType
    ; Common.tmCurrentModPath:=@tmCurrentModPath
    ; Common.tmQuoteInductive:=@tmQuoteInductive
    ; Common.tmQuoteUniverses:=@tmQuoteUniverses

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -42,6 +42,8 @@ Cumulative Inductive TM@{t} : Type@{t} -> Type :=
 | tmFreshName : ident -> TM ident
 
 | tmLocate : qualid -> TM (list global_reference)
+| tmLocateModule : qualid -> TM (list modpath)
+| tmLocateModType : qualid -> TM (list modpath)
 | tmCurrentModPath : TM modpath
 
 (* Quote the body of a definition or inductive. *)
@@ -69,6 +71,8 @@ Definition TypeInstance : Common.TMInstance :=
    ; Common.tmFail:=@tmFail
    ; Common.tmFreshName:=@tmFreshName
    ; Common.tmLocate:=@tmLocate
+   ; Common.tmLocateModule:=@tmLocateModule
+   ; Common.tmLocateModType:=@tmLocateModType
    ; Common.tmCurrentModPath:=fun _ => @tmCurrentModPath
    ; Common.tmQuoteInductive:=@tmQuoteInductive
    ; Common.tmQuoteUniverses:=@tmQuoteUniverses

--- a/test-suite/modules_sections.v
+++ b/test-suite/modules_sections.v
@@ -106,3 +106,10 @@ Module Y (A : X).
   MetaCoq Run (tmLocate1 "t''" >>= tmExistingInstance).
   Print Instances nat.
 End Y.
+
+MetaCoq Run (tmLocateModule1 "B" >>= tmPrint).
+MetaCoq Run (tmLocateModule1 "S" >>= tmPrint).
+MetaCoq Run (tmLocateModType1 "X" >>= tmPrint).
+Fail MetaCoq Run (tmLocateModType1 "B" >>= tmPrint).
+Fail MetaCoq Run (tmLocateModType1 "modules_sections.S" >>= tmPrint). (* finds (MPdot (MPfile ["FMapInterface"; "FSets"; "Coq"]) "S") if unqualified *)
+Fail MetaCoq Run (tmLocateModule1 "X" >>= tmPrint).


### PR DESCRIPTION
This is useful for scripting automation around, e.g., registering quotations for all the constants in a module, but not in the submodules of that module.

Fixes #852

Incidentally, this should also fix a segfault of the extractible monad using `tmCurrentModPath` (untested, see also
[zulip](https://coq.zulipchat.com/#narrow/stream/237658-MetaCoq/topic/segfaults.3F/near/336371390))