### PR TITLE
[Quotation] Add `quote_red`

### DIFF
--- a/quotation/theories/ToTemplate/All.v
+++ b/quotation/theories/ToTemplate/All.v
@@ -8,6 +8,7 @@ Module Raw.
   (* These are probably the only quotation functions that users of this development will want to use; other files should be considered internal to the development of quotation *)
   Definition quote_term : Ast.term -> Ast.term := Ast.quote_term.
   Definition quote_typing {cf : checker_flags} {Σ Γ t T} : (Σ ;;; Γ |- t : T) -> Ast.term := Typing.quote_typing.
+  Definition quote_red {Σ Γ x y} : @red Σ Γ x y -> Ast.term := Typing.quote_red.
   Definition quote_wf_local {cf : checker_flags} {Σ Γ} : wf_local Σ Γ -> Ast.term := Typing.quote_wf_local.
   Definition quote_wf {cf Σ} : @wf cf Σ -> Ast.term := Typing.quote_wf.
   Definition quote_wf_ext {cf Σ} : @wf_ext cf Σ -> Ast.term := Typing.quote_wf_ext.


### PR DESCRIPTION
This completes the export of the first projection of the two theorems mentioned at https://coq.zulipchat.com/#narrow/stream/237658-MetaCoq/topic/Doing.20better.20than.20a.20Trusted.20Theory.20Base/near/314881316:
```coq
From MetaCoq.Template Require Import config utils All.

Theorem reduction_quotation `{checker_flags} (Σ : global_env_ext) t t' :
  red Σ [] t t' -> { p & Σ;;; nil |- p : <% red Σ [] t t' %> }.
Admitted.

Theorem typing_quotation `{checker_flags} Σ t A :
  Σ;;; nil |- t : A -> { p & Σ;;; nil |- p : <% Σ;;; nil |- t : A %> }.
Admitted.
```
(cc @yforster)

The second projections of these theorems will be much trickier.