### PR TITLE
[quotation] Fuse Template Monad loops

### DIFF
--- a/quotation/theories/ToTemplate/Init.v
+++ b/quotation/theories/ToTemplate/Init.v
@@ -426,7 +426,8 @@ Ltac unfold_quotation_of _ :=
 
 (* for universe adjustment with [tmDeclareQuotationOfModule], [tmMakeQuotationOfModule] *)
 #[export] Unset MetaCoq Strict Unquote Universe Mode.
-Polymorphic Definition tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _above_u'} {debug:debug_opt} (work_around_coq_bug_17303 : bool) (include_submodule : list ident -> bool) (include_supermodule : list ident -> list ident -> bool) (base : modpath) (cs : list global_reference) : TemplateMonad@{t u} (list (string * typed_term@{u'}))
+(* N.B. We need to kludge around COQBUG(https://github.com/coq/coq/issues/17303) in Kernames :-( *)
+Polymorphic Definition tmMakeQuotationOfConstants_gen@{d t u _T _above_u'} {debug:debug_opt} (work_around_coq_bug_17303 : bool) (include_submodule : list ident -> bool) (include_supermodule : list ident -> list ident -> bool) (existing_instance : option hint_locality) (base : modpath) (cs : list global_reference) (tmDoWithDefinition : ident -> forall A : Type@{d}, A -> TemplateMonad@{t u} A) : TemplateMonad@{t u} unit
   := let warn_bad_ctx c ctx :=
        (_ <- tmMsg "tmPrepareMakeQuotationOfModule: cannot handle polymorphism";;
         _ <- tmPrint c;;
@@ -442,7 +443,7 @@ Polymorphic Definition tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _
      let on_bad_relevance r :=
        (_ <- tmDebugMsg "skipping irrelevant constant";;
         _ <- tmDebugPrint r;;
-        tmReturn []) in
+        tmReturn tt) in
      let make_qname '(mp, name)
        (* ideally we'd replace _ with __ so that there can't be any collision, but the utility functions aren't written and we don't need it in practice *)
        := option_map
@@ -462,15 +463,34 @@ Polymorphic Definition tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _
                  else None
             end%bs in
      let tmDebugSkipGR '(mp, name) :=
-       _ <- tmDebugMsg ("tmPrepareMakeQuotationOfConstants: skipping excluded constant " ++ name);;
+       _ <- tmDebugMsg ("tmMakeQuotationOfConstants_gen: skipping excluded constant " ++ name);;
        _ <- tmDebugPrint (split_common_prefix base mp);;
-       ret [] in
+       ret tt in
+     let make_definition '(name, tyv)
+       := ((let tmTyv := tmRetypeAroundMetaCoqBug853 name tyv in
+            _ <- tmDebugPrint tmTyv;;
+            '{| my_projT1 := ty ; my_projT2 := v |} <- tmTyv;;
+            tmDef_name <- tmEval cbv (@tmDoWithDefinition (name:string));;
+            let tmn := tmDef_name ty v in
+            _ <- tmDebugPrint tmn;;
+            n <- tmn;;
+            _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: tmQuoteToGlobalReference";;
+            qn <- tmQuoteToGlobalReference n;;
+            tmReturn qn) : TemplateMonad global_reference) in
+     let make_instance p
+       := (match existing_instance return TemplateMonad unit with
+           | Some locality
+             => let tmEx := tmExistingInstance locality p in
+                _ <- tmDebugPrint tmEx;;
+                tmEx
+           | None => tmReturn tt
+           end) in
      let cs := dedup_grefs cs in
      cs <- tmEval cbv cs;;
-     _ <- tmDebugMsg "tmPrepareMakeQuotationOfConstants: looking up module constants";;
+     _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: looking up module constants";;
      ps <- monad_map@{_ _ Set _above_u'}
              (fun r
-              => _ <- tmDebugMsg "tmPrepareMakeQuotationOfConstants: handling";;
+              => _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: handling";;
                  _ <- tmDebugPrint r;;
                  match r with
                  | ConstRef cr
@@ -487,12 +507,14 @@ Polymorphic Definition tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _
                       | _, None => tmDebugSkipGR cr
                       | Relevant, Some qname
                         => let c := tConst cr inst in
-                           _ <- tmDebugMsg "tmPrepareMakeQuotationOfConstants: tmUnquote";;
+                           _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: tmUnquote";;
                            '{| my_projT1 := cty ; my_projT2 := cv |} <- tmUnquote c;;
-                           _ <- tmDebugMsg "tmPrepareMakeQuotationOfConstants: tmUnquote done";;
-                           tmReturn [(qname, if work_around_coq_bug_17303
-                                             then {| my_projT1 := term ; my_projT2 := c |}
-                                             else {| my_projT1 := @quotation_of cty cv ; my_projT2 := c |})]
+                           _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: tmUnquote done";;
+                           def <- make_definition
+                                    (qname, if work_around_coq_bug_17303
+                                            then {| my_projT1 := term ; my_projT2 := c |}
+                                            else {| my_projT1 := @quotation_of cty cv ; my_projT2 := c |});;
+                           make_instance def
                       end
                  | IndRef ind
                    => match make_qname ind.(inductive_mind) with
@@ -506,9 +528,9 @@ Polymorphic Definition tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _
                                          tmReturn ([] : Instance.t)
                                     end);;
                            let c := tInd ind inst in
-                           _ <- tmDebugMsg "tmPrepareMakeQuotationOfConstants: tmUnquote";;
+                           _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: tmUnquote";;
                            '{| my_projT1 := cty ; my_projT2 := cv |} <- tmUnquote c;;
-                           _ <- tmDebugMsg "tmPrepareMakeQuotationOfConstants: tmUnquote done";;
+                           _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: tmUnquote done";;
                            let tmcty := tmRetypeRelaxSetInCodomain@{t t u} qname cty in
                            _ <- tmDebugPrint tmcty;;
                            cty <- tmcty;;
@@ -517,50 +539,14 @@ Polymorphic Definition tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _
                            cv <- tmcv;;
                            let ty := @inductive_quotation_of cty cv in
                            let v : ty := {| qinductive := ind ; qinst := inst |} in
-                           tmReturn [(qname, {| my_projT1 := ty ; my_projT2 := v |})]
+                           def <- make_definition
+                                    (qname, {| my_projT1 := ty ; my_projT2 := v |});;
+                           make_instance def
                       end
-                 | ConstructRef _ _ | VarRef _ => tmReturn []
+                 | ConstructRef _ _ | VarRef _ => tmReturn tt
                  end)
              cs;;
-     let ps := flat_map (fun x => x) ps in
-     ret ps.
-
-(* N.B. We need to kludge around COQBUG(https://github.com/coq/coq/issues/17303) in Kernames :-( *)
-Polymorphic Definition tmMakeQuotationOfConstants_gen@{U d t u u' _T _above_u _above_u' _above_gr} {debug:debug_opt} (work_around_coq_bug_17303 : bool) (include_submodule : list ident -> bool) (include_supermodule : list ident -> list ident -> bool) (existing_instance : option hint_locality) (base : modpath) (cs : list global_reference) (tmDoWithDefinition : ident -> forall A : Type@{d}, A -> TemplateMonad A) : TemplateMonad unit
-  := let tmDebugMsg s := (if debug
-                          then tmMsg s
-                          else tmReturn tt) in
-     let tmDebugPrint {T : Type@{_T}} (v : T)
-       := (if debug
-           then tmPrint v
-           else tmReturn tt) in
-     ps <- tmPrepareMakeQuotationOfConstants@{U t u u' _T _above_u _above_u'} work_around_coq_bug_17303 include_submodule include_supermodule base cs;;
-     _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: defining module constants";;
-     ps <- monad_map@{_ _ _above_gr _above_u'}
-             (fun '(name, tyv)
-              => let tmTyv := tmRetypeAroundMetaCoqBug853 name tyv in
-                 _ <- tmDebugPrint tmTyv;;
-                 '{| my_projT1 := ty ; my_projT2 := v |} <- tmTyv;;
-                 tmDef_name <- tmEval cbv (@tmDoWithDefinition (name:string));;
-                 let tmn := tmDef_name ty v in
-                 _ <- tmDebugPrint tmn;;
-                 n <- tmn;;
-                 _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: tmQuoteToGlobalReference";;
-                 qn <- tmQuoteToGlobalReference n;;
-                 tmReturn qn)
-             ps;;
-     _ <- (match existing_instance with
-           | Some locality
-             => _ <- tmDebugMsg "tmMakeQuotationOfConstants_gen: making instances";;
-                monad_map@{_ _ Set Set}
-                  (fun p
-                   => let tmEx := tmExistingInstance locality p in
-                      _ <- tmDebugPrint tmEx;;
-                      tmEx)
-                  ps
-           | None => tmReturn []
-           end);;
-     tmReturn tt.
+     ret tt.
 
 Definition tmMakeQuotationOfConstants {debug:debug_opt} (include_submodule : list ident -> bool) (include_supermodule : list ident -> list ident -> bool) (existing_instance : option hint_locality) (base : modpath) (cs : list global_reference) : TemplateMonad unit
   := tmMakeQuotationOfConstants_gen false include_submodule include_supermodule existing_instance base cs (fun name ty body => @tmDefinition name ty body).


### PR DESCRIPTION
I don't know if this will speed things up, but if it does, it's probably because the template monad spends too long reducing `monad_map`.

<strike>On top of #908</strike>

<details><summary>Timing Diff</summary>
<p>

```
    After |   Peak Mem | File Name                                                                     |    Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
24m01.35s | 1722424 ko | Total Time / Peak Mem                                                         | 27m56.55s | 1728408 ko || -3m55.20s ||     -5984 ko |  -14.02% |         -0.34%
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 0m12.76s |  990836 ko | ToTemplate/QuotationOf/Coq/MSets/MSetAVL/Sig.vo                               |  1m38.93s | 1412680 ko || -1m26.17s ||   -421844 ko |  -87.10% |        -29.86%
 0m08.46s |  904728 ko | ToTemplate/QuotationOf/Coq/MSets/MSetList/Sig.vo                              |  1m00.31s | 1284464 ko || -0m51.85s ||   -379736 ko |  -85.97% |        -29.56%
 0m11.40s |  826920 ko | ToTemplate/QuotationOf/Coq/MSets/MSetProperties/Sig.vo                        |  0m45.23s | 1003852 ko || -0m33.82s ||   -176932 ko |  -74.79% |        -17.62%
 1m19.47s | 1596212 ko | ToTemplate/Coq/MSets.vo                                                       |  1m38.20s | 1728408 ko || -0m18.73s ||   -132196 ko |  -19.07% |         -7.64%
 0m03.79s |  751408 ko | ToTemplate/QuotationOf/Coq/MSets/MSetDecide/Sig.vo                            |  0m11.25s |  747288 ko || -0m07.46s ||      4120 ko |  -66.31% |         +0.55%
 0m00.80s |  721232 ko | ToTemplate/QuotationOf/Coq/FSets/FMapFacts/Sig.vo                             |  0m08.30s |  727596 ko || -0m07.50s ||     -6364 ko |  -90.36% |         -0.87%
 0m04.49s |  721836 ko | ToTemplate/QuotationOf/Coq/Structures/OrdersAlt/Sig.vo                        |  0m10.69s |  741580 ko || -0m06.19s ||    -19744 ko |  -57.99% |         -2.66%
 0m04.59s |  728460 ko | ToTemplate/QuotationOf/Coq/Structures/OrdersFacts/Sig.vo                      |  0m10.48s |  749904 ko || -0m05.89s ||    -21444 ko |  -56.20% |         -2.85%
 0m02.94s |  734828 ko | ToTemplate/QuotationOf/Coq/MSets/MSetFacts/Sig.vo                             |  0m07.35s |  717660 ko || -0m04.41s ||     17168 ko |  -60.00% |         +2.39%
 0m02.01s |  702228 ko | ToTemplate/QuotationOf/Coq/FSets/FMapInterface/Sig.vo                         |  0m04.04s |  698904 ko || -0m02.03s ||      3324 ko |  -50.24% |         +0.47%
 0m02.24s |  697844 ko | ToTemplate/QuotationOf/Coq/MSets/MSetInterface/Sig.vo                         |  0m04.03s |  703936 ko || -0m01.79s ||     -6092 ko |  -44.41% |         -0.86%
 0m02.14s |  696180 ko | ToTemplate/QuotationOf/Coq/Structures/Equalities/Sig.vo                       |  0m03.62s |  699480 ko || -0m01.48s ||     -3300 ko |  -40.88% |         -0.47%
 0m02.03s |  705060 ko | ToTemplate/Coq/Init.vo                                                        |  0m03.10s |  711792 ko || -0m01.07s ||     -6732 ko |  -34.51% |         -0.94%
 3m44.84s | 1368456 ko | ToTemplate/QuotationOf/Common/Kernames/KernameMap/Instances.vo                |  3m44.84s | 1368456 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 3m18.00s | 1722424 ko | ToTemplate/QuotationOf/Coq/FSets/FMapAVL/Sig.vo                               |  3m18.00s | 1722424 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 1m29.10s | 1275632 ko | ToTemplate/QuotationOf/Common/Universes/ConstraintSet/Instances.vo            |  1m29.10s | 1275632 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 1m22.80s | 1276260 ko | ToTemplate/QuotationOf/Common/Kernames/KernameSet/Instances.vo                |  1m22.80s | 1276260 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 1m21.35s | 1275952 ko | ToTemplate/QuotationOf/Common/Universes/LevelSet/Instances.vo                 |  1m21.35s | 1275952 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 1m01.47s | 1389880 ko | ToTemplate/Coq/FSets.vo                                                       |  1m01.47s | 1389880 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m52.42s | 1086680 ko | ToTemplate/QuotationOf/Common/Universes/LevelExprSet/Instances.vo             |  0m52.42s | 1086680 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m52.40s |  878548 ko | ToTemplate/QuotationOf/Common/Universes/ConstraintSetOrdProp/Instances.vo     |  0m52.40s |  878548 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m50.59s |  872104 ko | ToTemplate/QuotationOf/Common/Universes/LevelExprSetOrdProp/Instances.vo      |  0m50.59s |  872104 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m48.68s |  857164 ko | ToTemplate/QuotationOf/Common/Universes/LevelSetOrdProp/Instances.vo          |  0m48.68s |  857164 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m47.98s |  864128 ko | ToTemplate/QuotationOf/Common/Kernames/KernameSetOrdProp/Instances.vo         |  0m47.98s |  864128 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m38.44s |  931460 ko | ToTemplate/QuotationOf/Coq/FSets/FMapList/Sig.vo                              |  0m38.44s |  931460 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m29.41s | 1116164 ko | ToTemplate/QuotationOf/Common/EnvironmentTyping/Sig.vo                        |  0m29.41s | 1116164 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m29.22s |  909244 ko | ToTemplate/QuotationOf/Common/Environment/Sig.vo                              |  0m29.22s |  909244 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m26.12s | 1284060 ko | ToTemplate/Common/EnvironmentTyping.vo                                        |  0m26.12s | 1284060 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m21.51s |  803672 ko | ToTemplate/QuotationOf/Template/Ast/Env/Instances.vo                          |  0m21.51s |  803672 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m20.82s | 1095908 ko | ToTemplate/Template/Typing.vo                                                 |  0m20.82s | 1095908 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m18.82s |  908440 ko | ToTemplate/Common/Universes.vo                                                |  0m18.82s |  908440 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m15.43s |  868820 ko | ToTemplate/Common/Kernames.vo                                                 |  0m15.43s |  868820 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m10.08s |  773444 ko | ToTemplate/QuotationOf/Template/Typing/TemplateGlobalMaps/Instances.vo        |  0m10.08s |  773444 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m08.17s |  796076 ko | ToTemplate/QuotationOf/Template/Typing/TemplateEnvTyping/Instances.vo         |  0m08.17s |  796076 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m06.84s |  697892 ko | ToTemplate/QuotationOf/Common/Kernames/KernameMapFact/Instances.vo            |  0m06.84s |  697892 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m06.58s |  998568 ko | ToTemplate/Template/TermEquality.vo                                           |  0m06.58s |  998568 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m06.30s |  995716 ko | ToTemplate/Template/WfAst.vo                                                  |  0m06.30s |  995716 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m05.88s |  935032 ko | ToTemplate/Common/Environment.vo                                              |  0m05.88s |  935032 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m03.94s |  747208 ko | ToTemplate/QuotationOf/Template/Ast/TemplateLookup/Instances.vo               |  0m03.94s |  747208 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m03.70s |  769896 ko | ToTemplate/QuotationOf/Template/Typing/TemplateConversion/Instances.vo        |  0m03.70s |  769896 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.90s |  990412 ko | ToTemplate/Template/Ast.vo                                                    |  0m02.90s |  990412 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.64s |  921532 ko | ToTemplate/QuotationOf/Template/Ast/EnvHelper/Instances.vo                    |  0m02.64s |  921532 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.63s |  700724 ko | ToTemplate/QuotationOf/Common/Universes/Level/Instances.vo                    |  0m02.63s |  700724 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.47s |  698728 ko | ToTemplate/QuotationOf/Coq/Structures/OrdersTac/Sig.vo                        |  0m02.47s |  698728 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.38s |  758748 ko | ToTemplate/QuotationOf/Template/Typing/TemplateDeclarationTyping/Instances.vo |  0m02.38s |  758748 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.04s |  701080 ko | ToTemplate/QuotationOf/Common/Universes/LevelExpr/Instances.vo                |  0m02.04s |  701080 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m02.01s | 1003068 ko | ToTemplate/All.vo                                                             |  0m02.01s | 1003068 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.94s |  701404 ko | ToTemplate/QuotationOf/Common/Kernames/Kername/Instances.vo                   |  0m01.94s |  701404 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.89s |  757188 ko | ToTemplate/QuotationOf/Template/Typing/TemplateTyping/Instances.vo            |  0m01.89s |  757188 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.84s |  705696 ko | ToTemplate/QuotationOf/Template/Ast/TemplateTerm/Instances.vo                 |  0m01.84s |  705696 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.70s |  698288 ko | ToTemplate/Init.vo                                                            |  0m02.35s |  696844 ko || -0m00.65s ||      1444 ko |  -27.65% |         +0.20%
 0m01.69s |  700096 ko | ToTemplate/QuotationOf/Common/Universes/UnivConstraint/Instances.vo           |  0m01.69s |  700096 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.59s |  712640 ko | ToTemplate/QuotationOf/Template/ReflectAst/EnvDecide/Instances.vo             |  0m01.59s |  712640 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.52s |  870516 ko | ToTemplate/Common/BasicAst.vo                                                 |  0m01.52s |  870516 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.52s |  694896 ko | ToTemplate/Utils/MCOption.vo                                                  |  0m01.54s |  694776 ko || -0m00.02s ||       120 ko |   -1.29% |         +0.01%
 0m01.51s |  696876 ko | ToTemplate/QuotationOf/Coq/Structures/Orders/Sig.vo                           |  0m02.35s |  699696 ko || -0m00.84s ||     -2820 ko |  -35.74% |         -0.40%
 0m01.50s |  960280 ko | ToTemplate/QuotationOf/Template/Ast/Instances.vo                              |  0m01.50s |  960280 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.46s |  985456 ko | ToTemplate/Template/AstUtils.vo                                               |  0m01.46s |  985456 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.37s |  695004 ko | ToTemplate/Utils/All_Forall.vo                                                |  0m01.96s |  696624 ko || -0m00.58s ||     -1620 ko |  -30.10% |         -0.23%
 0m01.34s |  693840 ko | ToTemplate/Coq/ssr.vo                                                         |  0m01.34s |  693840 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.32s |  710140 ko | ToTemplate/QuotationOf/Template/ReflectAst/TemplateTermDecide/Instances.vo    |  0m01.32s |  710140 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.29s |  754500 ko | ToTemplate/QuotationOf/Template/Typing/TemplateConversionPar/Instances.vo     |  0m01.29s |  754500 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.27s |  756972 ko | ToTemplate/QuotationOf/Template/Typing/Instances.vo                           |  0m01.27s |  756972 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.24s |  696128 ko | ToTemplate/Utils/MCProd.vo                                                    |  0m01.49s |  693456 ko || -0m00.25s ||      2672 ko |  -16.77% |         +0.38%
 0m01.20s |  746972 ko | ToTemplate/QuotationOf/Common/Universes/Instances.vo                          |  0m01.20s |  746972 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.19s |  765652 ko | ToTemplate/QuotationOf/Common/Kernames/Instances.vo                           |  0m01.19s |  765652 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.18s |  704780 ko | ToTemplate/QuotationOf/Template/Ast/TemplateTermUtils/Instances.vo            |  0m01.18s |  704780 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.14s |  694192 ko | ToTemplate/Utils/bytestring.vo                                                |  0m01.20s |  693144 ko || -0m00.06s ||      1048 ko |   -5.00% |         +0.15%
 0m01.13s |  692704 ko | ToTemplate/Coq/Bool.vo                                                        |  0m01.24s |  694592 ko || -0m00.11s ||     -1888 ko |   -8.87% |         -0.27%
 0m01.11s |  692748 ko | ToTemplate/Common/Primitive.vo                                                |  0m01.11s |  692748 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.09s |  695940 ko | ToTemplate/Coq/Strings.vo                                                     |  0m01.09s |  695940 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.09s |  694236 ko | ToTemplate/Utils/MCReflect.vo                                                 |  0m01.51s |  694220 ko || -0m00.41s ||        16 ko |  -27.81% |         +0.00%
 0m01.08s |  696792 ko | CommonUtils.vo                                                                |  0m01.76s |  697100 ko || -0m00.68s ||      -308 ko |  -38.63% |         -0.04%
 0m01.03s |  701348 ko | ToTemplate/QuotationOf/Template/ReflectAst/Instances.vo                       |  0m01.03s |  701348 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m01.01s |  693148 ko | ToTemplate/Common/config.vo                                                   |  0m01.01s |  693148 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.99s |  701420 ko | ToTemplate/Utils/utils.vo                                                     |  0m01.35s |  700116 ko || -0m00.36s ||      1304 ko |  -26.66% |         +0.18%
 0m00.93s |  693664 ko | ToTemplate/Utils/MCList.vo                                                    |  0m01.02s |  698120 ko || -0m00.08s ||     -4456 ko |   -8.82% |         -0.63%
 0m00.92s |  697284 ko | ToTemplate/Coq/Lists.vo                                                       |  0m01.36s |  697084 ko || -0m00.44s ||       200 ko |  -32.35% |         +0.02%
 0m00.92s |  699756 ko | ToTemplate/Coq/Numbers.vo                                                     |  0m01.62s |  700016 ko || -0m00.70s ||      -260 ko |  -43.20% |         -0.03%
 0m00.91s |  694628 ko | ToTemplate/Utils/ReflectEq.vo                                                 |  0m01.08s |  694044 ko || -0m00.17s ||       584 ko |  -15.74% |         +0.08%
 0m00.88s |  703368 ko | ToTemplate/Coq/Floats.vo                                                      |  0m01.45s |  704060 ko || -0m00.56s ||      -692 ko |  -39.31% |         -0.09%
 0m00.86s |  693616 ko | ToTemplate/Utils/MCArith.vo                                                   |  0m01.01s |  695988 ko || -0m00.15s ||     -2372 ko |  -14.85% |         -0.34%
 0m00.80s |  693592 ko | ToTemplate/Utils/MCUtils.vo                                                   |  0m01.33s |  694508 ko || -0m00.53s ||      -916 ko |  -39.84% |         -0.13%
 0m00.07s |   63300 ko | ToTemplate/Utils/MCPred.vo                                                    |  0m00.07s |   63300 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.07s |   63076 ko | ToTemplate/Utils/MCPrelude.vo                                                 |  0m00.06s |   62916 ko || +0m00.01s ||       160 ko |  +16.66% |         +0.25%
 0m00.06s |   63864 ko | ToTemplate/Utils/LibHypsNaming.vo                                             |  0m00.06s |   63864 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.06s |   64240 ko | ToTemplate/Utils/MCString.vo                                                  |  0m00.07s |   64460 ko || -0m00.01s ||      -220 ko |  -14.28% |         -0.34%
 0m00.06s |   66120 ko | ToTemplate/Utils/wGraph.vo                                                    |  0m00.06s |   66120 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.05s |   67780 ko | ToTemplate/Common/Reflect.vo                                                  |  0m00.05s |   67780 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.05s |   64504 ko | ToTemplate/Template/LiftSubst.vo                                              |  0m00.05s |   64504 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.05s |   64312 ko | ToTemplate/Utils/ByteCompare.vo                                               |  0m00.05s |   64312 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.05s |   63592 ko | ToTemplate/Utils/ByteCompareSpec.vo                                           |  0m00.05s |   63592 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.05s |   63160 ko | ToTemplate/Utils/MCRelations.vo                                               |  0m00.06s |   64596 ko || -0m00.00s ||     -1436 ko |  -16.66% |         -2.22%
 0m00.04s |   63060 ko | ToTemplate/Common/Transform.vo                                                |  0m00.04s |   63060 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.04s |   63428 ko | ToTemplate/Template/ReflectAst.vo                                             |  0m00.04s |   63428 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.03s |   64740 ko | ToTemplate/Template/Induction.vo                                              |  0m00.03s |   64740 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.03s |   64172 ko | ToTemplate/Template/UnivSubst.vo                                              |  0m00.03s |   64172 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.03s |   63548 ko | ToTemplate/Utils/ByteCompare_opt.vo                                           |  0m00.03s |   63548 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
 0m00.03s |   63636 ko | ToTemplate/Utils/MCSquash.vo                                                  |  0m00.04s |   63860 ko || -0m00.01s ||      -224 ko |  -25.00% |         -0.35%
 0m00.02s |   63864 ko | ToTemplate/Utils/MCCompare.vo                                                 |  0m00.06s |   64556 ko || -0m00.03s ||      -692 ko |  -66.66% |         -1.07%
 0m00.02s |   64480 ko | ToTemplate/Utils/MCEquality.vo                                                |  0m00.07s |   63164 ko || -0m00.05s ||      1316 ko |  -71.42% |         +2.08%
 0m00.02s |   63544 ko | ToTemplate/Utils/monad_utils.vo                                               |  0m00.07s |   64916 ko || -0m00.05s ||     -1372 ko |  -71.42% |         -2.11%

```
</p>
</details>