### PR TITLE
Adapt w.r.t. coq/coq#17564.

### DIFF
--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -128,7 +128,7 @@ Section fix_sigma.
     induction (normalization_in Σ wf wfΣ' Γ s H') as [s _ IH]. cbn in IH.
     induction (wf_cod' s) as [s _ IH_sub] in Γ, H , H', IH |- *.
     econstructor.
-    intros (Γ' & B & ?) [(na & A & ? & ?)]; eauto. subst.
+    eintros (Γ' & B & ?) [(na & A & ? & ?)]; eauto. subst.
     eapply Relation_Properties.clos_rt_rtn1 in r. inversion r.
       + subst. eapply IH_sub. econstructor. cbn. reflexivity.
         intros. eapply IH.
@@ -240,7 +240,7 @@ Section fix_sigma.
       * pose proof (abstract_env_ext_exists X) as [[Σ wfΣ]].
         pose proof (abstract_env_ext_wf X wfΣ) as [wfΣ'].
         specialize_Σ wfΣ. sq.
-        intros [T' [[HT'] isa]]; eauto.
+        eintros [T' [[HT'] isa]]; eauto.
         destruct (PCUICContextConversion.closed_red_confluence H HT') as (? & ? & ?); eauto.
         eapply invert_red_prod in c as (? & ? & []); eauto. subst.
         apply n. intros. rewrite (abstract_env_ext_irr _ H0 wfΣ).
@@ -633,7 +633,7 @@ Proof.
     all:try bang.
     all:try match goal with
       [ H : context [@is_erasableb ?X_type ?X ?normalization_in ?Γ ?t ?Ht ] |- _ ] =>
-        destruct (@is_erasableP X_type X normalization_in Γ t Ht) as [[H']|H'] => //; eauto ;
+        edestruct (@is_erasableP X_type X normalization_in Γ t Ht) as [[H']|H'] => //; eauto ;
         try now eapply erases_box
     end.
     all: try solve [constructor; eauto].
@@ -1512,7 +1512,7 @@ Lemma erase_global_includes X_type (X:X_type.π1) deps decls {normalization_in} 
 Proof.
   intros ? sub Σ wfΣ; cbn. induction decls in X, H, sub, prf, deps, deps', Σ , wfΣ, normalization_in |- *.
   - simpl. intros i hin. exfalso.
-    specialize (H i hin) as [[decl Hdecl]]; eauto.
+    edestruct (H i hin) as [[decl Hdecl]]; eauto.
     rewrite /lookup_env (prf _ wfΣ) in Hdecl. noconf Hdecl.
   - intros i hin.
     destruct (abstract_env_wf _ wfΣ) as [wf].

--- a/pcuic/theories/PCUICProgress.v
+++ b/pcuic/theories/PCUICProgress.v
@@ -105,7 +105,7 @@ Proof.
     econstructor. eexists; eauto. eexists; eauto. eapply isType_ws_cumul_pb_refl. eexists; eauto. }
   intros Hf Ht. simpl in Hf.
   specialize (IHu (tApp f a) T).
-  epose proof (IHu Hf) as (T' & H' & s' & H1 & H2 & H3 & H4); tea.
+  edestruct (IHu Hf) as (T' & H' & s' & H1 & H2 & H3 & H4); tea.
   edestruct @inversion_App_size with (H := H') as (na' & A' & B' & s_ & Hf' & Ha & HA & Hs1 & Hs2 & Hs3 & HA'''); tea.
   exists (tProd na' A' B'). exists Hf'. exists s_. exists HA.
   split. rewrite <- H2. lia.

--- a/safechecker/theories/PCUICSafeConversion.v
+++ b/safechecker/theories/PCUICSafeConversion.v
@@ -238,7 +238,7 @@ Section Conversion.
         * intros [t' h']. eapply Subterm.wf_lexprod.
           -- intro. eapply posR_Acc.
           -- intro. eapply stateR_Acc.
-        * intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]]; eauto.
+        * eintros x x' y [e] [y' [x'' [r [[e1] [e2]]]]]; eauto.
           eexists _,_. erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
           intuition eauto using sq.
           constructor. etransitivity; tea.
@@ -269,7 +269,7 @@ Section Conversion.
              end.
             rewrite ee. right. clear ee. assumption.
         * eapply wcored_wf.
-    - intros x x' y [e] [y' [x'' [r [[e1] [e2]]]]]; eauto.
+    - eintros x x' y [e] [y' [x'' [r [[e1] [e2]]]]]; eauto.
       intros. erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
       eexists _,_. intuition eauto using sq.
       constructor. etransitivity; eauto.
