### PR TITLE
Make proofs more robust for eventually making `All_Forall` polymorphic

### DIFF
--- a/erasure/theories/EConstructorsAsBlocks.v
+++ b/erasure/theories/EConstructorsAsBlocks.v
@@ -103,7 +103,7 @@ Section transform_blocks.
   Qed.
 
   Lemma chop_eq {A} n (l : list A) l1 l2 : chop n l = (l1, l2) -> l = l1 ++ l2.
-  Proof.
+  Proof using Type.
     rewrite chop_firstn_skipn. intros [= <- <-].
     now rewrite firstn_skipn.
   Qed.
@@ -188,7 +188,7 @@ Section transform_blocks.
       | view_other fn nconstr =>
           mkApps (transform_blocks fn) (map transform_blocks args)
       end.
-  Proof.
+  Proof using Type.
     destruct (decompose_app f) eqn:da.
     rewrite (decompose_app_inv da). rewrite transform_blocks_mkApps.
     now eapply decompose_app_notApp.
@@ -210,7 +210,7 @@ Section transform_blocks.
         P (mkApps (transform_blocks fn) (map transform_blocks args))
     end) ->
     P (transform_blocks (mkApps fn args)).
-  Proof.
+  Proof using Type.
     intros napp.
     move/isEtaExp_mkApps.
     rewrite decompose_app_mkApps //.
@@ -228,7 +228,7 @@ Section transform_blocks.
 
   Lemma transform_blocks_mkApps_eta_fn f args : isEtaExp Σ f ->
     transform_blocks (mkApps f args) = mkApps (transform_blocks f) (map (transform_blocks) args).
-  Proof.
+  Proof using Type.
     intros ef.
     destruct (decompose_app f) eqn:df.
     rewrite (decompose_app_inv df) in ef |- *.
@@ -1147,6 +1147,9 @@ Proof.
     destruct nth_error; try now inv Heq.
     destruct nth_error; invs Heq.
     rewrite /wf_minductive in E. rtoProp.
+    rename H4 into H4_old;
+    let H4' := match goal with H : context[has_cstr_params] |- _ => H end in
+    rename H4' into H4.
     rewrite haspars /= in H4.
     cbn in H4. eapply eqb_eq in H4.
     unfold cstr_arity in H0.
@@ -1154,6 +1157,8 @@ Proof.
     revert E1 E2.
     rewrite <- H0.
     rewrite !chop_firstn_skipn !firstn_all. intros [= <- <-] [= <- <-].
+    let X0' := match goal with H : All2 _ _ _ |- _ => H end in
+    rename X0' into X0.
     eapply All2_length in X0 as Hlen.
     cbn.
     rewrite !skipn_all Hlen skipn_all firstn_all. cbn.

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -662,6 +662,7 @@ Proof.
   destruct (isConstruct f) eqn:eqc.
   destruct f => //.
   - depelim H; try solve_discr_args => //.
