### PR TITLE
Disambiguate `Require`s among the MetaCoq modules

### DIFF
--- a/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Utf8 Program ssreflect ssrbool.
-From MetaCoq Require Import config utils Kernames BasicAst EnvMap.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import config Kernames BasicAst EnvMap.
 From MetaCoq.Erasure Require Import EAst EAstUtils EInduction ELiftSubst EWcbvEval EGlobalEnv
   EWellformed ECSubst EInduction EWcbvEvalInd EEtaExpanded.
 

--- a/erasure/theories/EWcbvEvalNamed.v
+++ b/erasure/theories/EWcbvEvalNamed.v
@@ -1,6 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Utf8 Program.
-From MetaCoq Require Import config utils BasicAst.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import config BasicAst.
 From MetaCoq.PCUIC Require PCUICWcbvEval.
 From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst EReflect EGlobalEnv
   EWellformed EWcbvEval.
@@ -690,7 +691,7 @@ Local Notation "'⊩' v ~ s" := (represents_value v s) (at level 50).
 Local Hint Constructors represents : core.
 Local Hint Constructors represents_value : core.
 
-From MetaCoq Require Import bytestring MCString.
+From MetaCoq.Utils Require Import bytestring MCString.
 Require Import BinaryString.
 Import String.
 
@@ -1426,7 +1427,7 @@ Proof.
     + eapply All2_All2_Set, All2_app. eapply H1; eauto. econstructor; eauto.
 Qed.
 
