### PR TITLE
Improve performance of PCUIC Template Monad

### DIFF
--- a/common/theories/MonadBasicAst.v
+++ b/common/theories/MonadBasicAst.v
@@ -1,5 +1,5 @@
 (* Distributed under the terms of the MIT license. *)
-From MetaCoq.Utils Require Import utils monad_utils.
+From MetaCoq.Utils Require Import utils monad_utils MCList.
 From MetaCoq.Common Require Import BasicAst.
 
 Import MCMonadNotation.
@@ -57,7 +57,7 @@ Section with_monad.
     Notation context term := (list (context_decl term)).
 
     Definition monad_fold_context_k (f : nat -> term -> T term') Γ :=
-      Γ <- monad_map_i (fun k' decl => monad_map_decl (f k') decl) (List.rev Γ);; ret (List.rev Γ).
+      Γ <- monad_map_i (fun k' decl => monad_map_decl (f k') decl) (rev Γ);; ret (rev Γ).
 
     Arguments monad_fold_context_k f Γ%list_scope.
 

--- a/common/theories/MonadBasicAst.v
+++ b/common/theories/MonadBasicAst.v
@@ -10,10 +10,17 @@ Section with_monad.
   Context {T} {M : Monad T}.
 
   Definition monad_map_binder_annot {A B} (f : A -> T B) (b : binder_annot A) : T (binder_annot B) :=
-    binder_name <- f b.(binder_name);; ret {| binder_name := binder_name; binder_relevance := b.(binder_relevance) |}.
+    let '{| binder_name := binder_name;
+           binder_relevance := binder_relevance |} := b in
+    binder_name <- f binder_name;;
+    ret {| binder_name := binder_name;
+          binder_relevance := binder_relevance |}.
 
   Definition monad_map_def {A B} (tyf bodyf : A -> T B) (d : def A) :=
-    dtype <- tyf d.(dtype);; dbody <- bodyf d.(dbody);; ret {| dname := d.(dname); dtype := dtype; dbody := dbody; rarg := d.(rarg) |}.
+    let '{| dname := dname; dtype := dtype; dbody := dbody; rarg := rarg |} := d in
+    dtype <- tyf dtype;;
+    dbody <- bodyf dbody;;
+    ret {| dname := dname; dtype := dtype; dbody := dbody; rarg := rarg |}.
 
   Definition monad_typ_or_sort_map {T' T''} (f: T' -> T T'') t :=
     match t with
