### PR TITLE
Parameterize reduction in PCUIC quotation with a typeclass

### DIFF
--- a/template-pcuic/theories/Loader.v
+++ b/template-pcuic/theories/Loader.v
@@ -4,13 +4,16 @@ From MetaCoq.Template Require Export Loader.
 From MetaCoq.TemplatePCUIC.PCUICTemplateMonad Require Core.
 From MetaCoq.TemplatePCUIC Require Import TemplateMonadToPCUIC.
 
+Notation eval_pcuic_quotation := eval_pcuic_quotation (only parsing).
+#[export] Existing Instance default_eval_pcuic_quotation.
+
 #[export] Set Warnings "-notation-overridden".
 (* Work around COQBUG(https://github.com/coq/coq/issues/16715) *)
-Notation "<% x %>" := (match monad_trans return _ with monad_trans => ltac:(let p y := exact y in let p y := run_template_program (monad_trans y) p in quote_term x p) end)
+Notation "<% x %>" := (match @monad_trans return _ with monad_trans => ltac:(let monad_trans := constr:(monad_trans _) in let p y := exact y in let p y := run_template_program (monad_trans y) p in quote_term x p) end)
   (only parsing).
 
 (* Work around COQBUG(https://github.com/coq/coq/issues/16715) with [match] *)
 (* Use [return _] to avoid running the program twice on failure *)
-Notation "<# x #>" := (match PCUICTemplateMonad.Core.tmQuoteRec x return _ with qx => ltac:(let p y := exact y in run_template_program qx p) end)
+Notation "<# x #>" := (match @PCUICTemplateMonad.Core.tmQuoteRec return _ with tmQuoteRec => ltac:(let qx := constr:(tmQuoteRec _ _ x) in let p y := exact y in run_template_program qx p) end)
   (only parsing).
 #[export] Set Warnings "+notation-overridden".

--- a/template-pcuic/theories/PCUICTemplateMonad/Core.v
+++ b/template-pcuic/theories/PCUICTemplateMonad/Core.v
@@ -11,16 +11,16 @@ Import MCMonadNotation.
 
 Definition tmQuote@{t u} {A:Type@{t}} (a : A) : TemplateMonad@{t u} PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
 Definition tmQuoteRecTransp@{t u} {A:Type@{t}} (a : A) (bypass_opacity : bool) : TemplateMonad@{t u} PCUICProgram.pcuic_program :=
-  (p <- tmQuoteRecTransp a bypass_opacity;; ret (trans_template_program p)).
+  (p <- tmQuoteRecTransp a bypass_opacity;; tmEval cbv (trans_template_program p)).
 Definition tmQuoteInductive@{t u} (kn : kername) : TemplateMonad@{t u} mutual_inductive_body := tmQuoteInductive@{t u} kn.
 Definition tmQuoteConstant@{t u} (kn : kername) (bypass_opacity : bool) : TemplateMonad@{t u} constant_body :=
   cb <- tmQuoteConstant kn bypass_opacity;; monad_trans_constant_body cb.
 Definition tmMkInductive@{t u} (b : bool) (mie : mutual_inductive_entry) : TemplateMonad@{t u} unit
-  := mie <- ret (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
-Definition tmUnquote@{t u} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- ret (PCUICToTemplate.trans t);; tmUnquote t.
-Definition tmUnquoteTyped@{t u} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- ret (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
+  := mie <- tmEval cbv (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
+Definition tmUnquote@{t u} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquote t.
+Definition tmUnquoteTyped@{t u} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
 
 (** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
 Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
 
-Definition tmMkDefinition@{t u} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- ret (PCUICToTemplate.trans tm);; tmMkDefinition id tm.
+Definition tmMkDefinition@{t u} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- tmEval cbv (PCUICToTemplate.trans tm);; tmMkDefinition id tm.

--- a/template-pcuic/theories/PCUICTemplateMonad/Core.v
+++ b/template-pcuic/theories/PCUICTemplateMonad/Core.v
@@ -9,18 +9,21 @@ Local Set Universe Polymorphism.
 Local Unset Universe Minimization ToSet.
 Import MCMonadNotation.
 
-Definition tmQuote@{t u} {A:Type@{t}} (a : A) : TemplateMonad@{t u} PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
-Definition tmQuoteRecTransp@{t u} {A:Type@{t}} (a : A) (bypass_opacity : bool) : TemplateMonad@{t u} PCUICProgram.pcuic_program :=
-  (p <- tmQuoteRecTransp a bypass_opacity;; tmEval cbv (trans_template_program p)).
-Definition tmQuoteInductive@{t u} (kn : kername) : TemplateMonad@{t u} mutual_inductive_body := tmQuoteInductive@{t u} kn.
-Definition tmQuoteConstant@{t u} (kn : kername) (bypass_opacity : bool) : TemplateMonad@{t u} constant_body :=
+Notation eval_pcuic_quotation := eval_pcuic_quotation (only parsing).
+#[export] Existing Instance default_eval_pcuic_quotation.
+
+Definition tmQuote@{t u} `{eval_pcuic_quotation} {A:Type@{t}} (a : A) : TemplateMonad@{t u} PCUICAst.term := qa <- tmQuote a;; monad_trans qa.
+Definition tmQuoteRecTransp@{t u} `{eval_pcuic_quotation} {A:Type@{t}} (a : A) (bypass_opacity : bool) : TemplateMonad@{t u} PCUICProgram.pcuic_program :=
+  (p <- tmQuoteRecTransp a bypass_opacity;; tmMaybeEval (trans_template_program p)).
+Definition tmQuoteInductive@{t u} `{eval_pcuic_quotation} (kn : kername) : TemplateMonad@{t u} mutual_inductive_body := tmQuoteInductive@{t u} kn.
+Definition tmQuoteConstant@{t u} `{eval_pcuic_quotation} (kn : kername) (bypass_opacity : bool) : TemplateMonad@{t u} constant_body :=
   cb <- tmQuoteConstant kn bypass_opacity;; monad_trans_constant_body cb.
-Definition tmMkInductive@{t u} (b : bool) (mie : mutual_inductive_entry) : TemplateMonad@{t u} unit
-  := mie <- tmEval cbv (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
-Definition tmUnquote@{t u} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquote t.
-Definition tmUnquoteTyped@{t u} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- tmEval cbv (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
+Definition tmMkInductive@{t u} `{eval_pcuic_quotation} (b : bool) (mie : mutual_inductive_entry) : TemplateMonad@{t u} unit
+  := mie <- tmMaybeEval (trans_mutual_inductive_entry mie);; tmMkInductive b mie.
+Definition tmUnquote@{t u} `{eval_pcuic_quotation} (t : PCUICAst.term) : TemplateMonad@{t u} typed_term := t <- tmMaybeEval (PCUICToTemplate.trans t);; tmUnquote t.
+Definition tmUnquoteTyped@{t u} `{eval_pcuic_quotation} A (t : PCUICAst.term) : TemplateMonad@{t u} A := t <- tmMaybeEval (PCUICToTemplate.trans t);; tmUnquoteTyped A t.
 
 (** We keep the original behaviour of [tmQuoteRec]: it quotes all the dependencies regardless of the opaqueness settings *)
-Definition tmQuoteRec {A} (a : A) := tmQuoteRecTransp a true.
+Definition tmQuoteRec `{eval_pcuic_quotation} {A} (a : A) := tmQuoteRecTransp a true.
 
-Definition tmMkDefinition@{t u} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- tmEval cbv (PCUICToTemplate.trans tm);; tmMkDefinition id tm.
+Definition tmMkDefinition@{t u} `{eval_pcuic_quotation} (id : ident) (tm : PCUICAst.term) : TemplateMonad@{t u} unit := tm <- tmMaybeEval (PCUICToTemplate.trans tm);; tmMkDefinition id tm.

--- a/template-pcuic/theories/TemplateMonadToPCUIC.v
+++ b/template-pcuic/theories/TemplateMonadToPCUIC.v
@@ -169,21 +169,30 @@ End with_tc.
 
 Import TemplateMonad.Core.
 
-Definition monad_trans@{t u} : Ast.term -> TemplateMonad@{t u} term
+Class eval_pcuic_quotation := pcuic_quotation_red_strategy : option reductionStrategy.
+#[export] Instance default_eval_pcuic_quotation : eval_pcuic_quotation := None.
+
+Definition tmMaybeEval@{t u} `{eval_pcuic_quotation} {A : Type@{t}} (v : A) : TemplateMonad@{t u} A
+  := match pcuic_quotation_red_strategy with
+     | None => tmReturn v
+     | Some s => tmEval s v
+     end.
+
+Definition monad_trans@{t u} `{eval_pcuic_quotation} : Ast.term -> TemplateMonad@{t u} term
   := tmFix@{u u t u}
        (fun monad_trans v
         => v <- @monad_trans'@{t u} TemplateMonad TemplateMonad_Monad
                   (@TransLookup_lookup_inductive' TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive (@tmFail))
-                  (@tmEval cbv)
+                  (fun A => tmMaybeEval)
                   v;;
-           tmEval cbv v).
+           tmMaybeEval v).
 
-Definition monad_trans_decl@{t u} := @monad_trans_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_local@{t u} := @monad_trans_local'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_constructor_body@{t u} := @monad_trans_constructor_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_projection_body@{t u} := @monad_trans_projection_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_one_ind_body@{t u} := @monad_trans_one_ind_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_constant_body@{t u} := @monad_trans_constant_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_minductive_body@{t u} := @monad_trans_minductive_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition monad_trans_global_decl@{t u} := @monad_trans_global_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
-Definition tmQuoteInductive@{t u} := @tmQuoteInductive'@{t u} TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive.
+Definition monad_trans_decl@{t u} `{eval_pcuic_quotation} := @monad_trans_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_local@{t u} `{eval_pcuic_quotation} := @monad_trans_local'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_constructor_body@{t u} `{eval_pcuic_quotation} := @monad_trans_constructor_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_projection_body@{t u} `{eval_pcuic_quotation} := @monad_trans_projection_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_one_ind_body@{t u} `{eval_pcuic_quotation} := @monad_trans_one_ind_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_constant_body@{t u} `{eval_pcuic_quotation} := @monad_trans_constant_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_minductive_body@{t u} `{eval_pcuic_quotation} := @monad_trans_minductive_body'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition monad_trans_global_decl@{t u} `{eval_pcuic_quotation} := @monad_trans_global_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
+Definition tmQuoteInductive@{t u} `{eval_pcuic_quotation} := @tmQuoteInductive'@{t u} TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive.

--- a/template-pcuic/theories/TemplateMonadToPCUIC.v
+++ b/template-pcuic/theories/TemplateMonadToPCUIC.v
@@ -174,9 +174,9 @@ Definition monad_trans@{t u} : Ast.term -> TemplateMonad@{t u} term
        (fun monad_trans v
         => v <- @monad_trans'@{t u} TemplateMonad TemplateMonad_Monad
                   (@TransLookup_lookup_inductive' TemplateMonad TemplateMonad_Monad monad_trans tmQuoteInductive (@tmFail))
-                  (@tmReturn)
+                  (@tmEval cbv)
                   v;;
-           ret v).
+           tmEval cbv v).
 
 Definition monad_trans_decl@{t u} := @monad_trans_decl'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.
 Definition monad_trans_local@{t u} := @monad_trans_local'@{t u} TemplateMonad TemplateMonad_Monad monad_trans.


### PR DESCRIPTION
By setting a `eval_pcuic_quotation` instance, reduction during quoting
and unquoting can be customized.  Adding Gallina quotation to for PCUIC
requires early reduction to avoid performance blowup, while the
test-suite requires avoiding reduction to avoid performance blowup.

With this strategy, we can support both use cases.