### PR TITLE
Take 2: Revert "Revert "CI:Add `concurrency` and `cancel-in-progress:true`""

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,16 @@ jobs:
 
     strategy:
       matrix:
-        coq_version: 
+        coq_version:
           - '8.16'
         ocaml_version:
           - '4.14-flambda'
         target: [ local, opam, quick ]
       fail-fast: true
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.target }}-Ubuntu-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
 

--- a/.github/workflows/nix-action-coq-8.16-macos.yml
+++ b/.github/workflows/nix-action-coq-8.16-macos.yml
@@ -2,6 +2,9 @@ jobs:
   coq:
     needs: []
     runs-on: macos-latest
+    concurrency:
+      group: ${{ github.workflow }}-MacOS-coq-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\
@@ -39,6 +42,9 @@ jobs:
     needs:
     - coq
     runs-on: macos-latest
+    concurrency:
+      group: ${{ github.workflow }}-MacOS-equations-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\
@@ -81,6 +87,9 @@ jobs:
     - coq
     - equations
     runs-on: macos-latest
+    concurrency:
+      group: ${{ github.workflow }}-MacOS-metacoq-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\

--- a/.github/workflows/nix-action-coq-8.16-ubuntu.yml
+++ b/.github/workflows/nix-action-coq-8.16-ubuntu.yml
@@ -2,6 +2,9 @@ jobs:
   coq:
     needs: []
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-Ubuntu-coq-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\
@@ -39,6 +42,9 @@ jobs:
     needs:
     - coq
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-Ubuntu-equations-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\
@@ -81,6 +87,9 @@ jobs:
     - coq
     - equations
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-Ubuntu-metacoq-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Determine which commit to test
       run: "if [ ${{ github.event_name }} = \"push\" ]; then\n  echo \"tested_commit=${{\


### PR DESCRIPTION
This reverts commit 2234055cda5ec60cfbaa5d6e4785f8c3b4c46450.

We no longer use the `env` object, under the hypothesis that it might have been behind the failures.  We hardcode the OS instead, and also extend the concurrency to other jobs in the nix workflows.