### PR TITLE
Support primitive array terms

### DIFF
--- a/common/theories/Primitive.v
+++ b/common/theories/Primitive.v
@@ -6,8 +6,8 @@ Local Open Scope bs.
 
 Variant prim_tag :=
   | primInt
-  | primFloat.
-  (* | primArray. *)
+  | primFloat
+  | primArray.
 Derive NoConfusion EqDec for prim_tag.
 
 Definition string_of_prim_int (i:Uint63.int) : string :=

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -525,7 +525,7 @@ Section isEtaExp.
     #|Γ| = k ->
     nth_error mfix idx = Some d ->
     closed (EAst.tFix mfix idx) ->
-    forallb (fun x => isLambda x.(dbody) &&  isEtaExp (rev_map (S ∘ rarg) mfix) x.(dbody)) mfix ->
+    forallb (fun x => isEtaExp (rev_map (S ∘ rarg) mfix) x.(dbody)) mfix ->
     isEtaExp (Γ ++ [1 + d.(EAst.rarg)] ++ Δ) b -> isEtaExp (Γ ++ Δ) (ECSubst.csubst (EAst.tFix mfix idx) k b).
   Proof using Type*.
     intros Hk Hnth Hcl.
@@ -631,13 +631,14 @@ Section isEtaExp.
   Qed.
 
   Lemma isEtaExp_fixsubstl Δ mfix t :
-    forallb (fun x => isLambda x.(dbody) &&
+    forallb (fun x =>
+      (* isLambda x.(dbody) && *)
       isEtaExp (rev_map (S ∘ rarg) mfix) x.(dbody)) mfix ->
     isEtaExp ((rev_map (S ∘ rarg) mfix) ++ Δ) t ->
     isEtaExp Δ (substl (fix_subst mfix) t).
   Proof using Type*.
     intros Hall Heta.
-    assert (Hcl : closed (EAst.tFix mfix 0) ). { cbn. solve_all. rtoProp; intuition auto. eapply isEtaExp_closed in H0. revert H0. now len. }
+    assert (Hcl : closed (EAst.tFix mfix 0) ). { cbn. solve_all. rtoProp; intuition auto. eapply isEtaExp_closed in H. revert H. now len. }
     revert Hcl Hall Heta.
     intros Hcl Hall Heta.
     cbn in Hcl. solve_all.

--- a/pcuic/theories/Conversion/PCUICWeakeningConfigConv.v
+++ b/pcuic/theories/Conversion/PCUICWeakeningConfigConv.v
@@ -97,6 +97,8 @@ Proof.
     eapply All2_impl'; tea.
     eapply All_impl; eauto.
     cbn. intros x [? ?] y [[[? ?] ?] ?]. repeat split; eauto.
+  - intros h; depelim h; constructor; cbn in X; intuition eauto.
+    depelim e; cbn in X; constructor; intuition eauto. solve_all.
 Qed.
 
 Lemma weakening_config_cumul_gen {cf1 cf2} pb Σ Γ M N :
@@ -142,6 +144,10 @@ Proof.
     * solve_all.
   - eapply cumul_Fix. solve_all.
   - eapply cumul_CoFix; solve_all.
+  - eapply cumul_Prim; solve_all.
+    destruct X; constructor; eauto.
+    * now eapply (@cmp_universe_config_impl cf1 cf2).
+    * solve_all.
   - eapply cumul_Ind; eauto. 2:solve_all.
     eapply @R_global_instance_weaken_subrel; [ .. | eassumption ].
     all: repeat change (@eq_universe ?cf) with (@compare_universe cf Conv).

--- a/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
+++ b/pcuic/theories/Conversion/PCUICWeakeningEnvConv.v
@@ -125,6 +125,8 @@ Proof using P Pcmp cf.
     eapply All2_impl'; tea.
     eapply All_impl; eauto.
     cbn. intros x [? ?] y [[[? ?] ?] ?]. repeat split; eauto.
+  - inversion 1; subst; constructor.
+    depelim X1; constructor; cbn in X; intuition eauto. solve_all.
 Qed.
 
 Lemma weakening_env_red1 Σ Σ' Γ M N :
@@ -198,6 +200,10 @@ Proof.
     * solve_all.
   - eapply cumul_Fix; solve_all.
   - eapply cumul_CoFix; solve_all.
+  - eapply cumul_Prim; solve_all.
+    destruct X; constructor; eauto.
+    * unfold compare_universe. eapply subrel_extends_eq; tea.
+    * solve_all.
   - eapply cumul_Ind; eauto. 2:solve_all.
     eapply @R_global_instance_weaken_env. 1,2,6:eauto. all: tc.
   - eapply cumul_Construct; eauto. 2:solve_all.

--- a/pcuic/theories/PCUICAst.v
+++ b/pcuic/theories/PCUICAst.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
-From Coq Require Import ssreflect Morphisms.
+From Coq Require Import ssreflect ssrbool Morphisms.
 From MetaCoq.Utils Require Import utils.
-From MetaCoq.Common Require Export Universes BasicAst Environment Reflect.
+From MetaCoq.Common Require Export Primitive Universes BasicAst Environment Reflect.
 From MetaCoq.Common Require EnvironmentTyping.
 From MetaCoq.PCUIC Require Export PCUICPrimitive.
 From Equations Require Import Equations.
@@ -238,6 +238,38 @@ Definition isLambda t :=
 Lemma isLambda_inv t : isLambda t -> exists na ty bod, t = tLambda na ty bod.
 Proof. destruct t => //; eauto. Qed.
 
+Set Equations Transparent.
+
+Definition mapu_array_model {term term'} (fl : Level.t -> Level.t) (f : term -> term')
+  (ar : array_model term) : array_model term' :=
+  {| array_level := fl ar.(array_level);
+      array_value := map f ar.(array_value);
+      array_default := f ar.(array_default);
+      array_type := f ar.(array_type) |}.
+
+Equations mapu_prim {term term'} (f : Level.t -> Level.t) (g : term -> term')
+  (p : PCUICPrimitive.prim_val term) : PCUICPrimitive.prim_val term' :=
+| _, _, (primInt; primIntModel i) => (primInt; primIntModel i)
+| _, _, (primFloat; primFloatModel fl) => (primFloat; primFloatModel fl)
+| f, g, (primArray; primArrayModel ar) =>
+  (primArray; primArrayModel (mapu_array_model f g ar)).
+
+Notation map_array_model := (mapu_array_model id).
+Notation map_prim := (mapu_prim id).
+
+Equations test_prim (p : term -> bool) (p : prim_val) : bool :=
+| p, (primInt; _) => true
+| p, (primFloat; _) => true
+| p, (primArray; primArrayModel ar) =>
+  List.forallb p ar.(array_value) && p ar.(array_default) && p ar.(array_type).
+
+Equations test_primu (p : Level.t -> bool) (t : term -> bool) (p : prim_val) : bool :=
+| _, _, (primInt; _) => true
+| _, _, (primFloat; _) => true
+| p, pt, (primArray; primArrayModel ar) =>
+  p ar.(array_level) && forallb pt ar.(array_value) &&
+  pt ar.(array_default) && pt ar.(array_type).
+
 (** Basic operations on the AST: lifting, substitution and tests for variable occurrences. *)
 
 Fixpoint lift n k t : term :=
@@ -261,6 +293,7 @@ Fixpoint lift n k t : term :=
     let k' := List.length mfix + k in
     let mfix' := List.map (map_def (lift n k) (lift n k')) mfix in
     tCoFix mfix' idx
+  | tPrim p => tPrim (map_prim (lift n k) p)
   | x => x
   end.
 
@@ -296,6 +329,7 @@ Fixpoint subst s k u :=
     let k' := List.length mfix + k in
     let mfix' := List.map (map_def (subst s k) (subst s k')) mfix in
     tCoFix mfix' idx
+  | tPrim p => tPrim (map_prim (subst s k) p)
   | x => x
   end.
 
