### PR TITLE
Primitive evaluation

### DIFF
--- a/common/theories/Environment.v
+++ b/common/theories/Environment.v
@@ -856,8 +856,8 @@ Module Environment (T : Term).
   Definition primitive_invariants (p : prim_tag) (cdecl : constant_body) :=
     match p with
     | primInt | primFloat =>
-     ∑ s, [/\ cdecl.(cst_type) = tSort s, cdecl.(cst_body) = None &
-             cdecl.(cst_universes) = Monomorphic_ctx]
+     [/\ cdecl.(cst_type) = tSort Universe.type0, cdecl.(cst_body) = None &
+          cdecl.(cst_universes) = Monomorphic_ctx]
     | primArray =>
       let s := Universe.make (Level.lvar 0) in
       [/\ cdecl.(cst_type) = tImpl (tSort s) (tSort s), cdecl.(cst_body) = None &

--- a/erasure-plugin/theories/ErasureCorrectness.v
+++ b/erasure-plugin/theories/ErasureCorrectness.v
@@ -262,7 +262,7 @@ Proof.
   intros Hf.
   fix aux 2.
   intros t fo; destruct fo.
-  eapply Hf => //. clear H. rename H0 into H.  
+  eapply Hf => //. clear H. rename H0 into H.
   move: args H.
   fix aux' 2.
   intros args []; constructor.
@@ -741,7 +741,7 @@ Proof.
   move: v; apply: firstorder_evalue_elim.
   intros.
   rewrite /flip (compile_evalue_box_mkApps) // ?app_nil_r.
-  pose proof (H' := H). 
+  pose proof (H' := H).
   eapply lookup_constructor_pars_args_nopars in H; tea. subst npars.
   rewrite skipn_0 in H1.
   constructor.
@@ -1559,7 +1559,7 @@ Section pipeline_cond.
     - cbn. intros wf ? ? ? ? ? ?. now eapply Normalisation.
   Qed.
 
-End pipeline_cond. 
+End pipeline_cond.
 
 Section pipeline_theorem.
 
@@ -1602,7 +1602,7 @@ Section pipeline_theorem.
 
   Lemma v_t_spec : v_t = (transform verified_erasure_pipeline (Σ, v) (precond2 _ _ _ _ expΣ expt typing _ _ Heval)).2.
   Proof.
-    unfold v_t. generalize fo_v. set (pre := precond2 _ _ _ _ _ _ _ _ _ _) in *. clearbody pre. 
+    unfold v_t. generalize fo_v. set (pre := precond2 _ _ _ _ _ _ _ _ _ _) in *. clearbody pre.
     intros hv.
     unfold verified_erasure_pipeline.
     rewrite -transform_compose_assoc.
@@ -1629,7 +1629,7 @@ Section pipeline_theorem.
     set (p := transform erase_transform _ _).
     pose proof (@erase_tranform_firstorder _ h v i u (List.map PCUICExpandLets.trans args) Normalisation').
     forward H0.
-    { cbn. rewrite -eqtr.  
+    { cbn. rewrite -eqtr.
       eapply (PCUICClassification.subject_reduction_eval (Σ := Σ)) in X; tea.
       eapply PCUICExpandLetsCorrectness.expand_lets_sound in X.
       now rewrite PCUICExpandLetsCorrectness.trans_mkApps /= in X. }
@@ -1664,24 +1664,24 @@ Section pipeline_theorem.
 
   Lemma verified_erasure_pipeline_lookup_env_in kn decl (efl := EInlineProjections.switch_no_params all_env_flags)  {has_rel : has_tRel} {has_box : has_tBox}  :
     EGlobalEnv.lookup_env Σ_v kn = Some (EAst.InductiveDecl decl) ->
-    exists decl', 
+    exists decl',
       PCUICAst.PCUICEnvironment.lookup_global (PCUICExpandLets.trans_global_decls
       (PCUICAst.PCUICEnvironment.declarations
          Σ.1)) kn = Some (PCUICAst.PCUICEnvironment.InductiveDecl decl')
-       /\ decl = ERemoveParams.strip_inductive_decl (erase_mutual_inductive_body decl'). 
-  Proof. 
+       /\ decl = ERemoveParams.strip_inductive_decl (erase_mutual_inductive_body decl').
+  Proof.
     Opaque compose.
     unfold Σ_v, verified_erasure_pipeline.
-    repeat rewrite -transform_compose_assoc. 
-    destruct_compose; intro. cbn. 
+    repeat rewrite -transform_compose_assoc.
     destruct_compose; intro. cbn.
-    set (erase_program _ _). 
+    destruct_compose; intro. cbn.
+    set (erase_program _ _).
     unfold verified_lambdabox_pipeline.
-    repeat rewrite -transform_compose_assoc. 
-    repeat (destruct_compose; intro). 
+    repeat rewrite -transform_compose_assoc.
+    repeat (destruct_compose; intro).
     unfold transform at 1. cbn -[transform].
     rewrite EConstructorsAsBlocks.lookup_env_transform_blocks.
-    set (EConstructorsAsBlocks.transform_blocks_decl _). 
+    set (EConstructorsAsBlocks.transform_blocks_decl _).
     unfold transform at 1. cbn -[transform].
     unfold transform at 1. cbn -[transform].
     erewrite EInlineProjections.lookup_env_optimize.
@@ -1692,7 +1692,7 @@ Section pipeline_theorem.
       rewrite erase_global_deps_fast_spec.
       eapply erase_global_deps_wf_glob.
       intros ? He; now rewrite He. }
-    set (EInlineProjections.optimize_decl _). 
+    set (EInlineProjections.optimize_decl _).
     unfold transform at 1. cbn -[transform].
     unfold transform at 1. cbn -[transform].
     erewrite EOptimizePropDiscr.lookup_env_remove_match_on_box.
@@ -1710,25 +1710,25 @@ Section pipeline_theorem.
     unfold transform at 1. cbn -[transform].
     rewrite erase_global_deps_fast_spec.
     2: { cbn. intros ? He. rewrite He. eauto. }
-    intro. 
+    intro.
     set (EAstUtils.term_global_deps _).
     set (build_wf_env_from_env _ _).
-    epose proof 
+    epose proof
       (lookup_env_in_erase_global_deps optimized_abstract_env_impl w t0
       _ kn _ Hyp0).
     set (EGlobalEnv.lookup_env _ _).
     case_eq o. 2: { intros ?. inversion 1. }
     destruct g3; intro Ho; [inversion 1|].
-    cbn. inversion 1.  
+    cbn. inversion 1.
     specialize (H8 m). forward H8.
     epose proof (wf_fresh_globals _ HΣ). clear - H10.
     revert H10. cbn. set (Σ.1). induction 1; econstructor; eauto.
     cbn. clear -H. induction H; econstructor; eauto.
-    unfold o in Ho; rewrite Ho in H8.   
-    specialize (H8 eq_refl). 
+    unfold o in Ho; rewrite Ho in H8.
+    specialize (H8 eq_refl).
     destruct H8 as [decl' [? ?]]. exists decl'; split ; eauto.
     rewrite <- H10. now destruct decl, m.
-  Qed. 
+  Qed.
 
   Lemma verified_erasure_pipeline_firstorder_evalue_block :
     firstorder_evalue_block Σ_v v_t.
@@ -1740,9 +1740,9 @@ Section pipeline_theorem.
     destruct_compose.
     generalize fo_v. intros hv.
     cbn [transform pcuic_expand_lets_transform].
-    intros pre1. destruct_compose. intros pre2. 
-    destruct lambdabox_pres_fo as [fn [tr hfn]].  
-    destruct tr. destruct typing as [typing']. pose proof (Heval' := Heval). sq. rewrite transform_fo. 
+    intros pre1. destruct_compose. intros pre2.
+    destruct lambdabox_pres_fo as [fn [tr hfn]].
+    destruct tr. destruct typing as [typing']. pose proof (Heval' := Heval). sq. rewrite transform_fo.
     { intro. eapply preserves_fo. }
     assert (eqtr : PCUICExpandLets.trans v = v).
     { clear -hv.
@@ -1759,7 +1759,7 @@ Section pipeline_theorem.
     set (p := transform erase_transform _ _).
     pose proof (@erase_tranform_firstorder _ pre1 v i u (List.map PCUICExpandLets.trans args) Normalisation').
     forward H0.
-    { cbn. 
+    { cbn.
       eapply (PCUICClassification.subject_reduction_eval (Σ := Σ)) in Heval'; tea.
       eapply PCUICExpandLetsCorrectness.expand_lets_sound in Heval'.
       now rewrite PCUICExpandLetsCorrectness.trans_mkApps /= in Heval'. }
@@ -1777,29 +1777,29 @@ Section pipeline_theorem.
       eapply PCUICWcbvEval.eval_closed; tea. apply HΣ.
       unshelve apply (PCUICClosedTyp.subject_closed typing'). now rewrite eqtr. }
     specialize (H0 _ eq_refl).
-    rewrite /p.  
+    rewrite /p.
     rewrite erase_transform_fo //. { cbn. rewrite eqtr. exact H. }
     set (Σer := (transform erase_transform _ _).1).
     assert (firstorder_evalue Σer (compile_value_erase v [])).
     { apply H0. }
-    simpl. unfold fo_evalue_map. rewrite eqtr. exact H1. 
-  Qed.   
+    simpl. unfold fo_evalue_map. rewrite eqtr. exact H1.
+  Qed.
 
   Lemma verified_erasure_pipeline_extends (efl := EInlineProjections.switch_no_params all_env_flags)  {has_rel : has_tRel} {has_box : has_tBox} :
    EGlobalEnv.extends Σ_v Σ_t.
   Proof.
     unfold Σ_v, Σ_t. unfold verified_erasure_pipeline.
-    repeat (destruct_compose; intro). destruct typing as [typing'], Heval. 
+    repeat (destruct_compose; intro). destruct typing as [typing'], Heval.
     cbn [transform compose pcuic_expand_lets_transform] in *.
     unfold run, time.
     cbn [transform erase_transform] in *.
     set (erase_program _ _). set (erase_program _ _).
     eapply verified_lambdabox_pipeline_extends.
-    eapply extends_erase_pcuic_program; eauto. 
+    eapply extends_erase_pcuic_program; eauto.
       unshelve eapply (PCUICExpandLetsCorrectness.trans_wcbveval (cf := extraction_checker_flags) (Σ := (Σ.1, Σ.2))).
       { now eapply PCUICExpandLetsCorrectness.trans_wf. }
       { clear -HΣ typing'. now eapply PCUICClosedTyp.subject_closed in typing'. }
-      assumption. 
+      assumption.
       now eapply PCUICExpandLetsCorrectness.trans_axiom_free.
       pose proof (PCUICExpandLetsCorrectness.expand_lets_sound typing').
       rewrite PCUICExpandLetsCorrectness.trans_mkApps in X. eapply X.
@@ -1808,8 +1808,9 @@ Section pipeline_theorem.
         rewrite PCUICExpandLetsCorrectness.trans_lookup.
         destruct PCUICAst.PCUICEnvironment.lookup_env => //.
         destruct g => //=.
-        eapply PCUICExpandLetsCorrectness.trans_firstorder_mutind. eapply PCUICExpandLetsCorrectness.trans_firstorder_env. }
-  Qed. 
+        eapply PCUICExpandLetsCorrectness.trans_firstorder_mutind.
+        eapply PCUICExpandLetsCorrectness.trans_firstorder_env. }
+  Qed.
 
   Lemma verified_erasure_pipeline_theorem :
     ∥ eval (wfl := extraction_wcbv_flags) Σ_t t_t v_t ∥.
@@ -1820,7 +1821,7 @@ Section pipeline_theorem.
     destruct Hev as [v' [[H1] H2]].
     move: H2.
     rewrite v_t_spec.
-    set (pre := precond2 _ _ _ _ _ _ _ _ _ _) in *. clearbody pre. 
+    set (pre := precond2 _ _ _ _ _ _ _ _ _ _) in *. clearbody pre.
     subst v_t Σ_t t_t.
     revert H1.
     unfold verified_erasure_pipeline.
@@ -1874,7 +1875,7 @@ Section pipeline_theorem.
     eapply (ErasureFunctionProperties.firstorder_erases_deterministic optimized_abstract_env_impl wfe Σ.2) in b0. 3:tea.
     2:{ cbn. reflexivity. }
     2:{ eapply PCUICExpandLetsCorrectness.trans_wcbveval. eapply PCUICWcbvEval.eval_closed; tea. apply HΣ.
-        clear -typing'' HΣ. now eapply PCUICClosedTyp.subject_closed in typing''. 
+        clear -typing'' HΣ. now eapply PCUICClosedTyp.subject_closed in typing''.
         eapply PCUICWcbvEval.value_final. now eapply PCUICWcbvEval.eval_to_value in X0. }
     (* 2:{ clear -fo. cbn. now eapply (PCUICExpandLetsCorrectness.trans_firstorder_ind Σ). }
         eapply PCUICWcbvEval.value_final. now eapply PCUICWcbvEval.eval_to_value in X. } *)

--- a/erasure/theories/EConstructorsAsBlocks.v
+++ b/erasure/theories/EConstructorsAsBlocks.v
@@ -87,7 +87,7 @@ Section transform_blocks.
 
   End Def.
 
-  Hint Rewrite @map_InP_spec : transform_blocks.
+  Hint Rewrite @map_primIn_spec @map_InP_spec : transform_blocks.
 
   Arguments eqb : simpl never.
 
@@ -427,6 +427,8 @@ Section transform_blocks.
     EWcbvEval.Build_WcbvFlags fl.(@with_prop_case) fl.(@with_guarded_fix) true.
 
 End transform_blocks.
+
+Global Hint Rewrite @map_primIn_spec @map_InP_spec : transform_blocks.
 
 Definition transform_blocks_constant_decl Σ cb :=
   {| cst_body := option_map (transform_blocks Σ) cb.(cst_body) |}.
@@ -985,7 +987,7 @@ Proof.
     + unfold constructor_isprop_pars_decl.
       rewrite lookup_constructor_transform_blocks. cbn [fst].
       rewrite eqc //= H8 //.
-    + now rewrite map_InP_spec nth_error_map H3; eauto.
+    + now rewrite nth_error_map H3; eauto.
     + len.
     + rewrite H9. len.
     + rewrite wellformed_mkApps in i4 => //.
@@ -1014,8 +1016,7 @@ Proof.
       * eauto.
       * revert e1.  set (x := transform_blocks Σ f5).
         simp transform_blocks.
-      * rewrite map_InP_spec.
-        cbn in i8. unfold wf_fix in i8. rtoProp.
+      * cbn in i8. unfold wf_fix in i8. rtoProp.
         erewrite <- transform_blocks_cunfold_fix => //.
         all: eauto.
         eapply closed_fix_subst. solve_all. destruct x; cbn in H5 |- *. eauto.
@@ -1049,7 +1050,7 @@ Proof.
   - simp transform_blocks. rewrite -!transform_blocks_equation_1.
     rewrite transform_blocks_mkApps //=.
     simp transform_blocks. rewrite -!transform_blocks_equation_1.
-    rewrite !map_InP_spec. cbn [plus].
+    cbn [plus].
     intros.
     destruct H3 as [ev wf eta etad].
     destruct H6.
@@ -1062,7 +1063,7 @@ Proof.
     now rewrite transform_blocks_mkApps_eta_fn in e.
   - intros; repeat match goal with [H : MCProd.and5 _ _ _ _ _ |- _] => destruct H end.
     rewrite transform_blocks_mkApps //= in e0.
-    simp transform_blocks in e0. rewrite -!transform_blocks_equation_1 map_InP_spec in e0. simpl in e0.
+    simp transform_blocks in e0. rewrite -!transform_blocks_equation_1 in e0. simpl in e0.
     simp transform_blocks. rewrite -!transform_blocks_equation_1.
     move: i; rewrite /= wellformed_mkApps //. move/and3P => [] hasp wffn wfargs.
     move: i4; rewrite /= wellformed_mkApps //. move/andP => [] wfcof _.
@@ -1174,6 +1175,11 @@ Proof.
     unfold cstr_arity. cbn. rewrite H4; len.
     solve_all. clear -X0. eapply All2_All2_Set. solve_all.
     match goal with H : _ |- _ => apply H end.
+  - intros X; depelim X; simp transform_blocks; repeat constructor.
+    destruct a0.
+    eapply All2_over_undep in a. eapply All2_Set_All2 in ev. eapply All2_All2_Set. solve_all.
+    now destruct b.
+    now destruct a0.
   - intros. destruct t; try solve [constructor; cbn in H, H0 |- *; try congruence].
     cbn -[lookup_constructor] in H |- *. destruct args => //.
     destruct lookup_constructor eqn:hl => //.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -345,6 +345,8 @@ Proof.
     now constructor.
   - congruence.
   - depelim er. now constructor.
+  - depelim er; depelim X; constructor; eauto.
+    eapply All2_over_undep in a0. solve_all.
   - easy.
 Qed.
 

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -773,6 +773,7 @@ Section isEtaExp.
 
 End isEtaExp.
 Global Hint Rewrite @forallb_InP_spec : isEtaExp.
+Global Hint Rewrite @test_primIn_spec : isEtaExp.
 
 Tactic Notation "simp_eta" "in" hyp(H) := simp isEtaExp in H; rewrite -?isEtaExp_equation_1 in H.
 Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.
@@ -859,7 +860,7 @@ Proof.
   - rewrite isEtaExp_Constructor. rtoProp. repeat split.
     2: eapply forallb_Forall; solve_all.
     eapply expanded_isEtaExp_app_; eauto.
-  - rewrite test_primIn_spec. solve_all.
+  - solve_all.
 Qed.
 
 Definition isEtaExp_constant_decl Σ cb :=
@@ -1000,7 +1001,7 @@ Proof.
   - eapply In_All in H0. solve_all.
   - eapply In_All in H; solve_all.
   - eapply InPrim_primProp in H.
-    rewrite !test_primIn_spec in H0 |- *. solve_all.
+    solve_all.
   - eapply In_All in H; solve_all.
     rewrite isEtaExp_Constructor //. rtoProp; intuition auto.
     eapply isEtaExp_app_extends; tea.
@@ -1045,8 +1046,8 @@ Lemma eval_etaexp {fl : WcbvFlags} {efl : EEnvFlags} {wcon : with_constructor_as
 Proof.
   intros etaΣ wfΣ.
   induction 1 as [ | ? ? ? ? ? ? ? ? IHs | | | | | ? ? ? ? ? ? ? ? ? ? ? IHs | ? ? ? ? ? ? ? ? ? ? ? IHs
-    | ? ? ? ? ? ? ? ? ? ? IHs | | | | | | | | | | ] using eval_mkApps_rect; try now congruence.
-  all:try simp isEtaExp; rewrite -!isEtaExp_equation_1 => //.
+    | ? ? ? ? ? ? ? ? ? ? IHs | | | | | | | | | | | ] using eval_mkApps_rect; try now congruence.
+  all:try simp isEtaExp; rewrite -?isEtaExp_equation_1 => //.
   6:{
     move/isEtaExp_tApp'.
     destruct decompose_app eqn:da.
@@ -1361,6 +1362,9 @@ Proof.
     destruct args => //. now rewrite nth_error_nil in e3.
     intros. rtoProp.
     eapply nth_error_forallb in e3; tea.
+  - solve_all.
+    depelim X; solve_all. eapply All2_over_undep in a. subst a0 a';
+      depelim H; constructor; solve_all. solve_all.
 Qed.
 
 Lemma isEtaExp_fixapp_mon {mfix idx n n'} : n <= n' -> isEtaExp_fixapp mfix idx n -> isEtaExp_fixapp mfix idx n'.
@@ -1944,6 +1948,9 @@ Proof.
       cbn. rewrite wguard in i.
       cbn. move: i. rewrite !negb_or; rtoProp; intuition auto.
       now eapply nisFixApp_nisFix.
+  - intros hexp. simp_eta in hexp. depelim X; repeat constructor; eauto.
+    eapply All2_over_undep in a. subst a0 a'. solve_all. depelim hexp; cbn in *. destruct p.
+    eapply All2_All2_Set. solve_all. solve_all. depelim hexp. destruct p. solve_all.
   - intros hexp. now eapply eval_atom.
     Unshelve. all: eauto.
 Qed.

--- a/erasure/theories/EImplementBox.v
+++ b/erasure/theories/EImplementBox.v
@@ -67,7 +67,7 @@ Section implement_box.
 
   End Def.
 
-  Hint Rewrite @map_InP_spec : implement_box.
+  Hint Rewrite @map_primIn_spec @map_InP_spec : implement_box.
 
   Arguments eqb : simpl never.
 
@@ -264,6 +264,8 @@ Section implement_box.
   Qed.
 
 End implement_box.
+
+Global Hint Rewrite @map_primIn_spec @map_InP_spec : implement_box.
 
 Definition implement_box_constant_decl cb :=
   {| cst_body := option_map implement_box cb.(cst_body) |}.
@@ -600,13 +602,12 @@ Proof.
       rewrite lookup_constructor_implement_box. cbn [fst].
       rewrite eqc //= H7 //. rewrite H8.
       reflexivity.
-    + rewrite !map_InP_spec.
-      rewrite map_map.
+    + rewrite map_map.
       rewrite nth_error_map H2; eauto.
       reflexivity.
-    + rewrite map_InP_spec. len.
-    + rewrite map_InP_spec. len.
-    + rewrite map_InP_spec.
+    + len.
+    + len.
+    +
       cbn [csubst].
       cbn [fst snd].
       rewrite closed_subst.
@@ -623,7 +624,7 @@ Proof.
       solve_all.
   - intros; repeat match goal with [H : MCProd.and3 _ _ _ |- _] => destruct H end.
     simp implement_box in *.
-    eapply eval_fix' => //; eauto. rewrite map_InP_spec.
+    eapply eval_fix' => //; eauto.
     eapply implement_box_cunfold_fix.
     eapply forallb_All. eapply closed_fix_subst.
     eapply wellformed_closed in i4.
@@ -641,7 +642,7 @@ Proof.
     destruct decl. cbn in *. now rewrite H0.
     eauto.
   - intros; repeat match goal with [H : MCProd.and3 _ _ _ |- _] => destruct H end.
-    simp implement_box in *. rewrite map_InP_spec in e0.
+    simp implement_box in *.
     unfold constructor_isprop_pars_decl in *.
     destruct lookup_constructor as [[[mdecl idecl] cdecl']|] eqn:hc => //.
     noconf H2.
@@ -663,12 +664,15 @@ Proof.
     rewrite implement_box_isConstructApp; eauto.
     rewrite implement_box_isPrimApp; eauto.
   - intros; repeat match goal with [H : MCProd.and3 _ _ _ |- _] => destruct H end.
-    simp implement_box in *. rewrite !map_InP_spec.
+    simp implement_box in *.
     eapply eval_construct_block; tea. eauto.
     2: len; eassumption.
     rewrite lookup_constructor_implement_box; eauto.
     eapply All2_All2_Set.
     solve_all. now destruct b.
+  - intros H; depelim H; simp implement_box; repeat constructor.
+    destruct a0. eapply All2_over_undep in a. eapply All2_All2_Set, All2_map.
+    cbn -[implement_box]. solve_all. now destruct H. now destruct a0.
   - intros. destruct t; try solve [constructor; cbn in H, H0 |- *; try congruence].
     cbn -[lookup_constructor] in H |- *. destruct args => //.
 Qed.

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -701,22 +701,26 @@ Proof.
     eapply eval_app_cong; eauto.
     eapply eval_to_value in ev1.
     destruct ev1; simpl in *; eauto.
-    * destruct t => //; rewrite optimize_mkApps /=.
+    * depelim a0.
+      + destruct t => //; rewrite optimize_mkApps /=.
+      + now rewrite /= !orb_false_r orb_true_r in i.
     * destruct with_guarded_fix.
       + move: i.
         rewrite !negb_or.
         rewrite optimize_mkApps !isFixApp_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         rewrite !andb_true_r.
-        rtoProp; intuition auto.
-        destruct v => /= //.
-        destruct v => /= //.
-        destruct v => /= //.
+        rtoProp; intuition auto;  destruct v => /= //.
       + move: i.
         rewrite !negb_or.
         rewrite optimize_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         destruct v => /= //.
+  - depelim X; repeat constructor.
+    eapply All2_over_undep in a.
+    eapply All2_Set_All2 in ev. eapply All2_All2_Set. primProp.
+    subst a0 a'; cbn in *. depelim H; cbn in *. intuition auto; solve_all.
+    primProp; depelim H; intuition eauto.
   - destruct t => //.
     all:constructor; eauto.
     cbn [atom optimize] in i |- *.

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -708,7 +708,8 @@ Proof.
     eapply Ee.eval_app_cong; eauto.
     eapply Ee.eval_to_value in ev1.
     destruct ev1; simpl in *; eauto.
-    * destruct t => //; rewrite remove_match_on_box_mkApps /=.
+    * depelim a0. destruct t => //; rewrite ?remove_match_on_box_mkApps /=.
+      cbn in i. now rewrite !orb_false_r orb_true_r in i.
     * destruct with_guarded_fix.
       + move: i.
         rewrite !negb_or.
@@ -724,6 +725,10 @@ Proof.
         rewrite remove_match_on_box_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         destruct v => /= //.
+  - depelim X; repeat constructor.
+    eapply All2_over_undep in a. eapply All2_All2_Set. eapply All2_Set_All2 in ev. subst a0 a'; cbn in *.
+    rewrite /test_array_model /= in H. rtoProp; intuition auto; solve_all. eapply e.
+    cbn in H. rewrite /test_array_model /= in H. now move/andP: H => [].
   - destruct t => //.
     all:constructor; eauto. cbn [atom remove_match_on_box] in i |- *.
     rewrite -lookup_constructor_remove_match_on_box //. destruct args => //.

--- a/erasure/theories/EPrimitive.v
+++ b/erasure/theories/EPrimitive.v
@@ -45,6 +45,10 @@ Definition prim_val term : Set := ∑ t : prim_tag, prim_model term t.
 Definition prim_val_tag {term} (s : prim_val term) := s.π1.
 Definition prim_val_model {term} (s : prim_val term) : prim_model term (prim_val_tag s) := s.π2.
 
+Definition prim_int {term} i : prim_val term := (primInt; primIntModel i).
+Definition prim_float {term} f : prim_val term := (primFloat; primFloatModel f).
+Definition prim_array {term} a : prim_val term := (primArray; primArrayModel a).
+
 Definition prim_model_val {term} (p : prim_val term) : prim_model_of term (prim_val_tag p) :=
   match prim_val_model p in prim_model _ t return prim_model_of term t with
   | primIntModel i => i

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -358,7 +358,7 @@ Section strip.
 
 End strip.
 
-Global Hint Rewrite @map_InP_spec : strip.
+Global Hint Rewrite @map_primIn_spec @map_InP_spec : strip.
 Tactic Notation "simp_eta" "in" hyp(H) := simp isEtaExp in H; rewrite -?isEtaExp_equation_1 in H.
 Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.
 Tactic Notation "simp_strip" "in" hyp(H) := simp strip in H; rewrite -?strip_equation_1 in H.
@@ -608,7 +608,7 @@ Module Fast.
         forward IHu. now rewrite -IHv. exact IHu.
       - intros Hl hargs args ->.
         rewrite strip_mkApps //=. simp_strip.
-        rewrite map_primIn_spec. f_equal. f_equal. cbn.
+        f_equal. f_equal. cbn.
         do 2 f_equal. rewrite /map_array_model.
         specialize (Hl [] eq_refl). f_equal; eauto.
       - intros Hl args ->.
@@ -849,6 +849,7 @@ Proof.
     eapply on_case; rtoProp; intuition auto. solve_all.
     eapply on_fix. solve_all. solve_all.
     eapply on_cofix; solve_all.
+    eapply on_prim; solve_all.
   - red. intros kn decl.
     move/(lookup_env_closed clΣ).
     unfold closed_decl. destruct EAst.cst_body => //.
@@ -1018,6 +1019,10 @@ Proof.
       eapply All2_impl; tea; cbn -[strip].
       intros x y []; auto.
 
+  - depelim X; simp strip; repeat constructor.
+    eapply All2_over_undep in a. eapply All2_Set_All2 in ev. eapply All2_All2_Set. solve_all. now destruct b.
+    now destruct a0.
+
   - destruct t => //.
     all:constructor; eauto. simp strip.
     cbn [atom strip] in H |- *.
@@ -1086,7 +1091,7 @@ Proof.
     all: eapply H; auto.
   - unfold wf_fix_gen in *. rewrite map_length. rtoProp; intuition auto. toAll; solve_all.
     now rewrite -strip_isLambda. toAll; solve_all.
-  - rewrite map_primIn_spec. primProp. rtoProp; intuition eauto; solve_all_k 6.
+  - primProp. rtoProp; intuition eauto; solve_all_k 6.
   - move:H1; rewrite !wellformed_mkApps //. rtoProp; intuition auto.
     toAll; solve_all. toAll; solve_all.
   - move:H0; rewrite !wellformed_mkApps //. rtoProp; intuition auto.

--- a/erasure/theories/ESubstitution.v
+++ b/erasure/theories/ESubstitution.v
@@ -112,9 +112,9 @@ Proof.
     intros ? ? [[] [? []]].
     split; eauto.
   - econstructor.
-    induction H2; constructor.
-    induction X3; constructor; depelim X2; eauto.
-    depelim X1.
+    induction H3; constructor.
+    induction X2; constructor; depelim X1; eauto.
+    depelim X0.
     eapply All2_All_mix_left in a0; eauto.
     eapply All2_impl. exact a0.
     cbn. intros ? ? [? ?]. eauto.
@@ -316,10 +316,10 @@ Proof.
     rewrite (All2_length X3) in IH |- *.
     apply IH. apply IH'.
 
-  - econstructor. depelim H3.
-    depelim X4; repeat constructor.
-    depelim X2; cbn. now eapply hdef.
-    depelim X2. cbn. eapply All2_map.
+  - econstructor. depelim H4.
+    depelim X3; repeat constructor.
+    depelim X1; cbn. now eapply hdef.
+    depelim X1. cbn. eapply All2_map.
     ELiftSubst.solve_all.
 Qed.
 
@@ -585,9 +585,9 @@ Proof.
         eapply typing_wf_local.  eassumption.
     + econstructor.
       eapply is_type_subst; eauto.
-  - cbn. depelim H1.
+  - cbn. depelim H2.
     * cbn; constructor.
-      depelim H1. depelim X5; depelim X2; repeat constructor; cbn; eauto.
+      depelim H2. depelim X4; depelim X1; repeat constructor; cbn; eauto.
       ELiftSubst.solve_all.
     * constructor. eapply is_type_subst in X3; tea.
       now cbn in X3.

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
@@ -15,7 +15,7 @@ Hint Constructors eval : core.
 
 Definition atomic_term (t : term) :=
   match t with
-  | tBox | tConst _ | tRel _ | tVar _ | tPrim _ => true
+  | tBox | tConst _ | tRel _ | tVar _ => true
   | _ => false
   end.
 
@@ -25,7 +25,6 @@ Definition has_atom {etfl : ETermFlags} (t : term) :=
   | tConst _ => has_tConst
   | tRel _ => has_tRel
   | tVar _ => has_tVar
-  | tPrim _ => has_tPrim
   | _ => false
   end.
 
@@ -343,6 +342,11 @@ Lemma eval_preserve_mkApps_ind :
     All2 P args args' ->
     P' (tConstruct ind i args) (tConstruct ind i args')) →
 
+
+  (forall p p' (ev : eval_primitive (eval Σ) p p'),
+    eval_primitive_ind _ (fun x y _ => P x y) _ _ ev ->
+    P' (tPrim p) (tPrim p')) ->
+
   (∀ t : term, atom Σ t → Q 0 t -> P' t t) ->
   ∀ (t t0 : term), Q 0 t -> eval Σ t t0 → P' t t0.
 Proof.
@@ -353,7 +357,7 @@ Proof.
   intros.
   pose proof (p := @Fix_F { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
   specialize (p (MR lt (fun x => eval_depth x.π2.π2.π2))).
-  set(foo := existT _ t (existT _ t0 (existT _ X16 H)) :  { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
+  set(foo := existT _ t (existT _ t0 (existT _ X17 H)) :  { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
   change t with (projT1 foo).
   change t0 with (projT1 (projT2 foo)).
   revert foo.
@@ -363,8 +367,8 @@ Proof.
   forward p.
   2:{ apply p. apply measure_wf, lt_wf. }
   clear p.
-  rename X16 into qt. rename X14 into Xcappexp.
-  rename X15 into Qatom.
+  rename X17 into qt. rename X14 into Xcappexp.
+  rename X15 into Qprim, X16 into Qatom.
   clear t t0 qt H.
   intros (t & t0 & qt & ev).
   intros IH.
@@ -547,12 +551,23 @@ Proof.
   - eapply (X13 _ _ _ _ ev1); tea.
     1,3:(apply and_assum; [ih|hp' P'Q]).
     intros. apply and_assum; [ih|hp' P'Q].
+  - unshelve eapply Qprim; tea. depelim e.
+    * constructor.
+    * constructor.
+    * eapply Qpres in qt. depelim qt. now cbn in i. constructor; eauto.
+      + apply All2_over_undep. cbn in IH.
+        depelim p0. destruct p.
+        clear -ev IH a0 P'Q and_assum. cbn in a0. subst a; cbn in *.
+        induction ev; constructor; eauto.
+        ** depelim a0.
+          eapply and_assum. unshelve eapply IH; tea. cbn. lia.
+          intros. split => //. eapply P'Q; tea.
+        ** depelim a0. intuition eauto. eapply X; intros.
+          unshelve eapply IH; tea. cbn; lia.
+      + depelim p0. destruct p.
+        eapply and_assum. unshelve eapply IH; tea. cbn; lia.
+        intros; split => //; eapply P'Q; tea.
   - eapply Qatom; tea.
-  - eapply Qatom; cbn; auto.
-  - eapply Qatom; cbn; auto.
-  - eapply Qatom; cbn; auto.
-  - eapply Qatom; cbn; auto.
-  - eapply Qatom; cbn; eauto.
 Qed.
 
 Lemma Qpreserves_wellformed (efl : EEnvFlags) Σ : wf_glob Σ -> Qpreserves (fun n x => wellformed Σ n x) Σ.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -26,7 +26,6 @@ Definition has_atom {etfl : ETermFlags} (t : term) :=
   | tConst _ => has_tConst
   | tRel _ => has_tRel
   | tVar _ => has_tVar
-  | tPrim _ => has_tPrim
   | _ => false
   end.
 
@@ -321,6 +320,10 @@ Lemma eval_preserve_mkApps_ind :
     All2 P args args' ->
     P' (mkApps (tConstruct ind i []) args) (mkApps (tConstruct ind i []) args')) →
 
+  (forall p p' (ev : eval_primitive (eval Σ) p p'),
+    eval_primitive_ind _ (fun x y _ => P x y) _ _ ev ->
+    P' (tPrim p) (tPrim p')) ->
+
   (∀ t : term, atom Σ t → Q 0 t -> isEtaExp Σ t -> P' t t) ->
   ∀ (t t0 : term), Q 0 t -> isEtaExp Σ t -> eval Σ t t0 → P' t t0.
 Proof.
@@ -328,10 +331,10 @@ Proof.
   assert (qfixs: Qfixs Q) by tc.
   assert (qcofixs: Qcofixs Q) by tc.
   intros.
-  enough (P' t t0 × isEtaExp Σ t0). apply X16.
+  enough (P' t t0 × isEtaExp Σ t0). apply X17.
   pose proof (p := @Fix_F { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
   specialize (p (MR lt (fun x => eval_depth x.π2.π2.π2))).
-  set(foo := existT _ t (existT _ t0 (existT _ X15 H0)) :  { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
+  set(foo := existT _ t (existT _ t0 (existT _ X16 H0)) :  { t : _ & { t0 : _ & { qt : Q 0 t & eval Σ t t0 }}}).
   move: H.
   change t with (projT1 foo).
   change t0 with (projT1 (projT2 foo)).
@@ -343,8 +346,8 @@ Proof.
   forward p.
   2:{ apply p. apply measure_wf, lt_wf. }
   clear p.
-  rename X15 into qt. rename X13 into Xcappexp.
-  rename X14 into Qatom.
+  rename X16 into qt. rename X13 into Xcappexp.
+  rename X14 into Qprim. rename X15 into Qatom.
   clear t t0 qt H0.
   intros (t & t0 & qt & ev).
   intros IH.
@@ -679,7 +682,34 @@ Proof.
       eapply All_tip.1. iheta q0.
       eapply (isEtaExp_mkApps_intro _ _ [a']) => //. iheta q.
       eapply All_tip.1. iheta q0.
-  - intros ise. split => //. eapply Qatom; tea.
+  - intros ise. simp_eta in ise.
+    depelim e.
+    * split; simp_eta. unshelve eapply Qprim. constructor. constructor.
+    * split; simp_eta. unshelve eapply Qprim. constructor. constructor.
+    * eapply Qpres in qt. depelim qt. now cbn in i.
+      split; simp_eta. unshelve eapply Qprim. constructor; eauto. constructor.
+      + apply All2_over_undep. cbn in IH.
+        ELiftSubst.solve_all.
+        depelim H. destruct p as [[] ?].
+        clear -ev IH a0 P'Q and_assum. cbn in a0. subst a; cbn in *.
+        induction ev; constructor; eauto.
+        ** depelim a0. destruct p as [].
+           eapply and_assum. unshelve eapply IH; tea. cbn. lia.
+           intros []. split => //. split => //. eapply P'Q; tea.
+        ** depelim a0. intuition eauto. eapply IHev; intros. 2:eauto.
+           unshelve eapply IH; tea. cbn; lia.
+      + ELiftSubst.solve_all. depelim H; destruct p as [[] ?].
+        eapply and_assum. unshelve eapply IH; tea. cbn; lia.
+        intros []; split => //; split => //. eapply P'Q; tea.
+      + ELiftSubst.solve_all. subst a a'; cbn in *.
+        depelim H; constructor; cbn in *; intuition eauto.
+        unshelve eapply IH. 2:tea. all:eauto. cbn; lia.
+        clear -ev IH b P'Q and_assum. cbn in b.
+        induction ev; constructor; eauto.
+        ** depelim b. destruct p. unshelve eapply IH. 2:tea. all:eauto. cbn. lia.
+        ** depelim b. intuition eauto. eapply IHev; intros. 2:eauto.
+           unshelve eapply IH; tea. cbn; lia.
+ - intros ise. split => //. eapply Qatom; tea.
 Qed.
 
 Definition term_flags :=
@@ -773,4 +803,7 @@ Proof.
     match goal with H : ?f ?n |- ?f ?n' => replace n' with n by congruence; exact H end.
     cbn; eapply All_forallb. eapply All2_All_right; tea.
     cbn. intros x y []; auto.
+  - depelim X;try constructor. destruct a0. simp_eta. subst a'. cbn.
+    apply All2_over_undep in a.
+    rewrite /test_array_model /=. rtoProp; intuition eauto. solve_all; now destruct H.
 Qed.

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -242,12 +242,16 @@ Section eval_mkApps_rect.
           (e0 : eval Σ a a'),
           P a a'
           → P (tApp f15 a)
-              (tApp f' a')
-              )
+              (tApp f' a')) ->
+
+   (forall p p' (ev : eval_primitive (eval Σ) p p'),
+      eval_primitive_ind _ (fun x y _ => P x y) _ _ ev ->
+      P (tPrim p) (tPrim p'))
+
     → (∀ t : term, atom Σ t → P t t)
     → ∀ t t0 : term, eval Σ t t0 → P t t0.
 Proof using Type.
-  intros ????????????????????? H.
+  intros ?????????????????????? H.
   pose proof (p := @Fix_F { t : _ & { t0 : _ & eval Σ t t0 }}).
   specialize (p (MR lt (fun x => eval_depth x.π2.π2))).
   set(foo := existT _ t (existT _ t0 H) :  { t : _ & { t0 : _ & eval Σ t t0 }}).
@@ -279,6 +283,14 @@ Proof using Type.
     clear -a IH'. induction a; constructor.
     eapply (IH' _ _ r). cbn. lia. apply IHa.
     intros. eapply (IH' _ _ H). cbn. lia.
+  - unshelve eapply X17; tea.
+    clear -e IH'.
+    induction e; constructor; eauto. subst a a'.
+    2:{ unshelve eapply IH'; tea; cbn; lia. }
+      eapply All2_over_undep.
+      induction ev; constructor; eauto.
+      unshelve eapply IH'; tea; cbn; lia.
+      eapply IHev. cbn. intros. unshelve eapply IH'; tea; cbn; lia.
 Qed.
 
 End eval_mkApps_rect.

--- a/erasure/theories/EWcbvEvalInd.v
+++ b/erasure/theories/EWcbvEvalInd.v
@@ -2,7 +2,7 @@
 From Coq Require Import Utf8 Program ssreflect ssrbool.
 From MetaCoq.Utils Require Import utils.
 From MetaCoq.Common Require Import config Kernames BasicAst EnvMap.
-From MetaCoq.Erasure Require Import EAst EAstUtils EInduction EWcbvEval EGlobalEnv ECSubst EInduction.
+From MetaCoq.Erasure Require Import EPrimitive EAst EAstUtils EInduction EWcbvEval EGlobalEnv ECSubst EInduction.
 
 Set Asymmetric Patterns.
 From Equations Require Import Equations.
@@ -280,7 +280,7 @@ Proof using Type.
     unshelve eapply H; try match goal with |- eval _ _ _ => tea end; tea; unfold IH; intros; unshelve eapply IH'; tea; cbn; try lia
   end].
   - eapply X15; tea; auto.
-    clear -a IH'. induction a; constructor.
+    clear -a IH'. induction a; constructor; eauto.
     eapply (IH' _ _ r). cbn. lia. apply IHa.
     intros. eapply (IH' _ _ H). cbn. lia.
   - unshelve eapply X17; tea.

--- a/erasure/theories/EWcbvEvalNamed.v
+++ b/erasure/theories/EWcbvEvalNamed.v
@@ -36,6 +36,7 @@ Inductive value : Set :=
 | vClos (na : ident) (b : term) (env : list (ident * value))
 | vConstruct (ind : inductive) (c : nat) (args : list (value))
 | vRecClos (b : list (ident * term)) (idx : nat) (env : list (ident * value)).
+(* | vPrim (p : EPrimitive.prim_val value). *)
 
 Definition environment := list (ident * value).
 Definition add : ident -> value -> environment -> environment := fun (x : ident) (v : value) env =>
@@ -1884,7 +1885,9 @@ Proof.
     + invs H2.
     + cbn in Hsunny. rtoProp.
       eapply eval_to_value in ev as Hval. invs Hval.
-      * destruct f'; cbn in *; try congruence.
+      * depelim X.
+        ** destruct t1; cbn in *; try congruence.
+        ** now rewrite /= in H.
       * invs H4; cbn in *; eauto.
       * invs H1; cbn in *; eauto; try congruence.
         rtoProp. edestruct s0 as (v & Hv1 & Hv2). 3: eauto. eauto. eauto.
@@ -1937,6 +1940,7 @@ Proof.
        destruct (nth_error (ind_ctors o) i) eqn:E2; cbn in *; try congruence.
        unfold cstr_arity in *.  invs H. lia.
        clear - Hvs; induction Hvs; econstructor; eauto. eapply r.
+  - todo "prim".
   - invs Hrep; cbn in *; try congruence; rtoProp.
     + econstructor. split; eauto. econstructor. eauto.
     + econstructor. split; eauto. econstructor.

--- a/erasure/theories/EWcbvEvalNamed.v
+++ b/erasure/theories/EWcbvEvalNamed.v
@@ -3,7 +3,7 @@ From Coq Require Import Utf8 Program.
 From MetaCoq.Common Require Import config BasicAst.
 From MetaCoq.Utils Require Import utils.
 From MetaCoq.PCUIC Require PCUICWcbvEval.
-From MetaCoq.Erasure Require Import EAst EAstUtils ELiftSubst ECSubst EReflect EGlobalEnv
+From MetaCoq.Erasure Require Import EPrimitive EAst EAstUtils ELiftSubst ECSubst EReflect EGlobalEnv
   EWellformed EWcbvEval.
 From MetaCoq.Utils Require Import bytestring MCString.
 From MetaCoq.Erasure Require Import EWcbvEvalCstrsAsBlocksFixLambdaInd.
@@ -35,8 +35,8 @@ Local Ltac inv H := inversion H; subst.
 Inductive value : Set :=
 | vClos (na : ident) (b : term) (env : list (ident * value))
 | vConstruct (ind : inductive) (c : nat) (args : list (value))
-| vRecClos (b : list (ident * term)) (idx : nat) (env : list (ident * value)).
-(* | vPrim (p : EPrimitive.prim_val value). *)
+| vRecClos (b : list (ident * term)) (idx : nat) (env : list (ident * value))
+| vPrim (p : EPrimitive.prim_val value).
 
 Definition environment := list (ident * value).
 Definition add : ident -> value -> environment -> environment := fun (x : ident) (v : value) env =>
@@ -144,7 +144,11 @@ Section Wcbv.
 
   | eval_construct_block_empty ind c mdecl idecl cdecl :
      lookup_constructor Σ ind c = Some (mdecl, idecl, cdecl) ->
-     eval Γ (tConstruct ind c []) (vConstruct ind c []).
+     eval Γ (tConstruct ind c []) (vConstruct ind c [])
+
+  | eval_prim p p' :
+    eval_primitive (eval Γ) p p' ->
+    eval Γ (tPrim p) (vPrim p').
 
   Program Definition eval_ind :=
     λ (P : ∀ (Γ : environment) (t : term) (v : value), eval Γ t v → Type) (f : ∀ (Γ : environment) (na : string) (v : value) (e : lookup Γ na = Some v),
@@ -240,7 +244,10 @@ Section Wcbv.
               (a : All2_Set (eval Γ) args args') (IHa : All2_over a (P Γ)), P Γ (tConstruct ind c args) (vConstruct ind c args') (eval_construct_block Γ ind c mdecl idecl cdecl args args' e l a))
       (f9 : ∀ (Γ : environment) (ind : inductive) (c : nat) (mdecl : mutual_inductive_body) (idecl : one_inductive_body) (cdecl : constructor_body)
               (e : lookup_constructor Σ ind c = Some (mdecl, idecl, cdecl)),
-          P Γ (tConstruct ind c []) (vConstruct ind c []) (eval_construct_block_empty Γ ind c mdecl idecl cdecl e)),
+          P Γ (tConstruct ind c []) (vConstruct ind c []) (eval_construct_block_empty Γ ind c mdecl idecl cdecl e))
+      (f10 : ∀ (Γ : environment) (p : prim_val term) (p' : prim_val value) (ev : eval_primitive (eval Γ) p p')
+        (evih : eval_primitive_ind (eval Γ) (P Γ) _ _ ev),
+        P Γ (tPrim p) (vPrim p') (eval_prim _ _ _ ev)),
       fix F (Γ : environment) (t : term) (v : value) (e : eval Γ t v) {struct e} : P Γ t v e :=
       match e as e0 in (eval _ t0 v0) return (P Γ t0 v0 e0) with
       | @eval_var _ na v0 e0 => f Γ na v0 e0
@@ -253,12 +260,10 @@ Section Wcbv.
           f5 Γ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
       | @eval_fix _ mfix idx nms Hlen Hbodies n f10 => f6 Γ mfix idx nms Hlen Hbodies n f10
       | @eval_delta _ c decl body isdecl res e0 e1 => f7 Γ c decl body isdecl res e0 e1 (F [] body res e1)
-      | @eval_construct_block _ ind c mdecl idecl cdecl args args' e0 l a => f8 Γ ind c mdecl idecl cdecl args args' e0 l a _
+      | @eval_construct_block _ ind c mdecl idecl cdecl args args' e0 l a => f8 Γ ind c mdecl idecl cdecl args args' e0 l a (map_All2_dep _ (F Γ) a)
       | @eval_construct_block_empty _ ind c mdecl idecl cdecl e0 => f9 Γ ind c mdecl idecl cdecl e0
+      | @eval_prim _ p p' ev => f10 Γ p p' ev (map_eval_primitive (P := P Γ) (F Γ) ev)
       end.
-  Next Obligation.
-    clear - a F. induction a; econstructor. eapply F. eapply IHa.
-  Defined.
 
 End Wcbv.
 
@@ -286,12 +291,17 @@ Inductive represents : list ident -> environment -> term -> term -> Set :=
   All2_Set (fun d n => d.(dname) = nNamed n) mfix nms ->
   All2_Set (fun d d' => (List.rev nms ++ Γ) ;;; E ⊩ d.(dbody) ~ d'.(dbody)) mfix mfix' ->
   Γ ;;; E ⊩ tFix mfix idx ~ tFix mfix' idx
+| represents_tPrim Γ E p p' :
+  onPrims (represents Γ E) p p' ->
+  Γ ;;; E ⊩ tPrim p ~ tPrim p'
 with represents_value : value -> term -> Set :=
 | represents_value_tClos na E s t na' : [na] ;;; E ⊩ s ~ t -> represents_value (vClos na s E) (tLambda na' t)
 | represents_value_tConstruct vs ts ind c : All2_Set represents_value vs ts -> represents_value (vConstruct ind c vs) (tConstruct ind c ts)
 | represents_value_tFix vfix i E mfix :
   All2_Set (fun v d => isLambda (snd v) × (List.rev (map fst vfix) ;;; E ⊩ snd v ~ d.(dbody))) vfix mfix -> represents_value (vRecClos vfix i E) (tFix mfix i)
+| represents_value_tPrim p p' : onPrims represents_value p p' -> represents_value (vPrim p) (tPrim p')
 where "Γ ;;; E ⊩ s ~ t" := (represents Γ E s t).
+Derive Signature for represents represents_value.
 
 Program Definition represents_ind :=
   (λ (P : ∀ (l : list ident) (e : environment) (t t0 : term),
@@ -359,6 +369,8 @@ Program Definition represents_ind :=
              (IH : All2_over a0 (fun t t' : def term => P (List.rev nms ++ Γ) E (dbody t) (dbody t'))),
          P Γ E (tFix mfix idx) (tFix mfix' idx)
            (represents_tFix Γ E mfix mfix' idx nms Hbodies Hnodup a a0))
+     (f9 : forall Γ E p p' (o : onPrims (represents Γ E) p p'), onPrims_dep _ (P Γ E) _ _ o ->
+        P Γ E  (tPrim p) (tPrim p') (represents_tPrim Γ E p p' o))
      (f10 :
        ∀ (na : ident)
          (E : environment)
@@ -381,7 +393,9 @@ Program Definition represents_ind :=
               (a : All2_Set (λ (v : ident × term) (d : def term), isLambda v.2 × List.rev (map fst vfix) ;;; E ⊩ v.2 ~ dbody d) vfix mfix)
               (IH : All2_over a (fun v d H => P (List.rev (map fst vfix)) E v.2 (dbody d) (snd H)  ) ),
          P0 (vRecClos vfix i E) (tFix mfix i)
-           (represents_value_tFix vfix i E mfix a)),
+           (represents_value_tFix vfix i E mfix a))
+     (f13 : forall p p' (o : onPrims represents_value p p'), onPrims_dep _ P0 _ _ o ->
+        P0 (vPrim p) (tPrim p') (represents_value_tPrim p p' o)),
     fix F
       (l : list ident) (e : environment) (t t0 : term)
       (r : l;;; e ⊩ t ~ t0) {struct r} : P l e t t0 r :=
@@ -403,6 +417,8 @@ Program Definition represents_ind :=
          f7 Γ E ind discr discr' brs brs' r0 (F Γ E discr discr' r0) Heq a _
      | represents_tFix Γ E mfix mfix' idx nms Hbodies Hnodup a a0 =>
          f8 Γ E mfix mfix' idx nms Hbodies Hnodup a a0 _
+     | represents_tPrim Γ E p p' r =>
+         f9 Γ E p p' r (map_onPrims (F Γ E) r)
      end
    with F0 (v : value) (t : term) (r : represents_value v t) {struct r} :
      P0 v t r :=
@@ -411,6 +427,7 @@ Program Definition represents_ind :=
               f10 na E s t0 na' r0 (F [na] E s t0 r0)
           | represents_value_tConstruct vs ts ind c a => f11 vs ts ind c a _
           | represents_value_tFix vfix i E mfix a => f12 vfix i E mfix a _
+          | represents_value_tPrim p p' r => f13 p p' r (map_onPrims F0 r)
           end
             for
             F).
@@ -500,6 +517,9 @@ Program Definition represents_value_ind :=
              (IH : All2_over a0 (fun t t' : def term => P (List.rev nms ++ Γ) E (dbody t) (dbody t'))),
          P Γ E (tFix mfix idx) (tFix mfix' idx)
            (represents_tFix Γ E mfix mfix' idx nms Hbodies Hnodup a a0))
+    (f9 : forall Γ E p p' (o : onPrims (represents Γ E) p p'), onPrims_dep _ (P Γ E) _ _ o ->
+        P Γ E  (tPrim p) (tPrim p') (represents_tPrim Γ E p p' o))
+
      (f10 :
        ∀ (na : ident)
          (E : environment)
@@ -524,7 +544,10 @@ Program Definition represents_value_ind :=
                      (List.rev (map fst vfix)) ;;; E ⊩ v.2 ~ d.(dbody)) vfix mfix)
               (IH : All2_over a (fun v d H => P (List.rev (map fst vfix)) E v.2 (dbody d) (snd H)  ) ),
          P0 (vRecClos vfix i E) (tFix mfix i)
-           (represents_value_tFix vfix i E mfix a)),
+           (represents_value_tFix vfix i E mfix a))
+    (f13 : forall p p' (o : onPrims represents_value p p'), onPrims_dep _ P0 _ _ o ->
+           P0 (vPrim p) (tPrim p') (represents_value_tPrim p p' o)),
+
     fix F
       (l : list ident) (e : environment) (t t0 : term)
       (r : l;;; e ⊩ t ~ t0) {struct r} : P l e t t0 r :=
@@ -546,6 +569,9 @@ Program Definition represents_value_ind :=
          f7 Γ E ind discr discr' brs brs' r0 (F Γ E discr discr' r0) Heq a _
      | represents_tFix Γ E mfix mfix' idx nms Hbodies Hnodup a a0 =>
          f8 Γ E mfix mfix' idx nms Hbodies Hnodup a a0 _
+    | represents_tPrim Γ E p p' r =>
+         f9 Γ E p p' r (map_onPrims (F Γ E) r)
+
      end
    with F0 (v : value) (t : term) (r : represents_value v t) {struct r} :
      P0 v t r :=
@@ -554,6 +580,7 @@ Program Definition represents_value_ind :=
               f10 na E s t0 na' r0 (F [na] E s t0 r0)
           | represents_value_tConstruct vs ts ind c a => f11 vs ts ind c a _
           | represents_value_tFix vfix i E mfix a => f12 vfix i E mfix a _
+          | represents_value_tPrim p p' r => f13 p p' r (map_onPrims F0 r)
           end
             for
             F0).
@@ -643,6 +670,9 @@ Definition rep_ind :=
              (IH : All2_over a0 (fun t t' : def term => P (List.rev nms ++ Γ) E (dbody t) (dbody t'))),
          P Γ E (tFix mfix idx) (tFix mfix' idx)
            (represents_tFix Γ E mfix mfix' idx nms Hbodies Hnodup a a0))
+      (f9 : forall Γ E p p' (o : onPrims (represents Γ E) p p'), onPrims_dep _ (P Γ E) _ _ o ->
+           P Γ E  (tPrim p) (tPrim p') (represents_tPrim Γ E p p' o))
+
    (f10 :
        ∀ (na : ident)
          (E : environment)
@@ -669,9 +699,12 @@ Definition rep_ind :=
                          dbody d) vfix mfix)
               (IH : All2_over a (fun v d H => P (List.rev (map fst vfix)) E v.2 (dbody d) (snd H)  ) ),
          P0 (vRecClos vfix i E) (tFix mfix i)
-           (represents_value_tFix vfix i E mfix a)),
-    (represents_ind P P0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f10 f11 f12,
-      represents_value_ind P P0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f10 f11 f12)).
+           (represents_value_tFix vfix i E mfix a))
+      (f13 : forall p p' (o : onPrims represents_value p p'), onPrims_dep _ P0 _ _ o ->
+           P0 (vPrim p) (tPrim p') (represents_value_tPrim p p' o))
+           ,
+    (represents_ind P P0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13,
+      represents_value_ind P P0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13)).
 
 Local Notation "'⊩' v ~ s" := (represents_value v s) (at level 50).
 Local Hint Constructors represents : core.
@@ -859,6 +892,7 @@ Fixpoint annotate (s : list ident) (u : term) {struct u} : term :=
       let nms := gen_many_fresh s (map dname mfix) in
       let mfix' := map2 (fun d na => map_def_name _ (fun _ => nNamed na) (annotate (List.rev (gen_many_fresh s ((map dname mfix))) ++ s)) d) mfix nms in
       tFix mfix' idx
+  | tPrim p => tPrim (map_prim (annotate s) p)
   | _ => u
   end.
 
@@ -883,7 +917,7 @@ Definition extraction_term_flags :=
   ; has_tProj := false
   ; has_tFix := true
   ; has_tCoFix := false
-  ; has_tPrim := false
+  ; has_tPrim := true
   |}.
 
 Definition extraction_env_flags :=
@@ -928,7 +962,7 @@ Definition named_extraction_term_flags :=
   ; has_tProj := false
   ; has_tFix := true
   ; has_tCoFix := false
-  ; has_tPrim := false
+  ; has_tPrim := true
   |}.
 
 Definition named_extraction_env_flags :=
@@ -1007,6 +1041,7 @@ Proof.
       - econstructor.
       - invs H1. cbn. destruct a; cbn. destruct dname; cbn; econstructor; eauto.
     }
+  - solve_all. eapply primProp_map. solve_all.
 Qed.
 
 Lemma wellformed_annotate Σ Γ s :
@@ -1058,13 +1093,15 @@ Proof.
       - econstructor.
       - cbn. destruct x; cbn. destruct dname; cbn; econstructor; eauto.
     }
+  - constructor; solve_all. depelim H; cbn; solve_all; try econstructor.
+    destruct a; constructor; solve_all. eapply All2_All2_Set. solve_all.
 Qed.
 
 Lemma unfolds_bound :
   (forall Γ E s t, Γ ;;; E ⊩ s ~ t -> closedn #|Γ| t) ×
     (forall v s, ⊩ v ~ s -> closedn 0 s).
 Proof.
-  refine (rep_ind _ _ _ _ _ _ _ _ _ _ _ _ _ _); intros; cbn; rtoProp; eauto.
+  refine (rep_ind _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _); intros; cbn; rtoProp; eauto.
   - eapply Nat.ltb_lt, nth_error_Some. congruence.
   - eapply closed_upwards; eauto. lia.
   - solve_all. induction a; cbn in *; econstructor; firstorder.
@@ -1080,6 +1117,8 @@ Proof.
     clear Hbodies a. induction a0; cbn in *; econstructor.
     rewrite app_length List.rev_length in IH. eapply IH.
     eapply IHa0. eapply IH.
+  - depelim X; solve_all; try constructor; cbn; solve_all.
+    eapply All2_over_undep in a. solve_all.
   - solve_all. induction a; cbn in *; rtoProp; eauto.
     econstructor. cbn in *. eapply IH. eapply IHa. eapply IH.
   - rewrite List.rev_length map_length in IH.
@@ -1088,6 +1127,8 @@ Proof.
     induction a; intros n H; cbn in *; rtoProp; split.
     + destruct H. revert i0. len.
     + eapply IHa. lia. eapply H.
+  - depelim X; solve_all; try constructor; cbn; solve_all.
+    eapply All2_over_undep in a. solve_all.
 Qed.
 
 Lemma represents_bound_head Γ E v s x :
@@ -1172,6 +1213,9 @@ Proof.
         rewrite app_length in H.
         rewrite <- !app_assoc in *. rewrite List.rev_length in H. eapply H; eauto.
       * eapply IHmfix; eauto.
+  - econstructor; eauto.
+    depelim X; solve_all; constructor; solve_all.
+    eapply All2_over_undep in a. eapply All2_All2_Set; solve_all.
 Qed.
 
 Lemma represents_subst E s s' t v na :
@@ -1286,6 +1330,9 @@ Proof.
   induction a in vs, Hall, iha |- *; cbn in *; invs Hall.
   - econstructor.
   - invs iha. econstructor; eauto.
+  - econstructor. depelim H1; depelim X; solve_all; cbn; try constructor. eauto.
+    eapply All2_over_undep in a. clear -a a2.
+    induction a in v, a2 |- *; depelim a2; constructor; eauto.
 Qed.
 
 Definition fresh (na : ident) Γ := ~~ in_dec (ReflectEq_EqDec _) na Γ.
@@ -1328,6 +1375,7 @@ Fixpoint sunny Γ (t : term) : bool :=
          dupfree names &&
            forallb (test_def (sunny (names ++ Γ))) mfix
   | tConstruct _ _ args => forallb (sunny Γ) args
+  | tPrim p => test_prim (sunny Γ) p
   | _ => true
   end.
 
@@ -1339,7 +1387,8 @@ Inductive wf : value -> Type :=
   (forall nm, In nm (map fst vfix) -> ~ In nm (map fst E)) ->
   All (fun t => sunny (map fst vfix ++ map fst E) (snd t)) vfix ->
   All (fun v => wf (snd v)) E ->
-  wf (vRecClos vfix idx E).
+  wf (vRecClos vfix idx E)
+| wf_vPrim p : primProp wf p -> wf (vPrim p).
 
 Lemma declared_constant_Forall P Σ c decl :
   Forall (P ∘ snd) Σ ->
@@ -1430,6 +1479,7 @@ Proof.
     eapply a; eauto.
     intros ? ?. rewrite -> in_app_iff in *.
     destruct H; eauto.
+  - rtoProp; solve_all.
 Qed.
 
 Lemma eval_wf Σ E s v :
@@ -1544,6 +1594,8 @@ Proof.
     + eapply IHa; eauto. now invs Hsunny.
     + eapply IHa0. eapply IHa. now invs Hsunny.
   - cbn. econstructor. econstructor.
+  - econstructor. solve_all. depelim evih; depelim Hsunny; try subst a0 a'; cbn; constructor; cbn in *; intuition solve_all.
+    eapply All2_over_undep in a. solve_all.
 Qed.
 
 Lemma eval_construct_All2 Σ E ind c args vs mdecl idecl cdecl :
@@ -1940,7 +1992,35 @@ Proof.
        destruct (nth_error (ind_ctors o) i) eqn:E2; cbn in *; try congruence.
        unfold cstr_arity in *.  invs H. lia.
        clear - Hvs; induction Hvs; econstructor; eauto. eapply r.
-  - todo "prim".
+  - invs Hrep.
+    * exists v. depelim X; split; eauto; try now econstructor.
+      eapply All2_over_undep in a. eapply All2_Set_All2 in ev.
+      (* eapply eval_to_values in ev. solve_all. *)
+      (* eapply eval_to_value in ed. subst a1 a'. *)
+      depelim H0. depelim o. constructor. constructor. eapply All2_Set_All2 in a2. subst a1 a'.
+      cbn in Hsunny. destruct a0. eapply eval_represents_value; tea.
+      eapply All2_Set_All2 in a2. solve_all.
+      eapply All2_trans' in a; tea. eapply All2_All2_Set; tea.
+      { intros x y z [? []]. eapply eval_represents_value; tea. }
+    * depelim X; depelim H3; try solve [eexists; split; repeat constructor].
+      eapply All2_over_undep in a. eapply All2_Set_All2 in a2, ev. solve_all.
+      destruct a0. specialize (s0 _ _ r). cbn in Hsunny. move/andP: Hsunny => [sd sv].
+      solve_all. destruct H as [vdef []].
+      eapply (All2_trans' _ _ (fun x z => ∑ v, ⊩ v ~ z × eval Σ' E x v)) in a; tea.
+      2:{ intros x y z. cbn. intros [[] [ev []]].
+          now specialize (s0 _ _ r1 i1 HE). }
+      assert ({ vs & All3 (fun v x z => ⊩ v ~ z × eval Σ' E x v) vs v0 v'}) as [vs Hvs].
+      { cbn in a. let X := match goal with H : All2 _ ?x ?y |- context[All3 _ _ ?x ?y] => H end in
+          clear - X; induction X. eexists; econstructor. repeat (destruct_head'_sigT; destruct_head'_prod).
+          eexists (_ :: _). econstructor; eauto.
+        }
+      exists (vPrim (prim_array {| array_default := vdef; array_value := vs |})).
+      subst a1 a' a3 a'0; cbn in *.
+      split; constructor.
+      + constructor; eauto. eapply All2_All2_Set.
+        { clear -Hvs; induction Hvs; constructor; intuition eauto. }
+      + constructor; eauto. eapply All2_All2_Set.
+        { clear -Hvs; induction Hvs; constructor; intuition eauto. }
   - invs Hrep; cbn in *; try congruence; rtoProp.
     + econstructor. split; eauto. econstructor. eauto.
     + econstructor. split; eauto. econstructor.
@@ -2068,6 +2148,7 @@ Proof.
       + intros l. destruct l; cbn in *; try congruence. econstructor.
       + intros []; cbn in *; try congruence. intros. econstructor; eauto.
     }
+  - solve_all.
 Qed.
 
 Lemma eval_to_eval_named_full (Σ Σ' : global_context) s t :

--- a/erasure/theories/ErasureCorrectness.v
+++ b/erasure/theories/ErasureCorrectness.v
@@ -182,14 +182,14 @@ Proof.
   assert (Σ ;;; [] |- mkApps (tConstruct ind c u) args :   mkApps (tInd ind (puinst p)) (pparams p ++ indices)).
   eapply subject_reduction_eval; eauto.
   assert (Hcstr := X0).
-  eapply Construct_Ind_ind_eq in X0; tea. 2:pcuic.
+  eapply Construct_Ind_ind_eq in X0; tea. 2:{ eapply declared_constructor_from_gen; tea. }
   destruct X0 as (((([_ Ru] & cu) & cpu) & ?) & (parsubst & argsubst & parsubst' & argsubst' & [])).
   invs He.
   + depelim Hed.
     rename H1 into decli. rename H2 into decli'.
     rename H3 into em. rename Hed into er.
     edestruct (IHeval1 _ scrut_ty) as (v' & Hv' & [He_v']); eauto.
-    pose proof e as Hnth.
+    pose proof e0 as Hnth.
     assert (lenppars : ind_npars mdecl = #|pparams p|).
     { now rewrite (wf_predicate_length_pars wf_pred). }
     unshelve eapply declared_inductive_to_gen in decli; eauto.
@@ -206,7 +206,7 @@ Proof.
       2: eapply declared_inductive_from_gen; eauto.
       2: split; auto; exists []; now destruct Σ.
       destruct (ind_ctors idecl) eqn:hctors.
-      { cbn in *. depelim brs_ty. rewrite nth_error_nil // in Hnth. }
+      { cbn in *. depelim brs_ty. depelim X0. rewrite nth_error_nil // in Hnth. }
       depelim brs_ty. cbn in H1.
       destruct l; cbn in *; try lia.
       depelim brs_ty. depelim X0. depelim X0.
@@ -215,7 +215,7 @@ Proof.
       destruct p0 as (? & ? & ? & ?).
       assert (c1 = cdecl).
       { destruct d.
-        rewrite hctors /= in e6. now noconf e6. }
+        rewrite hctors /= in H10. now noconf H10. }
       depelim H5.
       subst c1.
       destruct y0 as [n br']; cbn in *.
@@ -227,7 +227,7 @@ Proof.
       econstructor. econstructor.
       eauto.
       all:unfold iota_red in *. all:cbn in *.
-      { rewrite e3 e1. now f_equal. }
+      { rewrite e2 e1. now f_equal. }
       {
         assert (expand_lets (inst_case_branch_context p br) (br.(PCUICAst.bbody)) = br.(PCUICAst.bbody)) as ->. {
           unshelve edestruct @on_declared_constructor as (? & ? & ? & []).
@@ -273,7 +273,7 @@ Proof.
       apply declared_inductive_from_gen; eauto.
       invs e. cbn in *.
       rewrite map_length.
-      rewrite skipn_length e3 e2 in H11.
+      rewrite skipn_length H13 e3 in H11.
       rewrite (@assumption_context_assumptions (bcontext br)) // ?rev_repeat in H11 => //.
       { eapply assumption_context_compare_decls. symmetry in a. exact a.
         rewrite /cstr_branch_context. eapply assumption_context_expand_lets_ctx.
@@ -306,7 +306,7 @@ Proof.
 
       etransitivity. constructor. constructor.
       eauto.
-      { rewrite e0 /cstr_arity e2 e1 //. }
+      { rewrite e1 /cstr_arity e3. congruence. }
       unfold iota_red. reflexivity.
 
       {
@@ -358,7 +358,7 @@ Proof.
          erewrite isPropositional_propositional_cstr; eauto.
          move/negbTE: H13 => ->. reflexivity.
          eapply declared_constructor_from_gen; eauto.
-         rewrite  -(Forall2_length H3) /= e1 //.
+         rewrite  -(Forall2_length H3) /= e2 //.
          rewrite skipn_length -(Forall2_length H3) -e6 /= map_length.
          rewrite (All2_length a).
          replace #|cstr_branch_context ind mdecl cdecl|
@@ -366,7 +366,7 @@ Proof.
          2:{ eapply assumption_context_assumptions.
              apply declared_constructor_from_gen in d.
              eapply (assumption_context_cstr_branch_context d). }
-         rewrite e0 /cstr_arity e1 cstr_branch_context_assumptions; lia.
+         rewrite e2 /cstr_arity e1 cstr_branch_context_assumptions; lia.
       -- eapply Is_type_app in X1 as []; auto.
          2:{ eapply subject_reduction_eval. 2:eassumption. eauto. }
          assert (ispind : inductive_isprop_and_pars Σ' ind = Some (true, ind_npars mdecl)).
@@ -395,7 +395,7 @@ Proof.
          eapply PCUICReduction.red_case_c. eapply wcbveval_red. eauto.
          eauto. eauto.
          etransitivity. constructor. constructor. cbn. reflexivity.
-         { rewrite e0 /cstr_arity e2 e1 //. }
+         { rewrite e1 /cstr_arity e2 e3 //. }
          eauto.
 
          {
@@ -462,7 +462,7 @@ Proof.
          { eapply subject_reduction. eauto. exact Hty.
            eapply PCUICReduction.red_case_c. eapply wcbveval_red; eauto. }
 
-        rewrite eq_npars. rewrite List.skipn_length e0 /cstr_arity -e1 e2.
+        rewrite eq_npars. rewrite List.skipn_length e1 /cstr_arity -e2 e3.
         replace (ci_npar ind + context_assumptions (bcontext br) - ci_npar ind)
     with (context_assumptions (bcontext br)) by lia.
         subst n. rewrite map_length.
@@ -472,11 +472,11 @@ Proof.
         eapply (assumption_context_cstr_branch_context d).
     + exists EAst.tBox. split. econstructor.
       eapply Is_type_eval; eauto. constructor. econstructor; eauto.
-    + eapply declared_constructor_from_gen in d. eauto.
+
 
   - pose (Hty' := Hty).
     pose proof (proj2 (proj2 d)) as eqpars.
-    rename e0 into hnth. rename e into eargs.
+    rename e1 into hnth. rename e0 into eargs.
     eapply inversion_Proj in Hty' as (? & ? & ? & [] & ? & ? & ? & ? & ? & ?); [|easy].
     pose proof (wfΣ' := wfΣ.1).
     unshelve eapply declared_projection_to_gen in d0; eauto.
@@ -574,15 +574,17 @@ Proof.
     apply PCUICValidity.inversion_mkApps in HT as (? & ? & ?); auto.
     assert (Ht1 := t1).
     apply inversion_Fix in t1 as Hfix; auto.
+    rename e0 into hcum.
+    rename e1 into e.
     destruct Hfix as (? & ? & ? & ? & ? & ? & e1).
-    unfold cunfold_fix in e. rewrite e2 in e. invs e.
+    unfold cunfold_fix in e. rewrite e0 in e. invs e.
     depelim He; first last.
 
     + exists EAst.tBox. split; [|now constructor; constructor].
       econstructor.
       eapply Is_type_eval. 3:eapply X. eauto.
       eapply eval_fix; eauto.
-      rewrite /cunfold_fix e2 //. now rewrite H3.
+      rewrite /cunfold_fix e0 //. now rewrite H3.
     + depelim Hed.
       eapply IHeval1 in He1 as (er_stuck_v & er_stuck & [ev_stuck]); eauto.
       eapply IHeval2 in He2 as (er_argv & er_arg & [ev_arg]); eauto.
@@ -607,13 +609,13 @@ Proof.
           rewrite -mkApps_app. eapply value_final.
           eapply eval_to_value; eauto.
           eapply value_final, eval_to_value; eauto.
-          rewrite /cunfold_fix e2 //. auto.
+          rewrite /cunfold_fix e0 //. auto.
           now rewrite H3. auto. }
 
       invs H2.
       * assert (Hmfix' := X).
         eapply All2_nth_error_Some in X as (? & ? & ?); eauto.
-        pose proof (closed_fix_substl_subst_eq (subject_closed t1) e2) as cls.
+        pose proof (closed_fix_substl_subst_eq (subject_closed t1) e0) as cls.
         destruct x3. cbn in *. subst.
 
         enough (Σ;;; [] ,,, subst_context (fix_subst mfix) 0 []
@@ -621,8 +623,8 @@ Proof.
                 ⇝ℇ ELiftSubst.subst (EGlobalEnv.fix_subst mfix') 0 (Extract.E.dbody x4)).
         destruct a2.
 
-        clear e3. rename H into e3.
-        -- cbn in e3. rename x5 into L.
+        rename e3 into eargsv.
+        -- rename x5 into L.
            eapply (erases_mkApps _ _ _ _ (argsv ++ [av])) in H2; first last.
            { eapply Forall2_app.
              - exact H4.
@@ -641,10 +643,10 @@ Proof.
              eapply PCUICReduction.red_fix.
              rewrite closed_unfold_fix_cunfold_eq.
              now eapply subject_closed in t1.
-             rewrite /cunfold_fix e2 /= //.
-             pose proof (eval_to_value _ _ _ e3) as vfix.
+             rewrite /cunfold_fix e0 /= //.
+             pose proof (eval_to_value _ _ _ H) as vfix.
              eapply PCUICWcbvEval.stuck_fix_value_args in vfix; eauto.
-             2:{ rewrite /cunfold_fix e2 //. }
+             2:{ rewrite /cunfold_fix e0 //. }
              simpl in vfix.
              subst. unfold is_constructor.
              rewrite nth_error_snoc. lia.
@@ -652,7 +654,7 @@ Proof.
              { rewrite mkApps_app. eapply PCUICValidity.type_App'; eauto.
                eapply subject_reduction_eval; eauto. }
              epose proof (fix_app_is_constructor (args:=argsv ++ [av]) X).
-             rewrite /unfold_fix e2 in X0.
+             rewrite /unfold_fix e0 in X0.
              specialize (X0 eq_refl). simpl in X0.
              rewrite nth_error_snoc in X0. auto. apply X0.
              eapply value_axiom_free, eval_to_value; eauto.
@@ -664,8 +666,8 @@ Proof.
              - eapply erases_deps_eval in ev_stuck; [|now eauto].
                eapply erases_deps_mkApps_inv in ev_stuck as (? & ?).
                apply erases_deps_mkApps; [|now eauto].
-               depelim H.
-               eapply nth_error_forall in H as H'; eauto.
+               depelim H3.
+               eapply nth_error_forall in H3 as H'; eauto.
                apply erases_deps_subst; [|now eauto].
                now apply Forall_All, Forall_erases_deps_fix_subst; eauto.
              - now eapply erases_deps_eval in ev_arg; eauto. }
@@ -676,10 +678,11 @@ Proof.
            ++ eauto.
            ++ eauto.
            ++ rewrite <- Ee.closed_unfold_fix_cunfold_eq.
-              { unfold EGlobalEnv.unfold_fix. rewrite e -e4.
-                now rewrite (Forall2_length H4). }
-              eapply eval_closed in e3; eauto.
-              clear -e3 Hmfix'.
+              { unfold EGlobalEnv.unfold_fix. rewrite e.
+                eapply All2_nth_error in Hmfix' as []; tea. cbn in *.
+                rewrite -eargsv -(Forall2_length H4); trea. }
+              eapply eval_closed in H; eauto.
+              clear -H Hmfix'. rename H into e3.
               pose proof (All2_length Hmfix').
               rewrite closedn_mkApps in e3.
               apply andb_true_iff in e3 as (e3 & _).
@@ -721,7 +724,7 @@ Proof.
               rewrite mkApps_app.
               eapply eval_fix; eauto.
               1-2:eapply value_final, eval_to_value; eauto.
-              rewrite /cunfold_fix e2 //. congruence.
+              rewrite /cunfold_fix e0 //. congruence.
            ++ constructor. eapply Ee.eval_box; [|now eauto].
               apply eval_to_mkApps_tBox_inv in ev_stuck as ?; subst.
               eauto.
@@ -778,8 +781,8 @@ Proof.
            ++ eauto.
            ++ eauto.
            ++ eauto.
-           ++ unfold EGlobalEnv.cunfold_fix. now rewrite e0.
-           ++ eapply Forall2_length in H5. noconf e. lia.
+           ++ unfold EGlobalEnv.cunfold_fix. now rewrite e.
+           ++ eapply Forall2_length in H5. noconf e1. lia.
 
         -- exists E.tBox.
            apply eval_to_mkApps_tBox_inv in H3 as ?; subst.
@@ -1155,6 +1158,32 @@ Proof.
       eapply subject_closed in Ha; auto.
       eapply wcbveval_red; eauto.
 
+  - depelim X; (depelim He; try depelim H; [|now eapply nisErasable_tPrim in X]).
+    + exists (EAst.tPrim (EPrimitive.prim_int i)); split => //; repeat constructor.
+      depelim X. constructor.
+    + exists (EAst.tPrim (EPrimitive.prim_float f)); split => //; repeat constructor.
+      depelim X. constructor.
+    + depelim X. subst a0 a'; cbn in *.
+      depelim Hed; cbn in *.
+      eapply inversion_Prim in Hty as [prim_ty [cdecl []]]; cbn in *; eauto.
+      depelim p0; cbn in *. eapply e in hdef as [d' [er [e'v]]]; tea.
+      eapply All2_undep in a.
+      eapply (All2_apply ty) in a.
+      assert (exists ev, ∥ All3 (fun x y z => erases Σ [] x z /\ ∥ Σ' ⊢ y ⇓ z ∥) v' ev0 ev ∥).
+      { clear -a a2 H hvalue.
+        solve_all.
+        induction a in ev0, a2 |- *; depelim a2.
+        + exists []; repeat constructor.
+        + destruct (IHa _ a2) as [x0 [hx0]]. destruct p as [[] ?].
+          specialize (r t _ e e0) as [v' []].
+          exists (v' :: x0). sq. repeat constructor; intuition eauto. }
+      destruct H0 as [evr [Hevr]].
+      exists (EAst.tPrim (EPrimitive.prim_array {| EPrimitive.array_default := d'; EPrimitive.array_value := evr |})); split => //; eauto.
+      repeat constructor; eauto.
+      * clear -Hevr; induction Hevr; constructor; intuition eauto.
+      * clear -Hevr e'v; induction Hevr. repeat constructor; eauto.
+        destruct r; sq. constructor; intuition eauto. constructor; eauto. depelim IHHevr. depelim e. constructor; eauto. now cbn in i.
+
   - destruct t; try easy.
     + invs He. eexists. split; eauto. now constructor; econstructor.
     + invs He. eexists. split; eauto. now constructor; econstructor.
@@ -1180,10 +1209,6 @@ Proof.
       * eexists. split. 2: now constructor; econstructor.
         econstructor; eauto.
         Unshelve. all: repeat econstructor.
-    + invs He.
-      * eexists. split; eauto. now constructor; econstructor.
-      * eexists. split. 2: now constructor; econstructor.
-        econstructor; eauto.
 Qed.
 
 (* Print Assumptions erases_correct. *)

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -642,6 +642,17 @@ Proof.
     rewrite fold_left_eq (fold_left_eq _ (KernameSet.union _ _)).
     rewrite !global_deps_union !KernameSet.union_spec.
     destruct iha as [sub ih]. specialize (IHa ih). intuition eauto.
+  - depelim X; cbn; simp prim_global_deps; try knset.
+    eapply EWcbvEval.All2_over_undep in a.
+    eapply EWcbvEval.All2_Set_All2 in ev. cbn. solve_all.
+    rewrite fold_left_eq.
+    intros hin h.
+    rewrite fold_left_eq.
+    rewrite !global_deps_union !KernameSet.union_spec in h *. intuition eauto. left.
+    clear -H a. induction a. cbn; knset. cbn in H |- *.
+    rewrite fold_left_eq global_deps_union !KernameSet.union_spec in H.
+    rewrite fold_left_eq !global_deps_union !KernameSet.union_spec. intuition eauto.
+    rewrite global_deps_union !KernameSet.union_spec in H0. intuition auto; try knset.
 Qed.
 
 Lemma in_global_deps_fresh {efl : EWellformed.EEnvFlags} kn Σ deps :

--- a/erasure/theories/ErasureFunction.v
+++ b/erasure/theories/ErasureFunction.v
@@ -643,8 +643,8 @@ Proof.
     rewrite !global_deps_union !KernameSet.union_spec.
     destruct iha as [sub ih]. specialize (IHa ih). intuition eauto.
   - depelim X; cbn; simp prim_global_deps; try knset.
-    eapply EWcbvEval.All2_over_undep in a.
-    eapply EWcbvEval.All2_Set_All2 in ev. cbn. solve_all.
+    eapply All2_over_undep in a.
+    eapply All2_Set_All2 in ev. cbn. solve_all.
     rewrite fold_left_eq.
     intros hin h.
     rewrite fold_left_eq.

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -252,7 +252,7 @@ Proof.
     + subst types. eapply conv_context_app_same; auto.
     + subst types. eapply conv_context_wf_local_app; eauto.
     + assumption.
-  - econstructor. depelim H2; constructor. depelim X5; depelim X2; constructor; eauto.
+  - econstructor. depelim H3; constructor. depelim X4; depelim X1; constructor; eauto.
     solve_all.
 Qed.
 
@@ -411,8 +411,8 @@ Proof.
   f_equal.
   eapply fix_context_subst_instance. all: eauto.
 
-  - cbn; constructor. depelim H4.
-    depelim X2; depelim X5; repeat constructor; cbn; eauto.
+  - cbn; constructor. depelim H5.
+    depelim X1; depelim X4; repeat constructor; cbn; eauto.
     solve_all.
 Qed.
 
@@ -566,7 +566,7 @@ Section wellscoped.
     - now eapply nth_error_Some_length, Nat.ltb_lt in H0.
     - solve_all. destruct a as [s []], b.
       unfold test_def. len in i0. now rewrite i i0.
-    - depelim X1; solve_all; constructor; eauto.
+    - depelim X0; solve_all; constructor; eauto.
   Qed.
 
   Lemma welltyped_wellformed {Σ : global_env_ext} {wfΣ : wf Σ} {Γ a} : welltyped Σ Γ a -> wellformed Σ a.

--- a/erasure/theories/Typed/OptimizeCorrectness.v
+++ b/erasure/theories/Typed/OptimizeCorrectness.v
@@ -1929,6 +1929,9 @@ Proof.
     now apply (is_expanded_aux_upwards 0).
   - easy.
   - easy.
+  - depelim X; auto.
+    eapply All2_over_undep in a. eapply All2_Set_All2 in ev. solve_all. subst a0 a'; cbn in *.
+    depelim exp_t; constructor; cbn in *; intuition eauto. solve_all.
 Qed.
 
 Lemma valid_case_masks_lift ind c brs n k :
@@ -2559,6 +2562,9 @@ Proof with auto with dearg.
     easy.
   - easy.
   - easy.
+  - depelim X; auto.
+    eapply All2_over_undep in a. eapply All2_Set_All2 in ev. subst a0 a'; cbn -[test_prim] in *.
+    solve_all. depelim H0; constructor; cbn; intuition eauto. solve_all.
 Qed.
 
 Lemma lookup_env_dearg_env Σ kn :
@@ -4258,6 +4264,16 @@ Proof.
         -- now apply is_expanded_aux_subst.
         -- lia.
         -- eapply closedn_dearg_aux;eauto.
+    + depelim e; repeat constructor.
+      cbn in deriv_len. eapply All2_All2_Set, All2_map.
+      solve_all. subst a' a; cbn in *.
+      depelim H0; depelim H1. intuition auto; cbn in *.
+      clear -b0 deriv_len IH.
+      induction b0 in v', ev, deriv_len |- *; depelim ev; constructor; eauto.
+      specialize (IHb0 _ ev). unshelve eapply IH; intuition eauto. cbn. cbn in deriv_len. lia.
+      unshelve eapply IHb0; tea. cbn in deriv_len. lia.
+      cbn in *; unfold test_array_model in *; subst a a'; cbn in *.
+      unshelve eapply IH; tea; rtoProp; intuition eauto. lia.
     + destruct t; cbn in *; try destruct y; try congruence; now constructor.
 Qed.
 End dearg_correct.
@@ -4360,6 +4376,8 @@ Proof.
     assumption.
     eapply lookup_ctor_trans_env_inv;eauto.
     all : eauto.
+  - depelim X; repeat constructor.
+    eapply All2_over_undep in a. eapply All2_All2_Set. eapply All2_Set_All2 in ev; solve_all. eauto.
   - eapply eval_atom.
     depelim t;auto.
     destruct args;simpl in *;try congruence.

--- a/erasure/theories/Typed/WcbvEvalAux.v
+++ b/erasure/theories/Typed/WcbvEvalAux.v
@@ -281,7 +281,7 @@ Definition eval_prim_length {wfl : WcbvFlags} {Σ p p'} (len : forall t v, Σ e�
   match d with
   | evalPrimInt _ | evalPrimFloat _ => 0
   | evalPrimArray v d v' d' av ev =>
-    len _ _ ev + EWcbvEval.all2_size _ len av
+    len _ _ ev + EPrimitive.all2_size _ len av
   end.
 
 Fixpoint deriv_length {Σ t v} (ev : Σ e⊢ t ⇓ v) : nat :=

--- a/erasure/theories/Typed/WcbvEvalAux.v
+++ b/erasure/theories/Typed/WcbvEvalAux.v
@@ -277,6 +277,12 @@ Proof.
   now eapply closed_unfold_cofix.
 Qed.
 
+Definition eval_prim_length {wfl : WcbvFlags} {Σ p p'} (len : forall t v, Σ e⊢ t ⇓ v -> nat) (d : eval_primitive (eval Σ) p p') : nat :=
+  match d with
+  | evalPrimInt _ | evalPrimFloat _ => 0
+  | evalPrimArray v d v' d' av ev =>
+    len _ _ ev + EWcbvEval.all2_size _ len av
+  end.
 
 Fixpoint deriv_length {Σ t v} (ev : Σ e⊢ t ⇓ v) : nat :=
   match ev with
@@ -300,6 +306,7 @@ Fixpoint deriv_length {Σ t v} (ev : Σ e⊢ t ⇓ v) : nat :=
   | eval_fix _ _ _ _ _ _ _ _ _ ev1 ev2 _ ev3 =>
       S (deriv_length ev1 + deriv_length ev2 + deriv_length ev3)
   | eval_construct_block _ _ _ _ _ args _ _ _ _ _ => S #|args|
+  | eval_prim _ _ ev => S (eval_prim_length (@deriv_length _) ev)
   end.
 
 Lemma deriv_length_min {Σ t v} (ev : Σ e⊢ t ⇓ v) :

--- a/pcuic/theories/Bidirectional/BDStrengthening.v
+++ b/pcuic/theories/Bidirectional/BDStrengthening.v
@@ -472,7 +472,7 @@ Section OnFreeVars.
       cbn in Hmfix.
       by move: Hmfix => /andP [].
 
-    - intros. red. intros. destruct X1; cbn => //.
+    - intros. red. intros. destruct X0; cbn => //.
       simp prim_type. cbn in *. solve_all.
     - easy.
 
@@ -869,7 +869,7 @@ Proof using wfΣ.
 
   - intros. red. intros P Δ f hf ht.
     cbn. rewrite rename_prim_type. econstructor; tea; rewrite ?prim_val_tag_map //.
-    destruct X1; cbn in *; constructor; cbn; eauto.
+    destruct X0; cbn in *; constructor; cbn; eauto.
     * eapply hty; tea; solve_all.
     * eapply hdef; tea; solve_all.
     * solve_all.

--- a/pcuic/theories/Bidirectional/BDToPCUIC.v
+++ b/pcuic/theories/Bidirectional/BDToPCUIC.v
@@ -417,10 +417,10 @@ Section BDToPCUICTyping.
 
     - red; intros.
       econstructor; eauto.
-      depelim X1; constructor; eauto.
+      depelim X0; constructor; eauto.
       eapply hty; eauto. eexists. econstructor; eauto.
       eapply hdef; eauto. eexists; eauto. eapply hty; eauto. eexists; econstructor; eauto.
-      solve_all. eapply X7; eauto. eexists. eapply hty; eauto. eexists; econstructor; eauto.
+      solve_all. eapply X6; eauto. eexists. eapply hty; eauto. eexists; econstructor; eauto.
 
     - red ; intros.
       now eapply type_reduction.

--- a/pcuic/theories/Bidirectional/BDUnique.v
+++ b/pcuic/theories/Bidirectional/BDUnique.v
@@ -236,10 +236,10 @@ Proof using wfΣ.
       * fvs.
       * now eapply type_is_open_term, infering_typing.
 
-  - depelim X1; depelim X0.
-    * depelim X3. rewrite e in H; noconf H. eexists. split; eapply closed_red_refl; fvs.
-    * depelim X3. rewrite e in H; noconf H. eexists. split; eapply closed_red_refl; fvs.
-    * depelim X3. rewrite e in H; noconf H. eexists. split; eapply closed_red_refl; fvs.
+  - depelim X; depelim X0.
+    * depelim X2. rewrite e in H; noconf H. eexists. split; eapply closed_red_refl; fvs.
+    * depelim X2. rewrite e in H; noconf H. eexists. split; eapply closed_red_refl; fvs.
+    * depelim X2. rewrite e in H; noconf H. eexists. split; eapply closed_red_refl; fvs.
       all:simp prim_type; cbn. cbn in hty.
       all:eapply type_is_open_term, checking_typing; tea; eexists; eapply checking_typing; tea; eexists; econstructor; tea.
 

--- a/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
+++ b/pcuic/theories/Conversion/PCUICUnivSubstitutionConv.v
@@ -2042,12 +2042,12 @@ Section SubstIdentity.
     - solve_all. destruct a as [s [? ?]]. solve_all.
     - clear X0. eapply nth_error_all in X as [s [Hs [IHs _]]]; eauto.
     - destruct p as [? []]; cbn => //. do 2 f_equal.
-      depelim X1. specialize (hty X2); specialize (hdef X2).
+      depelim X0. specialize (hty X1); specialize (hdef X1).
       unfold mapu_array_model; destruct a; cbn -[Universe.make] in * => //=; f_equal; intuition eauto.
       * destruct array_level => //.
         rewrite subst_instance_univ_make in b. now injection b.
       * solve_all.
-    - depelim X1; cbn => //=. destruct X. simp prim_type. cbn. f_equal; intuition eauto.
+    - depelim X0; cbn => //=. depelim X. simp prim_type. cbn. f_equal; intuition eauto.
       do 2 f_equal. cbn -[Universe.make] in b. rewrite subst_instance_univ_make in b.
       now injection b.
   Qed.

--- a/pcuic/theories/PCUICCumulProp.v
+++ b/pcuic/theories/PCUICCumulProp.v
@@ -1339,12 +1339,13 @@ Proof using Hcf Hcf'.
     eapply eq_term_eq_term_prop_impl; eauto.
     now symmetry in a.
 
-  - depelim X4.
-    eapply inversion_Prim in X3 as [prim_ty' [cdecl' []]]; tea. depelim o.
+  - depelim X3.
+    eapply inversion_Prim in X2 as [prim_ty' [cdecl' []]]; tea. depelim o.
     1-2:rewrite H in e; noconf e; eapply cumul_cumul_prop; eauto; pcuic.
+    depelim X1.
     cbn in H, e2. rewrite H in e2. noconf e2. eapply cumul_cumul_prop; eauto; pcuic.
-    move: w; simp prim_type. intro. etransitivity; tea. constructor; fvs. cbn. fvs.
-    depelim X1. fvs. eapply eq_term_leq_term. symmetry; repeat constructor; eauto.
+    move: w; simp prim_type. intro. etransitivity; tea. constructor; fvs. cbn.
+    depelim X0. fvs. eapply eq_term_leq_term. symmetry; repeat constructor; eauto.
 Qed.
 
 End no_prop_leq_type.

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -3924,9 +3924,8 @@ Proof.
   - cbn. rewrite trans_prim_ty. econstructor; eauto. rewrite prim_val_tag_map //.
     * now eapply trans_declared_constant in H0.
     * destruct p as [? []]; cbn in X0 |- *.
-      1-2:destruct X0 as [s []]; exists s; split => //; rewrite ?H1 ?H2 //=.
-      destruct X0; split => //. rewrite H1 //. rewrite H2 //.
-    * depelim X1; depelim X2; constructor; intuition eauto. cbn. solve_all.
+      all:destruct H1 as []; split => //; rewrite ?H1 ?H2 //=.
+    * depelim X0; depelim X1; constructor; intuition eauto. cbn. solve_all.
   - eapply (type_ws_cumul_pb (pb:=Cumul)).
     + eauto.
     + now exists s.

--- a/pcuic/theories/PCUICExpandLetsCorrectness.v
+++ b/pcuic/theories/PCUICExpandLetsCorrectness.v
@@ -5275,13 +5275,13 @@ Proof.
     rewrite trans_mkApps in IHev1.
     econstructor.
     * eapply IHev1; eauto.
-    * rewrite !nth_error_map e //.
+    * rewrite !nth_error_map e0 //.
     * unshelve eapply @declared_constructor_to_gen with (cf :=cf' cf); eauto.
       eapply trans_declared_constructor; tea.
       apply declared_constructor_from_gen; eauto.
-    * len. rewrite e0 /cstr_arity.
+    * len. rewrite e1 /cstr_arity.
       cbn. rewrite context_assumptions_smash_context context_assumptions_map /= //.
-    * now rewrite e1.
+    * now rewrite e2.
     * cbn.
       rewrite trans_bcontext.
       rewrite !context_assumptions_smash_context !context_assumptions_map //.
@@ -5308,7 +5308,7 @@ Proof.
       { rewrite /iota_red.
         eapply closedn_subst0 => //.
         now rewrite forallb_rev; apply forallb_skipn.
-        cbn; len. rewrite skipn_length e0 /cstr_arity -e1 e2.
+        cbn; len. rewrite skipn_length e1 /cstr_arity -e2 e3.
         replace (ci_npar ci + context_assumptions (bcontext br) - ci_npar ci)
           with (context_assumptions (bcontext br)) by lia.
         eauto.
@@ -5341,9 +5341,9 @@ Proof.
     eapply trans_declared_projection in d; tea.
     econstructor; tea.
     unshelve eapply @declared_projection_to_gen with (cf:=cf' cf); eauto.
-    { len. rewrite /cstr_arity e. cbn.
+    { len. rewrite /cstr_arity e0. cbn.
       rewrite context_assumptions_smash_context /= /cstr_arity context_assumptions_map //. }
-    rewrite nth_error_map e0 //.
+    rewrite nth_error_map e1 //.
     apply IHev2.
     eapply eval_closed in ev1; tea.
     move: ev1; rewrite closedn_mkApps /= => onargs.
@@ -5353,12 +5353,12 @@ Proof.
     rewrite trans_mkApps /= in IHev1.
     eapply eval_closed in ev1; tea.
     move: ev1; rewrite closedn_mkApps => /andP[] clfix clargsv.
-    rewrite -closed_unfold_fix_cunfold_eq in e => //.
+    rewrite -closed_unfold_fix_cunfold_eq in e1 => //.
     forward IHev3.
     { cbn. apply/andP; split.
       rewrite closedn_mkApps /= clargsv andb_true_r.
       eapply closed_unfold_fix; tea. now eapply eval_closed in ev2. }
-    eapply (trans_unfold_fix xpred0) in e; tea.
+    eapply (trans_unfold_fix xpred0) in e1; tea.
     2:now eapply (@closedn_on_free_vars xpred0 0).
     eapply eval_fix; eauto. len.
     rewrite -closed_unfold_fix_cunfold_eq; tea.
@@ -5369,10 +5369,10 @@ Proof.
     rewrite trans_mkApps /= in IHev1.
     eapply eval_closed in ev1; tea.
     move: ev1; rewrite closedn_mkApps => /andP[] clfix clargsv.
-    rewrite -closed_unfold_fix_cunfold_eq in e => //.
+    rewrite -closed_unfold_fix_cunfold_eq in e1 => //.
     specialize (IHev1 clf).
     rewrite trans_mkApps /=.
-    eapply (trans_unfold_fix xpred0) in e; tea.
+    eapply (trans_unfold_fix xpred0) in e1; tea.
     2:now eapply (@closedn_on_free_vars xpred0 0).
     eapply eval_fix_value. eauto. eauto.
     rewrite -closed_unfold_fix_cunfold_eq; tea.
@@ -5432,6 +5432,8 @@ Proof.
     rewrite -isFixApp_trans -isConstructApp_trans -isPrimApp_trans.
     clear -i. induction f' => /= //.
 
+  - cbn. depelim X; do 2 constructor; eauto; cbn in *; rtoProp; intuition auto.
+    eapply All2_undep in a. solve_all.
   - move=> clt. eapply eval_atom.
     destruct t => //.
 Qed.

--- a/pcuic/theories/PCUICFirstorder.v
+++ b/pcuic/theories/PCUICFirstorder.v
@@ -632,7 +632,7 @@ Proof using Type.
   intros Hwf Hwfl Hty Hvalue.
   revert i u args Hty.
 
-  induction Hvalue as [ t Hvalue | t args' Hhead Hargs IH ] using PCUICWcbvEval.value_values_ind;
+  induction Hvalue as [ t Hvalue | p pv ih | t args' Hhead Hargs IH ] using PCUICWcbvEval.value_values_ind;
    intros i u args Hty Hfo.
   - destruct t; inversion_clear Hvalue.
     + exfalso. eapply inversion_Sort in Hty as (? & ? & Hcumul); eauto.
@@ -671,7 +671,7 @@ Proof using Type.
       eapply andb_true_iff in Hfo as [Hfo _].
       rewrite /check_recursivity_kind E in Hty.
       now eapply (negb_False _ Hfo).
-    + eapply inversion_Prim in Hty as [prim_ty [cdecl [wf hp hdecl inv ty cum]]]; eauto.
+  - eapply inversion_Prim in Hty as [prim_ty [cdecl [wf hp hdecl inv ty cum]]]; eauto.
       now eapply invert_cumul_prim_type_ind in cum; tea.
   - destruct t; inv Hhead.
     + exfalso. now eapply invert_ind_ind in Hty.

--- a/pcuic/theories/PCUICPrincipality.v
+++ b/pcuic/theories/PCUICPrincipality.v
@@ -741,12 +741,12 @@ Proof.
     constructor. apply eq_term_empty_leq_term in eqty.
     now eapply leq_term_empty_leq_term.
 
-  - epose proof (type_Prim _ _ _ _ _ X H H0 X0 X1). eapply validity in X5.
-    depelim X2; depelim X4; depelim o.
+  - epose proof (type_Prim _ _ _ _ _ X H H0 H1 X0). eapply validity in X4.
+    depelim X1; depelim X3; depelim o.
     1-2:econstructor; tea.
-    depelim X1. destruct X5 as [s ?].
+    depelim X0. destruct X4 as [s ?].
     econstructor; tea.
-    eapply inversion_Prim in X3 as [prim_ty' [cdecl' []]]; eauto.
+    eapply inversion_Prim in X2 as [prim_ty' [cdecl' []]]; eauto.
     rewrite e2 in H. noconf H.
     unshelve eapply declared_constant_to_gen in H0, d; tea.
     pose proof (declared_constant_inj _ _ H0 d). subst cdecl'.

--- a/pcuic/theories/PCUICProgress.v
+++ b/pcuic/theories/PCUICProgress.v
@@ -579,7 +579,7 @@ Proof.
   intros hdecl hb.
   induction args => //.
   destruct prim as [? []]; cbn in *; intros sp; destruct hb; simp prim_type in *.
-  1-2:destruct a0; eapply (typing_spine_axiom _ _ _ _ []) in sp; tea.
+  1-2:eapply (typing_spine_axiom _ _ _ _ []) in sp; tea.
   eapply (typing_spine_axiom _ _ _ _ [array_type a0]) in sp; tea.
 Qed.
 

--- a/pcuic/theories/PCUICSR.v
+++ b/pcuic/theories/PCUICSR.v
@@ -3075,21 +3075,21 @@ Proof.
     * apply conv_cumul, conv_sym. destruct disj as [<-|[_ eq]].
       reflexivity. noconf eq. rewrite H4; reflexivity.
 
-  - eapply OnOne2_prod_inv in X3 as [X3 _].
-    destruct X. depelim X1. depelim X2.
+  - eapply OnOne2_prod_inv in X2 as [X2 _].
+    destruct X. depelim X0. depelim X1.
     Transparent prim_type.
     eapply (type_Prim _ _ (primArray; primArrayModel (set_array_value arr value))); tea.
     constructor; cbn; eauto.
     solve_all.
     eapply OnOne2_All_All; tea; cbn; intuition eauto.
 
-  - destruct X. depelim X1. depelim X2.
+  - destruct X. depelim X0. depelim X1.
     Transparent prim_type.
     eapply (type_Prim _ _ (primArray; primArrayModel (set_array_default arr def))); tea.
     constructor; cbn; eauto.
 
-  - pose proof (type_Prim _ _ _ _ _ wfΓ heq_primitive_constant H0 X0 X1). eapply validity in X4.
-    destruct X. depelim X1. depelim X2.
+  - pose proof (type_Prim _ _ _ _ _ wfΓ heq_primitive_constant H0 H1 X0). eapply validity in X3.
+    destruct X. depelim X0. depelim X1.
     eapply (type_ws_cumul_pb (pb:=Conv)); tea.
     eapply (type_Prim _ _ (primArray; primArrayModel (set_array_type arr ty))); tea.
     constructor; cbn; eauto.

--- a/pcuic/theories/PCUICValidity.v
+++ b/pcuic/theories/PCUICValidity.v
@@ -399,11 +399,11 @@ Section Validity.
       eapply nth_error_all in X0 as [s Hs]; pcuic.
 
     - (* Primitive *)
-      depelim X1; depelim X2; simp prim_type; cbn in *.
-      1-2:destruct X0 as [s [hty hbod huniv]]; exists s@[[]]; change (tSort s@[[]]) with (tSort s)@[[]];
+      depelim X0; depelim X1; simp prim_type; cbn in *.
+      1-2:destruct H1 as [hty hbod huniv]; exists (Universe.type0)@[[]]; change (tSort (Universe.type0)@[[]]) with (tSort Universe.type0)@[[]];
           rewrite -hty; refine (type_Const _ _ _ [] _ wfΓ H0 _); rewrite huniv //.
       set (s := (Universe.make (array_level a))).
-      destruct X0 as [hty' hbod huniv].
+      destruct H1 as [hty' hbod huniv].
       exists s.
       eapply (type_App _ _ _ _ _ (tSort s)); tea; cycle 1.
       + eapply (type_Const _ _ _ [array_level a]) in H0; tea. rewrite hty' in H0. cbn in H0. exact H0.

--- a/pcuic/theories/PCUICWfUniverses.v
+++ b/pcuic/theories/PCUICWfUniverses.v
@@ -1250,9 +1250,9 @@ Qed.
       simpl in X0. now move: X0 => [s [Hty /andP[wfty _]]].
 
     - apply/andP; split; eauto.
-      destruct X2; cbn => //.
+      destruct X1; cbn => //.
       rtoProp; intuition eauto. solve_all.
-      destruct X2; cbn => //.
+      destruct X1; cbn => //.
       simp prim_type. cbn. rtoProp; intuition.
   Qed.
 

--- a/pcuic/theories/Typing/PCUICClosedTyp.v
+++ b/pcuic/theories/Typing/PCUICClosedTyp.v
@@ -297,7 +297,7 @@ Proof.
     Unshelve. all:eauto.
 
   - destruct p as [[] pv]; cbn in X0 |- *; simp prim_type => //.
-    depelim pv. simp prim_type. cbn. depelim X2.
+    depelim pv. simp prim_type. cbn. depelim X1.
     move/andP: hdef => [] -> ->; rewrite !andb_true_r. split => //.
     solve_all.
 Qed.

--- a/pcuic/theories/Typing/PCUICContextConversionTyp.v
+++ b/pcuic/theories/Typing/PCUICContextConversionTyp.v
@@ -292,7 +292,7 @@ Proof.
       intros d' Ht.
       apply infer_typing_sort_impl with id Ht; now intros [_ IH'].
   - econstructor; tea.
-    depelim X2; constructor; eauto. solve_all.
+    depelim X1; constructor; eauto. solve_all.
   - econstructor; eauto. pose proof (wf_local_closed_context wfΓ).
     pose proof (type_closed (forall_Γ' _ X5 X6)). eapply (@closedn_on_free_vars xpred0) in H0.
     pose proof (subject_closed (forall_Γ'0 _ X5 X6)). eapply (@closedn_on_free_vars xpred0) in H1.

--- a/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
+++ b/pcuic/theories/Typing/PCUICUnivSubstitutionTyp.v
@@ -397,7 +397,7 @@ Proof using Type.
     + now rewrite subst_instance_prim_val_tag.
     + exact H0.
     + now rewrite subst_instance_prim_val_tag.
-    + destruct p as [? []]; depelim X2; constructor; eauto.
+    + destruct p as [? []]; depelim X1; constructor; eauto.
       * rewrite -subst_instance_univ_make. eapply wf_universe_subst_instance => //.
       * cbn -[Universe.make] in hty.
         specialize (hty u univs). rewrite subst_instance_univ_make in hty. now eapply hty.

--- a/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
+++ b/pcuic/theories/Typing/PCUICWeakeningEnvTyp.v
@@ -130,7 +130,7 @@ Proof.
     + eapply (All_impl X1); intros d X.
       apply (lift_typing_impl X); now intros ? [].
   - econstructor; eauto with extends.
-    destruct X2; constructor; eauto with extends.
+    destruct X1; constructor; eauto with extends.
     * now eapply extends_wf_universe.
     * solve_all.
   - econstructor. 1: eauto.

--- a/pcuic/theories/utils/PCUICPrimitive.v
+++ b/pcuic/theories/utils/PCUICPrimitive.v
@@ -44,6 +44,10 @@ Definition prim_val term := ∑ t : prim_tag, prim_model term t.
 Definition prim_val_tag {term} (s : prim_val term) := s.π1.
 Definition prim_val_model {term} (s : prim_val term) : prim_model term (prim_val_tag s) := s.π2.
 
+Definition prim_int {term} i : prim_val term := (primInt; primIntModel i).
+Definition prim_float {term} f : prim_val term := (primFloat; primFloatModel f).
+Definition prim_array {term} a : prim_val term := (primArray; primArrayModel a).
+
 Definition prim_model_val {term} (p : prim_val term) : prim_model_of term (prim_val_tag p) :=
   match prim_val_model p in prim_model _ t return prim_model_of term t with
   | primIntModel i => i

--- a/safechecker/theories/PCUICTypeChecker.v
+++ b/safechecker/theories/PCUICTypeChecker.v
@@ -1316,32 +1316,30 @@ Section Typecheck.
   Equations? check_primitive_invariants (p : prim_tag) (decl : constant_body) : typing_result_comp (primitive_invariants p decl) :=
    | primInt | decl :=
       check_eq_true (eqb decl.(cst_body) None) (Msg "primitive type is registered to a defined constant") ;;
-      check_eq_true (eqb decl.(cst_universes) Monomorphic_ctx) (Msg "primitive type is registered to a polymorphic constant") ;;
-      check_eq_true (isSort decl.(cst_type)) (Msg "primitive type is registered to an axiom whose type is not a sort") ;;
+      check_eq_true (eqb decl.(cst_universes) Monomorphic_ctx) (Msg "primitive type is registered to a non-monomorphic constant") ;;
+      check_eq_true (eqb decl.(cst_type) (tSort Universe.type0)) (Msg "primitive type for integers is registered to an axiom whose type is not the sort Set") ;;
       ret _
    | primFloat | decl :=
       check_eq_true (eqb decl.(cst_body) None) (Msg "primitive type is registered to a defined constant") ;;
-      check_eq_true (eqb decl.(cst_universes) Monomorphic_ctx) (Msg "primitive type is registered to a polymorphic constant") ;;
-      check_eq_true (isSort decl.(cst_type)) (Msg "primitive type is registered to an axiom whose type is not a sort") ;;
+      check_eq_true (eqb decl.(cst_universes) Monomorphic_ctx) (Msg "primitive type for floats is registered to non-monomorphic constant") ;;
+      check_eq_true (eqb decl.(cst_type) (tSort Universe.type0)) (Msg "primitive type for floats is registered to an axiom whose type is not the sort Set") ;;
       ret _
    | primArray | decl :=
       let s := Universe.make (Level.lvar 0) in
       check_eq_true (eqb decl.(cst_body) None) (Msg "primitive type is registered to a defined constant") ;;
-      check_eq_true (eqb decl.(cst_universes) (Polymorphic_ctx array_uctx)) (Msg "primitive type is registered to a polymorphic constant") ;;
+      check_eq_true (eqb decl.(cst_universes) (Polymorphic_ctx array_uctx)) (Msg "primitive type is registered to a monomorphic constant") ;;
       check_eq_true (eqb decl.(cst_type) (tImpl (tSort s) (tSort s))) (Msg "primitive type for arrays is registered to an axiom whose type is not of shape Type -> Type") ;;
       ret _.
   Proof.
     all:try eapply eqb_eq in i.
     all:try apply eqb_eq in i0.
-    - destruct (cst_type decl) => //. now exists u.
-    - destruct X1 as []. rewrite H in absurd; eauto.
-    - destruct X1 as []. apply absurd. now rewrite H1; apply eqb_refl.
-    - destruct X1 as []. apply absurd; rewrite H0; apply eqb_refl.
-    - destruct (cst_type decl) => //. now exists u.
-    - destruct X1 as []. rewrite H in absurd; eauto.
-    - destruct X1 as []. apply absurd. now rewrite H1; apply eqb_refl.
-    - destruct X1 as []. apply absurd; rewrite H0; apply eqb_refl.
-    - destruct (cst_type decl) => //. split => //. now apply eqb_eq in i1.
+    all:try apply eqb_eq in i1 => //.
+    - destruct H as []. rewrite H in absurd; eauto.
+    - destruct H as []. apply absurd. now rewrite H1; apply eqb_refl.
+    - destruct H as []. apply absurd; rewrite H0; apply eqb_refl.
+    - destruct H as []. rewrite H in absurd; eauto.
+    - destruct H as []. apply absurd. now rewrite H1; apply eqb_refl.
+    - destruct H as []. apply absurd; rewrite H0; apply eqb_refl.
     - destruct H as []. rewrite H in absurd; eauto.
     - destruct H as []. apply absurd. now rewrite H1; apply eqb_refl.
     - destruct H as []. apply absurd; rewrite H0; apply eqb_refl.

--- a/template-coq/theories/WcbvEval.v
+++ b/template-coq/theories/WcbvEval.v
@@ -84,7 +84,9 @@ Definition atom t :=
   | tCoFix _ _
   | tLambda _ _ _
   | tSort _
-  | tProd _ _ _ => true
+  | tProd _ _ _
+  | tInt _
+  | tFloat _ => true
   | _ => false
   end.
 
@@ -122,6 +124,12 @@ Definition isCoFix t :=
 Definition isConstruct t :=
   match t with
   | tConstruct _ _ _ => true
+  | _ => false
+  end.
+
+Definition isPrim t :=
+  match t with
+  | tInt _ | tFloat _ | tArray _ _ _ _ => true
   | _ => false
   end.
 
@@ -260,7 +268,7 @@ Section Wcbv.
   | eval_app_cong f f' a a' :
       ~~ isApp f -> a <> [] -> (* This ensures eval only applies to well-formed terms *)
       eval f f' ->
-      ~~ (isLambda f' || isFixApp f' || isArityHead f' || isConstructApp f') ->
+      ~~ (isLambda f' || isFixApp f' || isArityHead f' || isConstructApp f' || isPrim f') ->
       All2 eval a a' ->
       eval (tApp f a) (mkApps f' a')
 
@@ -270,6 +278,11 @@ Section Wcbv.
   (*     Forall2 eval l l' -> *)
   (*     eval (tEvar n l) (tEvar n l') *)
 
+  | eval_tArray u v v' def def' ty ty' :
+    eval def def' ->
+    eval ty ty' ->
+    All2 eval v v' ->
+    eval (tArray u v def ty) (tArray u v' def' ty')
 
   (** Atoms are values (includes abstractions, cofixpoints and constructors
       along with type constructors) *)
@@ -365,11 +378,19 @@ Section Wcbv.
       (forall f f' a a',
           ~~ isApp f -> a <> [] ->
           eval f f' -> P f f' ->
-          ~~ (isLambda f' || isFixApp f' || isArityHead f' || isConstructApp f') ->
+          ~~ (isLambda f' || isFixApp f' || isArityHead f' || isConstructApp f' || isPrim f') ->
           All2 eval a a' -> All2 P a a' -> P (tApp f a) (mkApps f' a')) ->
-      (forall t : term, atom t -> P t t) -> forall t t0 : term, eval t t0 -> P t t0.
+
+      (forall u v v' def def' ty ty',
+          eval def def' -> P def def' ->
+          eval ty ty' -> P ty ty' ->
+          All2 eval v v' -> All2 P v v' ->
+          P (tArray u v def ty) (tArray u v' def' ty')) ->
+      (forall t : term, atom t -> P t t) ->
+
+      forall t t0 : term, eval t t0 -> P t t0.
   Proof.
-    intros P Hbeta Hlet Hcst Hcase Hproj Hfix Hstuckfix Hcofixcase Hcofixproj Happcstr Happcong Hatom.
+    intros P Hbeta Hlet Hcst Hcase Hproj Hfix Hstuckfix Hcofixcase Hcofixproj Happcstr Happcong Harr Hatom.
     fix eval_evals_ind 3. destruct 1;
              try solve [match goal with [ H : _ |- _ ] =>
                              match type of H with
@@ -390,6 +411,8 @@ Section Wcbv.
       revert args args' a. fix aux 3; destruct 1; constructor; auto.
     - eapply Happcong; auto. clear i0 n.
       revert a a' a0. fix aux 3; destruct 1; constructor; auto.
+    - eapply Harr; eauto.
+      exact (map_All2 eval_evals_ind a).
   Defined.
 
   (** Characterization of values for this reduction relation.
@@ -399,7 +422,6 @@ Section Wcbv.
       This ensures that constructors cannot be overapplied.
 
    *)
-
 
   Variant value_head (nargs : nat) : term -> Type :=
   | value_head_cstr ind c u mdecl idecl cdecl :
@@ -414,22 +436,30 @@ Section Wcbv.
     value_head nargs (tFix mfix idx).
   Derive Signature NoConfusion for value_head.
 
+  Inductive atomic_value (value : term -> Type) : term -> Type :=
+  | atomic_atom t : atom t -> atomic_value value t
+  | atomic_array u v def ty : All value v -> value def -> value ty -> atomic_value value (tArray u v def ty).
+  Derive Signature NoConfusion for atomic_value.
+
   Inductive value : term -> Type :=
-  | value_atom t : atom t -> value t
+  | value_atom t : atomic_value value t -> value t
   | value_app f args : value_head #|args| f -> args <> [] -> All value args -> value (mkApps f args).
   Derive Signature for value.
 
+  Notation atomic := (atomic_value value).
+
   Lemma value_values_ind : forall P : term -> Type,
       (forall t, atom t -> P t) ->
+      (forall u v def ty, All value v -> All P v -> value def -> P def -> value ty -> P ty -> P (tArray u v def ty)) ->
       (forall f args, value_head #|args| f -> args <> [] -> All value args -> All P args -> P (mkApps f args)) ->
       forall t : term, value t -> P t.
   Proof.
-    intros P ??.
+    intros P ???.
     fix value_values_ind 2. destruct 1.
-    - apply X; auto.
-    - eapply X0; auto; tea.
-      clear v n. revert args a. fix aux 2. destruct 1. constructor; auto.
-      constructor. now eapply value_values_ind. now apply aux.
+    - destruct a.
+      * apply X; auto.
+      * apply X0; eauto. eapply make_All_All; tea.
+    - eapply X1; auto; tea. eapply make_All_All; tea.
   Defined.
 
   Lemma value_head_nApp {nargs t} : value_head nargs t -> ~~ isApp t.
@@ -447,12 +477,16 @@ Section Wcbv.
   Lemma value_mkApps_inv t l :
     ~~ isApp t ->
     value (mkApps t l) ->
-    ((l = []) × atom t) + ([× l <> [], value_head #|l| t & All value l]).
+    ((l = []) × atomic t) +
+    ([× l <> [], value_head #|l| t & All value l]).
   Proof using Type.
     intros H H'. generalize_eq x (mkApps t l).
     revert t H. induction H' using value_values_ind.
     intros. subst.
-    - now eapply atom_mkApps in H.
+    - eapply atom_mkApps in H.
+      left. intuition auto. now constructor.
+    - intros. left. destruct l using rev_case; cbn in H0. subst t.
+      split => //. constructor 2; auto. solve_discr'. elim (app_tip_nil l x). congruence.
     - intros * isapp appeq. move: (value_head_nApp X) => Ht.
       right.
       apply mkApps_eq_inj in appeq => //. intuition subst; auto => //.
@@ -507,7 +541,7 @@ Section Wcbv.
 
     - apply All2_right in X0.
       destruct (is_nil (fixargsv ++ argsv)).
-      { rewrite e /=. now apply value_atom. }
+      { rewrite e /=. now apply value_atom; constructor. }
       eapply value_app => //.
       + econstructor; tea.
       + apply All_app_inv => //.
@@ -520,9 +554,8 @@ Section Wcbv.
 
     - eapply All2_right in X0.
       depelim IHeve.
-      destruct t; simpl in * |- *; try congruence.
-      eapply value_app => //. now constructor. now eapply All2_nil.
-      eapply value_app => //. now constructor. now eapply All2_nil.
+      destruct t; simpl in * |- *; try depelim a0; cbn in *; try congruence;
+        try solve [eapply value_app => //; [now constructor|now eapply All2_nil]].
       rewrite -mkApps_app. eapply value_app.
       rewrite !negb_or in H1.
       pose proof (value_head_nApp v).
@@ -534,6 +567,8 @@ Section Wcbv.
       * rewrite /isFixApp /= in H1. rtoProp; intuition auto.
       * eapply All2_nil in X; tea. destruct args; cbn; congruence.
       * eapply All_app_inv; tea.
+    - eapply All2_right in X0. constructor. constructor 2; auto.
+    - now do 2 constructor.
   Qed.
 
   Lemma value_head_spec n t :
@@ -556,6 +591,7 @@ Section Wcbv.
   Proof using Type.
     induction 1 using value_values_ind; simpl; auto using value.
     - now constructor.
+    - constructor; eauto. eapply All_All2; tea; eauto.
     - assert (All2 eval args args).
       { clear -X1; induction X1; constructor; auto. }
       destruct X.

--- a/template-coq/theories/WcbvEval.v
+++ b/template-coq/theories/WcbvEval.v
@@ -278,11 +278,10 @@ Section Wcbv.
   (*     Forall2 eval l l' -> *)
   (*     eval (tEvar n l) (tEvar n l') *)
 
-  | eval_tArray u v v' def def' ty ty' :
+  | eval_tArray u v v' def def' ty :
     eval def def' ->
-    eval ty ty' ->
     All2 eval v v' ->
-    eval (tArray u v def ty) (tArray u v' def' ty')
+    eval (tArray u v def ty) (tArray u v' def' ty)
 
   (** Atoms are values (includes abstractions, cofixpoints and constructors
       along with type constructors) *)
@@ -381,11 +380,10 @@ Section Wcbv.
           ~~ (isLambda f' || isFixApp f' || isArityHead f' || isConstructApp f' || isPrim f') ->
           All2 eval a a' -> All2 P a a' -> P (tApp f a) (mkApps f' a')) ->
 
-      (forall u v v' def def' ty ty',
+      (forall u v v' def def' ty,
           eval def def' -> P def def' ->
-          eval ty ty' -> P ty ty' ->
           All2 eval v v' -> All2 P v v' ->
-          P (tArray u v def ty) (tArray u v' def' ty')) ->
+          P (tArray u v def ty) (tArray u v' def' ty)) ->
       (forall t : term, atom t -> P t t) ->
 
       forall t t0 : term, eval t t0 -> P t t0.
@@ -438,7 +436,7 @@ Section Wcbv.
 
   Inductive atomic_value (value : term -> Type) : term -> Type :=
   | atomic_atom t : atom t -> atomic_value value t
-  | atomic_array u v def ty : All value v -> value def -> value ty -> atomic_value value (tArray u v def ty).
+  | atomic_array u v def ty : All value v -> value def -> atomic_value value (tArray u v def ty).
   Derive Signature NoConfusion for atomic_value.
 
   Inductive value : term -> Type :=
@@ -450,7 +448,7 @@ Section Wcbv.
 
   Lemma value_values_ind : forall P : term -> Type,
       (forall t, atom t -> P t) ->
-      (forall u v def ty, All value v -> All P v -> value def -> P def -> value ty -> P ty -> P (tArray u v def ty)) ->
+      (forall u v def ty, All value v -> All P v -> value def -> P def -> P (tArray u v def ty)) ->
       (forall f args, value_head #|args| f -> args <> [] -> All value args -> All P args -> P (mkApps f args)) ->
       forall t : term, value t -> P t.
   Proof.

--- a/template-pcuic/theories/PCUICToTemplateCorrectness.v
+++ b/template-pcuic/theories/PCUICToTemplateCorrectness.v
@@ -2374,11 +2374,11 @@ Proof.
   - cbn. destruct p as [? []]; simp prim_type; cbn; econstructor; eauto.
     1,3,5: eapply trans_declared_constant; tea.
     all:cbn in *.
-    all:move: X0; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
-    1-2:intros [s []]; exists s; split => //;
+    all:move: H1; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
+    1-2:intros []; split => //;
     destruct cdecl as [ty [?|] ?]; cbn in *; subst; auto => //.
     intros []; split => //. rewrite H1 //. rewrite H2 //.
-    all:depelim X2; eauto. intros _. solve_all.
+    all:depelim X1; eauto. intros _. solve_all.
   - eapply TT.type_Conv.
     + eassumption.
     + eassumption.

--- a/template-pcuic/theories/TemplateToPCUICCorrectness.v
+++ b/template-pcuic/theories/TemplateToPCUICCorrectness.v
@@ -2473,16 +2473,16 @@ Proof.
     econstructor; cbn; eauto.
     + rewrite trans_env_retroknowledge //.
     + now apply forall_decls_declared_constant.
-    + move: X0; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
-      intros [s []]; exists s; split => //;
+    + move: H1; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
+      intros []; split => //;
       destruct cdecl as [ty [?|] ?]; cbn in *; subst; auto => //.
     + constructor.
   - cbn. replace (tConst prim_ty []) with (prim_type (primFloat; primFloatModel p) prim_ty) by now simp prim_type.
     econstructor; cbn; eauto.
     + rewrite trans_env_retroknowledge //.
     + now apply forall_decls_declared_constant.
-    + move: X0; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
-      intros [s []]; exists s; split => //;
+    + move: H1; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
+      intros []; split => //;
       destruct cdecl as [ty [?|] ?]; cbn in *; subst; auto => //.
     + constructor.
   - cbn. set (a := {| array_level := _ |}).
@@ -2490,17 +2490,17 @@ Proof.
     econstructor; cbn; eauto.
     + rewrite trans_env_retroknowledge //.
     + now apply forall_decls_declared_constant.
-    + move: X0; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
+    + move: H1; rewrite /Ast.Env.primitive_invariants /primitive_invariants.
       intros []; split => //; eauto.
       * apply forall_decls_declared_constant in H0; eauto.
         rewrite /trans_constant_body in H0 |- *.
         now rewrite H1 H2 H3 /= in H0 |- *.
       * rewrite /trans_constant_body in H0 |- *.
         now rewrite H1 H2 H3 /= in H0 |- *.
-    + constructor; eauto. cbn [array_level a]. eapply validity in X2; eauto.
-      eapply PCUICWfUniverses.isType_wf_universes in X2. cbn [trans PCUICWfUniverses.wf_universes] in X2.
-      unfold PCUICWfUniverses.wf_universes in X2. cbn [PCUICWfUniverses.on_universes] in X2.
-      move: X2. case: PCUICWfUniverses.wf_universe_reflect => //; eauto. eauto.
+    + constructor; eauto. cbn [array_level a]. eapply validity in X1; eauto.
+      eapply PCUICWfUniverses.isType_wf_universes in X1. cbn [trans PCUICWfUniverses.wf_universes] in X1.
+      unfold PCUICWfUniverses.wf_universes in X1. cbn [PCUICWfUniverses.on_universes] in X1.
+      move: X1. case: PCUICWfUniverses.wf_universe_reflect => //; eauto. eauto.
       cbn [a array_value]. solve_all.
   - assert (WfAst.wf Σ B).
     { now apply typing_wf in X2. }

--- a/template-pcuic/theories/TemplateToPCUICWcbvEval.v
+++ b/template-pcuic/theories/TemplateToPCUICWcbvEval.v
@@ -565,6 +565,7 @@ Proof.
     eapply All2_All_mix_left in X0; tea.
     eapply All2_All_right; tea; cbv beta; intuition auto.
 
+  - wf_inv wf [[] ?]. constructor; eauto. solve_all.
   - auto.
 Qed.
 
@@ -576,7 +577,7 @@ Lemma value_mkApps_tFix Σ mfix idx args rarg fn :
 Proof.
   intros hc hargs vargs.
   destruct (WcbvEval.is_nil args).
-  - subst args. constructor => //.
+  - subst args. do 2 constructor => //.
   - eapply value_app => //. econstructor; tea.
 Qed.
 
@@ -782,7 +783,8 @@ Proof.
     { eapply All_map, All2_All_right; tea; cbv beta; intuition auto. now eapply eval_to_value. }
     move: H1. rewrite !negb_or.
     eapply WcbvEval.eval_to_value in ev.
-    destruct ev. destruct t => //.
+    destruct ev.
+    depelim a1. destruct t => //. now cbn.
     pose proof (WcbvEval.value_head_nApp _ v).
     rewrite trans_mkApps isFixApp_mkApps WcbvEval.isFixApp_mkApps // WcbvEval.isConstructApp_mkApps //.
     pose proof (WcbvEval.value_head_spec _ _ _ v).
@@ -796,6 +798,10 @@ Proof.
     rewrite isConstructApp_mkApps //.
     rewrite isPrimApp_mkApps //.
 
-  - eapply eval_atom.
-    destruct t => //.
+  - eapply eval_prim. wf_inv wf [[] ?].
+    constructor; eauto. solve_all.
+  - destruct t; cbn in H => //=;
+    try solve [eapply eval_atom; eauto].
+    eapply eval_prim; repeat constructor.
+    eapply eval_prim; repeat constructor.
 Qed.

--- a/utils/theories/All_Forall.v
+++ b/utils/theories/All_Forall.v
@@ -3813,6 +3813,14 @@ Proof.
     + now eapply H.
 Qed.
 
+Section map_All2.
+  Context {A B} {P Q : A -> B -> Type} (f : forall {x y}, P x y -> Q x y).
+
+  Equations map_All2 {l l'} (a : All2 P l l') : All2 Q l l' :=
+  | All2_nil := All2_nil
+  | All2_cons hd tl := All2_cons (f _ _ hd) (map_All2 tl).
+End map_All2.
+
 Lemma All2_map2_left {A B C D E} {P : E -> A -> Type} Q (R : B -> D -> Type) {f : B -> C -> E} {l l' l'' l'''} :
   All2 R l l''' ->
   All2 Q l' l'' ->


### PR DESCRIPTION
This adds evaluation of primitive terms to all the evaluation relations and proves correctness of erasure and all the compilation phases, i.e. they preserve evaluation of primitives. We still do not give semantics to primitive operations though, only explicit values are handled. An array is evaluated when its default value and list of values are evaluated, cbv-style.