### PR TITLE
Fix and generalize module quotation

### DIFF
--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -55,6 +55,8 @@ struct
   type quoted_global_env = global_env
   type quoted_program = program
 
+  type quoted_hint_locality = Hints.hint_locality
+
   let mkAnon = Ast_quoter.mkAnon
   let mkName = Ast_quoter.mkName
   let mkRel = mkRel
@@ -153,6 +155,8 @@ struct
     evm, mkEvar (id, l)
 
   let unquote_bool (q : quoted_bool) : bool = q
+
+  let unquote_hint_locality (l : quoted_hint_locality) : Hints.hint_locality = l
   
   let unquote_int63 i = i
 

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -245,6 +245,9 @@ struct
   let (tcbv, tcbn, thnf, tall, tlazy, tunfold) =
     (template "cbv", template "cbn", template "hnf", template "all", template "lazy", template "unfold")
 
+  let (thints_local, thints_export, thints_global) =
+    (template "hints.local", template "hints.export", template "hints.global")
+
 
   let constr_equall h t = Constr.equal h (Lazy.force t)
 

--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -171,24 +171,18 @@ let quote_module (qualid : qualid) : global_reference list =
   let mb = Global.lookup_module mp in
   let rec aux mb =
     let open Declarations in
-    let me = mb.mod_expr in
-    let get_refs s =
-      let body = Modops.destr_nofunctor mp s in
+    match mb.mod_type with
+    | MoreFunctor (_, _, body) -> []
+    | NoFunctor body ->
       let get_ref (label, field) =
-        let open Names in 
+        let open Names in
         match field with
-        | SFBconst _ -> [GlobRef.ConstRef (Constant.make2 mp label)]
-        | SFBmind _ -> [GlobRef.IndRef (MutInd.make2 mp label, 0)]
+        | SFBconst _ -> [GlobRef.ConstRef (Constant.make2 mb.mod_mp label)]
+        | SFBmind _ -> [GlobRef.IndRef (MutInd.make2 mb.mod_mp label, 0)]
         | SFBmodule mb -> aux mb
         | SFBmodtype mtb -> []
       in
       CList.map_append get_ref body
-    in
-    match me with
-    | Abstract -> []
-    | Algebraic _ -> []
-    | Struct s -> get_refs s
-    | FullStruct -> get_refs mb.Declarations.mod_type
   in aux mb
 
 let tmQuoteModule (qualid : qualid) : global_reference list tm =

--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -260,10 +260,10 @@ let tmInductive (infer_univs : bool) (mie : mutual_inductive_entry) : unit tm =
     ignore (DeclareInd.declare_mutual_inductive_with_eliminations mie names []) ;
     success ~st (Global.env ()) evd ()
 
-let tmExistingInstance (gr : Names.GlobRef.t) : unit tm =
+let tmExistingInstance (locality : Hints.hint_locality) (gr : Names.GlobRef.t) : unit tm =
   fun ~st env evd success _fail ->
     let q = Libnames.qualid_of_path (Nametab.path_of_global gr) in
-    Classes.existing_instance Hints.Local q None;
+    Classes.existing_instance locality q None;
     success ~st env evd ()
 
 let tmInferInstance (typ : term) : term option tm =

--- a/template-coq/src/plugin_core.mli
+++ b/template-coq/src/plugin_core.mli
@@ -61,6 +61,8 @@ val tmQuoteInductive : kername -> (Names.MutInd.t * mutual_inductive_body) optio
 val tmQuoteUniverses : UGraph.t tm
 val tmQuoteConstant : kername -> bool -> constant_body tm
 val tmQuoteModule : qualid -> global_reference list tm
+val tmQuoteModFunctor : qualid -> global_reference list tm
+val tmQuoteModType : qualid -> global_reference list tm
 
 val tmInductive : bool -> mutual_inductive_entry -> unit tm
 

--- a/template-coq/src/plugin_core.mli
+++ b/template-coq/src/plugin_core.mli
@@ -64,5 +64,5 @@ val tmQuoteModule : qualid -> global_reference list tm
 
 val tmInductive : bool -> mutual_inductive_entry -> unit tm
 
