### PR TITLE
Make Monad a cumulative inductive type

### DIFF
--- a/utils/theories/monad_utils.v
+++ b/utils/theories/monad_utils.v
@@ -6,6 +6,7 @@ Coercion is_true : bool >-> Sortclass.
 Import ListNotations.
 
 Set Universe Polymorphism.
+Set Polymorphic Inductive Cumulativity.
 
 Class Monad@{d c} (m : Type@{d} -> Type@{c}) : Type :=
 { ret : forall {t : Type@{d}}, t -> m t


### PR DESCRIPTION
For the work I'm doing on Gallina quotation, I either need this or I need
```diff
diff --git a/template-coq/theories/TemplateMonad/Core.v b/template-coq/theories/TemplateMonad/Core.v
index a463141c..472409b4 100644
--- a/template-coq/theories/TemplateMonad/Core.v
+++ b/template-coq/theories/TemplateMonad/Core.v
@@ -69,7 +69,7 @@ Cumulative Inductive TemplateMonad@{t u} : Type@{t} -> Prop :=
 .

 (** This allow to use notations of MonadNotation *)
-Global Instance TemplateMonad_Monad@{t u} : Monad@{t u} TemplateMonad@{t u} :=
+Global Instance TemplateMonad_Monad@{t u t' u'} : Monad@{t' u'} TemplateMonad@{t u} :=
   {| ret := @tmReturn ; bind := @tmBind |}.

 Polymorphic Definition tmDefinitionRed
```

I figured polymorphic cumulativity is a bit more general and future-proof.