@@ -1660,7 +1660,7 @@ Qed.
     erewrite <- abstract_env_lookup_correct' in eq1, eq2; eauto.
     symmetry in eq1, eq2.
     eapply declared_constant_from_gen in eq1, eq2.
-    generalize hΣ. intros []; eauto.
+    generalize hΣ. eintros []; eauto.
     unshelve eapply closed_red_mkApps_tConst_axiom in r1 as (?&->&?); eauto.
     eapply closed_red_mkApps_tConst_axiom in r2 as (?&->&?); eauto.
     apply eq_termp_mkApps_inv in eq as (eq&?); [|easy|easy].
@@ -2710,7 +2710,7 @@ Qed.
   Proof using Type.
     intros eq ir. pose proof (heΣ _ wfΣ) as [[]].
     pose proof (hΣ _ wfΣ).
-    destruct ir as (_&[wh]); eauto.
+    edestruct ir as (_&[wh]); eauto.
     eapply eqb_term_upto_univ_impl with (p := wf_universeb Σ) (q := closedu) in eq; tea.
     2-3: intros; apply iff_reflect; eapply (abstract_env_compare_universe_correct _ wfΣ Conv) ; now eapply wf_universe_iff.
     2:{ intros. rewrite wf_universeb_instance_forall in *.
@@ -2718,7 +2718,7 @@ Qed.
       apply wf_universe_instance_iff in H1.
       apply compare_global_instance_correct; eauto.
     }