-From MetaCoq Require Import EWcbvEvalCstrsAsBlocksFixLambdaInd.
+From MetaCoq.Erasure Require Import EWcbvEvalCstrsAsBlocksFixLambdaInd.
 
 Lemma lookup_in_env Σ Σ' ind i :
   All2 (fun d d' => d.1 = d'.1 × match d.2 with ConstantDecl (Build_constant_body (Some body)) =>

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -2452,7 +2452,7 @@ Proof.
     intros. sq. now rewrite (abstract_env_ext_irr _ H H2).
 Qed.
 
-From MetaCoq Require Import PCUICFirstorder.
+From MetaCoq.PCUIC Require Import PCUICFirstorder.
 
 
 Lemma welltyped_mkApps_inv {cf} {Σ : global_env_ext} Γ f args :  ∥ wf Σ ∥ ->
@@ -2527,7 +2527,7 @@ Proof.
     Unshelve. all: try exact False.
 Qed.
 
-From MetaCoq Require Import PCUICProgress.
+From MetaCoq.PCUIC Require Import PCUICProgress.
 
 Lemma erase_correct_strong' (wfl := Ee.default_wcbv_flags) X_type (X : X_type.π1)
 univs wfext {t v Σ' t' deps i u args mind} decls normalization_in prf

--- a/erasure/theories/Typed/ResultMonad.v
+++ b/erasure/theories/Typed/ResultMonad.v
@@ -1,4 +1,4 @@
-From MetaCoq Require Import monad_utils.
+From MetaCoq.Utils Require Import monad_utils.
 
 Inductive result T E :=
 | Ok (t : T)

--- a/erasure/theories/Typed/Utils.v
+++ b/erasure/theories/Typed/Utils.v
@@ -1,5 +1,4 @@
 From Equations Require Import Equations.
-From MetaCoq Require Import utils.
 From MetaCoq.Common Require Import BasicAst.
 From MetaCoq.Common Require Import Kernames.
 From MetaCoq.Template Require Import Ast.

--- a/pcuic/theories/Bidirectional/BDTyping.v
+++ b/pcuic/theories/Bidirectional/BDTyping.v
@@ -8,7 +8,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils
   PCUICLiftSubst PCUICUnivSubst PCUICEquality PCUICUtils
   PCUICPosition PCUICTyping PCUICCumulativity PCUICReduction.
 
-From MetaCoq Require Export LibHypsNaming.
+From MetaCoq.Utils Require Export LibHypsNaming.
 Require Import ssreflect.
 Set Asymmetric Patterns.
 Require Import Equations.Type.Relation.

--- a/pcuic/theories/PCUICFirstorder.v
+++ b/pcuic/theories/PCUICFirstorder.v
@@ -15,7 +15,7 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICPrimitive
   PCUICValidity PCUICPrincipality PCUICElimination
   PCUICOnFreeVars PCUICWellScopedCumulativity PCUICSN PCUICCanonicity.
 
-From MetaCoq Require Import PCUICArities PCUICSpine.
+From MetaCoq.PCUIC Require Import PCUICArities PCUICSpine.
 From MetaCoq.PCUIC Require PCUICWcbvEval.
 From MetaCoq.PCUIC Require Import PCUICEquality PCUICAlpha.
 

--- a/pcuic/theories/PCUICNormalization.v
+++ b/pcuic/theories/PCUICNormalization.v
@@ -19,7 +19,7 @@ From MetaCoq.PCUIC Require Import PCUICTyping PCUICEquality PCUICAst PCUICAstUti
 
 From Equations Require Import Equations.
 
-From MetaCoq Require Import PCUICSN.
+From MetaCoq.PCUIC Require Import PCUICSN.
 
 Lemma wh_normalization {cf:checker_flags} {no:normalizing_flags} {Σ} {normalization:NormalizationIn Σ} {t} : wf Σ -> axiom_free Σ ->
 {A & Σ ;;; [] |- t : A}  -> { v & whnf RedFlags.default Σ [] v * red Σ [] t v}.
@@ -59,7 +59,7 @@ Proof.
   eapply SN_to_WN; eauto.
 Qed.
 
-From MetaCoq Require Import PCUICFirstorder.
+From MetaCoq.PCUIC Require Import PCUICFirstorder.
 
 Lemma firstorder_value_irred {cf:checker_flags} Σ t t' :
   firstorder_value Σ [] t ->

--- a/pcuic/theories/PCUICTyping.v
+++ b/pcuic/theories/PCUICTyping.v
@@ -9,7 +9,7 @@ From MetaCoq.PCUIC Require Export PCUICCases.
 Import MCMonadNotation.
 
 (* TODO: remove this export *)
-From MetaCoq Require Export LibHypsNaming.
+From MetaCoq.Utils Require Export LibHypsNaming.
 
 Require Import ssreflect ssrbool.
 Require Import Equations.Type.Relation.

--- a/pcuic/theories/PCUICWeakeningConfig.v
+++ b/pcuic/theories/PCUICWeakeningConfig.v
@@ -4,7 +4,7 @@ From MetaCoq.Utils Require Import utils.
 From MetaCoq.Common Require Import config.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping.
 From Equations Require Import Equations.
-From MetaCoq Require Import LibHypsNaming.
+From MetaCoq.Utils Require Import LibHypsNaming.
 
 Require Import ssreflect.
 

--- a/pcuic/theories/PCUICWeakeningEnv.v
+++ b/pcuic/theories/PCUICWeakeningEnv.v
@@ -3,7 +3,7 @@ From MetaCoq.Utils Require Import utils.
 From MetaCoq.Common Require Import config.
 From MetaCoq.PCUIC Require Import PCUICAst PCUICAstUtils PCUICTyping.
 From Equations Require Import Equations.
-From MetaCoq Require Import LibHypsNaming.
+From MetaCoq.Utils Require Import LibHypsNaming.
 
 Require Import ssreflect.
 

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -1,5 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq Require Import utils Ast AstUtils Environment.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import Environment.
+From MetaCoq.Template Require Import Ast AstUtils.
 
 (** * Deriving a compact induction principle for terms
 

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -1,5 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq Require Import utils Ast AstUtils Primitive Environment LiftSubst Universes.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import Primitive Environment Universes.
+From MetaCoq.Template Require Import Ast AstUtils LiftSubst.
 
 (** * Pretty printing *)
 

--- a/template-coq/theories/UnivSubst.v
+++ b/template-coq/theories/UnivSubst.v
@@ -1,5 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq Require Import utils Ast AstUtils Environment Induction.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import Environment.
+From MetaCoq.Template Require Import Ast AstUtils Induction.
 
 (** * Universe substitution
 

--- a/test-suite/plugin-demo/theories/Extraction.v
+++ b/test-suite/plugin-demo/theories/Extraction.v
@@ -1,4 +1,4 @@
-From MetaCoq Require Import Template.Extraction.
+From MetaCoq.Template Require Import Extraction.
 Require Import Lens MyPlugin.
 
 Set Warnings "-extraction-opaque-accessed".

--- a/utils/theories/MCList.v
+++ b/utils/theories/MCList.v
@@ -1,6 +1,6 @@
 From Equations Require Import Equations.
 From Coq Require Import Bool Arith Lia SetoidList Utf8.
-From MetaCoq Require Import MCPrelude MCRelations.
+From MetaCoq.Utils Require Import MCPrelude MCRelations.
 
 Set Equations Transparent.
 
@@ -1218,7 +1218,7 @@ Proof.
 Qed.
 
 
-From MetaCoq Require Import ReflectEq.
+From MetaCoq.Utils Require Import ReflectEq.
 
 Section SplitPrefix.
   Context {A : Type} `{ReflectEq A}.

--- a/utils/theories/MCOption.v
+++ b/utils/theories/MCOption.v
@@ -1,6 +1,6 @@
 From Coq Require Import List ssreflect Arith Morphisms Relation_Definitions.
 
-From MetaCoq Require Import MCPrelude MCList MCProd MCReflect.
+From MetaCoq.Utils Require Import MCPrelude MCList MCProd MCReflect.
 
 Definition option_get {A} (default : A) (x : option A) : A
   := match x with


### PR DESCRIPTION
This will help when removing some dependencies from `MetaCoq.Quotation`, which overlaps with a bunch of other naming