### PR TITLE
Fix `update-_PluginProject.in` target

### DIFF
--- a/template-coq/Makefile
+++ b/template-coq/Makefile
@@ -91,7 +91,7 @@ PLUGIN_PROJECT_BLACKLIST_SED:=\($(subst $(space),\|,$(PLUGIN_PROJECT_BLACKLIST))
 .PHONY: update-_PluginProject.in
 update-_PluginProject.in:
 	@echo 'WARNING: This target only works correctly when gen-src has been populated from making Extraction.vo and contains no outdated .ml{,i} files'
-	contents="$$(cat _PluginProject.in | grep -v '^gen-src/.*\.\(mli\|ml\)$$')"; \
+	contents="$$(cat _PluginProject.in | grep -v '^\(# \|\)gen-src/.*\.\(mli\|ml\)$$')"; \
 	line="$$(printf "%s\n" "$${contents}" | grep -n "^# Generated" | head -1 | cut -d: -f1)"; \
 	{ printf "%s\n" "$${contents}" | head -n$${line}; \
 	  ls -1 gen-src/*.ml gen-src/*.mli | env LC_COLLATE=C sort | sed 's,^\(gen-src/$(PLUGIN_PROJECT_BLACKLIST_SED)\)$$,# \1,g'; \

--- a/template-coq/_PluginProject.in
+++ b/template-coq/_PluginProject.in
@@ -234,22 +234,6 @@ gen-src/zeven.ml
 gen-src/zeven.mli
 gen-src/zpower.ml
 gen-src/zpower.mli
-# gen-src/carryType.ml
-# gen-src/carryType.mli
-# gen-src/coreTactics.ml
-# gen-src/coreTactics.mli
-# gen-src/depElim.ml
-# gen-src/depElim.mli
-# gen-src/floatClass.ml
-# gen-src/floatClass.mli
-# gen-src/init.ml
-# gen-src/init.mli
-# gen-src/mCUint63.ml
-# gen-src/mCUint63.mli
-# gen-src/noConfusion.ml
-# gen-src/noConfusion.mli
-# gen-src/wf.ml
-# gen-src/wf.mli
 
 gen-src/metacoq_template_plugin.mlpack
 


### PR DESCRIPTION
Now it no longer adds an ever-growing list of commented-out lines when run.