@@ -323,6 +357,7 @@ Fixpoint closedn k (t : term) : bool :=
   | tCoFix mfix idx =>
     let k' := List.length mfix + k in
     List.forallb (test_def (closedn k) (closedn k')) mfix
+  | tPrim p => test_prim (closedn k) p
   | _ => true
   end.
 
@@ -360,6 +395,7 @@ Fixpoint nlict (t : term) : bool :=
     List.forallb (test_def nlict nlict) mfix
   | tCoFix mfix idx =>
     List.forallb (test_def nlict nlict) mfix
+  | tPrim p => test_prim nlict p
   | _ => true
   end.
 
@@ -386,6 +422,7 @@ Fixpoint noccur_between k n (t : term) : bool :=
   | tCoFix mfix idx =>
     let k' := List.length mfix + k in
     List.forallb (test_def (noccur_between k n) (noccur_between k' n)) mfix
+  | tPrim p => test_prim (noccur_between k n) p
   | _ => true
   end.
 
@@ -420,7 +457,7 @@ Instance subst_instance_constr : UnivSubst term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def (subst_instance_constr u) (subst_instance_constr u)) mfix in
     tCoFix mfix' idx
-  | tPrim _ => c
+  | tPrim p => tPrim (mapu_prim (subst_instance_level u) (subst_instance_constr u) p)
   end.
 
 (** Tests that the term is closed over [k] universe variables *)
@@ -444,6 +481,7 @@ Fixpoint closedu (k : nat) (t : term) : bool :=
     forallb (test_def (closedu k) (closedu k)) mfix
   | tCoFix mfix idx =>
     forallb (test_def (closedu k) (closedu k)) mfix
+  | tPrim p => test_primu (closedu_level k) (closedu k) p
   | _ => true
   end.
 
@@ -922,6 +960,151 @@ Lemma map_branches_map_branches
   map (map_branch (f ∘ f') (h ∘ h')) l.
 Proof.
   eapply map_ext => b. apply map_branch_map_branch.
+Qed.
+
+Lemma mapu_prim_compose {term term' term''}
+  f (g : term' -> term'') f' (g' : term -> term') : mapu_prim f g ∘ mapu_prim f' g' =1 mapu_prim (f ∘ f') (g ∘ g').
+Proof.
+  intros [? []]; cbn => //. do 3 f_equal.
+  unfold mapu_array_model; destruct a => //=. now rewrite map_map_compose.
+Qed.
+
+Lemma mapu_prim_compose_rew {term term' term''}
+  f (g : term' -> term'') f' (g' : term -> term') :
+  forall x, mapu_prim f g (mapu_prim f' g' x) = mapu_prim (f ∘ f') (g ∘ g') x.
+Proof. intros x. now rewrite (mapu_prim_compose _ _ _ _ x). Qed.
+
+#[global] Hint Rewrite @mapu_prim_compose_rew : map.
+
+Definition tPrimProp {term} (P : term -> Type) (p : PCUICPrimitive.prim_val term) : Type :=
+  match p.π2 return Type with
+  | primIntModel f => unit
+  | primFloatModel f => unit
+  | primArrayModel a => P a.(array_type) × P a.(array_default) × All P a.(array_value)
+  end.
+
+Lemma mapu_array_model_proper {term term'} (l l' : Level.t -> Level.t) (f g : term -> term') a :
+  l =1 l' -> f =1 g ->
+  mapu_array_model l f a = mapu_array_model l' g a.
+Proof.
+  destruct a; cbn ; rewrite /mapu_array_model /=. intros; f_equal; eauto. now eapply map_ext.
+Qed.
+
+Lemma mapu_array_model_proper_cond {term term'} (P : term -> Type) (l l' : Level.t -> Level.t) (f g : term -> term') a :
+  l =1 l' -> (forall x, P x -> f x = g x) ->
+  P a.(array_type) × P a.(array_default) × All P a.(array_value) ->
+  mapu_array_model l f a = mapu_array_model l' g a.
+Proof.
+  destruct a; cbn ; rewrite /mapu_array_model /=. intros hl hf [? []]; f_equal; eauto.
+  induction a; cbn => //. rewrite IHa. rewrite hf //.
+Qed.
+
+Lemma primProp_map_eq {term term'} P p l l' (f g : term -> term') :
+  tPrimProp P p ->
+  l =1 l' ->
+  (forall x, P x -> f x = g x) ->
+  mapu_prim l f p = mapu_prim l' g p.
+Proof.
+  destruct p as [? []]; cbn => //.
+  intros [? []] hl hp. do 2 f_equal.
+  eapply mapu_array_model_proper_cond; tea. intuition auto.
+Qed.
+
+Lemma primProp_map_id {term} P p (f : term -> term) :
+  tPrimProp P p ->
+  (forall x, P x -> f x = x) ->
+  map_prim f p = p.
+Proof.
+  intros hp hf.
+  rewrite (primProp_map_eq P p id id f id) //.
+  destruct p as [? []]; cbn => //.
+  destruct a => //=. rewrite /mapu_array_model /=. rewrite map_id //.
+Qed.
+
+Lemma test_prim_primProp {P p} : test_prim P p -> tPrimProp P p.
+Proof.
+  destruct p as [? []]; cbn => //.
+  move/andP => [] /andP[]. intuition auto.
+  now eapply forallb_All in a0.
+Qed.
+
+Lemma primProp_test_prim {P : term -> bool} {p} : tPrimProp P p -> test_prim P p.
+Proof.
+  destruct p as [? []]; cbn => //. intros. rtoProp.
+  intuition auto.
+  now eapply All_forallb.
+Qed.
+
+Lemma tPrimProp_impl {term} {P Q : term -> Type} {p} : tPrimProp P p -> (forall x, P x -> Q x) -> tPrimProp Q p.
+Proof.
+  intros hp hpq; destruct p as [? []]; cbn in * => //. intuition auto.
+  eapply All_impl; tea.
+Qed.
+
+Lemma tPrimProp_prod {term} {P Q : term -> Type} {p} : tPrimProp P p -> tPrimProp Q p -> tPrimProp (fun x => P x × Q x) p.
+Proof.
+  destruct p as [? []]; cbn => //. intuition auto.
+  now eapply All_prod.
+Qed.
+
+Lemma primProp_map {term} (P : term -> Type) f (p : PCUICPrimitive.prim_val term) :
+  tPrimProp (fun x => P (f x)) p ->
+  tPrimProp P (map_prim f p).
+Proof.
+  destruct p as [? []]; cbn => //. intuition eauto. now eapply All_map.
+Qed.
+
+Lemma primProp_map_inv {term} (P : term -> Type) f (p : PCUICPrimitive.prim_val term) :
+  tPrimProp P (map_prim f p) ->
+  tPrimProp (fun x => P (f x)) p.
+Proof.
+  destruct p as [? []]; cbn => //. intuition eauto; now eapply All_map_inv.
+Qed.
+
+Lemma primProp_mapu_id {P : term -> Type} {pu put} p f g :
+  tPrimProp P p -> test_primu pu put p ->
+  (forall u, pu u -> f u = u) ->
+  (forall t, P t -> put t -> g t = t) ->
+  mapu_prim f g p = p.
+Proof.
+  intros hp ht hf hg.
+  destruct p as [? []]; cbn => //. f_equal. f_equal.
+  destruct a; destruct hp; cbn in *. unfold mapu_array_model; cbn.
+  rtoProp. destruct p0. f_equal; intuition eauto.
+  eapply forallb_All in H2. eapply All_prod in a; tea.
+  eapply All_map_id, All_impl; tea. intuition eauto. apply hg; intuition auto.
+Qed.
+
+Lemma test_primu_test_primu_tPrimProp {P : term -> Type} {pu put} {pu' : Level.t -> bool} {put' : term -> bool} p f g :
+  tPrimProp P p -> test_primu pu put p ->
+  (forall u, pu u -> pu' (f u)) ->
+  (forall t, P t -> put t -> put' (g t)) ->
+  test_primu pu' put' (mapu_prim f g p).
+Proof.
+  intros hp ht hf hg.
+  destruct p as [? []]; cbn => //.
+  destruct a; destruct hp; cbn in *.
+  rtoProp. destruct p0. intuition eauto.
+  eapply forallb_All in H2. eapply All_prod in a; tea.
+  eapply All_forallb, All_map, All_impl; tea. intuition eauto. apply hg; intuition auto.
+Qed.
+
+Lemma test_prim_mapu {put l f p} :
+  test_prim put (mapu_prim l f p) = test_prim (fun x => put (f x)) p.
+Proof.
+  destruct p as [? []]; cbn; eauto.
+  now rewrite forallb_map.
+Qed.
+#[global] Hint Rewrite @test_prim_mapu : map.
+
+Lemma test_prim_eq_spec {P : term -> Type} {put} {put' : term -> bool} p :
+  tPrimProp P p ->
+  (forall t, P t -> put t = put' t) ->
+  test_prim put p = test_prim put' p.
+Proof.
+  destruct p as [? []]; cbn => //. intuition eauto.
+  f_equal; eauto. f_equal; eauto.
+  eapply All_forallb_eq_forallb; tea.
 Qed.
 
 Definition tCaseBrsProp {A} (P : A -> Type) (l : list (branch A)) :=

--- a/pcuic/theories/PCUICCSubst.v
+++ b/pcuic/theories/PCUICCSubst.v
@@ -40,6 +40,7 @@ Fixpoint csubst t k u :=
     let k' := List.length mfix + k in
     let mfix' := List.map (map_def (csubst t k) (csubst t k')) mfix in
     tCoFix mfix' idx
+  | tPrim p => tPrim (map_prim (csubst t k) p)
   | x => x
   end.
 

--- a/pcuic/theories/PCUICSigmaCalculus.v
+++ b/pcuic/theories/PCUICSigmaCalculus.v
@@ -116,6 +116,7 @@ Fixpoint rename (f : renamingT) t : term :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def (rename f) (rename (shiftn (List.length mfix) f))) mfix in
     tCoFix mfix' idx
+  | tPrim p => tPrim (map_prim (rename f) p)
   | x => x
   end.
 
@@ -583,6 +584,7 @@ Fixpoint inst s u :=
   | tCoFix mfix idx =>
     let mfix' := map (map_def (inst s) (inst (up (List.length mfix) s))) mfix in
     tCoFix mfix' idx
+  | tPrim p => tPrim (map_prim (inst s) p)
   | x => x
   end.
 

--- a/pcuic/theories/Syntax/PCUICClosed.v
+++ b/pcuic/theories/Syntax/PCUICClosed.v
@@ -121,6 +121,7 @@ Proof.
     autorewrite with map;
     simpl closed in *; solve_all;
     unfold test_def, test_snd, test_predicate_k, test_branch_k in *;
+    try eapply primProp_map;
       try solve [simpl lift; simpl closed; f_equal; auto; repeat (rtoProp; simpl in *; solve_all)]; try easy.
 
   - elim (Nat.leb_spec k' n0); intros. simpl.

--- a/pcuic/theories/Syntax/PCUICLiftSubst.v
+++ b/pcuic/theories/Syntax/PCUICLiftSubst.v
@@ -113,7 +113,7 @@ Proof.
   intros M.
   elim M using term_forall_list_ind; simpl in |- *; intros; try easy ;
     try (try rewrite H; try rewrite H0 ; try rewrite H1 ; easy);
-    try (f_equal; auto; solve_all).
+    try solve [(f_equal; auto; solve_all)].
 
   now elim (leb k n).
 Qed.
@@ -134,7 +134,7 @@ Proof.
     intros; simpl; autorewrite with map;
       try (rewrite -> H, ?H0, ?H1; auto); try (f_equal; auto; solve_all).
 
-  elim (leb_spec k n); intros.
+  - elim (leb_spec k n); intros.
   + elim (leb_spec i (n0 + n)); intros; lia.
   + elim (leb_spec i n); intros; lia.
 Qed.

--- a/pcuic/theories/Syntax/PCUICOnFreeVars.v
+++ b/pcuic/theories/Syntax/PCUICOnFreeVars.v
@@ -88,7 +88,7 @@ Fixpoint on_free_vars (p : nat -> bool) (t : term) : bool :=
   | tFix mfix idx | tCoFix mfix idx =>
     List.forallb (test_def (on_free_vars p) (on_free_vars (shiftnP #|mfix| p))) mfix
   | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => true
-  | tPrim _ => true
+  | tPrim pr => test_prim (on_free_vars p) pr
   end.
 
 Lemma on_free_vars_ext (p q : nat -> bool) t :
@@ -115,6 +115,7 @@ Proof.
     eapply b; rewrite H //.
   - simpl; intuition auto. f_equal; eauto 2.
     eapply b; rewrite H //.
+  - solve_all.
 Qed.
 
 #[global]
@@ -197,6 +198,7 @@ Proof.
   - unfold test_def; solve_all.
     rewrite shiftnP_closedP shiftnP_xpredT.
     now len in b.
+  - solve_all.
 Qed.
 
 Lemma closedn_on_free_vars {P n t} : closedn n t -> on_free_vars (shiftnP n P) t.
@@ -228,6 +230,7 @@ Proof.
   - repeat (solve_all; f_equal).
   - unfold test_def. solve_all.
   - unfold test_def; solve_all.
+  - solve_all.
 Qed.
 
 Definition on_free_vars_decl P d :=
@@ -373,6 +376,7 @@ Proof.
     len; rewrite shiftnP_strengthenP. f_equal; eauto.
   - unfold test_def in *. simpl; intros ? [].
     len; rewrite shiftnP_strengthenP. f_equal; eauto.
+  - solve_all.
 Qed.
 
 Definition on_free_vars_terms p s :=
@@ -403,7 +407,8 @@ Proof.
   revert t p k.
   induction t using PCUICInduction.term_forall_list_ind; simpl => //; intros;
     simpl.
-  all:try (rtoProp; rewrite ?shiftnP_substP; now rewrite ?IHt1 ?IHt2 ?IHt3).
+  all:try (rtoProp; rewrite ?shiftnP_substP; now rewrite ?IHt1 ?IHt2 ?IHt3);
+  try solve [solve_all].
   - intros. destruct (Nat.leb_spec k n).
     * destruct nth_error eqn:eq.
       + unfold on_free_vars_terms in *. toAll.
@@ -422,7 +427,6 @@ Proof.
         now rewrite H0.
     * simpl. rewrite /substP /strengthenP /=.
       rewrite H0. now nat_compare_specs.
-  - solve_all.
   - rtoProp. destruct X. solve_all.
     * len. rewrite shiftnP_substP. solve_all.
     * len. rewrite shiftnP_substP; solve_all.

--- a/pcuic/theories/Syntax/PCUICReflect.v
+++ b/pcuic/theories/Syntax/PCUICReflect.v
@@ -115,7 +115,7 @@ Fixpoint eqb_term (u v : term) : bool :=
       eqb x.(rarg) y.(rarg) &&
       eqb x.(dname) y.(dname)) mfix mfix'
 
-  | tPrim p, tPrim p' => eqb p p'
+  | tPrim p, tPrim p' => @eqb_prim_val _ eqb_term p p'
   | _, _ => false
   end.
 
@@ -194,6 +194,8 @@ Proof.
   destruct (eqb_spec na na'); t'; destruct (r ty'); t'; destruct (o b'); t'.
 Qed.
 
+Transparent eqb_prim_model eqb_prim_val.
+
 #[program,global] Instance eqb_term_reflect : ReflectEq term :=
   {| eqb := eqb_term |}.
 Next Obligation.
@@ -243,6 +245,16 @@ Proof.
       destruct (r0 dbody0); t'.
       destruct (eqb_spec rarg rarg0); t'.
       destruct (eqb_spec dname dname0); t'. }
+  - destruct p, p; cbn in *; destruct prim, p; cbn; nodec.
+    case: eqb_spec; intros; subst; nodec. constructor; auto.
+    case: eqb_spec; intros; subst; nodec. constructor; auto.
+    destruct X as [eqty [eqd eqv]]. unfold eqb_array.
+    destruct (eqty (array_type a0)); t'.
+    destruct (eqd (array_default a0)); t'. 2:noconf H1; auto.
+    2:{ noconf H0; auto. }
+    case: eqb_spec; intros; subst; nodec; cbn.
+    case: (reflect_prop_list eqv) => //. constructor; auto. f_equal. f_equal.
+    destruct a, a0; cbn in *; congruence. nodec.
 Qed.
 
 #[global]

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -295,6 +295,11 @@ Proof.
     destruct X0 as [s [Hs cl]].
     now rewrite andb_true_r in cl.
     Unshelve. all:eauto.
+
+  - destruct p as [[] pv]; cbn in X0 |- *; simp prim_type => //.
+    depelim pv. simp prim_type. cbn. depelim X2.
+    move/andP: hdef => [] -> ->; rewrite !andb_true_r. split => //.
+    solve_all.
 Qed.
 
 Lemma declared_minductive_closed {cf:checker_flags} {Σ : global_env} {wfΣ : wf Σ} {mdecl mind} :
@@ -806,6 +811,8 @@ Proof.
     rewrite -(fix_context_length mfix0).
     rewrite on_ctx_free_vars_extend // hctx.
     now apply on_free_vars_fix_context.
+  - cbn. toAll. solve_all.
+    eapply OnOne2_impl_All_r; eauto; solve_all.
 Qed.
 
 Lemma red_on_free_vars {cf} {P : nat -> bool} {Σ Γ u v} {wfΣ : wf Σ} :
@@ -839,7 +846,7 @@ Lemma term_closedn_list_ind :
     (forall k (s : projection) (t : term), P k t -> P k (tProj s t)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tFix m n)) ->
     (forall k (m : mfixpoint term) (n : nat), tFixProp (P k) (P (#|fix_context m| + k)) m -> P k (tCoFix m n)) ->
-    (forall k p, P k (tPrim p)) ->
+    (forall k p, tPrimProp (P k) p -> P k (tPrim p)) ->
     forall k (t : term), closedn k t -> P k t.
 Proof.
   intros until t. revert k t.
@@ -928,6 +935,12 @@ Proof.
     simpl in clt. move/andP: clt  => [clt cll].
     simpl in clt. move/andP: clt. intuition auto.
     move/andP: clt => [cd cmfix]. apply auxm; auto.
+
+  - destruct prim as [? []]; cbn in clt |- *; rtoProp; intuition eauto.
+    move: H. clear -auxt. generalize (array_value a).
+    fix auxl 1. destruct l; intro.
+    * constructor.
+    * cbn in H; move/andP: H => []; eauto.
 Defined.
 
 Lemma term_noccur_between_list_ind :
@@ -951,7 +964,7 @@ Lemma term_noccur_between_list_ind :
     (forall k n (s : projection) (t : term), P k n t -> P k n (tProj s t)) ->
     (forall k n (m : mfixpoint term) (i : nat), tFixProp (P k n) (P (#|fix_context m| + k) n) m -> P k n (tFix m i)) ->
     (forall k n (m : mfixpoint term) (i : nat), tFixProp (P k n) (P (#|fix_context m| + k) n) m -> P k n (tCoFix m i)) ->
-    (forall k n p, P k n (tPrim p)) ->
+    (forall k n p, tPrimProp (P k n) p -> P k n (tPrim p)) ->
     forall k n (t : term), noccur_between k n t -> P k n t.
 Proof.
   intros until t. revert k n t.
@@ -1034,4 +1047,11 @@ Proof.
     simpl in clt. move/andP: clt  => [clt cll].
     simpl in clt. move/andP: clt. intuition auto.
     move/andP: clt => [cd cmfix]. apply auxm; auto.
+
+
+  - destruct prim as [? []]; cbn in clt |- *; rtoProp; intuition eauto.
+    move: H. clear -auxt. generalize (array_value a).
+    fix auxl 1. destruct l; intro.
+    * constructor.
+    * cbn in H; move/andP: H => []; eauto.
 Defined.

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -119,6 +119,13 @@ Proof.
   - eapply cumul_CoFix. apply All2_map. repeat toAll. eapply All2_impl. 1: tea.
     cbn; intros; intuition.
     rewrite -> subst_instance_app, fix_context_subst_instance in *; eauto.
+  - eapply cumul_Prim. depelim e0.
+    * depelim i; depelim X. cbn in H. cbn. constructor.
+    * depelim f; depelim X. cbn in H. constructor.
+    * depelim X. cbn in H. noconf H; cbn in H. constructor; cbn -[Universe.make]; eauto.
+      + rewrite -!subst_instance_univ_make.
+        eapply eq_universe_subst_instance; tea.
+      + solve_all.
  - repeat rewrite subst_instance_mkApps. eapply cumul_Ind.
     * apply precompose_subst_instance_global.
       rewrite map_length. eapply R_global_instance_impl_same_napp; try eapply H; eauto.
@@ -188,6 +195,18 @@ Proof using Type.
   intros valid.
   intros; eapply All2_fold_map, All2_fold_impl; tea => ? ? d d'.
   now eapply cumul_decls_subst_instance.
+Qed.
+
+Lemma subst_instance_prim_type p prim_ty u : (prim_type p prim_ty)@[u] = prim_type (mapu_prim (subst_instance_level u) (subst_instance u) p) prim_ty.
+Proof.
+  destruct p as [? []]; simp prim_type => //=.
+Qed.
+
+Lemma subst_instance_prim_val_tag (p : PCUICPrimitive.prim_val term) u :
+  prim_val_tag (mapu_prim (subst_instance_level u) (subst_instance u) p) =
+  prim_val_tag p.
+Proof.
+  destruct p as [? []]; simp prim_type => //=.
 Qed.
 
 Hint Resolve subst_instance_cstrs_two
@@ -374,7 +393,18 @@ Proof using Type.
         rewrite map_map_compose.
         now rewrite subst_instance_check_one_cofix.
 
-  - econstructor; eauto.
+  - intros.
+    rewrite subst_instance_prim_type.
+    econstructor.
+    + eauto.
+    + now rewrite subst_instance_prim_val_tag.
+    + exact H0.
+    + now rewrite subst_instance_prim_val_tag.
+    + destruct p as [? []]; depelim X2; constructor; eauto.
+      * rewrite -subst_instance_univ_make. eapply wf_universe_subst_instance => //.
+      * cbn -[Universe.make] in hty.
+        specialize (hty u univs). rewrite subst_instance_univ_make in hty. now eapply hty.
+      * cbn. solve_all.
 
   - intros t0 A B X X0 X1 X2 X3 X4 cum u univs wfΣ' H.
     econstructor.

--- a/pcuic/theories/Typing/PCUICWeakeningConfigTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningConfigTyp.v
@@ -20,11 +20,11 @@ Local Ltac constructor_per_goal _ :=
   unshelve constructor_per_goal' (); shelve_unifiable.
 
 Lemma weakening_config_wf_local_sized {cf1 cf2 : checker_flags} Σ Γ
-  (Hwf : match cf1 with _ => wf_local Σ Γ end)
+  (Hwf :  All_local_env (lift_typing (@typing cf1) Σ) Γ)
   (IH : forall Γ0 t0 T0 (H0 : @typing cf1 Σ Γ0 t0 T0),
       typing_size H0 < S (All_local_env_size (fun _ _ _ _ H => typing_size H) Σ Γ Hwf)
       -> @typing cf2 Σ Γ0 t0 T0)
-  : match cf2 with _ => wf_local Σ Γ end.
+  : wf_local Σ Γ.
 Proof.
   simpl in *.
   induction Hwf; [ constructor 1 | constructor 2 | constructor 3 ].
@@ -64,6 +64,7 @@ Proof.
   intros (Σ & Γ & t & T & H). simpl.
   intros IH. specialize (fun Σ Γ t T H => IH (Σ; Γ; t; T; H)). simpl in IH.
   destruct H; constructor_per_goal (); try eassumption.
+  5:destruct p1; constructor; eauto; solve_all.
   all: try (unshelve eapply IH; [ eassumption .. | ];
             try solve [ constructor; simpl; lia ]).
   all: try (eapply (@weakening_config_cumulSpec cf1 cf2); eassumption).
@@ -112,6 +113,7 @@ Proof.
        end.
   all: repeat match goal with H : Forall2 _ (_ :: _) (_ :: _) |- _ => depelim H end.
   all: try assumption.
+  2:{ eapply (All_map_size (fun x H => typing_size H) _ hvalue). intros. eapply (IH _ _ _ p). lia. }
   all: [ > unshelve eapply (@weakening_config_wf_local_sized cf1 cf2); [ eassumption | ] .. ].
   all: intros; unshelve eapply IH; [ eassumption | ].
   all: simpl in *; try lia.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -86,11 +86,11 @@ Lemma extends_primitive_constant Σ Σ' p t :
 Proof.
   intros [_ _ ext].
   unfold primitive_constant.
-  case: ext.
-  destruct p; case => //.
-  - move=> _. case => //.
-  - move=> _; case => //.
-  - case => //.
+  case: ext => o [] o' o''.
+  destruct p => //.
+  - intros hr. now rewrite hr in o; depelim o.
+  - intros hr. now rewrite hr in o'; depelim o'.
+  - intros hr. now rewrite hr in o''; depelim o''.
 Qed.
 Local Hint Resolve extends_primitive_constant : extends.
 
@@ -129,6 +129,10 @@ Proof.
       apply (lift_typing_impl X); now intros ? [].
     + eapply (All_impl X1); intros d X.
       apply (lift_typing_impl X); now intros ? [].
+  - econstructor; eauto with extends.
+    destruct X2; constructor; eauto with extends.
+    * now eapply extends_wf_universe.
+    * solve_all.
   - econstructor. 1: eauto.
     + eapply forall_Σ'1; eauto.
     + destruct Σ as [Σ φ]. eapply weakening_env_cumulSpec in cumulA; eauto.

--- a/pcuic/theories/utils/PCUICPretty.v
+++ b/pcuic/theories/utils/PCUICPretty.v
@@ -117,11 +117,11 @@ Module PrintTermTree.
     Import bytestring.Tree.
     Infix "^" := append.
 
-    Definition print_prim {term} (soft : term -> Tree.t) (p : prim_val) : Tree.t :=
+    Definition print_prim (soft : term -> Tree.t) (p : prim_val) : Tree.t :=
       match p.π2 return Tree.t with
       | primIntModel f => "(int: " ^ Primitive.string_of_prim_int f ^ ")"
       | primFloatModel f => "(float: " ^ Primitive.string_of_float f ^ ")"
-      (* | primArrayModel a => "(array:" ^ ")" *)
+      | primArrayModel a => "(array:" ^ string_of_list soft a.(array_value) ^ ")"
       end.
 
     Section Aux.

--- a/pcuic/theories/utils/PCUICPrimitive.v
+++ b/pcuic/theories/utils/PCUICPrimitive.v
@@ -6,27 +6,30 @@ From Equations Require Import Equations.
 From Coq Require Import ssreflect.
 From Coq Require Import Uint63 SpecFloat.
 
-(** We don't enforce the type of the array here*)
-Record array_model (term : Type) :=
-  { array_instance : Instance.t;
+Record array_model {term : Type} :=
+  { array_level : Level.t;
     array_type : term;
     array_default : term;
     array_value : list term }.
 Derive NoConfusion for array_model.
+
+Arguments array_model : clear implicits.
 #[global]
 Instance array_model_eqdec {term} (e : EqDec term) : EqDec (array_model term).
 Proof. eqdec_proof. Qed.
 
+(* We use this inductive definition instead of the more direct case analysis
+  [prim_model_of] so that [prim_model] can be used in the inductive definition
+  of terms, otherwise it results in a non-strictly positive definition.
+  *)
 Inductive prim_model (term : Type) : prim_tag -> Type :=
 | primIntModel (i : PrimInt63.int) : prim_model term primInt
-| primFloatModel (f : PrimFloat.float) : prim_model term primFloat.
+| primFloatModel (f : PrimFloat.float) : prim_model term primFloat
+| primArrayModel (a : array_model term) : prim_model term primArray.
 
-(* | primIntModel (i : Int63.t) : prim_model term primInt *)
-(* | primFloatModel (f : float64_model) : prim_model term primFloat. *)
-(* | primArrayModel (a : array_model term) : prim_model term primArray. *)
 Arguments primIntModel {term}.
 Arguments primFloatModel {term}.
-(* Arguments primArrayModel {term}. *)
+Arguments primArrayModel {term}.
 
 Derive Signature NoConfusion for prim_model.
 
@@ -34,7 +37,7 @@ Definition prim_model_of (term : Type) (p : prim_tag) : Type :=
   match p with
   | primInt => PrimInt63.int
   | primFloat => PrimFloat.float
-  (* | primArray => array_model term *)
+  | primArray => array_model term
   end.
 
 Definition prim_val term := ∑ t : prim_tag, prim_model term t.
@@ -45,7 +48,7 @@ Definition prim_model_val {term} (p : prim_val term) : prim_model_of term (prim_
   match prim_val_model p in prim_model _ t return prim_model_of term t with
   | primIntModel i => i
   | primFloatModel f => f
-  (* | primArrayModel a => a *)
+  | primArrayModel a => a
   end.
 
 Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) : proj1_sig x = proj1_sig y -> x = y.
@@ -73,40 +76,73 @@ Qed.
 #[global]
 Instance reflect_eq_spec_float : ReflectEq SpecFloat.spec_float := EqDec_ReflectEq _.
 
-Equations eqb_prim_model {term} {t : prim_tag} (x y : prim_model term t) : bool :=
+Import ReflectEq.
+
+Definition eqb_array {term} {eqt : term -> term -> bool} (x y : array_model term) : bool :=
+   eqb x.(array_level) y.(array_level) &&
+   forallb2 eqt x.(array_value) y.(array_value) &&
+   eqt x.(array_default) y.(array_default) &&
+   eqt x.(array_type) y.(array_type).
+
+#[program,global]
+Instance reflect_eq_array {term} {req : ReflectEq term}: ReflectEq (array_model term) :=
+  { eqb := eqb_array (eqt := eqb) }.
+Next Obligation.
+  intros term req [] []; cbn. unfold eqb_array. cbn.
+  change (forallb2 eqb) with (eqb (A := list term)).
+  case: eqb_spec => //=. intros ->.
+  case: eqb_spec => //=. intros ->.
+  case: eqb_spec => //=. intros ->.
+  case: eqb_spec => //=. intros ->. constructor; auto.
+  all:constructor; congruence.
+Qed.
+
+Equations eqb_prim_model {term} {req : term -> term -> bool} {t : prim_tag} (x y : prim_model term t) : bool :=
   | primIntModel x, primIntModel y := ReflectEq.eqb x y
-  | primFloatModel x, primFloatModel y := ReflectEq.eqb x y.
+  | primFloatModel x, primFloatModel y := ReflectEq.eqb x y
+  | primArrayModel x, primArrayModel y := eqb_array (eqt:=req) x y.
 
 #[global, program]
-Instance prim_model_reflecteq {term} {p : prim_tag} : ReflectEq (prim_model term p) :=
-  {| ReflectEq.eqb := eqb_prim_model |}.
+Instance prim_model_reflecteq {term} {req : ReflectEq term} {p : prim_tag} : ReflectEq (prim_model term p) :=
+  {| ReflectEq.eqb := eqb_prim_model (req := eqb) |}.
 Next Obligation.
   intros. depelim x; depelim y; simp eqb_prim_model.
   case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
   case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
+  change (eqb_array a a0) with (eqb a a0).
+  case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
 Qed.
 
 #[global]
-Instance prim_model_eqdec {term} : forall p : prim_tag, EqDec (prim_model term p) := _.
+Instance prim_model_eqdec {term} {req : ReflectEq term} : forall p : prim_tag, EqDec (prim_model term p) := _.
 
-Equations eqb_prim_val {term} (x y : prim_val term) : bool :=
-  | (primInt; i), (primInt; i') := ReflectEq.eqb i i'
-  | (primFloat; f), (primFloat; f') := ReflectEq.eqb f f'
+Equations eqb_prim_val {term} {req : term -> term -> bool} (x y : prim_val term) : bool :=
+  | (primInt; i), (primInt; i') := eqb_prim_model (req := req) i i'
+  | (primFloat; f), (primFloat; f') := eqb_prim_model (req := req) f f'
+  | (primArray; a), (primArray; a') := eqb_prim_model (req := req) a a'
   | x, y := false.
 
 #[global, program]
-Instance prim_val_reflect_eq {term} : ReflectEq (prim_val term) :=
-  {| ReflectEq.eqb := eqb_prim_val |}.
+Instance prim_val_reflect_eq {term} {req : ReflectEq term} : ReflectEq (prim_val term) :=
+  {| ReflectEq.eqb := eqb_prim_val (req := eqb) |}.
 Next Obligation.
   intros. funelim (eqb_prim_val x y); simp eqb_prim_val.
+  change (eqb_prim_model i i') with (eqb i i').
   case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H. cbn in n. auto.
   constructor. intros H; noconf H; auto.
   constructor. intros H; noconf H; auto.
+  constructor. intros H; noconf H; auto.
+  change (eqb_prim_model f f') with (eqb f f').
+  case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H; auto.
+  constructor. intros H; noconf H; auto.
+  constructor. intros H; noconf H; auto.
+  constructor. intros H; noconf H; auto.
+  change (eqb_prim_model a a') with (eqb a a').
   case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H; auto.
 Qed.
 
 #[global]
-Instance prim_tag_model_eqdec term : EqDec (prim_val term) := _.
+Instance prim_tag_model_eqdec term {req : ReflectEq term} : EqDec (prim_val term) := _.
 
 (** Printing *)
 
@@ -114,5 +150,5 @@ Definition string_of_prim {term} (soft : term -> string) (p : prim_val term) : s
   match p.π2 return string with
   | primIntModel f => "(int: " ^ string_of_prim_int f ^ ")"
   | primFloatModel f => "(float: " ^ string_of_float f ^ ")"
-  (* | primArrayModel a => "(array:" ^ ")" *)
+  | primArrayModel a => "(array:" ^ string_of_list soft a.(array_value) ^ ")"
   end.

--- a/pcuic/theories/utils/PCUICSize.v
+++ b/pcuic/theories/utils/PCUICSize.v
@@ -23,6 +23,13 @@ Definition predicate_size (size : term -> nat) (p : PCUICAst.predicate term) :=
   context_size size p.(pcontext) +
   size p.(preturn).
 
+Definition prim_size (size : term -> nat) (p : prim_val) : nat :=
+  match p.π2 return nat with
+  | primIntModel f => 0
+  | primFloatModel f => 0
+  | primArrayModel a => size a.(array_type) + size a.(array_default) + list_size size a.(array_value)
+  end.
+
 Fixpoint size t : nat :=
   match t with
   | tRel i => 1
@@ -36,6 +43,7 @@ Fixpoint size t : nat :=
   | tProj p c => S (size c)
   | tFix mfix idx => S (mfixpoint_size size mfix)
   | tCoFix mfix idx => S (mfixpoint_size size mfix)
+  | tPrim p => S (prim_size size p)
   | _ => 1
   end.
 

--- a/template-coq/src/ast_denoter.ml
+++ b/template-coq/src/ast_denoter.ml
@@ -28,6 +28,7 @@ struct
   type quoted_constraint_type = Universes0.ConstraintType.t
   type quoted_univ_constraint = Universes0.UnivConstraint.t
   type quoted_univ_constraints = Universes0.ConstraintSet.t
+  type quoted_univ_level = Universes0.Level.t
   type quoted_univ_instance = Universes0.Instance.t
   type quoted_univ_context = Universes0.UContext.t
   type quoted_univ_contextset = Universes0.ContextSet.t
@@ -105,7 +106,7 @@ struct
       aci_relevance = x.ci_relevance }
 
   let inspect_term (tt: t):(t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind,
-    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj,
+    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_level, quoted_univ_instance, quoted_proj,
     quoted_int63, quoted_float64) structure_of_term =
     match tt with
     | Coq_tRel n -> ACoq_tRel n
@@ -127,6 +128,7 @@ struct
     | Coq_tCoFix (a,b) -> ACoq_tCoFix (List.map unquote_def a,b)
     | Coq_tInt i -> ACoq_tInt i
     | Coq_tFloat f -> ACoq_tFloat f
+    | Coq_tArray (u, arr, def, ty) -> ACoq_tArray (u, Array.of_list arr, def, ty)
 
   let unquote_string = Caml_bytestring.caml_string_of_bytestring
 
@@ -223,6 +225,7 @@ struct
        let u = List.fold_left Univ.Universe.sup (List.hd l) (List.tl l) in
        evd, Sorts.sort_of_univ u
 
+  let unquote_universe_level evm l = evm, unquote_level l
   let unquote_universe_instance(evm: Evd.evar_map) (l: quoted_univ_instance): Evd.evar_map * Univ.Instance.t
   = (evm,  Univ.Instance.of_array (Array.of_list (List0.map unquote_level l)))
 

--- a/template-coq/src/ast_quoter.ml
+++ b/template-coq/src/ast_quoter.ml
@@ -29,6 +29,7 @@ struct
   type quoted_constraint_type = Universes0.ConstraintType.t
   type quoted_univ_constraint = Universes0.UnivConstraint.t
   type quoted_univ_constraints = Universes0.ConstraintSet.t
+  type quoted_univ_level = Universes0.Level.t
   type quoted_univ_instance = Universes0.Instance.t
   type quoted_univ_context = Universes0.UContext.t
   type quoted_univ_contextset = Universes0.ContextSet.t
@@ -156,6 +157,7 @@ struct
     try ((quote_nonprop_level l, quote_constraint_type ct), quote_nonprop_level l')
     with e -> assert false
 
+  let quote_univ_level = quote_nonprop_level
   let quote_univ_instance (i : Univ.Instance.t) : quoted_univ_instance =
     let arr = Univ.Instance.to_array i in
     (* we assume that valid instances do not contain [Prop] or [SProp] *)
@@ -235,6 +237,7 @@ struct
   let mkLetIn na b t t' = Coq_tLetIn (na,b,t,t')
   let mkInt i = Coq_tInt i
   let mkFloat f = Coq_tFloat f
+  let mkArray u arr ~default ~ty = Coq_tArray (u, Array.to_list arr, default, ty)
 
   let rec seq f t =
     if f < t then
@@ -313,11 +316,13 @@ struct
 
   type pre_quoted_retroknowledge =
     { retro_int63 : quoted_kernel_name option;
-      retro_float64 : quoted_kernel_name option }
+      retro_float64 : quoted_kernel_name option;
+      retro_array : quoted_kernel_name option }
 
   let quote_retroknowledge r =
     { Environment.Retroknowledge.retro_int63 = r.retro_int63;
-      Environment.Retroknowledge.retro_float64 = r.retro_float64 }
+      Environment.Retroknowledge.retro_float64 = r.retro_float64;
+      Environment.Retroknowledge.retro_array = r.retro_array }
 
   let mk_global_env universes declarations retroknowledge = { universes; declarations; retroknowledge }
   let mk_program decls tm = (decls, tm)
@@ -366,7 +371,8 @@ struct
     | None -> None *)
 
   let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind,
-    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj,
+    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_level,
+    quoted_univ_instance, quoted_proj,
     quoted_int63, quoted_float64) structure_of_term =
    match t with
   | Coq_tRel n -> ACoq_tRel n

--- a/template-coq/src/constr_reification.ml
+++ b/template-coq/src/constr_reification.ml
@@ -23,6 +23,7 @@ struct
   type quoted_constraint_type = Constr.t (* of type Universes.constraint_type *)
   type quoted_univ_constraint = Constr.t (* of type Universes.univ_constraint *)
   type quoted_univ_constraints = Constr.t (* of type Universes.constraints *)
+  type quoted_univ_level = Constr.t (* of type Universes.Level.t *)
   type quoted_univ_instance = Constr.t (* of type Universes.universe_instance *)
   type quoted_univ_context = Constr.t (* of type Universes.UContext.t *)
   type quoted_univ_contextset = Constr.t (* of type Universes.ContextSet.t *)
@@ -149,18 +150,19 @@ struct
   let tmk_branch = ast "mk_branch"
   let tmkdecl = ast "mkdecl"
   let (tTerm,tRel,tVar,tEvar,tSort,tCast,tProd,
-       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj,tInt,tFloat) =
+       tLambda,tLetIn,tApp,tCase,tFix,tConstructor,tConst,tInd,tCoFix,tProj,tInt,tFloat,tArray) =
     (ast "term", ast "tRel", ast "tVar", ast "tEvar",
      ast "tSort", ast "tCast", ast "tProd", ast "tLambda",
      ast "tLetIn", ast "tApp", ast "tCase", ast "tFix",
-     ast "tConstruct", ast "tConst", ast "tInd", ast "tCoFix", ast "tProj", ast "tInt", ast "tFloat")
+     ast "tConstruct", ast "tConst", ast "tInd", ast "tCoFix", ast "tProj", ast "tInt", ast "tFloat",
+     ast "tArray")
   let tkername = ast "kername"
   let tmodpath = ast "modpath"
   let tMPfile = ast "MPfile"
   let tMPbound = ast "MPbound"
   let tMPdot = ast "MPdot"
   let tfresh_evar_id = ast "fresh_evar_id"
-  
+
   let tproplevel = ast "level.prop_level_type"
   let tlevelSProp = ast "level.lsprop"
   let tlevelProp = ast "level.lprop"
@@ -211,7 +213,7 @@ struct
   let (cFinite,cCoFinite,cBiFinite) = (ast "Finite", ast "CoFinite", ast "BiFinite")
   let tconstructor_body = ast "constructor_body"
   let tBuild_constructor_body = ast "Build_constructor_body"
-  let tprojection_body = ast "projection_body" 
+  let tprojection_body = ast "projection_body"
   let tBuild_projection_body = ast "Build_projection_body"
   let tone_inductive_body = ast "one_inductive_body"
   let tBuild_one_inductive_body = ast "Build_one_inductive_body"

--- a/template-coq/src/denoter.ml
+++ b/template-coq/src/denoter.ml
@@ -23,10 +23,11 @@ sig
   (*val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
   val unquote_proj : quoted_proj -> (quoted_inductive * quoted_int * quoted_int)
   val unquote_universe : Evd.evar_map -> quoted_sort -> Evd.evar_map * Sorts.t
+  val unquote_universe_level : Evd.evar_map -> quoted_univ_level -> Evd.evar_map * Univ.Level.t
   val unquote_universe_instance: Evd.evar_map -> quoted_univ_instance -> Evd.evar_map * Univ.Instance.t
   (* val representsIndConstuctor : quoted_inductive -> Term.constr -> bool *)
-  val inspect_term : t -> (t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind, 
-    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_instance, quoted_proj, 
+  val inspect_term : t -> (t, quoted_int, quoted_ident, quoted_aname, quoted_sort, quoted_cast_kind,
+    quoted_kernel_name, quoted_inductive, quoted_relevance, quoted_univ_level, quoted_univ_instance, quoted_proj,
     quoted_int63, quoted_float64) structure_of_term
 
 end
@@ -68,7 +69,7 @@ struct
       match D.inspect_term trm with
       | ACoq_tRel x -> evm, Constr.mkRel (D.unquote_int x + 1)
       | ACoq_tVar x -> evm, Constr.mkVar (D.unquote_ident x)
-      | ACoq_tEvar (n, l) -> 
+      | ACoq_tEvar (n, l) ->
         let evm, l' = map_evm (aux env) evm l in
         D.unquote_evar env evm n l'
       | ACoq_tSort x -> let evm, u = D.unquote_universe evm x in evm, Constr.mkSort u
@@ -84,7 +85,7 @@ struct
         let evm, t = aux env evm t in
         let evm, b = aux (Environ.push_rel (LocalAssum (n, t)) env) evm b in
         evm, Constr.mkLambda (n, t, b)
-      | ACoq_tLetIn (n,e,t,b) -> 
+      | ACoq_tLetIn (n,e,t,b) ->
         let n = D.unquote_aname n in
         let evm, e = aux env evm e in
         let evm, t = aux env evm t in
@@ -107,20 +108,20 @@ struct
         evm, Constr.mkIndU (i, u)
       | ACoq_tCase (ci, p, c, brs) ->
         let ind = D.unquote_inductive ci.aci_ind in
-        let relevance = D.unquote_relevance ci.aci_relevance in 
+        let relevance = D.unquote_relevance ci.aci_relevance in
         let ci = Inductiveops.make_case_info (Global.env ()) ind relevance Constr.RegularStyle in
         let evm, puinst = D.unquote_universe_instance evm p.auinst in
         let evm, pars = map_evm (aux env) evm p.apars in
         let pars = Array.of_list pars in
         let napctx = CArray.map_of_list D.unquote_aname (List.rev p.apcontext) in
-        let pctx = CaseCompat.case_predicate_context env ci puinst pars napctx in 
+        let pctx = CaseCompat.case_predicate_context env ci puinst pars napctx in
         let evm, pret = aux (Environ.push_rel_context pctx env) evm p.apreturn in
         let evm, c = aux env evm c in
         let brs = List.map (fun { abcontext = bctx; abbody = bbody } ->
           let nabctx = CArray.map_of_list D.unquote_aname (List.rev bctx) in
           (nabctx, bbody)) brs in
         let brs = CaseCompat.case_branches_contexts env ci puinst pars (Array.of_list brs) in
-        let denote_br evm (nas, bctx, bbody) = 
+        let denote_br evm (nas, bctx, bbody) =
           let evm, bbody = aux (Environ.push_rel_context bctx env) evm bbody in
           evm, (nas, bbody)
         in
@@ -160,6 +161,12 @@ struct
          evm, Constr.mkProj (p', t')
       | ACoq_tInt x -> evm, Constr.mkInt (D.unquote_int63 x)
       | ACoq_tFloat x -> evm, Constr.mkFloat (D.unquote_float64 x)
+      | ACoq_tArray (u, arr, def, ty) ->
+          let evm, u = D.unquote_universe_level evm u in
+          let evm, arr = Array.fold_left_map (fun evm a -> aux env evm a) evm arr in
+          let evm, def = aux env evm def in
+          let evm, ty = aux env evm ty in
+          evm, Constr.mkArray (Univ.Instance.of_array [|u|], arr, def, ty)
 
     in aux env evm trm
 

--- a/template-coq/src/quoter.ml
+++ b/template-coq/src/quoter.ml
@@ -15,13 +15,13 @@ let cast_prop = ref (false)
 
 (* whether Set Template Cast Propositions is on, as needed for erasure in Certicoq *)
 let is_cast_prop () = !cast_prop
-let warn_primitive_turned_into_axiom = 
+let warn_primitive_turned_into_axiom =
   CWarnings.create ~name:"primitive-turned-into-axiom" ~category:"metacoq"
           Pp.(fun prim -> str "Quoting primitive " ++ str prim ++ str " into an axiom.")
 let warn_ignoring_private_polymorphic_universes =
   CWarnings.create ~name:"private-polymorphic-universes-ignored" ~category:"metacoq"
           Pp.(fun () -> str "Ignoring private polymorphic universes.")
-          
+
 let toDecl (old: Name.t Context.binder_annot * ((Constr.constr) option) * Constr.constr) : Constr.rel_declaration =
   let (name,value,typ) = old in
   match value with
@@ -69,6 +69,7 @@ sig
   val mkCoFix : quoted_int * (quoted_aname array * t array * t array) -> t
   val mkInt : quoted_int63 -> t
   val mkFloat : quoted_float64 -> t
+  val mkArray : quoted_univ_level -> t array -> default:t -> ty:t -> t
 
   val mkBindAnn : quoted_name -> quoted_relevance -> quoted_aname
   val mkName : quoted_ident -> quoted_name
@@ -93,6 +94,7 @@ sig
 
   val quote_constraint_type : Univ.constraint_type -> quoted_constraint_type
   val quote_univ_constraint : Univ.univ_constraint -> quoted_univ_constraint
+  val quote_univ_level : Univ.Level.t -> quoted_univ_level
   val quote_univ_instance : Univ.Instance.t -> quoted_univ_instance
   val quote_univ_constraints : Univ.Constraints.t -> quoted_univ_constraints
   val quote_univ_context : Univ.UContext.t -> quoted_univ_context
@@ -122,17 +124,17 @@ sig
   val quote_context : quoted_context_decl list -> quoted_context
 
   val mk_one_inductive_body :
-    quoted_ident * 
+    quoted_ident *
     quoted_context (* ind indices context *) *
     quoted_sort (* ind sort *) *
     t (* ind type *) *
-    quoted_sort_family * 
+    quoted_sort_family *
     (quoted_ident * quoted_context (* arguments context *) *
       t list (* indices in the conclusion *) *
-      t (* constr type *) * 
+      t (* constr type *) *
       quoted_int (* arity (w/o lets) *)) list *
     (quoted_ident * quoted_relevance *  t (* projection type *)) list *
-    quoted_relevance -> 
+    quoted_relevance ->
     quoted_one_inductive_body
 
   val mk_mutual_inductive_body :
@@ -152,10 +154,11 @@ sig
 
   val empty_global_declarations : unit -> quoted_global_declarations
   val add_global_decl : quoted_kernel_name -> quoted_global_decl -> quoted_global_declarations -> quoted_global_declarations
-  
-  type pre_quoted_retroknowledge = 
+
+  type pre_quoted_retroknowledge =
     { retro_int63 : quoted_kernel_name option;
-      retro_float64 : quoted_kernel_name option }
+      retro_float64 : quoted_kernel_name option;
+      retro_array : quoted_kernel_name option }
 
   val quote_retroknowledge : pre_quoted_retroknowledge -> quoted_retroknowledge
 
@@ -187,12 +190,12 @@ struct
 
   let quote_ugraph ?kept (g : UGraph.t) =
     debug Pp.(fun () -> str"Quoting ugraph");
-    let levels, cstrs, eqs = 
+    let levels, cstrs, eqs =
       match kept with
       | None ->
         let cstrs, eqs = UGraph.constraints_of_universes g in
         UGraph.domain g, cstrs, eqs
-      | Some l -> 
+      | Some l ->
         debug Pp.(fun () -> str"Quoting graph restricted to: " ++ Univ.Level.Set.pr Univ.Level.pr l);
         (* Feedback.msg_debug Pp.(str"Graph is: "  ++ UGraph.pr_universes Univ.Level.pr (UGraph.repr g)); *)
         let dom = UGraph.domain g in
@@ -201,7 +204,7 @@ struct
         let cstrs = time Pp.(str"Computing graph restriction") (UGraph.constraints_for ~kept) g in
         l, cstrs, []
     in
-    let levels, cstrs = 
+    let levels, cstrs =
       List.fold_right (fun eqs acc ->
         match Univ.Level.Set.elements eqs with
         | [] -> acc
@@ -213,7 +216,7 @@ struct
     in
     let levels = Univ.Level.Set.add Univ.Level.set levels in
     debug Pp.(fun () -> str"Universe context: " ++ Univ.pr_universe_context_set Univ.Level.pr (levels, cstrs));
-    time (Pp.str"Quoting universe context") 
+    time (Pp.str"Quoting universe context")
       (fun uctx -> Q.quote_univ_contextset uctx) (levels, cstrs)
 
   let quote_inductive' (ind, i) : Q.quoted_inductive =
@@ -227,7 +230,7 @@ struct
         let b', acc = quote_term acc env sigma b in
         let t', acc = quote_term acc env sigma t in
         (Q.quote_context_decl (Q.quote_aname na) (Some b') t', acc)
-  
+
   let quote_rel_context quote_term acc env sigma ctx =
       let decls, env, acc =
         List.fold_right (fun decl (ds, env, acc) ->
@@ -236,14 +239,14 @@ struct
           ctx ([],env,acc) in
       Q.quote_context decls, acc
 
-  let quote_binder b = 
+  let quote_binder b =
     Q.quote_aname b
 
   let quote_name_annots nas =
     Array.map quote_binder nas
 
   let quote_terms quote_term acc env sigma ts =
-    let acc, ts = 
+    let acc, ts =
       CArray.fold_left_map (fun acc t -> let (x, acc) = quote_term acc env sigma t in acc, x) acc ts
     in ts, acc
 
@@ -307,13 +310,13 @@ struct
                                       Q.quote_int (snd ci.Constr.ci_ind)) in
         let npar = Q.quote_int ci.Constr.ci_npar in
         let q_relevance = Q.quote_relevance ci.Constr.ci_relevance in
-        let acc, q_pars = CArray.fold_left_map (fun acc par -> let (qt, acc) = quote_term acc env sigma par in acc, qt) acc pars in 
+        let acc, q_pars = CArray.fold_left_map (fun acc par -> let (qt, acc) = quote_term acc env sigma par in acc, qt) acc pars in
         let qu = Q.quote_univ_instance u in
-        let pctx = CaseCompat.case_predicate_context (snd env) ci u pars predctx in 
+        let pctx = CaseCompat.case_predicate_context (snd env) ci u pars predctx in
         let qpctx = quote_name_annots predctx in
         let (qpred,acc) = quote_term acc (push_rel_context pctx env) sigma pred in
         let (qdiscr,acc) = quote_term acc env sigma discr in
-        let cbrs = CaseCompat.case_branches_contexts (snd env) ci u pars brs in  
+        let cbrs = CaseCompat.case_branches_contexts (snd env) ci u pars brs in
         let (branches,acc) =
           CArray.fold_left2 (fun (bodies,acc) (brnas, brctx, bbody) narg ->
             let (qbody,acc) = quote_term acc (push_rel_context brctx env) sigma bbody in
@@ -335,7 +338,12 @@ struct
       | Constr.Int i -> (Q.mkInt (Q.quote_int63 i), acc)
       | Constr.Float f -> (Q.mkFloat (Q.quote_float64 f), acc)
       | Constr.Meta _ -> failwith "Meta not supported by TemplateCoq"
-      | Constr.Array _ -> failwith "Primitive arrays not supported by TemplateCoq"
+      | Constr.Array (u, ar, def, ty) ->
+        let u = match Univ.Instance.to_array u with [| u |] -> u | _ -> assert false in
+        let def', acc = quote_term acc env sigma def in
+        let ty', acc = quote_term acc env sigma ty in
+        let acc, arr' = Array.fold_left_map (fun acc t -> let t', acc = quote_term acc env sigma t in acc, t') acc ar in
+        Q.mkArray (Q.quote_univ_level u) arr' ~default:def' ~ty:ty', acc
       in
       aux acc env trm
     and quote_recdecl (acc : 'a) env sigma b (ns,ts,ds) =
@@ -378,7 +386,7 @@ struct
             let ctx = oib.mind_arity_ctxt in
             CList.chop (List.length ctx - List.length mib.mind_params_ctxt) ctx
           in
-          let indices, acc = quote_rel_context quote_term acc (push_rel_context pars env) sigma indices in 
+          let indices, acc = quote_rel_context quote_term acc (push_rel_context pars env) sigma indices in
           let indty, acc = quote_term acc env sigma indty in
           let indsort = Q.quote_sort (inductive_sort oib) in
           let (reified_ctors,acc) =
@@ -387,11 +395,11 @@ struct
               let ty = Inductive.abstract_constructor_type_relatively_to_inductive_types_context ntyps t ty in
               let ctx, concl = Term.decompose_prod_assum ty in
               let argctx, parsctx =
-                CList.chop (List.length ctx - List.length mib.mind_params_ctxt) ctx 
+                CList.chop (List.length ctx - List.length mib.mind_params_ctxt) ctx
               in
               let envcstr = push_rel_context parsctx envind in
               let qargctx, acc = quote_rel_context quote_term acc envcstr sigma argctx in
-              let qindices, acc = 
+              let qindices, acc =
                 let hd, args = Constr.decompose_appvect concl in
                 let pars, args = CArray.chop mib.mind_nparams args in
                 let envconcl = push_rel_context argctx envcstr in
@@ -432,7 +440,7 @@ struct
       let mind = Q.mk_mutual_inductive_body finite nparams paramsctx bodies uctx var in
       ref_name, Q.mk_inductive_decl mind, acc
     in ((fun acc env -> quote_term acc (false, env)),
-        (fun acc env t mib -> 
+        (fun acc env t mib ->
         quote_minductive_type acc (false, env) t mib))
 
   let quote_term env sigma trm =
@@ -447,17 +455,17 @@ struct
     Ind of Names.inductive * mutual_inductive_body
   | Const of KerName.t
 
-  let universes_of_ctx ctx = 
+  let universes_of_ctx ctx =
     Context.Rel.fold_inside (fun univs d -> Univ.Level.Set.union univs
       (Context.Rel.Declaration.fold_constr (fun c univs -> Univ.Level.Set.union univs (Vars.universes_of_constr c)) d univs))
       ~init:Univ.Level.Set.empty ctx
-  
-  let universes_of_mib mib = 
+
+  let universes_of_mib mib =
     let pars = mib.mind_params_ctxt in
     let univs = universes_of_ctx pars in
       Array.fold_left (fun univs oib ->
         let univsty = universes_of_ctx oib.mind_arity_ctxt in
-        Array.fold_left (fun univs cty -> 
+        Array.fold_left (fun univs cty ->
           let univscty = Vars.universes_of_constr cty in
           Univ.Level.Set.union univs univscty)
           univsty oib.mind_user_lc)
@@ -495,7 +503,7 @@ struct
             let cd = Environ.lookup_constant c env in
             let body = match cd.const_body with
               | Undef _ -> None
-              | Primitive t -> 
+              | Primitive t ->
                   warn_primitive_turned_into_axiom (CPrimitives.to_string t);
                   None
               | Def cs -> Some cs
@@ -504,9 +512,9 @@ struct
                   let c, univs = Global.force_proof Library.indirect_accessor lc in
                   match univs with
                   | Opaqueproof.PrivateMonomorphic () -> Some c
-                  | Opaqueproof.PrivatePolymorphic csts -> 
-                    let () = 
-                      if not (Univ.ContextSet.is_empty csts) then 
+                  | Opaqueproof.PrivatePolymorphic csts ->
+                    let () =
+                      if not (Univ.ContextSet.is_empty csts) then
                         warn_ignoring_private_polymorphic_universes ()
                     in Some c
                 else None
@@ -514,7 +522,7 @@ struct
             let tm, acc =
               match body with
               | None -> None, acc
-              | Some tm -> 
+              | Some tm ->
                 let univs = Vars.universes_of_constr tm in
                 let () = universes := Univ.Level.Set.union univs !universes in
                 try let (tm, acc) = quote_term acc (Global.env ()) (Evd.from_env @@ Global.env ()) tm in
@@ -535,7 +543,7 @@ struct
             in
             let rel = Q.quote_relevance cd.const_relevance in
             let cst_bdy = Q.mk_constant_body ty tm uctx rel in
-            let decl = Q.mk_constant_decl cst_bdy in            
+            let decl = Q.mk_constant_decl cst_bdy in
             constants := (Q.quote_kn kn, decl) :: !constants
           end
     in
@@ -552,22 +560,23 @@ struct
     in
     let (tm, _) = quote_rem () env sigma trm in
     let decls = List.fold_right (fun (kn, d) acc -> Q.add_global_decl kn d acc) !constants (Q.empty_global_declarations ()) in
-    let univs = 
-      if with_universes then 
+    let univs =
+      if with_universes then
         let univs = Univ.Level.Set.union (Vars.universes_of_constr trm) !universes in
         let univs = Univ.Level.Set.filter (fun l -> Option.is_empty (Univ.Level.var_index l)) univs in
         quote_ugraph ~kept:univs (Environ.universes env)
-      else 
+      else
         (debug Pp.(fun () -> str"Skipping universes: ");
-         time (Pp.str"Quoting empty universe context") 
+         time (Pp.str"Quoting empty universe context")
            (fun uctx -> Q.quote_univ_contextset uctx) Univ.ContextSet.empty)
     in
     let retro =
       let retro = env.Environ.retroknowledge in
       let quote_retro = Option.map (fun c -> Q.quote_kn (Names.Constant.canonical c)) in
-      let pre = 
+      let pre =
         { Q.retro_int63 = quote_retro retro.Retroknowledge.retro_int63 ;
-          Q.retro_float64 = quote_retro retro.Retroknowledge.retro_float64 }
+          Q.retro_float64 = quote_retro retro.Retroknowledge.retro_float64 ;
+          Q.retro_array = quote_retro retro.Retroknowledge.retro_array }
       in Q.quote_retroknowledge pre
     in
     let env = Q.mk_global_env univs decls retro in

--- a/template-coq/src/reification.ml
+++ b/template-coq/src/reification.ml
@@ -23,6 +23,7 @@ sig
   type quoted_constraint_type
   type quoted_univ_constraint
   type quoted_univ_constraints
+  type quoted_univ_level
   type quoted_univ_instance
   type quoted_univ_context
   type quoted_univ_contextset

--- a/template-coq/src/tm_util.ml
+++ b/template-coq/src/tm_util.ml
@@ -1,5 +1,5 @@
 open Pp
-  
+
 let contrib_name = "template-coq"
 
 let gen_constant_in_modules s =
@@ -9,15 +9,15 @@ let gen_constant_in_modules s =
   )
   (* lazy (Universes.constr_of_global (Coqlib.gen_reference_in_modules locstr dirs s)) *)
 
-(* This allows to load template_plugin and the extractable plugin at the same time 
+(* This allows to load template_plugin and the extractable plugin at the same time
   while have option settings apply to both *)
   let timing_opt =
   let open Goptions in
   let key = ["MetaCoq"; "Timing"] in
   let tables = get_tables () in
-  try 
+  try
     let _ = OptionMap.find key tables in
-    fun () -> 
+    fun () ->
       let tables = get_tables () in
       let opt = OptionMap.find key tables in
       match opt.opt_value with
@@ -27,21 +27,21 @@ let gen_constant_in_modules s =
     declare_bool_option_and_ref ~depr:false ~key ~value:false
 
 let time prefix f x =
-  if timing_opt () then 
+  if timing_opt () then
     let start = Unix.gettimeofday () in
     let res = f x in
     let stop = Unix.gettimeofday () in
     let () = Feedback.msg_info Pp.(prefix ++ str " executed in: " ++ Pp.real (stop -. start) ++ str "s") in
     res
   else f x
-  
+
 let debug_opt =
   let open Goptions in
   let key = ["MetaCoq"; "Debug"] in
   let tables = get_tables () in
-  try 
+  try
     let _ = OptionMap.find key tables in
-    fun () -> 
+    fun () ->
       let tables = get_tables () in
       let opt = OptionMap.find key tables in
       match opt.opt_value with
@@ -65,7 +65,7 @@ let rec filter_map f l =
     match f x with
     | Some x' -> x' :: filter_map f xs
     | None -> filter_map f xs
-    
+
 let rec app_full trm acc =
   match Constr.kind trm with
     Constr.App (f, xs) -> app_full f (Array.to_list xs @ acc)
@@ -140,7 +140,7 @@ module CaseCompat =
     let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
     let paramsubst = Vars.subst_of_rel_context_instance paramdecl params in
     case_predicate_context_gen mip ci u paramsubst nas
-      
+
   let case_branches_contexts_gen mib ci u params brs =
     (* Γ ⊢ c : I@{u} params args *)
     (* Γ, indices, self : I@{u} params indices ⊢ p : Type *)
@@ -156,7 +156,7 @@ module CaseCompat =
         (nas, ctx, br)
       in
       Array.map2_i build_one_branch brs mip.mind_nf_lc
-    in 
+    in
     ebr
 
   let case_branches_contexts env ci u pars brs =
@@ -171,7 +171,7 @@ module RetypeMindEntry =
   open Names
   open Univ
 
-  let retype env evm c = 
+  let retype env evm c =
     Typing.type_of env evm (EConstr.of_constr c)
 
   let retype_decl env evm decl =
@@ -184,15 +184,15 @@ module RetypeMindEntry =
       let evm, ty = Typing.solve_evars env evm (EConstr.of_constr ty) in
       let evm = Typing.check env evm b ty in
       evm, Context.Rel.Declaration.LocalDef (na, b, ty)
-    
-  let retype_context env evm ctx = 
+
+  let retype_context env evm ctx =
     let env, evm, ctx = Context.Rel.fold_outside (fun decl (env, evm, ctx) ->
       let evm, d = retype_decl env evm decl in
-      (EConstr.push_rel d env, evm, d :: ctx)) 
+      (EConstr.push_rel d env, evm, d :: ctx))
       ctx ~init:(env, evm, [])
     in evm, ctx
 
-  let sup_sort s1 s2 = 
+  let sup_sort s1 s2 =
     let open Sorts in
     match s1, s2 with
   | (_, SProp) -> assert false (* template SProp not allowed *)
@@ -207,8 +207,8 @@ module RetypeMindEntry =
     let evm, pars' = retype_context env evm pars in
     let envpars = Environ.push_rel_context pars env in
     let evm, arities =
-      List.fold_left 
-        (fun (evm, ctx) oib -> 
+      List.fold_left
+        (fun (evm, ctx) oib ->
           let ty = oib.mind_entry_arity in
           let evm, s = retype envpars evm ty in
           let ty = Term.it_mkProd_or_LetIn ty pars in
@@ -218,9 +218,9 @@ module RetypeMindEntry =
     let env = Environ.push_rel_context arities env in
     let env = Environ.push_rel_context pars env in
     let evm =
-      List.fold_left 
+      List.fold_left
         (fun evm oib ->
-          let evm, cstrsort = 
+          let evm, cstrsort =
             List.fold_left (fun (evm, sort) cstr ->
               let evm, cstrty = retype env evm cstr in
               let _, cstrsort = Reduction.dest_arity env (EConstr.to_constr evm cstrty) in
@@ -240,7 +240,7 @@ module RetypeMindEntry =
     let nf_evar c = EConstr.Unsafe.to_constr (Evarutil.nf_evar evm (EConstr.of_constr c)) in
     let inds =
       List.map
-          (fun oib -> 
+          (fun oib ->
             let arity = nf_evar oib.mind_entry_arity in
             let cstrs = List.map nf_evar oib.mind_entry_lc in
             { oib with mind_entry_arity = arity; mind_entry_lc = cstrs })
@@ -248,8 +248,8 @@ module RetypeMindEntry =
       in
       { mind with mind_entry_params = pars; mind_entry_inds = inds }
 
-  let infer_mentry_univs env evm mind = 
-    let evm = 
+  let infer_mentry_univs env evm mind =
+    let evm =
       match mind.mind_entry_universes with
       | Entries.Monomorphic_ind_entry -> evm
       | Entries.Template_ind_entry uctx -> evm
@@ -260,7 +260,7 @@ module RetypeMindEntry =
     let evm, mind = infer_mentry_univs env evm mind in
     let evm = Evd.minimize_universes evm in
     let mind = nf_mentry_univs evm mind in
-    let ctx, mind = 
+    let ctx, mind =
       match mind.mind_entry_universes with
       | Entries.Monomorphic_ind_entry ->
         Evd.universe_context_set evm, { mind with mind_entry_universes = Entries.Monomorphic_ind_entry }
@@ -270,14 +270,14 @@ module RetypeMindEntry =
         let uctx' = Evd.to_universe_context evm in
         Univ.ContextSet.empty, { mind with mind_entry_universes = Entries.Polymorphic_ind_entry uctx' }
     in ctx, mind
-end 
+end
 
 type ('term, 'name, 'nat) adef = { adname : 'name; adtype : 'term; adbody : 'term; rarg : 'nat }
 
 type ('term, 'name, 'nat) amfixpoint = ('term, 'name, 'nat) adef list
 
-type ('term, 'name, 'universe_instance) apredicate = 
-  { auinst : 'universe_instance; 
+type ('term, 'name, 'universe_instance) apredicate =
+  { auinst : 'universe_instance;
     apars : 'term list;
     apcontext : 'name list;
     apreturn : 'term }
@@ -290,8 +290,8 @@ type ('nat, 'inductive, 'relevance) acase_info =
   { aci_ind : 'inductive;
     aci_npar : 'nat;
     aci_relevance : 'relevance }
-    
-type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'relevance, 'universe_instance, 'projection, 'int63, 'float64) structure_of_term =
+
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'relevance, 'universe_level, 'universe_instance, 'projection, 'int63, 'float64) structure_of_term =
   | ACoq_tRel of 'nat
   | ACoq_tVar of 'ident
   | ACoq_tEvar of 'nat * 'term list
@@ -304,7 +304,7 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | ACoq_tConst of 'kername * 'universe_instance
   | ACoq_tInd of 'inductive * 'universe_instance
   | ACoq_tConstruct of 'inductive * 'nat * 'universe_instance
-  | ACoq_tCase of ('nat, 'inductive, 'relevance) acase_info * 
+  | ACoq_tCase of ('nat, 'inductive, 'relevance) acase_info *
     ('term, 'name, 'universe_instance) apredicate *
     'term * ('term, 'name) abranch list
   | ACoq_tProj of 'projection * 'term
@@ -312,4 +312,5 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
   | ACoq_tInt of 'int63
   | ACoq_tFloat of 'float64
+  | ACoq_tArray of 'universe_level * 'term array * 'term * 'term
 

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -1,10 +1,10 @@
 (* Distributed under the terms of the MIT license. *)
+From Equations Require Import Equations.
 From MetaCoq.Utils Require Import utils.
 From MetaCoq.Common Require Export Environment EnvironmentTyping Universes BasicAst.
 (* For primitive integers and floats  *)
-From Coq Require Uint63 Floats.PrimFloat Floats.SpecFloat.
+From Coq Require Uint63 Floats.PrimFloat Floats.SpecFloat PArray.
 From Coq Require Import ssreflect Morphisms.
-From Equations Require Import Equations.
 
 (** * AST of Coq kernel terms and kernel data structures
 
@@ -415,7 +415,8 @@ Inductive term : Type :=
 | tFix (mfix : mfixpoint term) (idx : nat)
 | tCoFix (mfix : mfixpoint term) (idx : nat)
 | tInt (i : PrimInt63.int)
-| tFloat (f : PrimFloat.float).
+| tFloat (f : PrimFloat.float)
+| tArray (u : Level.t) (arr : list term) (default : term) (type : term).
 
 (** This can be used to represent holes, that, when unquoted, turn into fresh existential variables.
     The fresh evar will depend on the whole context at this point in the term, despite the empty instance.
@@ -457,6 +458,8 @@ Fixpoint lift n k t : term :=
     let k' := List.length mfix + k in
     let mfix' := List.map (map_def (lift n k) (lift n k')) mfix in
     tCoFix mfix' idx
+  | tArray u arr def ty =>
+    tArray u (List.map (lift n k) arr) (lift n k def) (lift n k ty)
   | x => x
   end.
 
@@ -494,6 +497,8 @@ Fixpoint subst s k u :=
     let k' := List.length mfix + k in
     let mfix' := List.map (map_def (subst s k) (subst s k')) mfix in
     tCoFix mfix' idx
+  | tArray u arr def ty =>
+    tArray u (List.map (subst s k) arr) (subst s k def) (subst s k ty)
   | x => x
   end.
 
@@ -523,6 +528,8 @@ Fixpoint closedn k (t : term) : bool :=
   | tCoFix mfix idx =>
     let k' := List.length mfix + k in
     List.forallb (test_def (closedn k) (closedn k')) mfix
+  | tArray u arr def ty =>
+    List.forallb (closedn k) arr && closedn k def && closedn k ty
   | _ => true
   end.
 
@@ -548,6 +555,9 @@ Fixpoint noccur_between k n (t : term) : bool :=
   | tCoFix mfix idx =>
     let k' := List.length mfix + k in
     List.forallb (test_def (noccur_between k n) (noccur_between k' n)) mfix
+  | tArray u arr def ty =>
+    List.forallb (noccur_between k n) arr &&
+    noccur_between k n def && noccur_between k n ty
   | _ => true
   end.
 
@@ -556,6 +566,8 @@ Fixpoint noccur_between k n (t : term) : bool :=
   match c with
   | tRel _ | tVar _ => c
   | tInt _ | tFloat _ => c
+  | tArray u' arr def ty => tArray (subst_instance_level u u') (List.map (subst_instance_constr u) arr)
+    (subst_instance_constr u def) (subst_instance_constr u ty)
   | tEvar ev args => tEvar ev (List.map (subst_instance_constr u) args)
   | tSort s => tSort (subst_instance_univ u s)
   | tConst c u' => tConst c (subst_instance_instance u u')
@@ -602,6 +614,8 @@ Fixpoint closedu (k : nat) (t : term) : bool :=
     forallb (test_def (closedu k) (closedu k)) mfix
   | tCoFix mfix idx =>
     forallb (test_def (closedu k) (closedu k)) mfix
+  | tArray u arr def ty =>
+    closedu_level k u && forallb (closedu k) arr && closedu k def && closedu k ty
   | _ => true
   end.
 
@@ -821,4 +835,3 @@ Definition case_branch_type_gen ind mdecl params puinst ptm i cdecl (br : branch
 
 Definition case_branch_type ind mdecl p ptm i cdecl br : context * term :=
   case_branch_type_gen ind mdecl p.(pparams) p.(puinst) ptm i cdecl br.
-

--- a/template-coq/theories/AstUtils.v
+++ b/template-coq/theories/AstUtils.v
@@ -68,6 +68,8 @@ Module string_of_term_tree.
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
   | tFloat f => "Float(" ^ string_of_float f ^ ")"
+  | tArray u arr def ty => "Array(" ^ string_of_level u ^ "," ^
+    string_of_list string_of_term arr ^ "," ^ string_of_term def ^ "," ^ string_of_term ty ^ ")"
   end.
 End string_of_term_tree.
 
@@ -252,6 +254,8 @@ Fixpoint strip_casts t :=
   | tCoFix mfix idx =>
     let mfix' := List.map (map_def strip_casts strip_casts) mfix in
     tCoFix mfix' idx
+  | tArray u arr def ty =>
+    tArray u (List.map strip_casts arr) (strip_casts def) (strip_casts ty)
   | tRel _ | tVar _ | tSort _ | tConst _ _ | tInd _ _ | tConstruct _ _ _ => t
   | tInt _ | tFloat _ => t
   end.

--- a/template-coq/theories/Checker.v
+++ b/template-coq/theories/Checker.v
@@ -800,7 +800,7 @@ Section Typecheck.
       | None => raise (IllFormedFix mfix n)
       end
 
-    | tInt _ | tFloat _ => raise (NotSupported "primitive types")
+    | tInt _ | tFloat _ | tArray _ _ _ _ => raise (NotSupported "primitive types")
     end.
 
   Definition check (Γ : context) (t : term) (ty : term) : typing_result unit :=

--- a/template-coq/theories/Constants.v
+++ b/template-coq/theories/Constants.v
@@ -178,6 +178,7 @@ Register MetaCoq.Template.Ast.tFix as metacoq.ast.tFix.
 Register MetaCoq.Template.Ast.tCoFix as metacoq.ast.tCoFix.
 Register MetaCoq.Template.Ast.tInt as metacoq.ast.tInt.
 Register MetaCoq.Template.Ast.tFloat as metacoq.ast.tFloat.
+Register MetaCoq.Template.Ast.tArray as metacoq.ast.tArray.
 
 (* Local and global declarations *)
 Register MetaCoq.Template.Ast.parameter_entry as metacoq.ast.parameter_entry.

--- a/template-coq/theories/EtaExpand.v
+++ b/template-coq/theories/EtaExpand.v
@@ -139,6 +139,7 @@ Section Eta.
                        ++ string_of_kername ind.(inductive_mind))
         end
     | tCast t1 k t2 => tCast (eta_expand Γ t1) k (eta_expand Γ t2)
+    | tArray u arr def ty => tArray u (List.map (eta_expand Γ) arr) (eta_expand Γ def) (eta_expand Γ ty)
     | tInt _ | tFloat _ => t
     end.
 
@@ -294,7 +295,12 @@ Inductive expanded (Γ : list nat): term -> Prop :=
     Forall (expanded Γ) args ->
     expanded Γ (tApp (tConstruct ind c u) args)
 | expanded_tInt i : expanded Γ (tInt i)
-| expanded_tFloat f : expanded Γ (tFloat f).
+| expanded_tFloat f : expanded Γ (tFloat f)
+| expanded_tArray u arr def ty :
+  Forall (expanded Γ) arr ->
+  expanded Γ def ->
+  expanded Γ ty ->
+  expanded Γ (tArray u arr def ty).
 
 End expanded.
 
@@ -359,9 +365,14 @@ forall (Σ : global_env) (P : list nat -> term -> Prop),
  P Γ(tApp (tConstruct ind c u) args)) ->
 (forall Γ i, P Γ (tInt i)) ->
 (forall Γ f, P Γ (tFloat f)) ->
+(forall Γ u arr def ty,
+  Forall (P Γ) arr ->
+  P Γ def ->
+  P Γ ty ->
+  P Γ (tArray u arr def ty)) ->
  forall Γ, forall t : term, expanded Σ Γ t -> P Γ t.
 Proof.
-  intros Σ P HRel HRel_app HVar HEvar HSort HCast HProd HLamdba HLetIn HApp HConst HInd HConstruct HCase HProj HFix HCoFix HConstruct_app Hint Hfloat.
+  intros Σ P HRel HRel_app HVar HEvar HSort HCast HProd HLamdba HLetIn HApp HConst HInd HConstruct HCase HProj HFix HCoFix HConstruct_app Hint Hfloat Harr.
   fix f 3.
   intros Γ t Hexp.  destruct Hexp; eauto.
   all: match goal with [H : Forall _ _ |- _] => let all := fresh "all" in rename H into all end.
@@ -381,6 +392,7 @@ Proof.
     generalize mfix at 1 3. intros mfix0 H.  induction H; econstructor; cbn in *; eauto; split.
   - eapply HConstruct_app; eauto.
     clear - all f. induction all; econstructor; eauto.
+  - eapply Harr; eauto. clear -all f. induction all; constructor; auto.
 Qed.
 
 Local Hint Constructors expanded : core.
@@ -627,6 +639,7 @@ Proof.
   - destruct t; invs H4.
     eapply expanded_tConstruct_app; eauto. revert H0.
     now len. solve_all.
+  - constructor; eauto. solve_all.
 Qed.
 
 Lemma expanded_lift {Σ : global_env} Γ' Γ'' Γ t :
@@ -672,6 +685,7 @@ Proof.
     shelve. autorewrite with len list in H |- *. eapply H.
   - eapply expanded_tConstruct_app; eauto.
     now len. solve_all.
+  - constructor; eauto. eapply Forall_map. solve_all.
 Qed.
 
 Lemma expanded_lift' {Σ : global_env} Γ' Γ'' Γ t Γassum Γgoal n m :
@@ -1222,6 +1236,7 @@ Proof.
      assert (#|Typing.fix_context mfix| = #|mfix|). { unfold Typing.fix_context. now len. }
      revert H4. generalize (Typing.fix_context mfix). clear.
      induction #|mfix|; intros []; cbn; intros; try congruence; econstructor; eauto.
+  - cbn. econstructor; eauto. solve_all. eapply b; tea. solve_all.
   - eapply typing_wf_local; eauto.
 Qed.
 

--- a/template-coq/theories/Induction.v
+++ b/template-coq/theories/Induction.v
@@ -34,6 +34,7 @@ Lemma term_forall_list_ind :
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
     (forall i, P (tInt i)) ->
     (forall f, P (tFloat f)) ->
+    (forall u arr def ty, Forall P arr -> P def -> P ty -> P (tArray u arr def ty)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.
@@ -77,6 +78,7 @@ Lemma term_forall_list_rect :
     (forall (m : mfixpoint term) (n : nat), tFixType P P m -> P (tCoFix m n)) ->
     (forall i, P (tInt i)) ->
     (forall f, P (tFloat f)) ->
+    (forall u arr def ty, All P arr -> P def -> P ty -> P (tArray u arr def ty)) ->
     forall t : term, P t.
 Proof.
   intros until t. revert t.

--- a/template-coq/theories/Pretty.v
+++ b/template-coq/theories/Pretty.v
@@ -252,6 +252,8 @@ Module PrintTermTree.
                               " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ binder_name ∘ dname) l) n)
   | tInt i => "Int(" ^ string_of_prim_int i ^ ")"
   | tFloat f => "Float(" ^ string_of_float f ^ ")"
+  | tArray u arr def ty => "Array(" ^ string_of_level u ^ "," ^
+    string_of_list string_of_term arr ^ "," ^ string_of_term def ^ "," ^ string_of_term ty ^ ")"
   end.
 
   Definition pr_context_decl Γ (c : context_decl) : ident * t :=

--- a/template-coq/theories/ReflectAst.v
+++ b/template-coq/theories/ReflectAst.v
@@ -158,6 +158,16 @@ Proof.
     subst. left. reflexivity.
   - destruct (eq_dec f f0) ; nodec.
     subst. left. reflexivity.
+  - destruct (IHx1 t1); subst; nodec.
+    destruct (IHx2 t2); subst; nodec.
+    destruct (eq_dec u u0); nodec; subst.
+    revert arr0.
+    induction X.
+    + intros []; auto. nodec.
+    + intros []; auto. nodec.
+      destruct (IHX l0). noconf e.
+      destruct (p t); nodec. subst. left; auto.
+      nodec.
 Defined.
 
 #[global] Instance reflect_term : ReflectEq term :=

--- a/template-coq/theories/TermEquality.v
+++ b/template-coq/theories/TermEquality.v
@@ -239,7 +239,12 @@ Inductive eq_term_upto_univ_napp Σ (Re Rle : Universe.t -> Universe.t -> Prop) 
   eq_term_upto_univ_napp Σ Re Rle napp (tCast t1 c t2) (tCast t1' c' t2')
 
 | eq_Int i : eq_term_upto_univ_napp Σ Re Rle napp (tInt i) (tInt i)
-| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f).
+| eq_Float f : eq_term_upto_univ_napp Σ Re Rle napp (tFloat f) (tFloat f)
+| eq_Array u u' arr arr' def def' ty ty' :
+  All2 (eq_term_upto_univ_napp Σ Re Rle 0) arr arr' ->
+  eq_term_upto_univ_napp Σ Re Rle 0 def def' ->
+  eq_term_upto_univ_napp Σ Re Rle 0 ty ty' ->
+  eq_term_upto_univ_napp Σ Re Rle napp (tArray u arr def ty) (tArray u' arr' def' ty').
 
 Notation eq_term_upto_univ Σ Re Rle := (eq_term_upto_univ_napp Σ Re Rle 0).
 
@@ -313,6 +318,7 @@ Proof.
     intros x [? ?]. repeat split ; auto.
   - eapply All_All2. 1: eassumption.
     intros x [? ?]. repeat split ; auto.
+  - eapply All_All2; tea. cbn. eauto.
 Qed.
 
 Lemma eq_term_refl `{checker_flags} Σ φ t : eq_term Σ φ t t.
@@ -477,6 +483,8 @@ Proof.
     eapply All2_impl'; tea.
     eapply All_impl; eauto.
     cbn. intros x [? ?] y [[[? ?] ?] ?]. repeat split; eauto.
+  - inversion 1; subst; constructor; eauto.
+    eapply All2_impl'; tea. eapply All_impl; eauto.
 Qed.
 
 

--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -845,15 +845,26 @@ Inductive typing `{checker_flags} (Σ : global_env_ext) (Γ : context) : term ->
     wf_local Σ Γ ->
     primitive_constant Σ primInt = Some prim_ty ->
     declared_constant Σ prim_ty cdecl ->
-    primitive_invariants cdecl ->
+    primitive_invariants primInt cdecl ->
     Σ ;;; Γ |- tInt p : tConst prim_ty []
 
 | type_Float p prim_ty cdecl :
     wf_local Σ Γ ->
     primitive_constant Σ primFloat = Some prim_ty ->
     declared_constant Σ prim_ty cdecl ->
-    primitive_invariants cdecl ->
+    primitive_invariants primFloat cdecl ->
     Σ ;;; Γ |- tFloat p : tConst prim_ty []
+
+| type_Array prim_ty cdecl u arr def ty :
+  wf_local Σ Γ ->
+  primitive_constant Σ primArray = Some prim_ty ->
+  declared_constant Σ prim_ty cdecl ->
+  primitive_invariants primArray cdecl ->
+  let s := Universe.make u in
+  Σ ;;; Γ |- ty : tSort s ->
+  Σ ;;; Γ |- def : ty ->
+  All (fun t => Σ ;;; Γ |- t : ty) arr ->
+  Σ ;;; Γ |- tArray u arr def ty : tApp (tConst prim_ty [u]) [ty]
 
 | type_Conv t A B s :
     Σ ;;; Γ |- t : A ->
@@ -969,6 +980,7 @@ Proof.
   - exact (S (Nat.max (Nat.max (All_local_env_size typing_size _ _ a) (all_size _ (fun x p => infer_sort_size (typing_sort_size typing_size) Σ _ _ p) a0)) (all_size _ (fun x p => typing_size Σ _ _ _ p) a1))).
   - exact (S (All_local_env_size typing_size _ _ a)).
   - exact (S (All_local_env_size typing_size _ _ a)).
+  - exact (S (Nat.max d2 (Nat.max d3 (all_size _ (fun t => typing_size Σ Γ t ty) a0)))).
 Defined.
 
 Lemma typing_size_pos `{checker_flags} {Σ Γ t T} (d : Σ ;;; Γ |- t : T) : typing_size d > 0.
@@ -1245,15 +1257,28 @@ Lemma typing_ind_env `{cf : checker_flags} :
         PΓ Σ Γ wfΓ ->
         primitive_constant Σ primInt = Some prim_ty ->
         declared_constant Σ prim_ty cdecl ->
-        primitive_invariants cdecl ->
+        primitive_invariants primInt cdecl ->
         P Σ Γ (tInt p) (tConst prim_ty [])) ->
 
     (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) p prim_ty cdecl,
         PΓ Σ Γ wfΓ ->
         primitive_constant Σ primFloat = Some prim_ty ->
         declared_constant Σ prim_ty cdecl ->
-        primitive_invariants cdecl ->
+        primitive_invariants primFloat cdecl ->
         P Σ Γ (tFloat p) (tConst prim_ty [])) ->
+
+    (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) u arr def ty prim_ty cdecl,
+        PΓ Σ Γ wfΓ ->
+        primitive_constant Σ primArray = Some prim_ty ->
+        declared_constant Σ prim_ty cdecl ->
+        primitive_invariants primArray cdecl ->
+        let s := Universe.make u in
+        Σ ;;; Γ |- ty : tSort s ->
+        P Σ Γ ty (tSort s) ->
+        Σ ;;; Γ |- def : ty ->
+        P Σ Γ def ty ->
+        All (fun t => Σ ;;; Γ |- t : ty × P Σ Γ t ty) arr ->
+        P Σ Γ (tArray u arr def ty) (tApp (tConst prim_ty [u]) [ty])) ->
 
     (forall Σ (wfΣ : wf Σ) (Γ : context) (wfΓ : wf_local Σ Γ) (t A B : term) s,
         PΓ Σ Γ wfΓ ->
@@ -1268,7 +1293,7 @@ Lemma typing_ind_env `{cf : checker_flags} :
 Proof.
   intros P Pdecl PΓ; unfold env_prop.
   intros XΓ.
-  intros X X0 Xcast X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 Xint Xfloat X12 Σ wfΣ Γ wfΓ t T H.
+  intros X X0 Xcast X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 Xint Xfloat Xarr X12 Σ wfΣ Γ wfΓ t T H.
   (* NOTE (Danil): while porting to 8.9, I had to split original "pose" into 2 pieces,
    otherwise it takes forever to execure the "pose", for some reason *)
   pose (@Fix_F ({ Σ : global_env_ext & { wfΣ : wf Σ & { Γ & { t & { T & Σ ;;; Γ |- t : T }}}}})) as p0.
@@ -1549,6 +1574,17 @@ Proof.
              eapply (X _ (typing_wf_local p) _ _ p). simpl. lia.
            ++ eapply IHa1. intros.
              eapply (X _ X0 _ _ Hty). simpl; lia.
+      -- eapply Xarr; tea.
+        * eapply (X14 _ _ _ H). simpl. subst s; lia.
+        * eapply (X14 _ _ _ H0). simpl. subst s; lia.
+        * clear -a0 X14.
+          assert (forall (Γ0 : context) (t T : term) (Hty : Σ;;; Γ0 |- t : T),
+          typing_size Hty < S (all_size _ (fun t p => typing_size p) a0) ->
+          on_global_env cumul_gen (lift_typing P) Σ.1 × P Σ Γ0 t T).
+          { intros ??? Hty ?; eapply (X14 _ _ _ Hty). simpl. lia. }
+          clear X14. clear -X a0. induction a0; constructor; eauto.
+          split => //. eapply (X _ _ _ p). cbn. lia.
+          eapply IHa0. intros. eapply (X _ _ _ Hty). simpl. lia.
 Qed.
 
 (** * Lemmas about All_local_env *)

--- a/template-coq/theories/TypingWf.v
+++ b/template-coq/theories/TypingWf.v
@@ -1031,6 +1031,10 @@ Section TypingWf.
         solve_all; destruct a, b.
         all: intuition.
       + eapply All_nth_error in X0; eauto. destruct X0 as [s ?]; intuition.
+
+    - split => //.
+      + constructor; intuition auto. solve_all.
+      + constructor => //. constructor => //. constructor; intuition auto.
   Qed.
 
   Lemma typing_all_wf_decl Σ (wfΣ : wf Σ.1) Γ (wfΓ : wf_local Σ Γ) :

--- a/template-coq/theories/WfAst.v
+++ b/template-coq/theories/WfAst.v
@@ -57,7 +57,8 @@ Inductive wf {Σ} : term -> Type :=
                    wf (tFix mfix k)
 | wf_tCoFix mfix k : All (fun def => wf def.(dtype) × wf def.(dbody)) mfix -> wf (tCoFix mfix k)
 | wf_tInt i : wf (tInt i)
-| wf_tFloat f : wf (tFloat f).
+| wf_tFloat f : wf (tFloat f)
+| wf_tArray u arr def ty : All wf arr -> wf def -> wf ty -> wf (tArray u arr def ty).
 Arguments wf : clear implicits.
 Derive Signature for wf.
 
@@ -67,6 +68,7 @@ Definition wf_Inv Σ (t : term) : Type :=
   match t with
   | tRel _ | tVar _ | tSort _ => unit
   | tInt _ | tFloat _ => unit
+  | tArray u arr def ty => All (wf Σ) arr * wf Σ def * wf Σ ty
   | tEvar n l => All (wf Σ) l
   | tCast t k t' => wf Σ t * wf Σ t'
   | tProd na t b => wf Σ t * wf Σ b
@@ -150,9 +152,10 @@ Lemma term_wf_forall_list_ind Σ :
     (forall (m : mfixpoint term) (n : nat), tFixProp P P m -> P (tCoFix m n)) ->
     (forall i, P (tInt i)) ->
     (forall f, P (tFloat f)) ->
+    (forall u arr def ty, All P arr -> P def -> P ty ->  P (tArray u arr def ty)) ->
     forall t : term, wf Σ t -> P t.
 Proof.
-  intros P H2 H3 H4 H5 H6 H7 H8 H9 H10 H11 H12 H13 H14 H15 H16 H17 H18 H19.
+  intros P H2 H3 H4 H5 H6 H7 H8 H9 H10 H11 H12 H13 H14 H15 H16 H17 H18 H19 Harr.
   intros until t. revert t.
   apply (term_forall_list_rect (fun t => wf Σ t -> P t));
     intros; try solve [match goal with
@@ -180,6 +183,7 @@ Proof.
     apply H16. red. red in X. solve_all.
   - inv X0; auto.
     apply H17. red. red in X. solve_all.
+  - inv X2; auto. eapply Harr; eauto using lift_to_wf_list.
 Qed.
 
 Definition wf_decl Σ d :=


### PR DESCRIPTION
This is a work-in-progress to at least carry around primitive arrays down the MetaCoq pipeline.
I tried to impact as little as possible the derivations, by using nested inductive types for auxilliary judgements.

As of Oct 30, everything up to universe substitution is proven, and the typing reduction and comparison relations are extended.