### PR TITLE
Add `.github/dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This will ensure that dependabot will automatically open PRs updating the CI configuration so we don't need to make PRs like https://github.com/MetaCoq/metacoq/pull/866 manually.