-val tmExistingInstance : global_reference -> unit tm
+val tmExistingInstance : Hints.hint_locality -> global_reference -> unit tm
 val tmInferInstance : term -> term option tm

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -228,6 +228,10 @@ let rec interp_tm (t : 'a coq_TM) : 'a tm =
     tmMap (fun x -> failwith "tmQuoteUniverses") tmQuoteUniverses
   | Coq_tmQuoteModule id ->
     tmMap (fun x -> Obj.magic (List.map quote_global_reference x)) (tmQuoteModule (to_qualid id))
+  | Coq_tmQuoteModFunctor id ->
+    tmMap (fun x -> Obj.magic (List.map quote_global_reference x)) (tmQuoteModFunctor (to_qualid id))
+  | Coq_tmQuoteModType id ->
+    tmMap (fun x -> Obj.magic (List.map quote_global_reference x)) (tmQuoteModType (to_qualid id))
   | Coq_tmQuoteConstant (kn, b) ->
     tmBind (tmQuoteConstant (unquote_kn kn) b)
            (fun x -> Obj.magic (tmOfConstantBody x))

--- a/template-coq/src/run_extractable.ml
+++ b/template-coq/src/run_extractable.ml
@@ -181,7 +181,7 @@ let dbg = function
   | Coq_tmQuoteUniverses -> "tmQuoteUniverses"
   | Coq_tmQuoteConstant (kn, b) -> "tmQuoteConstant"
   | Coq_tmInductive i -> "tmInductive"
-  | Coq_tmExistingInstance k -> "tmExistingInstance"
+  | Coq_tmExistingInstance (l, k) -> "tmExistingInstance"
   | Coq_tmInferInstance t -> "tmInferInstance"
 *)
 
