### PR TITLE
Add boolean versions of the varieties of `extends`

### DIFF
--- a/common/_CoqProject.in
+++ b/common/_CoqProject.in
@@ -11,5 +11,6 @@ theories/MonadBasicAst.v
 theories/Environment.v
 theories/Reflect.v
 theories/EnvironmentTyping.v
+theories/EnvironmentReflect.v
 theories/EnvMap.v
 theories/Transform.v

--- a/common/theories/EnvironmentReflect.v
+++ b/common/theories/EnvironmentReflect.v
@@ -1,0 +1,119 @@
+(* Distributed under the terms of the MIT license. *)
+From Coq Require Import ssreflect ssrbool ssrfun Morphisms Setoid.
+From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import BasicAst Primitive Universes Environment Reflect.
+From Equations.Prop Require Import Classes EqDecInstances.
+
+Module EnvironmentReflect (T : Term) (Import E : EnvironmentSig T) (Import TDec : TermDecide T) (Import EDec : EnvironmentDecide T E).
+
+  Local Notation extendsb_decls_part Σ Σ'
+    := (forallb (fun d => let c := d.1 in skipn (#|lookup_envs Σ' c| - #|lookup_envs Σ c|) (lookup_envs Σ' c) == lookup_envs Σ c) (declarations Σ)) (only parsing).
+  Local Notation strictly_extendsb_decls_part Σ Σ'
+    := (skipn (#|Σ'.(declarations)| - #|Σ.(declarations)|) Σ'.(declarations) == Σ.(declarations)) (only parsing).
+
+  Lemma extends_decls_partT (Σ Σ' : global_env)
+    : reflectT (forall c, ∑ decls, lookup_envs Σ' c = decls ++ lookup_envs Σ c) (extendsb_decls_part Σ Σ').
+  Proof.
+    case: (@forallbP _ _ _ _ (fun _ => eqb_specT _ _)) => H; constructor.
+    all: setoid_rewrite Forall_forall in H.
+    { move => c.
+      specialize (fun d => H (c, d)).
+      cbn [fst] in *.
+      specialize (fun pf : { d : _ | In (c, d) _ } => H (proj1_sig pf) (proj2_sig pf)).
+      destruct (lookup_envs Σ c) eqn:H'.
+      { eexists; rewrite app_nil_r; reflexivity. }
+      rewrite <- H; clear H.
+      { eexists; symmetry; apply firstn_skipn. }
+      unfold lookup_envs in *.
+      move: H'; elim: (declarations Σ); cbn [lookup_globals] => //= ??.
+      case: eqb_specT => ?; subst.
+      all: move => H H'; try destruct (H H'); rdest; eauto. }
+    { intro H'; apply H; clear H; intros [c ?]; specialize (H' c).
+      destruct H' as [decls H'].
+      cbn [fst].
+      rewrite H' app_length Nat.add_sub skipn_all_app //. }
+  Qed.
+
+  Lemma strictly_extends_decls_partT (Σ Σ' : global_env)
+    : reflectT (∑ Σ'', declarations Σ' = Σ'' ++ declarations Σ) (strictly_extendsb_decls_part Σ Σ').
+  Proof.
+    case: eqb_specT => H; constructor.
+    { rewrite -H.
+      eexists; symmetry; apply firstn_skipn. }
+    { move => [Σ'' H'].
+      move: H. rewrite H' app_length Nat.add_sub skipn_all_app //. }
+  Qed.
+
+  Definition extendsb (Σ Σ' : global_env) : bool
+    := Σ.(universes) ⊂?_cs Σ'.(universes)
+       && extendsb_decls_part Σ Σ'
+       && Retroknowledge.extendsb Σ.(retroknowledge) Σ'.(retroknowledge).
+
+  Definition extends_declsb (Σ Σ' : global_env) : bool
+    := (Σ.(universes) == Σ'.(universes))
+       && extendsb_decls_part Σ Σ'
+       && (Σ.(retroknowledge) == Σ'.(retroknowledge)).
+
+  Definition extends_strictly_on_declsb (Σ Σ' : global_env) : bool
+    := (Σ.(universes) ⊂?_cs Σ'.(universes))
+       && strictly_extendsb_decls_part Σ Σ'
+       && Retroknowledge.extendsb Σ.(retroknowledge) Σ'.(retroknowledge).
+
+  Definition strictly_extends_declsb (Σ Σ' : global_env) : bool
+    := (Σ.(universes) == Σ'.(universes))
+       && strictly_extendsb_decls_part Σ Σ'
+       && (Σ.(retroknowledge) == Σ'.(retroknowledge)).
+
+  Lemma extendsT Σ Σ' : reflectT (extends Σ Σ') (extendsb Σ Σ').
+  Proof.
+    rewrite /extends/extendsb.
+    case: extends_decls_partT; case: Retroknowledge.extendsT; case: ContextSet.subsetP; cbn;
+      constructor; intuition.
+  Qed.
+
+  Lemma extends_declsT Σ Σ' : reflectT (extends_decls Σ Σ') (extends_declsb Σ Σ').
+  Proof.
+    rewrite /extends_decls/extends_declsb.
+    case: extends_decls_partT; case: eqb_specT; case: eqb_specT; cbn;
+      constructor; intuition.
+  Qed.
+
+  Lemma extends_strictly_on_declsT Σ Σ' : reflectT (extends_strictly_on_decls Σ Σ') (extends_strictly_on_declsb Σ Σ').
+  Proof.
+    rewrite /extends_strictly_on_decls/extends_strictly_on_declsb.
+    case: strictly_extends_decls_partT; case: Retroknowledge.extendsT; case: ContextSet.subsetP; cbn;
+      constructor; intuition.
+  Qed.
+
+  Lemma strictly_extends_declsT Σ Σ' : reflectT (strictly_extends_decls Σ Σ') (strictly_extends_declsb Σ Σ').
+  Proof.
+    rewrite /strictly_extends_decls/strictly_extends_declsb.
+    case: strictly_extends_decls_partT; case: eqb_specT; case: eqb_specT; cbn;
+      constructor; intuition.
+  Qed.
+
+  Lemma extends_spec Σ Σ' : extendsb Σ Σ' <~> extends Σ Σ'.
+  Proof.
+    case: extendsT; split; intuition congruence.
+  Qed.
+
+  Lemma extends_decls_spec Σ Σ' : extends_declsb Σ Σ' <~> extends_decls Σ Σ'.
+  Proof.
+    case: extends_declsT; split; intuition congruence.
+  Qed.
+
+  Lemma extends_strictly_on_decls_spec Σ Σ' : extends_strictly_on_declsb Σ Σ' <~> extends_strictly_on_decls Σ Σ'.
+  Proof.
+    case: extends_strictly_on_declsT; split; intuition congruence.
+  Qed.
+
+  Lemma strictly_extends_decls_spec Σ Σ' : strictly_extends_declsb Σ Σ' <~> strictly_extends_decls Σ Σ'.
+  Proof.
+    case: strictly_extends_declsT; split; intuition congruence.
+  Qed.
+
+End EnvironmentReflect.
+
+Module Type EnvironmentReflectSig (T : Term) (E : EnvironmentSig T) (TDec : TermDecide T) (EDec : EnvironmentDecide T E).
+  Include EnvironmentReflect T E TDec EDec.
+End EnvironmentReflectSig.

--- a/pcuic/theories/Syntax/PCUICReflect.v
+++ b/pcuic/theories/Syntax/PCUICReflect.v
@@ -4,6 +4,7 @@ From Equations Require Import Equations.
 
 From MetaCoq.PCUIC Require Import PCUICAst PCUICInduction.
 From MetaCoq.Utils Require Import utils.
+From MetaCoq.Common Require Import EnvironmentReflect.
 From MetaCoq.Common Require Export Reflect.
 
 Open Scope pcuic.
@@ -375,6 +376,7 @@ Qed.
 
 Module PCUICTermDecide <: TermDecide PCUICTerm.
   #[export] Instance term_eq_dec : EqDec term := _.
+  Include TermDecideReflectInstances PCUICTerm.
 End PCUICTermDecide.
 
 Module PCUICEnvironmentDecide <: EnvironmentDecide PCUICTerm PCUICEnvironment.
@@ -385,4 +387,7 @@ Module PCUICEnvironmentDecide <: EnvironmentDecide PCUICTerm PCUICEnvironment.
   #[export] Instance mutual_inductive_body_eq_dec : EqDec mutual_inductive_body := _.
   #[export] Instance constant_body_eq_dec : EqDec constant_body := _.
   #[export] Instance global_decl_eq_dec : EqDec global_decl := _.
+  Include EnvironmentDecideReflectInstances PCUICTerm PCUICEnvironment.
 End PCUICEnvironmentDecide.
+
+Module PCUICEnvironmentReflect := EnvironmentReflect PCUICTerm PCUICEnvironment PCUICTermDecide PCUICEnvironmentDecide.

--- a/quotation/theories/ToPCUIC/Common/Universes.v
+++ b/quotation/theories/ToPCUIC/Common/Universes.v
@@ -63,8 +63,8 @@ Export (hints) QuoteUniverses1.
   UContext.t
   AUContext.t
   ContextSet.t
-  ContextSet.equal
-  ContextSet.subset
+  ContextSet.Equal
+  ContextSet.Subset
   : quotation.
 
 #[export] Typeclasses Transparent

--- a/quotation/theories/ToTemplate/Common/Universes.v
+++ b/quotation/theories/ToTemplate/Common/Universes.v
@@ -63,8 +63,8 @@ Export (hints) QuoteUniverses1.
   UContext.t
   AUContext.t
   ContextSet.t
-  ContextSet.equal
-  ContextSet.subset
+  ContextSet.Equal
+  ContextSet.Subset
   : quotation.
 
 #[export] Typeclasses Transparent

--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -2,7 +2,7 @@
 (* For primitive integers and floats  *)
 From Coq Require Numbers.Cyclic.Int63.Uint63 Floats.PrimFloat Floats.FloatAxioms.
 From MetaCoq.Utils Require Import utils.
-From MetaCoq.Common Require Import BasicAst Reflect Environment.
+From MetaCoq.Common Require Import BasicAst Reflect Environment EnvironmentReflect.
 From MetaCoq.Template Require Import AstUtils Ast Induction.
 Require Import ssreflect.
 From Equations Require Import Equations.
@@ -248,6 +248,7 @@ Defined.
 
 Module TemplateTermDecide <: TermDecide TemplateTerm.
   #[export] Instance term_eq_dec : EqDec term := _.
+  Include TermDecideReflectInstances TemplateTerm.
 End TemplateTermDecide.
 
 Module EnvDecide <: EnvironmentDecide TemplateTerm Env.
@@ -258,4 +259,7 @@ Module EnvDecide <: EnvironmentDecide TemplateTerm Env.
   #[export] Instance mutual_inductive_body_eq_dec : EqDec mutual_inductive_body := _.
   #[export] Instance constant_body_eq_dec : EqDec constant_body := _.
   #[export] Instance global_decl_eq_dec : EqDec global_decl := _.
+  Include EnvironmentDecideReflectInstances TemplateTerm Env.
 End EnvDecide.
+
+Module EnvReflect := EnvironmentReflect TemplateTerm Env TemplateTermDecide EnvDecide.


### PR DESCRIPTION
This is required for having environment extension be easily decidable, which we'll need for automation around showing that Gallina quotation is well-typed.

Also rename `ContextSet.{equal,subset}` to `ContextSet.{Equals,Subset}` to make room for boolean versions that follow the convention of other definitions.