+    let H3 := match goal with H : tConstruct _ _ _ = tConstruct _ _ _ |- _ => H end in
     noconf H3.
     eapply expanded_tConstruct_app; tea. cbn in H0. lia. solve_all.
   - destruct args using rev_ind; cbn => //.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -1570,7 +1570,7 @@ Lemma eval_app_cong_tApp' fl Σ t arg arg' res :
   @eval (switch_unguarded_fix fl) Σ (tApp t arg') res ->
   @eval (switch_unguarded_fix fl) Σ (tApp t arg) res.
 Proof.
-  intros. depind H0.
+  intros X H H0. depind H0.
   - eapply eval_app_cong_tApp; tea. econstructor. constructor. constructor. exact H.
   - pose proof (eval_trans' H H0_0). subst a'. econstructor; tea.
   - pose proof (eval_trans' H H0_0). subst av. eapply eval_fix; tea.
@@ -1612,7 +1612,7 @@ Lemma eval_app_cong_mkApps {fl} {Σ} {f f' res : EAst.term} {args args'} :
   @eval (switch_unguarded_fix fl) Σ (mkApps f args) res.
 Proof.
   revert args' res; induction args using rev_ind.
-  - cbn. intros. eapply eval_trans. tea. now depelim X.
+  - cbn. intros args' res ? X ?. eapply eval_trans. tea. now depelim X.
   - intros args' res evf evargs evf'.
     rewrite !mkApps_app. cbn.
     eapply All2_app_inv_l in evargs as [r1 [r2 [? []]]]. depelim a0. depelim a0. subst args'.
@@ -1737,7 +1737,7 @@ Proof.
       rewrite -[tApp _ _](mkApps_app _ _ [av]) in IHeval3.
       forward_keep IHeval2.
       { rewrite ha. now eapply forallb_last. }
-      unshelve epose proof (eval_mkApps_tFix_inv_size _ _ _ _ _ _ H') => //; auto.
+      unshelve epose proof (eval_mkApps_tFix_inv_size _ _ _ _ _ _ H') as X => //; auto.
       intros hev.
       destruct X as [[args' [hargs heq]]|].
       { solve_discr. noconf H5.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -899,7 +899,7 @@ Section Wcbv.
 
   Lemma value_app_inv L : value (mkApps tBox L) -> L = nil.
   Proof.
-    intros. depelim X.
+    intro X. depelim X.
     - destruct L using rev_ind.
       reflexivity.
       rewrite mkApps_app in i. inv i.
@@ -1059,7 +1059,8 @@ Section Wcbv.
       { clear -X; induction X; constructor; auto. }
       econstructor; tea; auto.
     - assert (All2 eval args args).
-      { clear -X0; induction X0; constructor; auto. }
+      { let X0 := match goal with H : All (fun t => eval t t) _ |- _ => H end in
+        clear -X0; induction X0; constructor; auto. }
       eapply eval_mkApps_cong => //. now eapply value_head_final.
   Qed.
 
@@ -1294,7 +1295,7 @@ Section Wcbv.
     All2 eval t v' ->
     v = v'.
   Proof.
-    induction 1 in v' |- *; intros H; depelim H; auto. f_equal; eauto.
+    induction 1 in v' |- *; intros H'; depelim H'; auto. f_equal; eauto.
     now eapply eval_deterministic.
   Qed.
 
@@ -2037,7 +2038,7 @@ Lemma eval_box_apps {wfl : WcbvFlags}:
     eval Σ' e tBox -> eval Σ' (mkApps e x) tBox.
 Proof.
   intros Σ' e x H2.
-  revert e H2; induction x using rev_ind; cbn; intros; eauto.
+  revert e H2; induction x using rev_ind; cbn; intros e ? X ?; eauto.
   eapply All2_app_inv_l in X as (l1' & l2' & -> & H' & H2).
   depelim H2.
   specialize (IHx e _ H'). simpl.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -765,7 +765,10 @@ Proof.
   all:intuition auto.
   - eapply eval_wellformed; tea => //.
   - rewrite isEtaExp_Constructor => //.
+    let X0 := multimatch goal with H : All2 _ _ _ |- _ => H end in
+    let H1 := multimatch goal with H : _ = _ |- _ => H end in
     rewrite -(All2_length X0) H1. cbn. rtoProp; intuition eauto.
+    match goal with H : ?f ?n |- ?f ?n' => replace n' with n by congruence; exact H end.
     cbn; eapply All_forallb. eapply All2_All_right; tea.
     cbn. intros x y []; auto.
 Qed.

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -264,6 +264,7 @@ Proof.
       2:{
       exists x2. split; eauto. constructor. eapply eval_iota_sing => //.
       pose proof (Ee.eval_to_value _ _ He_v').
+      let X0 := match goal with H : Ee.value _ (EAst.mkApps _ _) |- _ => H end in
       eapply value_app_inv in X0. subst. eassumption.
       depelim H2.
       eapply isErasable_Propositional in X0; eauto.
@@ -417,7 +418,11 @@ Proof.
             eapply declared_constructor_from_gen in d.
             eapply (declared_constructor_assumption_context d).
             destruct s3 as [? [? [eqp _]]].
-            rewrite lenppars (firstn_app_left) // in eqp. congruence.
+            rewrite lenppars (firstn_app_left) // in eqp.
+            match goal with
+            | [ H : ?f (firstn ?n ?ls) ?p |- ?f (firstn ?n' ?ls) ?p ]
+              => replace n' with n; first [ exact H | congruence ]
+            end.
             move: wf_brs. now rewrite /wf_branches hctors => h; depelim h.
             rewrite -eq_npars. exact s1.
           - eapply All2_rev. cbn.
@@ -438,7 +443,7 @@ Proof.
          constructor.
          destruct x1 as [n br'].
          eapply eval_iota_sing => //.
-         pose proof (Ee.eval_to_value _ _ He_v').
+         pose proof (Ee.eval_to_value _ _ He_v') as X0.
          apply value_app_inv in X0; subst x0.
          apply He_v'.
          now rewrite -eq_npars.
@@ -509,7 +514,7 @@ Proof.
         eapply isErasable_Proof. constructor. eauto.
 
         eapply eval_proj_prop => //.
-        pose proof (Ee.eval_to_value _ _ Hty_vc').
+        pose proof (Ee.eval_to_value _ _ Hty_vc') as X0.
         eapply value_app_inv in X0. subst. eassumption.
         now rewrite -eqpars.
       * rename H3 into Hinf.
@@ -549,7 +554,7 @@ Proof.
           eassumption.
           eapply isErasable_Proof.
           constructor. eapply eval_proj_prop => //.
-          pose proof (Ee.eval_to_value _ _ Hty_vc').
+          pose proof (Ee.eval_to_value _ _ Hty_vc') as X0.
           eapply value_app_inv in X0. subst. eassumption.
           now rewrite -eqpars.
         -- eapply erases_deps_eval in Hty_vc'; [|now eauto].

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -1468,7 +1468,7 @@ Qed.
 Lemma OnOne2All_map2_map_all {A B I I'} {P} {i : list I} {l l' : list A} (g : B -> I -> I') (f : A -> B) :
   OnOne2All (fun i x y => P (g (f x) i) (f x) (f y)) i l l' -> OnOne2All P (map2 g (map f l) i) (map f l) (map f l').
 Proof.
-  induction 1; simpl; constructor; try congruence. len.
+  induction 1; simpl; constructor; try congruence; try assumption. len.
   now rewrite map2_length !map_length.
 Qed.
 

--- a/pcuic/theories/PCUICParallelReduction.v
+++ b/pcuic/theories/PCUICParallelReduction.v
@@ -2220,7 +2220,7 @@ Section ParallelSubstitution.
         rewrite !inst_inst_case_context_wf //.
         eapply on_free_vars_ctx_inst_case_context; tea; solve_all.
         eapply pred1_pred1_ctx in X7.
-        eapply on_contexts_app_inv => //. now rewrite /id.
+        eapply on_contexts_app_inv => //. now rewrite /id; (* congruence is enough in monomorphic mode, but we have to work around COQBUG(https://github.com/coq/coq/issues/5481) *) cbv [pcontext] in *; repeat destruct ?; cbn in *; subst; assumption.
         eapply (on_contexts_length X).
         rewrite /id. rewrite {2}H1.
         apply: X6; tea. 3:now len.
@@ -2351,7 +2351,7 @@ Section ParallelSubstitution.
         rewrite !inst_inst_case_context_wf //.
         eapply on_free_vars_ctx_inst_case_context; tea; solve_all.
         eapply pred1_pred1_ctx in X3 => //.
-        eapply on_contexts_app_inv => //. now rewrite /id.
+        eapply on_contexts_app_inv => //. now rewrite /id; (* congruence is enough in monomorphic mode, but we have to work around COQBUG(https://github.com/coq/coq/issues/5481) *) cbv [pcontext] in *; repeat destruct ?; cbn in *; subst; assumption.
         eapply (on_contexts_length X). 2:len; lia.
         now rewrite {2}H0.
       + solve_all. rewrite /inst_case_branch_context in a1 *.

--- a/pcuic/theories/Syntax/PCUICReflect.v
+++ b/pcuic/theories/Syntax/PCUICReflect.v
@@ -215,7 +215,7 @@ Proof.
     destruct (eqb_spec (puinst p) (puinst p0)); t'.
     destruct X as [? []]. red in X0.
     destruct (r (preturn p0)); t'.
-    destruct (reflect_prop_list (l':= pparams p0) a); t'.
+    case: (reflect_prop_list (l':= pparams p0) a); t'.
     case: (reflect_prop_list (l:=l) (l' := brs)); t'.
     { eapply All_impl; tea; cbv beta. intros [bctx bbody] [].
       intros [bctx' bbody']; cbn in *.

--- a/safechecker/theories/PCUICEqualityDec.v
+++ b/safechecker/theories/PCUICEqualityDec.v
@@ -452,7 +452,7 @@ Proof.
       1: eapply (All2_All_mix_left H0), (All2_All_mix_right H3), All2_map_inv ;
         eassumption.
       now move=> x y [? []] /X.
-    * destruct (reflect_eq_ctx (pcontext pr) (pcontext pr')) => //.
+    * case: (reflect_eq_ctx (pcontext pr) (pcontext pr')) => //.
     * now destruct (r equ Re 0 X (preturn pr')) ; nodec ; subst.
   - move/andb_and => [/andb_and [/andb_and [ppars pinst] pctx] pret].
     intuition auto.
@@ -464,7 +464,7 @@ Proof.
       1: eapply (All2_All_mix_left H0), (All2_All_mix_right H3), All2_map_inv;
         eassumption.
       now move=> x y [? []] /X.
-    * now destruct (reflect_eq_ctx (pcontext pr) (pcontext pr')).
+    * move: pctx; case: (reflect_eq_ctx (pcontext pr) (pcontext pr')) => //.
     * now destruct (r _ _ 0 X (preturn pr')).
 Qed.
 
@@ -639,7 +639,7 @@ Proof.
     2:{ rewrite andb_false_r /=.
         constructor. intros bot; inv bot; contradiction.
     }
-    destruct Hr => /=.
+    case: Hr => e' /=.
     2:{
       constructor. intro bot. inversion bot. subst.
       auto.
@@ -657,17 +657,17 @@ Proof.
         cbn - [eqb]. inversion X. subst.
         destruct a, b. cbn - [eqb eqb_binder_annots].
         destruct X0 as [onc onbod].
-        destruct (reflect_eq_ctx bcontext bcontext0) => // /=.
+        case: (reflect_eq_ctx bcontext bcontext0) => a // /=.
         2:{ constructor. intro bot. inversion bot. subst.
-          inversion X3. subst. destruct X4. cbn in e1. subst.
+          inversion X3. subst. destruct X4. cbn in *. subst.
           contradiction.
         }
         cbn - [eqb].
         pose proof (onbod equ Re 0 he bbody0) as hh. cbn in hh.
-        destruct hh => //=.
+        case: hh => //= [e1|f].
         2:{ constructor. intro bot. apply f. inversion bot. subst.
           inversion X3. subst. destruct X4. assumption. }
-        cbn -[eqb eqb_binder_annots] in *. destruct (IHl X1 brs) => //.
+        cbn -[eqb eqb_binder_annots] in *. case: (IHl X1 brs) => // [e2|f].
         2:{ constructor. intro bot. apply f. inversion bot. subst.
         inversion X3. subst. constructor; auto. }
         constructor. inversion e2. subst.

--- a/template-pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/template-pcuic/theories/PCUICToTemplateCorrectness.v
@@ -1210,7 +1210,7 @@ Qed.
 Lemma OnOne2All_map2_map_all {A B I I'} {P} {i : list I} {l l' : list A} (g : B -> I -> I') (f : A -> B) :
   OnOne2All (fun i x y => P (g (f x) i) (f x) (f y)) i l l' -> OnOne2All P (map2 g (map f l) i) (map f l) (map f l').
 Proof.
-  induction 1; simpl; constructor; try congruence. len.
+  induction 1; simpl; constructor; try congruence; try assumption. len.
   now rewrite map2_length !map_length.
 Qed.
 

--- a/utils/theories/All_Forall.v
+++ b/utils/theories/All_Forall.v
@@ -355,7 +355,7 @@ Lemma All2_map_equiv {A B C D} {R : C -> D -> Type} {f : A -> C} {g : B -> D} {l
   All2 (fun x y => R (f x) (g y)) l l' <~> All2 R (map f l) (map g l').
 Proof.
   split.
-  - induction 1; simpl; constructor; try congruence.
+  - induction 1; simpl; constructor; try congruence; try assumption.
   - induction l in l' |- *; destruct l'; intros H; depelim H; constructor; auto.
 Qed.
 
@@ -833,11 +833,11 @@ Proof. induction 1; simpl; congruence. Qed.
 
 Lemma OnOne2_mapP {A B} {P} {l l' : list A} (f : A -> B) :
   OnOne2 (on_rel P f) l l' -> OnOne2 P (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. Qed.
 
 Lemma OnOne2_map {A B} {P : B -> B -> Type} {l l' : list A} (f : A -> B) :
   OnOne2 (on_Trel P f) l l' -> OnOne2 P (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. Qed.
 
 Lemma OnOne2_sym {A} (P : A -> A -> Type) l l' : OnOne2 (fun x y => P y x) l' l -> OnOne2 P l l'.
 Proof.
@@ -1048,11 +1048,11 @@ Proof. induction 1; simpl; congruence. Qed.
 
 Lemma OnOne2i_mapP {A B} {P} {i} {l l' : list A} (f : A -> B) :
   OnOne2i (fun i => on_rel (P i) f) i l l' -> OnOne2i P i (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. Qed.
 
 Lemma OnOne2i_map {A B} {P : nat -> B -> B -> Type} {i} {l l' : list A} (f : A -> B) :
   OnOne2i (fun i => on_Trel (P i) f) i l l' -> OnOne2i P i (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. Qed.
 
 Lemma OnOne2i_sym {A} (P : nat -> A -> A -> Type) i l l' : OnOne2i (fun i x y => P i y x) i l' l -> OnOne2i P i l l'.
 Proof.
@@ -1234,15 +1234,15 @@ Proof. induction 1; simpl; congruence. Qed.
 
 Lemma OnOne2All_mapP {A B I} {P} {i : list I} {l l' : list A} (f : A -> B) :
   OnOne2All (fun i => on_rel (P i) f) i l l' -> OnOne2All P i (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. now rewrite map_length. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. now rewrite map_length. Qed.
 
 Lemma OnOne2All_map {A I B} {P : I -> B -> B -> Type} {i : list I} {l l' : list A} (f : A -> B) :
   OnOne2All (fun i => on_Trel (P i) f) i l l' -> OnOne2All P i (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. now rewrite map_length. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. now rewrite map_length. Qed.
 
 Lemma OnOne2All_map_all {A B I I'} {P} {i : list I} {l l' : list A} (g : I -> I') (f : A -> B) :
   OnOne2All (fun i => on_Trel (P (g i)) f) i l l' -> OnOne2All P (map g i) (map f l) (map f l').
-Proof. induction 1; simpl; constructor; try congruence. apply p. now rewrite !map_length. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. now rewrite !map_length. Qed.
 
 
 Lemma OnOne2All_sym {A B} (P : B -> A -> A -> Type) i l l' : OnOne2All (fun i x y => P i y x) i l' l -> OnOne2All P i l l'.
@@ -2894,11 +2894,11 @@ Qed.
 
 Lemma All2i_map {A B C D} (R : nat -> C -> D -> Type) (f : A -> C) (g : B -> D) n l l' :
   All2i (fun i x y => R i (f x) (g y)) n l l' -> All2i R n (map f l) (map g l').
-Proof. induction 1; simpl; constructor; try congruence. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. Qed.
 
 Lemma All2i_map_right {B C D} (R : nat -> C -> D -> Type) (g : B -> D) n l l' :
   All2i (fun i x y => R i x (g y)) n l l' -> All2i R n l (map g l').
-Proof. induction 1; simpl; constructor; try congruence. Qed.
+Proof. induction 1; simpl; constructor; try congruence; try assumption. Qed.
 
 Lemma All2i_nth_impl_gen {A B} (R : nat -> A -> B -> Type) n l l' :
   All2i R n l l' ->


### PR DESCRIPTION
Work around COQBUG(https://github.com/coq/coq/issues/5481)

Work around COQBUG(https://github.com/coq/coq/issues/17168)

This is the part of #888 that is ready for merge.  I'd rather it not bitrot; it's about making proofs more robust to changes in `congruence` and especially to changes in automatic naming.