-    - epose proof (reduce_term_complete _ _ _ _ _ _) as [wh'].
+    - epose proof (reduce_term_complete _ _ _ _ _ _) as Hr; edestruct Hr as [wh'].
       eapply whnf_eq_term in eq; [|exact wh'].
       rewrite zipp_as_mkApps in wh.
       depelim wh; solve_discr.
@@ -2780,7 +2780,7 @@ Qed.
      ws_cumul_pb_brs Σ (Γ,,, stack_context π) p brs brs' &
      ws_cumul_pb_terms Σ (Γ,,, stack_context π) (decompose_stack π).1 (decompose_stack π').1]∥.
   Proof using Type.
-    intros [] c_is_red%eq_sym c'_is_red%eq_sym wtc wtc' isr1 isr2 cc; eauto.
+    eintros [] c_is_red%eq_sym c'_is_red%eq_sym wtc wtc' isr1 isr2 cc; eauto.
     eapply reduced_case_discriminee_whne in c_is_red as wh1; eauto.
     eapply reduced_case_discriminee_whne in c'_is_red as wh2; eauto.
     destruct (hΣ _ wfΣ) as [hΣ], wh1 as [wh1], wh2 as [wh2].
@@ -2806,7 +2806,7 @@ Qed.
     ∥whne RedFlags.default Σ (Γ,,, stack_context π) c∥.
   Proof using Type.
     intros eq%eq_sym ir.
-    destruct ir as (_&[wh]); eauto.
+    edestruct ir as (_&[wh]); eauto.
     pose proof (hΣ _ wfΣ).
     eapply eqb_term_upto_univ_impl in eq; tea.
     2-3: intros; apply iff_reflect; eapply (abstract_env_compare_universe_correct _ wfΣ Conv) ; now eapply wf_universe_iff.
@@ -2814,7 +2814,7 @@ Qed.
         apply wf_universe_instance_iff in H0.
         apply wf_universe_instance_iff in H1.
         eapply (compare_global_instance_correct wfΣ); eauto. }
-    - epose proof (reduce_term_complete _ _ _ _ _ _) as [wh'].
+    - epose proof (reduce_term_complete _ _ _ _ _ _) as Hr; edestruct Hr as [wh'].
       eapply whnf_eq_term in eq; [|exact wh'].
       rewrite zipp_as_mkApps in wh.
       depelim wh; solve_discr.
@@ -2846,7 +2846,7 @@ Qed.
      Σ;;; Γ,,, stack_context π ⊢ c = c' ×
      ws_cumul_pb_terms Σ (Γ,,, stack_context π) (decompose_stack π).1 (decompose_stack π').1∥.
   Proof using Type.
-    intros [] c_is_red c'_is_red isr1 isr2 cc; eauto.
+    eintros [] c_is_red c'_is_red isr1 isr2 cc; eauto.
     eapply reduced_proj_body_whne in c_is_red as wh1; eauto.
     eapply reduced_proj_body_whne in c'_is_red as wh2; eauto.
     destruct (hΣ _ wfΣ) as [hΣ], wh1 as [wh1], wh2 as [wh2].
@@ -2888,12 +2888,12 @@ Qed.
           mfix mfix' &
      ws_cumul_pb_terms Σ (Γ,,, stack_context π) (decompose_stack π).1 (decompose_stack π').1]∥.
   Proof using Type.
-    intros [?] uf1 uf2 cc; eauto.
+    eintros [?] uf1 uf2 cc; eauto.
     rewrite !zipp_as_mkApps in cc; eauto.
     apply unfold_one_fix_None in uf1.
-    destruct uf1 as [(?&?&?)]; eauto.
+    edestruct uf1 as [(?&?&?)]; eauto.
     apply unfold_one_fix_None in uf2.
-    destruct uf2 as [(?&?&?)]; eauto.
+    edestruct uf2 as [(?&?&?)]; eauto.
     destruct (hΣ _ wfΣ).
     eapply conv_cum_red_conv_inv in cc.
     2: eassumption.
@@ -2932,7 +2932,7 @@ Qed.
           mfix mfix' ×
      ws_cumul_pb_terms Σ (Γ,,, stack_context π) (decompose_stack π).1 (decompose_stack π').1∥.
   Proof using Type.
-    intros [?] cc; eauto. specialize_Σ wfΣ.
+    eintros [?] cc; eauto. specialize_Σ wfΣ.
     rewrite !zipp_as_mkApps in cc.
     destruct (hΣ _ wfΣ).
     apply conv_cum_mkApps_inv in cc as [(ws_cumul_pb_CoFix&conv_args)]; auto.
@@ -3835,7 +3835,7 @@ Qed.
     specialize_Σ wfΣ.
     match goal with
       | |- context [ reduce_term ?f ?Σ ?hΣ ?Γ ?t ?h ] =>
-        pose proof (reduce_term_sound f Σ hΣ Γ t h) as [hr]
+        pose proof (reduce_term_sound f Σ hΣ Γ t h) as Hr; edestruct Hr as [hr]
     end; eauto.
     eapply red_welltyped ; [auto|..].
     - exact h2'.
@@ -3843,7 +3843,7 @@ Qed.
       eapply red_case_c; auto. eapply hr.
   Qed.
   Next Obligation.
-    destruct (abstract_env_ext_exists X) as [[Σ wfΣ]];
+    edestruct (abstract_env_ext_exists X) as [[Σ wfΣ]];
     specialize_Σ wfΣ.
     match goal with
     | |- context [ reduce_term ?f _ ?X ?Γ c' ?h ] =>
@@ -3925,7 +3925,7 @@ Qed.
     pose proof (hΣ _ wfΣ) as []. pose proof hx as hx'.
     specialize_Σ wfΣ.
     destruct hx'.
-    epose proof (reduce_term_sound _ _ _ _ _ _) as [r]; eauto.
+    epose proof (reduce_term_sound _ _ _ _ _ _) as Hr; edestruct Hr as [r]; eauto.
     eapply conv_cum_red_conv_inv.
     all: tea.
     1: reflexivity.
@@ -3939,7 +3939,7 @@ Qed.
     clear aux eq3. specialize_Σ wfΣ.
     match goal with
       | |- context [ reduce_term ?f ?Σ ?hΣ ?Γ ?t ?h ] =>
-        pose proof (reduce_term_sound f Σ hΣ Γ t h) as [hr]
+        pose proof (reduce_term_sound f Σ hΣ Γ t h) as Hr; edestruct Hr as [hr]
     end; eauto.
     sq.
     eapply red_welltyped ; [auto|..].
@@ -4024,7 +4024,7 @@ Qed.
     apply h; clear h. intros Σ wfΣ.
     pose proof (hΣ _ wfΣ) as [].
     destruct (hx _ wfΣ).
-    epose proof (reduce_term_sound _ _ _ _ _ _) as [r]; eauto.
+    epose proof (reduce_term_sound _ _ _ _ _ _) as Hr; edestruct Hr as [r]; eauto.
     eapply conv_cum_red_inv.
     1: eauto.
     2: reflexivity.
@@ -4091,7 +4091,7 @@ Qed.
     pose proof (heΣ _ wfΣ) as [].
     match goal with
     | |- context [ reduce_term ?f ?Σ ?hΣ ?Γ ?t ?h ] =>
-      pose proof (reduce_term_sound f Σ hΣ Γ t h) as [hr]
+      pose proof (reduce_term_sound f Σ hΣ Γ t h) as Hr; edestruct Hr as [hr]
     end; eauto.
     eapply red_welltyped ; [auto|..].
     - exact (h2 _ wfΣ).
@@ -4195,7 +4195,7 @@ Qed.
     pose proof (heΣ _ wfΣ) as [].
     match goal with
       | |- context [ reduce_term ?f _ ?X ?Γ ?t ?h ] =>
-        pose proof (reduce_term_sound f _ X Γ t h) as [hr]
+        pose proof (reduce_term_sound f _ X Γ t h) as Hr; edestruct Hr as [hr]
     end; eauto.
     sq.
     eapply red_welltyped ; [auto|..].
@@ -5611,7 +5611,7 @@ Qed.
   Qed.
   Next Obligation.
     apply h; clear h. intros Σ wfΣ.
-    destruct ir1 as (notapp1&[whδ1]), ir2 as (notapp2&[whδ2]); eauto.
+    edestruct ir1 as (notapp1&[whδ1]), ir2 as (notapp2&[whδ2]); eauto.
     erewrite !zipp_as_mkApps in *.
     eapply reducible_head_None in nored1 as [(?&?&s1&r1&wh1)]; eauto.
     eapply reducible_head_None in nored2 as [(?&?&s2&r2&wh2)]; eauto.
@@ -5643,7 +5643,7 @@ Qed.
   Next Obligation.
     unfold eqb_termp_napp in noteq.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
-    destruct ir1 as (notapp1&[whδ1]), ir2 as (notapp2&[whδ2]); eauto.
+    edestruct ir1 as (notapp1&[whδ1]), ir2 as (notapp2&[whδ2]); eauto.
     erewrite !zipp_as_mkApps in *.
     eapply reducible_head_None in nored1 as [(?&?&s1&rargs1&wh1)]; eauto.
     eapply reducible_head_None in nored2 as [(?&?&s2&rargs2&wh2)]; eauto.

--- a/safechecker/theories/PCUICSafeReduce.v
+++ b/safechecker/theories/PCUICSafeReduce.v
@@ -1129,7 +1129,7 @@ Corollary R_Acc_aux :
   Proof using Type.
     intros Σ wfΣ Γ t π h.
     unfold reduce_stack.
-    destruct (reduce_stack_full Γ t π h) as [[t' π'] [r _]];
+    edestruct (reduce_stack_full Γ t π h) as [[t' π'] [r _]];
     eassumption.
   Qed.
 
@@ -1152,7 +1152,7 @@ Corollary R_Acc_aux :
     intros Γ t π h.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     unfold reduce_stack.
-    destruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p p']]];
+    edestruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p p']]];
     try eassumption.
     unfold Pr in p. symmetry. assumption.
   Qed.
@@ -1186,7 +1186,7 @@ Corollary R_Acc_aux :
     intros Γ t π h hr.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     unfold reduce_stack.
-    destruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p [hApp hLam]]]]; eauto.
+    edestruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p [hApp hLam]]]]; eauto.
     split.
     - assumption.
     - apply hLam. assumption.
@@ -1199,7 +1199,7 @@ Corollary R_Acc_aux :
     intros Γ t π h.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     unfold reduce_stack.
-    destruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p [hApp hLam]]]]; eauto.
+    edestruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p [hApp hLam]]]]; eauto.
   Qed.
 
   Lemma reduce_stack_noLamApp :