@@ -22,9 +29,12 @@ Section with_monad.
     end.
 
   Definition monad_map_decl {term term'} (f : term -> T term') (d : context_decl term) : T (context_decl term') :=
-    decl_body <- monad_option_map f d.(decl_body);;
-    decl_type <- f d.(decl_type);;
-    ret {| decl_name := d.(decl_name);
+    let '{| decl_name := decl_name;
+           decl_body := decl_body;
+           decl_type := decl_type |} := d in
+    decl_body <- monad_option_map f decl_body;;
+    decl_type <- f decl_type;;
+    ret {| decl_name := decl_name;
           decl_body := decl_body;
           decl_type := decl_type |}.
 

--- a/template-coq/theories/MonadAst.v
+++ b/template-coq/theories/MonadAst.v
@@ -15,12 +15,16 @@ Section with_monad.
     Context (paramf preturnf : term -> T term').
 
     Definition monad_map_predicate (p : predicate term) :=
-      pparams <- monad_map paramf p.(pparams);;
-      puinst <- uf p.(puinst);;
-      preturn <- preturnf p.(preturn);;
+      let '{| pparams := pparams;
+             puinst := puinst;
+             pcontext := pcontext;
+             preturn := preturn |} := p in
+      pparams <- monad_map paramf pparams;;
+      puinst <- uf puinst;;
+      preturn <- preturnf preturn;;
       ret {| pparams := pparams;
             puinst := puinst;
-            pcontext := p.(pcontext);
+            pcontext := pcontext;
             preturn := preturn |}.
   End map_predicate.
 
@@ -30,12 +34,16 @@ Section with_monad.
     Context (f : nat -> term -> T term).
 
     Definition monad_map_predicate_k k (p : predicate term) :=
-      pparams <- monad_map (f k) p.(pparams);;
-      puinst <- uf p.(puinst);;
-      preturn <- f (#|p.(pcontext)| + k) p.(preturn);;
+      let '{| pparams := pparams;
+             puinst := puinst;
+             pcontext := pcontext;
+             preturn := preturn |} := p in
+      pparams <- monad_map (f k) pparams;;
+      puinst <- uf puinst;;
+      preturn <- f (#|pcontext| + k) preturn;;
       ret {| pparams := pparams;
             puinst := puinst;
-            pcontext := p.(pcontext);
+            pcontext := pcontext;
             preturn := preturn |}.
 
   End map_predicate_k.
@@ -45,13 +53,15 @@ Section with_monad.
     Context (bbodyf : term -> T term').
 
     Definition monad_map_branch (b : branch term) :=
-      bbody <- bbodyf b.(bbody);;
-      ret {| bcontext := b.(bcontext);
+      let '{| bcontext := bcontext;
+             bbody := bbody |} := b in
+      bbody <- bbodyf bbody;;
+      ret {| bcontext := bcontext;
             bbody := bbody |}.
   End map_branch.
 
   Definition monad_map_branches {term B} (f : term -> T B) l := monad_map (monad_map_branch f) l.
 
-  Notation map_branches_k f k brs :=
+  Notation monad_map_branches_k f k brs :=
     (monad_map (fun b => monad_map_branch (f (#|b.(bcontext)| + k)) b) brs).
 End with_monad.

--- a/template-pcuic/theories/PCUICTemplateMonad/Core.v
+++ b/template-pcuic/theories/PCUICTemplateMonad/Core.v
@@ -9,18 +9,18 @@ Local Set Universe Polymorphism.
 Local Unset Universe Minimization ToSet.
 Import MCMonadNotation.
 
-Definition tmQuote {A:Type} (a : A) : TemplateMonad PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
-Definition tmQuoteRecTransp {A:Type} (a : A) (bypass_opacity : bool) : TemplateMonad PCUICProgram.pcuic_program :=
+Definition tmQuote@{t u} {A:Type@{t}} (a : A) : TemplateMonad@{t u} PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
+Definition tmQuoteRecTransp@{t u} {A:Type@{t}} (a : A) (bypass_opacity : bool) : TemplateMonad@{t u} PCUICProgram.pcuic_program :=
   (p <- tmQuoteRecTransp a bypass_opacity;; tmEval cbv (trans_template_program p)).
-Definition tmQuoteInductive (kn : kername) : TemplateMonad mutual_inductive_body := tmQuoteInductive kn.
-Definition tmQuoteConstant (kn : kername) (bypass_opacity : bool) : TemplateMonad constant_body :=
+Definition tmQuoteInductive@{t u} (kn : kername) : TemplateMonad@{t u} mutual_inductive_body := tmQuoteInductive@{t u} kn.
+Definition tmQuoteConstant@{t u} (kn : kername) (bypass_opacity : bool) : TemplateMonad@{t u} constant_body :=
   cb <- tmQuoteConstant kn bypass_opacity;; monad_trans_constant_body cb.
-Definition tmMkInductive (b : bool) (mie : mutual_inductive_entry) : TemplateMonad unit
+Definition tmMkInductive@{t u} (b : bool) (mie : mutual_inductive_entry) : TemplateMonad@{t u} unit
   := mie <- tmEval cbv (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
-Definition tmUnquote (t : PCUICAst.term) : TemplateMonad typed_term := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquote t.
-Definition tmUnquoteTyped A (t : PCUICAst.term) : TemplateMonad A := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
+Definition tmUnquote@{t u} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquote t.
+Definition tmUnquoteTyped@{t u} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
 
 (** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
 Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
 
-Definition tmMkDefinition (id : ident) (tm : PCUICAst.term) : TemplateMonad unit := tm <- tmEval cbv (PCUICToTemplate.trans tm);; tmMkDefinition id tm.
+Definition tmMkDefinition@{t u} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- tmEval cbv (PCUICToTemplate.trans tm);; tmMkDefinition id tm.

--- a/template-pcuic/theories/PCUICTemplateMonad/Core.v
+++ b/template-pcuic/theories/PCUICTemplateMonad/Core.v
@@ -8,18 +8,18 @@ From MetaCoq.TemplatePCUIC Require Import TemplateMonadToPCUIC TemplateToPCUIC P
 Local Set Universe Polymorphism.
 Import MCMonadNotation.
 
-Definition tmQuote {A:Type} (a : A) : TemplateMonad PCUICAst.term := (qa <- tmQuote a;; monad_trans qa).
+Definition tmQuote {A:Type} (a : A) : TemplateMonad PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
 Definition tmQuoteRecTransp {A:Type} (a : A) (bypass_opacity : bool) : TemplateMonad PCUICProgram.pcuic_program :=
-  (p <- tmQuoteRecTransp a bypass_opacity;; ret (trans_template_program p)).
+  (p <- tmQuoteRecTransp a bypass_opacity;; tmEval cbv (trans_template_program p)).
 Definition tmQuoteInductive (kn : kername) : TemplateMonad mutual_inductive_body := tmQuoteInductive kn.
 Definition tmQuoteConstant (kn : kername) (bypass_opacity : bool) : TemplateMonad constant_body :=
   cb <- tmQuoteConstant kn bypass_opacity;; monad_trans_constant_body cb.
 Definition tmMkInductive (b : bool) (mie : mutual_inductive_entry) : TemplateMonad unit
-  := tmMkInductive b (trans_mutual_inductive_entry mie).
-Definition tmUnquote (t : PCUICAst.term) : TemplateMonad typed_term := tmUnquote (PCUICToTemplate.trans t).
-Definition tmUnquoteTyped A (t : PCUICAst.term) : TemplateMonad A := tmUnquoteTyped A (PCUICToTemplate.trans t).
+  := mie <- tmEval cbv (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
+Definition tmUnquote (t : PCUICAst.term) : TemplateMonad typed_term := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquote t.
+Definition tmUnquoteTyped A (t : PCUICAst.term) : TemplateMonad A := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
 
 (** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
 Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
 
-Definition tmMkDefinition (id : ident) (tm : PCUICAst.term) : TemplateMonad unit := tmMkDefinition id (PCUICToTemplate.trans tm).
+Definition tmMkDefinition (id : ident) (tm : PCUICAst.term) : TemplateMonad unit := tm <- tmEval cbv (PCUICToTemplate.trans tm);; tmMkDefinition id tm.

--- a/template-pcuic/theories/PCUICTemplateMonad/Core.v
+++ b/template-pcuic/theories/PCUICTemplateMonad/Core.v
@@ -11,16 +11,16 @@ Import MCMonadNotation.
 
 Definition tmQuote@{t u} {A:Type@{t}} (a : A) : TemplateMonad@{t u} PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
 Definition tmQuoteRecTransp@{t u} {A:Type@{t}} (a : A) (bypass_opacity : bool) : TemplateMonad@{t u} PCUICProgram.pcuic_program :=
-  (p <- tmQuoteRecTransp a bypass_opacity;; tmEval cbv (trans_template_program p)).
+  (p <- tmQuoteRecTransp a bypass_opacity;; ret (trans_template_program p)).
 Definition tmQuoteInductive@{t u} (kn : kername) : TemplateMonad@{t u} mutual_inductive_body := tmQuoteInductive@{t u} kn.
 Definition tmQuoteConstant@{t u} (kn : kername) (bypass_opacity : bool) : TemplateMonad@{t u} constant_body :=
   cb <- tmQuoteConstant kn bypass_opacity;; monad_trans_constant_body cb.
 Definition tmMkInductive@{t u} (b : bool) (mie : mutual_inductive_entry) : TemplateMonad@{t u} unit
-  := mie <- tmEval cbv (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
-Definition tmUnquote@{t u} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquote t.
-Definition tmUnquoteTyped@{t u} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
+  := mie <- ret (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
+Definition tmUnquote@{t u} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- ret (PCUICToTemplate.trans t);; tmUnquote t.
+Definition tmUnquoteTyped@{t u} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- ret (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
 
 (** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
 Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
 
-Definition tmMkDefinition@{t u} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- tmEval cbv (PCUICToTemplate.trans tm);; tmMkDefinition id tm.
+Definition tmMkDefinition@{t u} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- ret (PCUICToTemplate.trans tm);; tmMkDefinition id tm.

--- a/template-pcuic/theories/PCUICTemplateMonad/Core.v
+++ b/template-pcuic/theories/PCUICTemplateMonad/Core.v
@@ -6,6 +6,7 @@ From MetaCoq.PCUIC Require Import PCUICAst.
 From MetaCoq.TemplatePCUIC Require Import TemplateMonadToPCUIC TemplateToPCUIC PCUICToTemplate.
 
 Local Set Universe Polymorphism.
+Local Unset Universe Minimization ToSet.
 Import MCMonadNotation.
 
 Definition tmQuote {A:Type} (a : A) : TemplateMonad PCUICAst.term := qa <- tmQuote a;; monad_trans qa.

--- a/template-pcuic/theories/TemplateMonadToPCUIC.v
+++ b/template-pcuic/theories/TemplateMonadToPCUIC.v
@@ -11,6 +11,8 @@ From MetaCoq.PCUIC Require Import PCUICAst PCUICPrimitive PCUICCases PCUICProgra
 From MetaCoq.TemplatePCUIC Require Import TemplateToPCUIC.
 
 Import MCMonadNotation.
+Local Set Universe Polymorphism.
+Local Unset Universe Minimization ToSet.
 
 Section with_tc.
   Context {TM : TMInstance}.

--- a/template-pcuic/theories/TemplateMonadToPCUIC.v
+++ b/template-pcuic/theories/TemplateMonadToPCUIC.v
@@ -15,15 +15,17 @@ Local Set Universe Polymorphism.
 Local Unset Universe Minimization ToSet.
 
 Section with_tc.
-  Context {TM : TMInstance}.
-  Local Notation TemplateMonad := (TemplateMonad TM).
-  Context {M : Monad TemplateMonad}.
+  Universes t u.
+  Context {T : Type@{t} -> Type@{u}}.
+  Context {M : Monad@{t u} T}.
 
   Section helpers.
-    Context (monad_trans : Ast.term -> TemplateMonad term).
+    Context (monad_trans : Ast.term -> T term)
+      (tmQuoteInductive : kername -> T Ast.Env.mutual_inductive_body)
+      (tmFail : forall {A:Type@{t}}, string -> T A).
 
     Definition monad_trans_decl' (d : Ast.Env.context_decl) :=
-      decl_body <- monad_option_map monad_trans d.(decl_body);;
+      decl_body <- monad_option_map@{t u t t} monad_trans d.(decl_body);;
       decl_type <- monad_trans d.(decl_type);;
       ret {| decl_name := d.(decl_name);
             decl_body := decl_body;
@@ -33,13 +35,14 @@ Section with_tc.
 
     Definition monad_trans_constructor_body' (d : Ast.Env.constructor_body) :=
       cstr_args <- monad_trans_local' d.(Ast.Env.cstr_args);;
-      cstr_indices <- monad_map monad_trans d.(Ast.Env.cstr_indices);;
+      cstr_indices <- monad_map@{t u t t} monad_trans d.(Ast.Env.cstr_indices);;
       cstr_type <- monad_trans d.(Ast.Env.cstr_type);;
       ret {| cstr_name := d.(Ast.Env.cstr_name);
             cstr_args := cstr_args;
             cstr_indices := cstr_indices;
             cstr_type := cstr_type;
             cstr_arity := d.(Ast.Env.cstr_arity) |}.
+
     Definition monad_trans_projection_body' (d : Ast.Env.projection_body) :=
       proj_type <- monad_trans d.(Ast.Env.proj_type);;
       ret {| proj_name := d.(Ast.Env.proj_name);
@@ -49,8 +52,8 @@ Section with_tc.
     Definition monad_trans_one_ind_body' (d : Ast.Env.one_inductive_body) :=
       ind_indices <- monad_trans_local' d.(Ast.Env.ind_indices);;
       ind_type <- monad_trans d.(Ast.Env.ind_type);;
-      ind_ctors <- monad_map monad_trans_constructor_body' d.(Ast.Env.ind_ctors);;
-      ind_projs <- monad_map monad_trans_projection_body' d.(Ast.Env.ind_projs);;
+      ind_ctors <- monad_map@{t u t t} monad_trans_constructor_body' d.(Ast.Env.ind_ctors);;
+      ind_projs <- monad_map@{t u t t} monad_trans_projection_body' d.(Ast.Env.ind_projs);;
       ret {| ind_name := d.(Ast.Env.ind_name);
             ind_relevance := d.(Ast.Env.ind_relevance);
             ind_indices := ind_indices;
@@ -62,7 +65,7 @@ Section with_tc.
 
     Definition monad_trans_constant_body' bd :=
       cst_type <- monad_trans bd.(Ast.Env.cst_type);;
-      cst_body <- monad_option_map monad_trans bd.(Ast.Env.cst_body);;
+      cst_body <- monad_option_map@{t u t t} monad_trans bd.(Ast.Env.cst_body);;
       ret {| cst_type := cst_type;
             cst_body := cst_body;
             cst_universes := bd.(Ast.Env.cst_universes);
@@ -70,7 +73,7 @@ Section with_tc.
 
     Definition monad_trans_minductive_body' md :=
       ind_params <- monad_trans_local' md.(Ast.Env.ind_params);;
-      ind_bodies <- monad_map monad_trans_one_ind_body' md.(Ast.Env.ind_bodies);;
+      ind_bodies <- monad_map@{t u t t} monad_trans_one_ind_body' md.(Ast.Env.ind_bodies);;
       ret {| ind_finite := md.(Ast.Env.ind_finite);
             ind_npars := md.(Ast.Env.ind_npars);
             ind_params := ind_params;
@@ -84,40 +87,40 @@ Section with_tc.
       | Ast.Env.InductiveDecl bd => bd <- monad_trans_minductive_body' bd;; ret (InductiveDecl bd)
       end.
 
-    Definition tmQuoteInductive' (mind : kername) : TemplateMonad mutual_inductive_body :=
-      bd <- tmQuoteInductive TM mind;;
+    Definition tmQuoteInductive' (mind : kername) : T mutual_inductive_body :=
+      bd <- tmQuoteInductive mind;;
       monad_trans_minductive_body' bd.
 
-    Definition TransLookup_lookup_inductive' (ind : inductive) : TemplateMonad (mutual_inductive_body × one_inductive_body) :=
+    Definition TransLookup_lookup_inductive' (ind : inductive) : T (mutual_inductive_body × one_inductive_body) :=
       mdecl <- tmQuoteInductive' (inductive_mind ind);;
       match nth_error (ind_bodies mdecl) (inductive_ind ind) with
       | Some idecl => ret (mdecl, idecl)
-      | None => tmFail TM "TransLookup.lookup_inductive: nth_error: Not_found"
+      | None => tmFail _ "TransLookup.lookup_inductive: nth_error: Not_found"
       end.
 
   End helpers.
 
   Section with_helper.
-    Context (TransLookup_lookup_inductive' : inductive -> TemplateMonad (mutual_inductive_body × one_inductive_body))
-      (tmEval : forall {A}, A -> TemplateMonad A).
+    Context (TransLookup_lookup_inductive' : inductive -> T (mutual_inductive_body × one_inductive_body))
+      (tmEval : forall {A:Type@{t}}, A -> T A).
 
-    Fixpoint monad_trans' (t : Ast.term) : TemplateMonad term
+    Fixpoint monad_trans' (t : Ast.term) : T term
       := match t with
          | Ast.tRel n => ret (tRel n)
          | Ast.tVar n => ret (tVar n)
-         | Ast.tEvar ev args => args <- monad_map monad_trans' args;; ret (tEvar ev args)
+         | Ast.tEvar ev args => args <- monad_map@{t u t t} monad_trans' args;; ret (tEvar ev args)
          | Ast.tSort u => ret (tSort u)
          | Ast.tConst c u => ret (tConst c u)
          | Ast.tInd c u => ret (tInd c u)
          | Ast.tConstruct c k u => ret (tConstruct c k u)
          | Ast.tLambda na T M => T <- monad_trans' T;; M <- monad_trans' M;; ret (tLambda na T M)
-         | Ast.tApp u v => u <- monad_trans' u;; v <- monad_map monad_trans' v;; ret (mkApps u v)
+         | Ast.tApp u v => u <- monad_trans' u;; v <- monad_map@{t u t t} monad_trans' v;; ret (mkApps u v)
          | Ast.tProd na A B => A <- monad_trans' A;; B <- monad_trans' B;; ret (tProd na A B)
          | Ast.tCast c kind t => t <- monad_trans' t;; c <- monad_trans' c;; ret (tApp (tLambda (mkBindAnn nAnon Relevant) t (tRel 0)) c)
          | Ast.tLetIn na b t b' => b <- monad_trans' b;; t <- monad_trans' t;; b' <- monad_trans' b';; ret (tLetIn na b t b')
          | Ast.tCase ci p c brs =>
              p' <- monad_map_predicate ret monad_trans' monad_trans' p;;
-             brs' <- monad_map (monad_map_branch monad_trans') brs;;
+             brs' <- monad_map@{t u t t} (monad_map_branch monad_trans') brs;;
              '(mdecl, idecl) <- TransLookup_lookup_inductive' ci.(ci_ind);;
              tp <- tmEval _ (trans_predicate ci.(ci_ind) mdecl idecl p'.(Ast.pparams) p'.(Ast.puinst) p'.(Ast.pcontext) p'.(Ast.preturn));;
              tbrs <- tmEval
@@ -127,10 +130,10 @@ Section with_tc.
              ret (tCase ci tp c tbrs)
          | Ast.tProj p c => c <- monad_trans' c;; ret (tProj p c)
          | Ast.tFix mfix idx =>
-             mfix' <- monad_map (monad_map_def monad_trans' monad_trans') mfix;;
+             mfix' <- monad_map@{t u t t} (monad_map_def monad_trans' monad_trans') mfix;;
              ret (tFix mfix' idx)
          | Ast.tCoFix mfix idx =>
-             mfix' <- monad_map (monad_map_def monad_trans' monad_trans') mfix;;
+             mfix' <- monad_map@{t u t t} (monad_map_def monad_trans' monad_trans') mfix;;
              ret (tCoFix mfix' idx)
          | Ast.tInt n => ret (tPrim (primInt; primIntModel n))
          | Ast.tFloat n => ret (tPrim (primFloat; primFloatModel n))
@@ -140,17 +143,21 @@ End with_tc.
 
 Import TemplateMonad.Core.
 
-Definition monad_trans : Ast.term -> TemplateMonad term
-  := tmFix (fun monad_trans v
-            => v <- @monad_trans' TypeInstance TemplateMonad_Monad (@TransLookup_lookup_inductive' TypeInstance TemplateMonad_Monad monad_trans) (@tmEval cbv) v;;
-               tmEval cbv v).
+Definition monad_trans@{t u} : Ast.term -> TemplateMonad@{t u} term
+  := tmFix@{u u t u}
+       (fun monad_trans v
+        => v <- @monad_trans'@{t u} TemplateMonad TemplateMonad_Monad
+                  (@TransLookup_lookup_inductive' TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive (@tmFail))
+                  (@tmEval cbv)
+                  v;;
+           tmEval cbv v).
 
-Definition monad_trans_decl := @monad_trans_decl' TypeInstance TemplateMonad_Monad monad_trans.
-Definition monad_trans_local := @monad_trans_local' TypeInstance TemplateMonad_Monad monad_trans.
-Definition monad_trans_constructor_body := @monad_trans_constructor_body' TypeInstance TemplateMonad_Monad monad_trans.
-Definition monad_trans_projection_body := @monad_trans_projection_body' TypeInstance TemplateMonad_Monad monad_trans.
-Definition monad_trans_one_ind_body := @monad_trans_one_ind_body' TypeInstance  TemplateMonad_Monad monad_trans.
-Definition monad_trans_constant_body := @monad_trans_constant_body' TypeInstance  TemplateMonad_Monad monad_trans.
-Definition monad_trans_minductive_body := @monad_trans_minductive_body' TypeInstance  TemplateMonad_Monad monad_trans.
-Definition monad_trans_global_decl := @monad_trans_global_decl' TypeInstance  TemplateMonad_Monad monad_trans.
-Definition tmQuoteInductive := @tmQuoteInductive' TypeInstance  TemplateMonad_Monad monad_trans.
+Definition monad_trans_decl@{t u} := @monad_trans_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_local@{t u} := @monad_trans_local'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_constructor_body@{t u} := @monad_trans_constructor_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_projection_body@{t u} := @monad_trans_projection_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_one_ind_body@{t u} := @monad_trans_one_ind_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_constant_body@{t u} := @monad_trans_constant_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_minductive_body@{t u} := @monad_trans_minductive_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_global_decl@{t u} := @monad_trans_global_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition tmQuoteInductive@{t u} := @tmQuoteInductive'@{t u} TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive.

--- a/template-pcuic/theories/TemplateMonadToPCUIC.v
+++ b/template-pcuic/theories/TemplateMonadToPCUIC.v
@@ -174,9 +174,9 @@ Definition monad_trans@{t u} : Ast.term -> TemplateMonad@{t u} term
        (fun monad_trans v
         => v <- @monad_trans'@{t u} TemplateMonad TemplateMonad_Monad
                   (@TransLookup_lookup_inductive' TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive (@tmFail))
-                  (@tmEval cbv)
+                  (@tmReturn)
                   v;;
-           tmEval cbv v).
+           ret v).
 
 Definition monad_trans_decl@{t u} := @monad_trans_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
 Definition monad_trans_local@{t u} := @monad_trans_local'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.

--- a/template-pcuic/theories/TemplateMonadToPCUIC.v
+++ b/template-pcuic/theories/TemplateMonadToPCUIC.v
@@ -25,61 +25,82 @@ Section with_tc.
       (tmFail : forall {A:Type@{t}}, string -> T A).
 
     Definition monad_trans_decl' (d : Ast.Env.context_decl) :=
-      decl_body <- monad_option_map@{t u t t} monad_trans d.(decl_body);;
-      decl_type <- monad_trans d.(decl_type);;
-      ret {| decl_name := d.(decl_name);
+      let '{| decl_body := decl_body ; decl_type := decl_type ; decl_name := decl_name |} := d in
+      decl_body <- monad_option_map@{t u t t} monad_trans decl_body;;
+      decl_type <- monad_trans decl_type;;
+      ret {| decl_name := decl_name;
             decl_body := decl_body;
             decl_type := decl_type |}.
 
     Definition monad_trans_local' Γ := monad_map monad_trans_decl' Γ.
 
     Definition monad_trans_constructor_body' (d : Ast.Env.constructor_body) :=
-      cstr_args <- monad_trans_local' d.(Ast.Env.cstr_args);;
-      cstr_indices <- monad_map@{t u t t} monad_trans d.(Ast.Env.cstr_indices);;
-      cstr_type <- monad_trans d.(Ast.Env.cstr_type);;
-      ret {| cstr_name := d.(Ast.Env.cstr_name);
+      let '{| Ast.Env.cstr_args := cstr_args ; Ast.Env.cstr_name := cstr_name ; Ast.Env.cstr_indices := cstr_indices ; Ast.Env.cstr_type := cstr_type ; Ast.Env.cstr_arity := cstr_arity |} := d in
+      cstr_args <- monad_trans_local' cstr_args;;
+      cstr_indices <- monad_map@{t u t t} monad_trans cstr_indices;;
+      cstr_type <- monad_trans cstr_type;;
+      ret {| cstr_name := cstr_name;
             cstr_args := cstr_args;
             cstr_indices := cstr_indices;
             cstr_type := cstr_type;
-            cstr_arity := d.(Ast.Env.cstr_arity) |}.
+            cstr_arity := cstr_arity |}.
 
     Definition monad_trans_projection_body' (d : Ast.Env.projection_body) :=
-      proj_type <- monad_trans d.(Ast.Env.proj_type);;
-      ret {| proj_name := d.(Ast.Env.proj_name);
+      let '{| Ast.Env.proj_name := proj_name ; Ast.Env.proj_type := proj_type ; Ast.Env.proj_relevance := proj_relevance |} := d in
+      proj_type <- monad_trans proj_type;;
+      ret {| proj_name := proj_name;
             proj_type := proj_type;
-            proj_relevance := d.(Ast.Env.proj_relevance) |}.
+            proj_relevance := proj_relevance |}.
 
     Definition monad_trans_one_ind_body' (d : Ast.Env.one_inductive_body) :=
-      ind_indices <- monad_trans_local' d.(Ast.Env.ind_indices);;
-      ind_type <- monad_trans d.(Ast.Env.ind_type);;
-      ind_ctors <- monad_map@{t u t t} monad_trans_constructor_body' d.(Ast.Env.ind_ctors);;
-      ind_projs <- monad_map@{t u t t} monad_trans_projection_body' d.(Ast.Env.ind_projs);;
-      ret {| ind_name := d.(Ast.Env.ind_name);
-            ind_relevance := d.(Ast.Env.ind_relevance);
+      let '{| Ast.Env.ind_name := ind_name;
+             Ast.Env.ind_relevance := ind_relevance;
+             Ast.Env.ind_indices := ind_indices;
+             Ast.Env.ind_sort := ind_sort;
+             Ast.Env.ind_type := ind_type;
+             Ast.Env.ind_kelim := ind_kelim;
+             Ast.Env.ind_ctors := ind_ctors;
+             Ast.Env.ind_projs := ind_projs |} := d in
+      ind_indices <- monad_trans_local' ind_indices;;
+      ind_type <- monad_trans ind_type;;
+      ind_ctors <- monad_map@{t u t t} monad_trans_constructor_body' ind_ctors;;
+      ind_projs <- monad_map@{t u t t} monad_trans_projection_body' ind_projs;;
+      ret {| ind_name := ind_name;
+            ind_relevance := ind_relevance;
             ind_indices := ind_indices;
-            ind_sort := d.(Ast.Env.ind_sort);
+            ind_sort := ind_sort;
             ind_type := ind_type;
-            ind_kelim := d.(Ast.Env.ind_kelim);
+            ind_kelim := ind_kelim;
             ind_ctors := ind_ctors;
             ind_projs := ind_projs |}.
 
     Definition monad_trans_constant_body' bd :=
-      cst_type <- monad_trans bd.(Ast.Env.cst_type);;
-      cst_body <- monad_option_map@{t u t t} monad_trans bd.(Ast.Env.cst_body);;
+      let '{| Ast.Env.cst_type := cst_type;
+             Ast.Env.cst_body := cst_body;
+             Ast.Env.cst_universes := cst_universes;
+             Ast.Env.cst_relevance := cst_relevance |} := bd in
+      cst_type <- monad_trans cst_type;;
+      cst_body <- monad_option_map@{t u t t} monad_trans cst_body;;
       ret {| cst_type := cst_type;
             cst_body := cst_body;
-            cst_universes := bd.(Ast.Env.cst_universes);
-            cst_relevance := bd.(Ast.Env.cst_relevance) |}.
+            cst_universes := cst_universes;
+            cst_relevance := cst_relevance |}.
 
     Definition monad_trans_minductive_body' md :=
-      ind_params <- monad_trans_local' md.(Ast.Env.ind_params);;
-      ind_bodies <- monad_map@{t u t t} monad_trans_one_ind_body' md.(Ast.Env.ind_bodies);;
-      ret {| ind_finite := md.(Ast.Env.ind_finite);
-            ind_npars := md.(Ast.Env.ind_npars);
+      let '{| Ast.Env.ind_finite := ind_finite;
+             Ast.Env.ind_npars := ind_npars;
+             Ast.Env.ind_params := ind_params;
+             Ast.Env.ind_bodies := ind_bodies;
+             Ast.Env.ind_universes := ind_universes;
+             Ast.Env.ind_variance := ind_variance |} := md in
+      ind_params <- monad_trans_local' ind_params;;
+      ind_bodies <- monad_map@{t u t t} monad_trans_one_ind_body' ind_bodies;;
+      ret {| ind_finite := ind_finite;
+            ind_npars := ind_npars;
             ind_params := ind_params;
             ind_bodies := ind_bodies;
-            ind_universes := md.(Ast.Env.ind_universes);
-            ind_variance := md.(Ast.Env.ind_variance) |}.
+            ind_universes := ind_universes;
+            ind_variance := ind_variance |}.
 
     Definition monad_trans_global_decl' (d : Ast.Env.global_decl) :=
       match d with
@@ -92,8 +113,10 @@ Section with_tc.
       monad_trans_minductive_body' bd.
 
     Definition TransLookup_lookup_inductive' (ind : inductive) : T (mutual_inductive_body × one_inductive_body) :=
-      mdecl <- tmQuoteInductive' (inductive_mind ind);;
-      match nth_error (ind_bodies mdecl) (inductive_ind ind) with
+      let '{| inductive_mind := inductive_mind ; inductive_ind := inductive_ind |} := ind in
+      mdecl <- tmQuoteInductive' inductive_mind;;
+      let '{| ind_bodies := ind_bodies |} := mdecl in
+      match nth_error ind_bodies inductive_ind with
       | Some idecl => ret (mdecl, idecl)
       | None => tmFail _ "TransLookup.lookup_inductive: nth_error: Not_found"
       end.
@@ -119,13 +142,16 @@ Section with_tc.
          | Ast.tCast c kind t => t <- monad_trans' t;; c <- monad_trans' c;; ret (tApp (tLambda (mkBindAnn nAnon Relevant) t (tRel 0)) c)
          | Ast.tLetIn na b t b' => b <- monad_trans' b;; t <- monad_trans' t;; b' <- monad_trans' b';; ret (tLetIn na b t b')
          | Ast.tCase ci p c brs =>
+             let '{| ci_ind := ci_ind |} := ci in
              p' <- monad_map_predicate ret monad_trans' monad_trans' p;;
+             let '{| Ast.pparams := pparams ; Ast.puinst := puinst ; Ast.pcontext := pcontext ; Ast.preturn := preturn |} := p' in
              brs' <- monad_map@{t u t t} (monad_map_branch monad_trans') brs;;
-             '(mdecl, idecl) <- TransLookup_lookup_inductive' ci.(ci_ind);;
-             tp <- tmEval _ (trans_predicate ci.(ci_ind) mdecl idecl p'.(Ast.pparams) p'.(Ast.puinst) p'.(Ast.pcontext) p'.(Ast.preturn));;
+             '(mdecl, idecl) <- TransLookup_lookup_inductive' ci_ind;;
+             let '{| ind_ctors := ind_ctors |} := idecl in
+             tp <- tmEval _ (trans_predicate ci_ind mdecl idecl pparams puinst pcontext preturn);;
              tbrs <- tmEval
-                       _ (map2 (fun cdecl br => trans_branch ci.(ci_ind) mdecl cdecl br.(Ast.bcontext) br.(Ast.bbody))
-                            idecl.(ind_ctors) brs');;
+                       _ (map2 (fun cdecl '{| Ast.bcontext := bcontext ; Ast.bbody := bbody |} => trans_branch ci_ind mdecl cdecl bcontext bbody)
+                            ind_ctors brs');;
              c <- monad_trans' c;;
              ret (tCase ci tp c tbrs)
          | Ast.tProj p c => c <- monad_trans' c;; ret (tProj p c)


### PR DESCRIPTION
We eliminate some projections and make judicious use of reduction.  This is necessary to have Gallina quotation to PCUIC in anything approximating a reasonable amount of time.  It's unfortunately not sufficient.  I haven't tried out `lazy` instead of `cbv`.  If anyone has good ideas for debugging reduction in the template monad, I'm quite interested.