@@ -233,8 +233,8 @@ let rec interp_tm (t : 'a coq_TM) : 'a tm =
            (fun x -> Obj.magic (tmOfConstantBody x))
   | Coq_tmInductive (inferu, i) ->
     tmMap (fun _ -> Obj.magic ()) (tmInductive (unquote_bool inferu) (to_mie i))
-  | Coq_tmExistingInstance k ->
-    Obj.magic (tmExistingInstance (unquote_global_reference k))
+  | Coq_tmExistingInstance (locality, k) ->
+    Obj.magic (tmExistingInstance (unquote_hint_locality locality) (unquote_global_reference k))
   | Coq_tmInferInstance t ->
     tmBind (tmInferInstance (to_constr t))
       (function

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -471,6 +471,20 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
          let l = List.map quote_global_reference l in
          let l = to_coq_listl tglobal_reference l in
          k ~st env evm l)
+  | TmQuoteModFunctor id ->
+    let id = unquote_string (reduce_all env evm id) in
+    Plugin_core.run ~st (Plugin_core.tmQuoteModFunctor (Libnames.qualid_of_string id)) env evm
+      (fun ~st env evm l ->
+         let l = List.map quote_global_reference l in
+         let l = to_coq_listl tglobal_reference l in
+         k ~st env evm l)
+  | TmQuoteModType id ->
+    let id = unquote_string (reduce_all env evm id) in
+    Plugin_core.run ~st (Plugin_core.tmQuoteModType (Libnames.qualid_of_string id)) env evm
+      (fun ~st env evm l ->
+         let l = List.map quote_global_reference l in
+         let l = to_coq_listl tglobal_reference l in
+         k ~st env evm l)
   | TmPrint trm ->
     Feedback.msg_info (Printer.pr_constr_env env evm trm);
     k ~st env evm (Lazy.force unit_tt)

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -15,7 +15,6 @@ open Template_monad
 let reduce_all env evm trm =
   EConstr.to_constr evm (Reductionops.nf_all env evm (EConstr.of_constr trm))
 
-
 let unquote_reduction_strategy env evm trm (* of type reductionStrategy *) : Redexpr.red_expr =
   let (trm, args) = app_full trm [] in
   (* from g_tactic.ml4 *)
@@ -33,6 +32,13 @@ let unquote_reduction_strategy env evm trm (* of type reductionStrategy *) : Red
        Unfold [Locus.AllOccurrences, Tacred.evaluable_of_global_reference env (GlobRef.ConstRef (Constant.make1 name))]
     | _ -> bad_term_verb trm "unquote_reduction_strategy"
   else not_supported_verb trm "unquote_reduction_strategy"
+
+let unquote_hint_locality env evm trm (* of type Hints.hint_locality *) : Hints.hint_locality =
+  let (trm, args) = app_full trm [] in
+  if constr_equall trm thints_local then Hints.Local
+  else if constr_equall trm thints_export then Hints.Export
+  else if constr_equall trm thints_global then Hints.SuperGlobal
+  else not_supported_verb trm "unquote_hint_locality"
 
 let denote_mind_entry_finite trm =
   let (h,args) = app_full trm [] in
@@ -531,12 +537,13 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
     let name = reduce_all env evm name in
     let name' = Namegen.next_ident_away_from (unquote_ident name) (fun id -> Nametab.exists_cci (Lib.make_path id)) in
     k ~st env evm (quote_ident name')
-  | TmExistingInstance gr ->
+  | TmExistingInstance (locality, gr) ->
+    let locality = reduce_all env evm locality in
+    let locality = unquote_hint_locality env evm locality in
     let gr = reduce_all env evm gr in
     let gr = unquote_global_reference gr in
-    let q = Libnames.qualid_of_path (Nametab.path_of_global gr) in
-    Classes.existing_instance Hints.SuperGlobal q None;
-    k ~st env evm (Lazy.force unit_tt)
+    Plugin_core.run ~st (Plugin_core.tmExistingInstance locality gr) env evm
+      (fun ~st env evm () -> k ~st env evm (Lazy.force unit_tt))
   | TmInferInstance (s, typ) ->
     begin
       let evm, typ =

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -180,7 +180,7 @@ type template_monad =
   | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
 
     (* typeclass resolution *)
-  | TmExistingInstance of Constr.t
+  | TmExistingInstance of Constr.t * Constr.t
   | TmInferInstance of Constr.t * Constr.t (* only Prop *)
   | TmInferInstanceTerm of Constr.t        (* only Extractable *)
 
@@ -372,9 +372,9 @@ let next_action env evd (pgm : constr) : template_monad * _ =
 
   else if eq_gr ptmExistingInstance || eq_gr ttmExistingInstance then
     match args with
-    | name :: [] ->
-       (TmExistingInstance name, universes)
-    | _ -> monad_failure "tmExistingInstance" 1
+    | locality :: name :: [] ->
+       (TmExistingInstance (locality, name), universes)
+    | _ -> monad_failure "tmExistingInstance" 2
   else if eq_gr ptmInferInstance then
     match args with
     | s :: typ :: [] ->

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -37,6 +37,8 @@ let (ptmReturn,
      ptmQuoteConstant,
      ptmQuoteUniverses,
      ptmQuoteModule,
+     ptmQuoteModFunctor,
+     ptmQuoteModType,
 
      ptmUnquote,
      ptmUnquoteTyped,
@@ -76,6 +78,8 @@ let (ptmReturn,
    r_template_monad_prop_p "tmQuoteConstant",
    r_template_monad_prop_p "tmQuoteUniverses",
    r_template_monad_prop_p "tmQuoteModule",
+   r_template_monad_prop_p "tmQuoteModFunctor",
+   r_template_monad_prop_p "tmQuoteModType",
 
    r_template_monad_prop_p "tmUnquote",
    r_template_monad_prop_p "tmUnquoteTyped",
@@ -106,6 +110,8 @@ let (ttmReturn,
      ttmQuoteInductive,
      ttmQuoteUniverses,
      ttmQuoteModule,
+     ttmQuoteModFunctor,
+     ttmQuoteModType,
      ttmQuoteConstant,
      ttmInductive,
      ttmInferInstance,
@@ -130,6 +136,8 @@ let (ttmReturn,
    r_template_monad_type_p "tmQuoteInductive",
    r_template_monad_type_p "tmQuoteUniverses",
    r_template_monad_type_p "tmQuoteModule",
+   r_template_monad_type_p "tmQuoteModFunctor",
+   r_template_monad_type_p "tmQuoteModType",
    r_template_monad_type_p "tmQuoteConstant",
 
    r_template_monad_type_p "tmInductive",
@@ -175,6 +183,8 @@ type template_monad =
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
   | TmQuoteModule of Constr.t
+  | TmQuoteModFunctor of Constr.t
+  | TmQuoteModType of Constr.t
 
   | TmUnquote of Constr.t                   (* only Prop *)
   | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
@@ -336,6 +346,16 @@ let next_action env evd (pgm : constr) : template_monad * _ =
     | [id] ->
        (TmQuoteModule id, universes)
     | _ -> monad_failure "tmQuoteModule" 0
+  else if eq_gr ptmQuoteModFunctor || eq_gr ttmQuoteModFunctor then
+    match args with
+    | [id] ->
+       (TmQuoteModFunctor id, universes)
+    | _ -> monad_failure "tmQuoteModFunctor" 0
+  else if eq_gr ptmQuoteModType || eq_gr ttmQuoteModType then
+    match args with
+    | [id] ->
+       (TmQuoteModType id, universes)
+    | _ -> monad_failure "tmQuoteModType" 0
   else if eq_gr ptmQuoteConstant then
     match args with
     | name::bypass::[] ->

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -43,6 +43,8 @@ type template_monad =
   | TmQuoteConst of Constr.t * Constr.t * bool (* strict *)
   | TmQuoteUnivs
   | TmQuoteModule of Constr.t
+  | TmQuoteModFunctor of Constr.t
+  | TmQuoteModType of Constr.t
 
   | TmUnquote of Constr.t                   (* only Prop *)
   | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)

--- a/template-coq/src/template_monad.mli
+++ b/template-coq/src/template_monad.mli
@@ -48,7 +48,7 @@ type template_monad =
   | TmUnquoteTyped of Constr.t * Constr.t (* only Prop *)
 
     (* typeclass resolution *)
-  | TmExistingInstance of Constr.t
+  | TmExistingInstance of Constr.t * Constr.t
   | TmInferInstance of Constr.t * Constr.t (* only Prop *)
   | TmInferInstanceTerm of Constr.t        (* only Extractable *)
 

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -230,6 +230,11 @@ Register MetaCoq.Template.TemplateMonad.Common.all as metacoq.template.all.
 Register MetaCoq.Template.TemplateMonad.Common.lazy as metacoq.template.lazy.
 Register MetaCoq.Template.TemplateMonad.Common.unfold as metacoq.template.unfold.
 
+Register MetaCoq.Template.TemplateMonad.Common.local as metacoq.template.hints.local.
+Register MetaCoq.Template.TemplateMonad.Common.export as metacoq.template.hints.export.
+Register MetaCoq.Template.TemplateMonad.Common.global as metacoq.template.hints.global.
+
+
 (* Prop *)
 Register MetaCoq.Template.TemplateMonad.Core.tmReturn as metacoq.templatemonad.prop.tmReturn.
 Register MetaCoq.Template.TemplateMonad.Core.tmBind as metacoq.templatemonad.prop.tmBind.

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -259,6 +259,8 @@ Register MetaCoq.Template.TemplateMonad.Core.tmQuoteInductive as metacoq.templat
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteConstant as metacoq.templatemonad.prop.tmQuoteConstant.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteUniverses as metacoq.templatemonad.prop.tmQuoteUniverses.
 Register MetaCoq.Template.TemplateMonad.Core.tmQuoteModule as metacoq.templatemonad.prop.tmQuoteModule.
+Register MetaCoq.Template.TemplateMonad.Core.tmQuoteModFunctor as metacoq.templatemonad.prop.tmQuoteModFunctor.
+Register MetaCoq.Template.TemplateMonad.Core.tmQuoteModType as metacoq.templatemonad.prop.tmQuoteModType.
 
 Register MetaCoq.Template.TemplateMonad.Core.tmUnquote as metacoq.templatemonad.prop.tmUnquote.
 Register MetaCoq.Template.TemplateMonad.Core.tmUnquoteTyped as metacoq.templatemonad.prop.tmUnquoteTyped.
@@ -290,6 +292,8 @@ Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteInductive as metacoq.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteUniverses as metacoq.templatemonad.type.tmQuoteUniverses.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteConstant as metacoq.templatemonad.type.tmQuoteConstant.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteModule as metacoq.templatemonad.type.tmQuoteModule.
+Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteModFunctor as metacoq.templatemonad.type.tmQuoteModFunctor.
+Register MetaCoq.Template.TemplateMonad.Extractable.tmQuoteModType as metacoq.templatemonad.type.tmQuoteModType.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmInductive as metacoq.templatemonad.type.tmInductive.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmInferInstance as metacoq.templatemonad.type.tmInferInstance.
 Register MetaCoq.Template.TemplateMonad.Extractable.tmExistingInstance as metacoq.templatemonad.type.tmExistingInstance.

--- a/template-coq/theories/Extraction.v
+++ b/template-coq/theories/Extraction.v
@@ -26,6 +26,7 @@ From MetaCoq.Template Require Import TemplateMonad.Extractable Induction
      LiftSubst UnivSubst Pretty TemplateProgram.
 Import Init.Nat.
 
+Extract Inductive Common.hint_locality => "Hints.hint_locality" ["Hints.Local" "Hints.Export" "Hints.SuperGlobal"].
 Extract Constant Typing.guard_checking => "{ fix_guard = (fun _ _ _ -> true); cofix_guard = (fun _ _ _ -> true) }".
 
 Cd "gen-src".

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -10,6 +10,9 @@ Local Set Universe Polymorphism.
 Monomorphic Variant reductionStrategy : Set :=
   cbv | cbn | hnf | all | lazy | unfold (i : kername).
 
+Monomorphic Variant hint_locality : Set :=
+  local | export | global.
+
 Record typed_term : Type := existT_typed_term
 { my_projT1 : Type
 ; my_projT2 : my_projT1
@@ -43,7 +46,7 @@ Record TMInstance@{t u r} :=
 (* FIXME take an optional universe context as well *)
 ; tmMkInductive : bool (* infer universes? *) -> mutual_inductive_entry -> TemplateMonad unit
 (* Typeclass registration and querying for an instance *)
-; tmExistingInstance : global_reference -> TemplateMonad unit
+; tmExistingInstance : hint_locality -> global_reference -> TemplateMonad unit
 }.
 
 Monomorphic Variant import_status : Set :=

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -60,8 +60,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmUnquoteTyped : forall A : Type@{t}, Ast.term -> TemplateMonad A
 
 (* Typeclass registration and querying for an instance *)
-(* Rk: This is *Global* Existing Instance, not Local *)
-| tmExistingInstance : global_reference -> TemplateMonad unit
+| tmExistingInstance : hint_locality -> global_reference -> TemplateMonad unit
 | tmInferInstance : option reductionStrategy -> forall A : Type@{t}, TemplateMonad (option_instance A)
 .
 

--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -53,6 +53,8 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 | tmQuoteUniverses : TemplateMonad ConstraintSet.t
 | tmQuoteConstant : kername -> bool (* bypass opacity? *) -> TemplateMonad constant_body
 | tmQuoteModule : qualid -> TemplateMonad (list global_reference)
+| tmQuoteModFunctor : qualid -> TemplateMonad (list global_reference)
+| tmQuoteModType : qualid -> TemplateMonad (list global_reference)
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)
 | tmMkInductive : bool -> mutual_inductive_entry -> TemplateMonad unit

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -51,6 +51,8 @@ Cumulative Inductive TM@{t} : Type@{t} -> Type :=
   : TM constant_body
 | tmQuoteUniverses : TM ConstraintSet.t
 | tmQuoteModule : qualid -> TM (list global_reference)
+| tmQuoteModFunctor : qualid -> TM (list global_reference)
+| tmQuoteModType : qualid -> TM (list global_reference)
 
 (* unquote before making the definition *)
 (* FIXME take an optional universe context as well *)

--- a/template-coq/theories/TemplateMonad/Extractable.v
+++ b/template-coq/theories/TemplateMonad/Extractable.v
@@ -57,7 +57,7 @@ Cumulative Inductive TM@{t} : Type@{t} -> Type :=
 | tmInductive : bool -> mutual_inductive_entry -> TM unit
 
 (* Typeclass registration and querying for an instance *)
-| tmExistingInstance : global_reference -> TM unit
+| tmExistingInstance : hint_locality -> global_reference -> TM unit
 | tmInferInstance (type : Ast.term)
   : TM (option Ast.term)
 .

--- a/test-suite/modules_sections.v
+++ b/test-suite/modules_sections.v
@@ -90,19 +90,19 @@ Module Type X.
   Parameter t' : nat.
   Parameter t'' : nat.
   Print Instances nat.
-  MetaCoq Run (tmLocate1 "t" >>= tmExistingInstance).
-  MetaCoq Run (tmLocate1 "t'" >>= tmExistingInstance).
+  MetaCoq Run (tmLocate1 "t" >>= tmExistingInstance global).
+  MetaCoq Run (tmLocate1 "t'" >>= tmExistingInstance global).
   Print Instances nat.
 End X.
 
 Section XX.
   Variable u : nat.
-  Fail MetaCoq Run (tmLocate1 "u" >>= tmExistingInstance).
+  Fail MetaCoq Run (tmLocate1 "u" >>= tmExistingInstance global).
   Print Instances nat.
 End XX.
 
 Module Y (A : X).
   Print Instances nat.
-  MetaCoq Run (tmLocate1 "t''" >>= tmExistingInstance).
+  MetaCoq Run (tmLocate1 "t''" >>= tmExistingInstance global).
   Print Instances nat.
 End Y.

--- a/test-suite/tmExistingInstance.v
+++ b/test-suite/tmExistingInstance.v
@@ -4,11 +4,9 @@ Import MCMonadNotation.
 
 MetaCoq Run (tmLocate1 "I" >>= tmDefinition "qI").
 
-Fail MetaCoq Run (tmExistingInstance qI).
+Fail MetaCoq Run (tmExistingInstance global qI).
 
 Existing Class True.
 
-MetaCoq Run (tmExistingInstance qI).
+MetaCoq Run (tmExistingInstance global qI).
 Print Instances True.
-
-

--- a/test-suite/tmQuoteModule.v
+++ b/test-suite/tmQuoteModule.v
@@ -6,5 +6,29 @@ Module Foo.
   Definition t := nat.
 End Foo.
 
-MetaCoq Run (tmQuoteModule "Foo"%bs).
-MetaCoq Run (tmQuoteModule "Datatypes"%bs).
+MetaCoq Run (tmQuoteModule "Foo"%bs >>= tmPrint).
+MetaCoq Run (tmQuoteModule "Datatypes"%bs >>= tmPrint).
+
+Module Type Typ. Axiom t : Type. End Typ.
+
+Module Outer.
+  Module Inner.
+    Definition t := nat.
+  End Inner.
+  Definition t := bool.
+  Module Type InnerT.
+    Axiom t : Set.
+  End InnerT.
+  Module InnerF (T : Typ).
+    Axiom t : Set.
+  End InnerF.
+End Outer.
+
+MetaCoq Run (m <- tmQuoteModule "Outer"%bs;; _ <- tmPrint m;; match m ==
+                                               [ConstRef
+   (MPdot (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs) "Inner"%bs,
+    "t"%bs);
+ ConstRef (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs, "t"%bs)]%list with true
+                                               => ret tt
+                                                              | _ => tmFail "bad"%bs
+                                                              end).

--- a/test-suite/tmQuoteModule.v
+++ b/test-suite/tmQuoteModule.v
@@ -32,3 +32,32 @@ MetaCoq Run (m <- tmQuoteModule "Outer"%bs;; _ <- tmPrint m;; match m ==
                                                => ret tt
                                                               | _ => tmFail "bad"%bs
                                                               end).
+(** currently QuoteModFunctor means "include functors", maybe it should mean something else? *)
+MetaCoq Run (m <- tmQuoteModFunctor "Outer"%bs;; _ <- tmPrint m;; match m ==
+                                   [ConstRef
+   (MPdot (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs) "Inner"%bs,
+    "t"%bs);
+ ConstRef (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs, "t"%bs);
+ ConstRef
+   (MPdot (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs) "InnerF"%bs,
+    "t"%bs)]%list
+ with true
+                                               => ret tt
+                                                              | _ => tmFail "bad"%bs
+                                                                  end).
+(** currently QuoteModType means "include functors and types", but maybe it should mean something else? *)
+MetaCoq Run (m <- tmQuoteModType "Outer"%bs;; _ <- tmPrint m;; match m ==
+[ConstRef
+   (MPdot (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs) "Inner"%bs,
+    "t"%bs);
+ ConstRef (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs, "t"%bs);
+ ConstRef
+   (MPdot (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs) "InnerT"%bs,
+    "t"%bs);
+ ConstRef
+   (MPdot (MPdot (MPfile ["tmQuoteModule"%bs; "TestSuite"%bs; "MetaCoq"%bs]) "Outer"%bs) "InnerF"%bs,
+    "t"%bs)]%list
+ with true
+                                               => ret tt
+                                                              | _ => tmFail "bad"%bs
+                                                              end).


### PR DESCRIPTION
Fixes #847
Fixes #850

Currently `tmQuoteModFunctor` means "include functors", maybe it should mean something else?
Currently `tmQuoteModType` means "include functors and types", but maybe it should mean something else?  (I want to be able to quote a module functor type signature so that I can automate the generation of another module type.)

Edit: I don't actually need to be able to quote module functors and types, so if y'all'd rather I remove the ability to quote functors and module types, I'm happy to update this to only fix module quotation.