### PR TITLE
Make `option_instance` universe polymorphic

### DIFF
--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -87,8 +87,8 @@ struct
   let cposI = resolve "metacoq.pos.xI"
   let cposO = resolve "metacoq.pos.xO"
 
-  let cSome_instance = resolve "metacoq.option_instance.some"
-  let cNone_instance = resolve "metacoq.option_instance.none"
+  let cSome_instance = resolve_ref "metacoq.option_instance.some"
+  let cNone_instance = resolve_ref "metacoq.option_instance.none"
 
   let unit_tt = resolve "metacoq.unit.intro"
 

--- a/template-coq/src/run_template_monad.ml
+++ b/template-coq/src/run_template_monad.ml
@@ -582,9 +582,12 @@ let rec run_template_program_rec ~poly ?(intactic=false) (k : Constr.t Plugin_co
         | None -> evm, typ in
       try
         let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
-        k ~st env evm (constr_mkApp (cSome_instance, [| typ; EConstr.to_constr evm t|]))
+        let (evm, cSome_instance) = Evd.fresh_global env evm (Lazy.force cSome_instance) in
+        k ~st env evm (Constr.mkApp (EConstr.to_constr evm cSome_instance, [| typ; EConstr.to_constr evm t|]))
       with
-        Not_found -> k ~st env evm (constr_mkApp (cNone_instance, [|typ|]))
+        Not_found ->
+        let (evm, cNone_instance) = Evd.fresh_global env evm (Lazy.force cNone_instance) in
+        k ~st env evm (Constr.mkApp (EConstr.to_constr evm cNone_instance, [|typ|]))
     end
   | TmInferInstanceTerm typ ->
     let evm,typ = denote_term env evm (reduce_all env evm typ) in

--- a/template-coq/theories/TemplateMonad/Common.v
+++ b/template-coq/theories/TemplateMonad/Common.v
@@ -18,7 +18,7 @@ Record typed_term : Type := existT_typed_term
 ; my_projT2 : my_projT1
 }.
 
-Monomorphic Inductive option_instance (A : Type) : Type := my_Some : A -> option_instance A | my_None : option_instance A.
+Inductive option_instance (A : Type) : Type := my_Some : A -> option_instance A | my_None : option_instance A.
 
 Arguments Some {A} a.
 Arguments None {A}.


### PR DESCRIPTION
Needed for ease of universes in gallina quotation.

I guess the monad running code will need some sort of adaptation?