### PR TITLE
Fix safechecker plugin install

### DIFF
--- a/coq-metacoq-safechecker-plugin.opam
+++ b/coq-metacoq-safechecker-plugin.opam
@@ -28,6 +28,7 @@ install: [
 ]
 depends: [
   "coq-metacoq-template-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
 ]
 synopsis: "Implementation and verification of an erasure procedure for Coq"
 description: """

--- a/coq-metacoq-template-pcuic.opam
+++ b/coq-metacoq-template-pcuic.opam
@@ -30,6 +30,6 @@ depends: [
   "coq-metacoq-template" {= version}
   "coq-metacoq-pcuic" {= version}
 ]
-synopsis: "Translations between Template Coq and PCUIC and proofs of correctness."
+synopsis: "Translations between Template Coq and PCUIC and proofs of correctness"
 description: """
 """


### PR DESCRIPTION
`opam install` fails on the `coq-8.16` branch because the `coq-metacoq-safechecker-plugin` package doesn't depend on `coq-metacoq-safechecker`.