### PR TITLE
Add `conv_pb_leqb`

### DIFF
--- a/common/theories/BasicAst.v
+++ b/common/theories/BasicAst.v
@@ -89,6 +89,13 @@ Inductive conv_pb :=
   | Cumul.
 Derive NoConfusion EqDec for conv_pb.
 
+Definition conv_pb_leqb (pb1 pb2 : conv_pb) : bool
+  := match pb1, pb2 with
+     | Conv, _ => true
+     | _, Conv => false
+     | Cumul, Cumul => true
+     end.
+
 (* This opaque natural number is a hack to inform unquoting to generate
   a fresh evar when encountering it. *)
 Definition fresh_evar_id : nat. exact 0. Qed.

--- a/common/theories/BasicAst.v
+++ b/common/theories/BasicAst.v
@@ -91,9 +91,8 @@ Derive NoConfusion EqDec for conv_pb.
 
 Definition conv_pb_leqb (pb1 pb2 : conv_pb) : bool
   := match pb1, pb2 with
-     | Conv, _ => true
-     | _, Conv => false
-     | Cumul, Cumul => true
+     | Cumul, Conv => false
+     | _, _ => true
      end.
 
 (* This opaque natural number is a hack to inform unquoting to generate


### PR DESCRIPTION
For a stronger `cumulSpec0_ind` lemma

Not sure if this is the right notion of comparison; I went with "leqb means 'stricter than'"