### PR TITLE
Finish Gallina quotation to Template, inlcuding TypingWf

### DIFF
--- a/quotation/_CoqProject.in
+++ b/quotation/_CoqProject.in
@@ -88,6 +88,7 @@ theories/ToTemplate/Template/LiftSubst.v
 theories/ToTemplate/Template/ReflectAst.v
 theories/ToTemplate/Template/TermEquality.v
 theories/ToTemplate/Template/Typing.v
+theories/ToTemplate/Template/TypingWf.v
 theories/ToTemplate/Template/UnivSubst.v
 theories/ToTemplate/Template/WfAst.v
 theories/ToTemplate/Utils/All_Forall.v

--- a/quotation/theories/CommonUtils.v
+++ b/quotation/theories/CommonUtils.v
@@ -1,3 +1,4 @@
+From MetaCoq.Template Require TypingWf. (* Kludge to avoid universe inconsistencies that arise when this file is required later, things like Error: Universe inconsistency. Cannot enforce Coq.Init.Datatypes.26 < replace_quotation_of.u0 because replace_quotation_of.u0 <= MetaCoq.Template.MonadAst.6 <= prod.u0 = Coq.Init.Datatypes.26. *)
 From MetaCoq.Utils Require Import utils monad_utils MCList.
 From MetaCoq.Common Require Import Kernames MonadBasicAst.
 From MetaCoq.Template Require MonadAst TemplateMonad Ast Loader.

--- a/quotation/theories/CommonUtils.v
+++ b/quotation/theories/CommonUtils.v
@@ -1,4 +1,3 @@
-From MetaCoq.Template Require TypingWf. (* Kludge to avoid universe inconsistencies that arise when this file is required later, things like Error: Universe inconsistency. Cannot enforce Coq.Init.Datatypes.26 < replace_quotation_of.u0 because replace_quotation_of.u0 <= MetaCoq.Template.MonadAst.6 <= prod.u0 = Coq.Init.Datatypes.26. *)
 From MetaCoq.Utils Require Import utils monad_utils MCList.
 From MetaCoq.Common Require Import Kernames MonadBasicAst.
 From MetaCoq.Template Require MonadAst TemplateMonad Ast Loader.

--- a/quotation/theories/ToTemplate/All.v
+++ b/quotation/theories/ToTemplate/All.v
@@ -1,7 +1,7 @@
 From MetaCoq.Common Require Import config.
 From MetaCoq.Template Require Import Ast Typing.
-From MetaCoq.Template Require WfAst (*WfTyping*).
-From MetaCoq.Quotation.ToTemplate.Template Require Ast Typing WfAst (*WfTyping*).
+From MetaCoq.Template Require WfAst TypingWf.
+From MetaCoq.Quotation.ToTemplate.Template Require Ast Typing WfAst TypingWf.
 
 (* without typing derivations *)
 Module Raw.
@@ -14,7 +14,7 @@ Module Raw.
   Module WfAst.
     Definition quote_wf {Σ t} : @WfAst.wf Σ t -> Ast.term := WfAst.quote_wf.
   End WfAst.
-  (* TODO: do we want anything from WfTyping? Is there anything else missing here? *)
+  (* TODO: do we want anything from TypingWf? Is there anything else missing here? *)
 End Raw.
 
 (* eventually we'll have proofs that the above definitions are well-typed *)

--- a/quotation/theories/ToTemplate/Template/TypingWf.v
+++ b/quotation/theories/ToTemplate/Template/TypingWf.v
@@ -1,0 +1,8 @@
+From MetaCoq.Template Require Import TypingWf.
+From MetaCoq.Quotation.ToTemplate Require Import Init.
+From MetaCoq.Quotation.ToTemplate Require Import (hints) Coq.Init.
+From MetaCoq.Quotation.ToTemplate.Utils Require Import (hints) All_Forall.
+From MetaCoq.Quotation.ToTemplate.Common Require Import (hints) BasicAst.
+From MetaCoq.Quotation.ToTemplate.Template Require Import (hints) Ast WfAst.
+
+#[export] Instance quote_wf_inductive_body {Σ idecl} : ground_quotable (@wf_inductive_body Σ idecl) := ltac:(destruct 1; exact _).


### PR DESCRIPTION
This PR adds `quote_wf_inductive_body` and makes the universes in quotation compatible with TypingWf

<strike>Opening as draft because it depends on a bunch of other PRs, including #888 which still has some kinks to be worked out (cf https://github.com/mattam82/Coq-Equations/issues/545)

This is on top of #894, and should not be reviewed until #894, #888, #896, and #897 are merged and this is rebased.  Opening for visibility, though.</strike>