@@ -1211,7 +1211,7 @@ Corollary R_Acc_aux :
     intros Γ t π h.
     unfold reduce_stack.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
-    destruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p [hApp hLam]]]]; eauto.
+    edestruct (reduce_stack_full Γ t π h) as [[t' π'] [r [p [hApp hLam]]]]; eauto.
   Qed.
 
   Definition reduce_term Γ t
@@ -1868,8 +1868,8 @@ Section ReduceFns.
       now rewrite eq.
     * destruct (abstract_env_ext_exists X) as [[Σ wfΣ]]. specialize (X1 _ wfΣ).
       pose proof (hΣ := hΣ _ X _ wfΣ). sq.
-      pose proof (@hnf_complete Γ t h) as [wh]; eauto.
-      pose proof (@hnf_sound Γ t h) as [r']; eauto.
+      edestruct (@hnf_complete Γ t h) as [wh]; eauto.
+      edestruct (@hnf_sound Γ t h) as [r']; eauto.
       eapply PCUICContextConversion.closed_red_confluence in X1 as (?&r1&r2); eauto.
       apply invert_red_sort in r2 as ->.
       eapply whnf_red_inv in r1; eauto.
@@ -1913,8 +1913,8 @@ Section ReduceFns.
     * destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
       specialize (X3 _ wfΣ).
       sq.
-      pose proof (@hnf_complete Γ t h) as [wh]; eauto.
-      pose proof (@hnf_sound Γ t h) as [r']; eauto.
+      edestruct (@hnf_complete Γ t h) as [wh]; eauto.
+      edestruct (@hnf_sound Γ t h) as [r']; eauto.
       destruct (hΣ _ _ _ wfΣ).
       eapply PCUICContextConversion.closed_red_confluence in X3 as (?&r1&r2); eauto.
       apply invert_red_prod in r2 as (?&?&[-> ? ?]); auto.
@@ -1966,7 +1966,7 @@ Section ReduceFns.
       assert (π = appstack l []) as ->.
       2: { now rewrite zipc_appstack in H. }
       unfold reduce_stack in eq.
-      destruct reduce_stack_full as (?&_&stack_val&?); eauto.
+      edestruct reduce_stack_full as (?&_&stack_val&?); eauto.
       subst x.
       unfold Pr in stack_val.
       cbn in *.
@@ -1980,7 +1980,7 @@ Section ReduceFns.
       pose proof (hΣ := hΣ _ _ _ wfΣ). sq.
       pose proof (reduce_stack_whnf RedFlags.default _ X Γ t [] h _  wfΣ) as wh.
       unfold reduce_stack in *.
-      destruct reduce_stack_full as ((hd&π')&r'&stack_valid&(notapp&_)); eauto.
+      edestruct reduce_stack_full as ((hd&π')&r'&stack_valid&(notapp&_)); eauto.
       destruct wh as [wh].
       apply Req_red in r' as [r'].
       unfold Pr in stack_valid.

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -2008,7 +2008,7 @@ Section Typecheck.
     cbn in *. apply absurd. intros.
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2032,7 +2032,7 @@ Section Typecheck.
     cbn in *. apply absurd. intros.
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2051,7 +2051,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2071,7 +2071,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2090,7 +2090,7 @@ Section Typecheck.
     cbn in *. apply absurd. intros.
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2123,7 +2123,7 @@ Section Typecheck.
     cbn in *. apply absurd. intros.
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2145,7 +2145,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2188,7 +2188,7 @@ Section Typecheck.
     cbn in *. apply absurd; intros.
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2205,7 +2205,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2224,7 +2224,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     destruct (hΣ _ wfΣ). unshelve eapply declared_inductive_to_gen in isdecl, H3; eauto.
     eapply declared_inductive_inj in isdecl as []. 2: exact H3.
@@ -2239,7 +2239,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     apply absurd.
     do 2 eexists. intros; erewrite (abstract_env_ext_irr _ _ wfΣ); eauto.
@@ -2254,7 +2254,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     cbn in *.
     apply absurd.
@@ -2270,7 +2270,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     cbn in *.
     apply absurd.
@@ -2292,7 +2292,7 @@ Section Typecheck.
     destruct (abstract_env_ext_exists X) as [[Σ wfΣ]].
     pose proof (heΣ _ wfΣ) as [heΣ].
     cbn in *. specialize_Σ wfΣ ; sq.
-    destruct X0 as [? [ty]]; eauto.
+    edestruct X0 as [? [ty]]; clear X0; eauto.
     inversion ty ; subst.
     cbn in *.
     sq.


### PR DESCRIPTION
Should be backwards compatible. This fixes metacoq relying on faulty silent evar shelving with intropatterns.