### PR TITLE
Add `Set MetaCoq Template Monad Debug`

### DIFF
--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -155,6 +155,41 @@ let (ttmReturn,
 
 type constr = Constr.t
 
+module Debug : sig
+  val ppdebug : int -> (unit -> Pp.t) -> unit
+end = struct
+  let template_monad_debug = ref 0
+
+  let set_template_monad_debug d = (:=) template_monad_debug (if d then 1 else 0)
+  let get_template_monad_debug () = if !template_monad_debug > 0 then true else false
+
+  let set_template_monad_verbose = function
+    | None -> template_monad_debug := 0
+    | Some n -> template_monad_debug := n
+  let get_template_monad_verbose () =
+    if !template_monad_debug = 0 then None else Some !template_monad_debug
+
+  let () =
+    let open Goptions in
+    declare_bool_option
+      { optdepr  = false;
+        optkey   = ["MetaCoq";"Template";"Monad";"Debug"];
+        optread  = get_template_monad_debug;
+        optwrite = set_template_monad_debug; }
+
+  let () =
+    let open Goptions in
+    declare_int_option
+      { optdepr  = false;
+        optkey   = ["MetaCoq";"Template";"Monad";"Debug";"Verbosity"];
+        optread  = get_template_monad_verbose;
+        optwrite = set_template_monad_verbose; }
+
+  let ppdebug lvl pp =
+    if !template_monad_debug > lvl then Feedback.msg_debug (pp ())
+end
+open Debug
+
 type template_monad =
     TmReturn of Constr.t
   | TmBind  of Constr.t * Constr.t
@@ -216,7 +251,9 @@ let monad_failure s k =
                           str "Please file a bug with MetaCoq.")
 
 let next_action env evd (pgm : constr) : template_monad * _ =
+  let () = ppdebug 1 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to reduce " ++ Printer.pr_constr_env env evd pgm)) in
   let pgm = Reduction.whd_all env pgm in
+  let () = ppdebug 0 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to run " ++ Printer.pr_constr_env env evd pgm)) in
   let (coConstr, args) = app_full pgm [] in
   let (glob_ref, universes) =
     try

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -251,7 +251,7 @@ let monad_failure s k =
                           str "Please file a bug with MetaCoq.")
 
 let next_action env evd (pgm : constr) : template_monad * _ =
-  let () = ppdebug 2 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to reduce " ++ Printer.pr_constr_env env evd pgm)) in
+  let () = ppdebug 2 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to reduce " ++ fnl () ++ Printer.pr_constr_env env evd pgm)) in
   let pgm = Reduction.whd_all env pgm in
   let (coConstr, args) = app_full pgm [] in
   let (glob_ref, universes) =
@@ -274,7 +274,7 @@ let next_action env evd (pgm : constr) : template_monad * _ =
        (TmBind (a, f), universes)
     | _ -> monad_failure "tmBind" 4
   else
-    let () = ppdebug 0 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to run " ++ Printer.pr_constr_env env evd pgm)) in
+    let () = ppdebug 0 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to run:" ++ fnl () ++ Printer.pr_constr_env env evd pgm)) in
     if eq_gr ptmReturn || eq_gr ttmReturn then
       match args with
       | _::h::[] ->

--- a/template-coq/src/template_monad.ml
+++ b/template-coq/src/template_monad.ml
@@ -251,7 +251,7 @@ let monad_failure s k =
                           str "Please file a bug with MetaCoq.")
 
 let next_action env evd (pgm : constr) : template_monad * _ =
-  let () = ppdebug 1 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to reduce " ++ Printer.pr_constr_env env evd pgm)) in
+  let () = ppdebug 2 (fun () -> Pp.(str "MetaCoq: TemplateProgram: Going to reduce " ++ Printer.pr_constr_env env evd pgm)) in
   let pgm = Reduction.whd_all env pgm in
   let (coConstr, args) = app_full pgm [] in
   let (glob_ref, universes) =
@@ -268,7 +268,7 @@ let next_action env evd (pgm : constr) : template_monad * _ =
   in
   let eq_gr t = Names.GlobRef.equal glob_ref (Lazy.force t) in
   if eq_gr ptmBind || eq_gr ttmBind then
-    let () = ppdebug 0 (fun () -> Pp.(str "MetaCoq: TemplateProgram: processing tmBind")) in
+    let () = ppdebug 1 (fun () -> Pp.(str "MetaCoq: TemplateProgram: processing tmBind")) in
     match args with
     | _::_::a::f::[] ->
        (TmBind (a, f), universes)


### PR DESCRIPTION
Also `Set MetaCoq Template Monad Debug Verbosity {0,1,2,3}`.  Copied from the analogous typeclass debug options.

Fixes #878
