### PR TITLE
[CI] Add `concurrency` and `cancel-in-progress: true`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,16 @@ jobs:
 
     strategy:
       matrix:
-        coq_version: 
+        coq_version:
           - '8.16'
         ocaml_version:
           - '4.14-flambda'
         target: [ local, opam, quick ]
       fail-fast: true
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.target }}-${{ env.RUNNER_OS }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
 

--- a/.github/workflows/nix-action-coq-8.16-macos.yml
+++ b/.github/workflows/nix-action-coq-8.16-macos.yml
@@ -2,6 +2,9 @@ jobs:
   coq:
     needs: []
     runs-on: macos-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ env.RUNNER_OS }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\

--- a/.github/workflows/nix-action-coq-8.16-ubuntu.yml
+++ b/.github/workflows/nix-action-coq-8.16-ubuntu.yml
@@ -2,6 +2,9 @@ jobs:
   coq:
     needs: []
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ env.RUNNER_OS }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\


### PR DESCRIPTION
When new commits are added to a PR, in-progress CI jobs for that PR will be cancelled.  CI jobs on repository branches (not on PRs) will not be cancelled.  This should make the CI a bit more responsive.