### PR TITLE
Adapt to coq PR #17991 which lets "simpl" refolds partial applications of fixpoints

### DIFF
--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -1410,10 +1410,11 @@ Proof.
                 typing_size Hty <
                 S
                   ((typing_spine_size
-                      (fun x (x0 : context) (x1 x2 : term) (x3 : x;;; x0 |- x1 : x2) =>
-                         typing_size x3) Σ Γ t_ty l t' t0)) ->
+                      (@typing_size cf) Σ Γ t_ty l t' t0)) ->
                 on_global_env cumul_gen (lift_typing P) Σ.1 * P Σ Γ0 t1 T). {
-       intros. unshelve eapply X14; eauto. lia. }
+       intros. unshelve eapply X14; eauto.
+       change (fun x x0 x1 x2 x3 => typing_size x3) with (@typing_size cf). (* Needed with old versions of "simpl" in "simpl in X14" *) 
+       lia. }
        clear X14. simpl in pΓ. clear n e H pΓ.
        induction t0; constructor.
        unshelve eapply X; clear X; simpl; auto with arith.


### PR DESCRIPTION
The `simpl` reduction used to not refold the partially applied recursive calls of reducible fixpoints as this was requiring eta-conversion. Thanks to eta-conversion support, this is not anymore needed and Coq PR coq/coq#17991 implements refolding of partial applications.

This has an impact on metacoq, in the file `Typing.v` of template-coq, namely, the expression
```coq
typing_size (type_App Σ Γ t l t_ty t' H e n t0)
```
reduces with the Coq PR to
```coq
S (Nat.max (typing_size H) (typing_spine_size (@typing_size cf) Σ Γ t_ty l t' t0))
```
while it reduced before to
```coq
S (Nat.max (typing_size H)
             (typing_spine_size
                (fun (x : global_env_ext) (x0 : context) 
                   (x1 x2 : term) (x3 : x;;; x0 |- x1 : x2) => 
                 typing_size x3) Σ Γ t_ty l t' t0
```

Assuming that the new behavior is "better" (more intelligible, more intuitive), this metacoq PR ensures that `Typing.v` compiles both with and without the change of behavior of `simpl` (the change is not very smart but works).

If ok for you, the PR can then be merged as soon as now.