### PR TITLE
Primitive flags

### DIFF
--- a/erasure/theories/EConstructorsAsBlocks.v
+++ b/erasure/theories/EConstructorsAsBlocks.v
@@ -87,6 +87,7 @@ Section transform_blocks.
 
   End Def.
 
+  #[universes(polymorphic)]
   Hint Rewrite @map_primIn_spec @map_InP_spec : transform_blocks.
 
   Arguments eqb : simpl never.
@@ -428,6 +429,7 @@ Section transform_blocks.
 
 End transform_blocks.
 
+#[universes(polymorphic)]
 Global Hint Rewrite @map_primIn_spec @map_InP_spec : transform_blocks.
 
 Definition transform_blocks_constant_decl Σ cb :=

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -100,6 +100,7 @@ Section isEtaExp.
 
 End isEtaExp.
 
+#[universes(polymorphic)]
 Global Hint Rewrite @test_primIn_spec @forallb_InP_spec : isEtaExp.
 Tactic Notation "simp_eta" "in" hyp(H) := simp isEtaExp in H; rewrite -?isEtaExp_equation_1 in H.
 Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -334,7 +334,7 @@ Section isEtaExp.
   Qed.
 
   Hint Rewrite @forallb_InP_spec : isEtaExp.
-  Hint Rewrite @test_primIn_spec : isEtaExp.
+  #[universes(polymorphic)] Hint Rewrite @test_primIn_spec : isEtaExp.
 
   Lemma isEtaExp_mkApps_nonnil Γ f v :
     ~~ isApp f -> v <> [] ->
@@ -773,7 +773,7 @@ Section isEtaExp.
 
 End isEtaExp.
 Global Hint Rewrite @forallb_InP_spec : isEtaExp.
-Global Hint Rewrite @test_primIn_spec : isEtaExp.
+#[universes(polymorphic)] Global Hint Rewrite @test_primIn_spec : isEtaExp.
 
 Tactic Notation "simp_eta" "in" hyp(H) := simp isEtaExp in H; rewrite -?isEtaExp_equation_1 in H.
 Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.

--- a/erasure/theories/EImplementBox.v
+++ b/erasure/theories/EImplementBox.v
@@ -67,6 +67,7 @@ Section implement_box.
 
   End Def.
 
+  #[universes(polymorphic)]
   Hint Rewrite @map_primIn_spec @map_InP_spec : implement_box.
 
   Arguments eqb : simpl never.
@@ -265,6 +266,7 @@ Section implement_box.
 
 End implement_box.
 
+#[universes(polymorphic)]
 Global Hint Rewrite @map_primIn_spec @map_InP_spec : implement_box.
 
 Definition implement_box_constant_decl cb :=

--- a/erasure/theories/EImplementBox.v
+++ b/erasure/theories/EImplementBox.v
@@ -672,7 +672,7 @@ Proof.
     rewrite lookup_constructor_implement_box; eauto.
     eapply All2_All2_Set.
     solve_all. now destruct b.
-  - intros H; depelim H; simp implement_box; repeat constructor.
+  - intros wf H; depelim H; simp implement_box; repeat constructor.
     destruct a0. eapply All2_over_undep in a. eapply All2_All2_Set, All2_map.
     cbn -[implement_box]. solve_all. now destruct H. now destruct a0.
   - intros. destruct t; try solve [constructor; cbn in H, H0 |- *; try congruence].

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -166,7 +166,7 @@ Section optimize.
     - len. rtoProp; solve_all. solve_all.
       now eapply isLambda_optimize. solve_all.
     - len. rtoProp; repeat solve_all.
-    - rewrite test_prim_map. solve_all.
+    - rewrite test_prim_map. rtoProp; intuition eauto; solve_all.
   Qed.
 
   Lemma optimize_csubst {a k b} n :
@@ -716,11 +716,12 @@ Proof.
         rewrite optimize_mkApps !isConstructApp_mkApps !isPrimApp_mkApps.
         destruct args using rev_case => // /=. rewrite map_app !mkApps_app /= //.
         destruct v => /= //.
-  - depelim X; repeat constructor.
+  - intros; rtoProp; intuition eauto.
+    depelim X; repeat constructor.
     eapply All2_over_undep in a.
     eapply All2_Set_All2 in ev. eapply All2_All2_Set. primProp.
-    subst a0 a'; cbn in *. depelim H; cbn in *. intuition auto; solve_all.
-    primProp; depelim H; intuition eauto.
+    subst a0 a'; cbn in *. depelim H0; cbn in *. intuition auto; solve_all.
+    primProp; depelim H0; intuition eauto.
   - destruct t => //.
     all:constructor; eauto.
     cbn [atom optimize] in i |- *.

--- a/erasure/theories/EPrimitive.v
+++ b/erasure/theories/EPrimitive.v
@@ -7,184 +7,194 @@ From Equations Require Import Equations.
 From Coq Require Import ssreflect Utf8.
 From Coq Require Import Uint63 SpecFloat.
 
-Implicit Type term : Set.
+Set Universe Polymorphism.
 
-Record array_model {term : Set} : Set :=
+Section PrimModel.
+  Universe i.
+  Context {term : Type@{i}}.
+
+  Record array_model : Type@{i} :=
   { array_default : term;
     array_value : list term }.
-Derive NoConfusion for array_model.
+  Derive NoConfusion for array_model.
+  Arguments array_model : clear implicits.
+
+  #[global]
+  Instance array_model_eqdec (e : EqDec term) : EqDec array_model.
+  Proof. eqdec_proof. Qed.
+
+  (* We use this inductive definition instead of the more direct case analysis
+    [prim_model_of] so that [prim_model] can be used in the inductive definition
+    of terms, otherwise it results in a non-strictly positive definition.
+    *)
+  Inductive prim_model : prim_tag -> Type@{i} :=
+  | primIntModel (i : PrimInt63.int) : prim_model primInt
+  | primFloatModel (f : PrimFloat.float) : prim_model primFloat
+  | primArrayModel (a : array_model) : prim_model primArray.
+
+  Derive Signature NoConfusion NoConfusionHom for prim_model.
+
+  Definition prim_model_of (p : prim_tag) : Type@{i} :=
+    match p with
+    | primInt => PrimInt63.int
+    | primFloat => PrimFloat.float
+    | primArray => array_model
+    end.
+
+  Definition prim_val : Type@{i} := ∑ t : prim_tag, prim_model t.
+  Definition prim_val_tag (s : prim_val) := s.π1.
+  Definition prim_val_model (s : prim_val) : prim_model (prim_val_tag s) := s.π2.
+
+  Definition prim_int i : prim_val := (primInt; primIntModel i).
+  Definition prim_float f : prim_val := (primFloat; primFloatModel f).
+  Definition prim_array a : prim_val := (primArray; primArrayModel a).
+
+  Definition prim_model_val (p : prim_val) : prim_model_of (prim_val_tag p) :=
+    match prim_val_model p in prim_model t return prim_model_of t with
+    | primIntModel i => i
+    | primFloatModel f => f
+    | primArrayModel a => a
+    end.
+
+  Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) :
+    proj1_sig x = proj1_sig y -> x = y.
+  Proof.
+    destruct x as [x p], y as [y q]; simpl; intros ->.
+    now destruct (uip p q).
+  Qed.
+
+  #[global]
+  Instance reflect_eq_Z : ReflectEq Z := EqDec_ReflectEq _.
+
+  Import ReflectEq.
+
+  Local Obligation Tactic := idtac.
+
+  Definition eqb_array {eqt : term -> term -> bool} (x y : array_model) :=
+    forallb2 eqt x.(array_value) y.(array_value) &&
+    eqt x.(array_default) y.(array_default).
+
+  #[program,global]
+  Instance reflect_eq_array {req : ReflectEq term}: ReflectEq (array_model) :=
+    { eqb := eqb_array (eqt := eqb) }.
+  Next Obligation.
+    intros req [] []; cbn. unfold eqb_array. cbn.
+    change (forallb2 eqb) with (eqb (A := list term)).
+    case: eqb_spec => //=. intros ->.
+    case: eqb_spec => //=. intros ->. constructor; auto.
+    all:constructor; congruence.
+  Qed.
+
+  Equations eqb_prim_model {req : term -> term -> bool} {t : prim_tag} (x y : prim_model t) : bool :=
+    | primIntModel x, primIntModel y := ReflectEq.eqb x y
+    | primFloatModel x, primFloatModel y := ReflectEq.eqb x y
+    | primArrayModel x, primArrayModel y := eqb_array (eqt:=req) x y.
+
+  #[global, program]
+  Instance prim_model_reflecteq {req : ReflectEq term} {p : prim_tag} : ReflectEq (prim_model p) :=
+    {| ReflectEq.eqb := eqb_prim_model (req := eqb) |}.
+  Next Obligation.
+    intros. depelim x; depelim y; simp eqb_prim_model.
+    case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
+    case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
+    change (eqb_array a a0) with (eqb a a0).
+    case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
+  Qed.
+
+  #[global]
+  Instance prim_model_eqdec {req : ReflectEq term} : forall p : prim_tag, EqDec (prim_model p) := _.
+
+  Equations eqb_prim_val {req : term -> term -> bool} (x y : prim_val) : bool :=
+    | (primInt; i), (primInt; i') := eqb_prim_model (req := req) i i'
+    | (primFloat; f), (primFloat; f') := eqb_prim_model (req := req) f f'
+    | (primArray; a), (primArray; a') := eqb_prim_model (req := req) a a'
+    | x, y := false.
+
+  #[global, program]
+  Instance prim_val_reflect_eq {req : ReflectEq term} : ReflectEq (prim_val) :=
+    {| ReflectEq.eqb := eqb_prim_val (req := eqb) |}.
+  Next Obligation.
+    intros. funelim (eqb_prim_val x y); simp eqb_prim_val.
+    change (eqb_prim_model i i') with (eqb i i').
+    case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H. cbn in n. auto.
+    constructor. intros H; noconf H; auto.
+    constructor. intros H; noconf H; auto.
+    constructor. intros H; noconf H; auto.
+    change (eqb_prim_model f f') with (eqb f f').
+    case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H; auto.
+    constructor. intros H; noconf H; auto.
+    constructor. intros H; noconf H; auto.
+    constructor. intros H; noconf H; auto.
+    change (eqb_prim_model a a') with (eqb a a').
+    case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H; auto.
+  Qed.
+
+  #[global]
+  Instance prim_tag_model_eqdec {req : ReflectEq term} : EqDec (prim_val) := _.
+
+  (** Printing *)
+
+  Definition string_of_prim (soft : term -> string) (p : prim_val) : string :=
+    match p.π2 return string with
+    | primIntModel f => "(int: " ^ string_of_prim_int f ^ ")"
+    | primFloatModel f => "(float: " ^ string_of_float f ^ ")"
+    | primArrayModel a => "(array:" ^ soft a.(array_default) ^ " , " ^ string_of_list soft a.(array_value) ^ ")"
+    end.
+
+  Definition test_array_model (f : term -> bool) (a : array_model) : bool :=
+    f a.(array_default) && forallb f a.(array_value).
+
+  Definition test_prim (f : term -> bool) (p : prim_val) : bool :=
+    match p.π2 return bool with
+    | primIntModel f => true
+    | primFloatModel f => true
+    | primArrayModel a => test_array_model f a
+    end.
+
+  Inductive primProp P : prim_val -> Type :=
+    | primPropInt i : primProp P (primInt; primIntModel i)
+    | primPropFloat f : primProp P (primFloat; primFloatModel f)
+    | primPropArray a : P a.(array_default) × All P a.(array_value) ->
+        primProp P (primArray; primArrayModel a).
+  Derive Signature NoConfusion for primProp.
+
+  Definition fold_prim {A} (f : A -> term -> A) (p : prim_val) (acc : A) : A :=
+    match p.π2 return A with
+    | primIntModel f => acc
+    | primFloatModel f => acc
+    | primArrayModel a => fold_left f a.(array_value) (f acc a.(array_default))
+    end.
+End PrimModel.
 
 Arguments array_model : clear implicits.
-#[global]
-Instance array_model_eqdec {term} (e : EqDec term) : EqDec (array_model term).
-Proof. eqdec_proof. Qed.
+Arguments prim_val : clear implicits.
 
-(* We use this inductive definition instead of the more direct case analysis
-  [prim_model_of] so that [prim_model] can be used in the inductive definition
-  of terms, otherwise it results in a non-strictly positive definition.
-  *)
-Inductive prim_model (term : Set) : prim_tag -> Set :=
-| primIntModel (i : PrimInt63.int) : prim_model term primInt
-| primFloatModel (f : PrimFloat.float) : prim_model term primFloat
-| primArrayModel (a : array_model term) : prim_model term primArray.
+Section PrimOps.
+  Universes i j.
+  Context {term : Type@{i}} {term' : Type@{j}}.
 
-Arguments primIntModel {term}.
-Arguments primFloatModel {term}.
-Arguments primArrayModel {term}.
+  Definition map_array_model (f : term -> term') (a : array_model term) : array_model term' :=
+    {| array_default := f a.(array_default);
+      array_value := map f a.(array_value) |}.
 
-Derive Signature NoConfusion NoConfusionHom for prim_model.
-
-Definition prim_model_of (term : Set) (p : prim_tag) : Set :=
-  match p with
-  | primInt => PrimInt63.int
-  | primFloat => PrimFloat.float
-  | primArray => array_model term
-  end.
-
-Definition prim_val term : Set := ∑ t : prim_tag, prim_model term t.
-Definition prim_val_tag {term} (s : prim_val term) := s.π1.
-Definition prim_val_model {term} (s : prim_val term) : prim_model term (prim_val_tag s) := s.π2.
-
-Definition prim_int {term} i : prim_val term := (primInt; primIntModel i).
-Definition prim_float {term} f : prim_val term := (primFloat; primFloatModel f).
-Definition prim_array {term} a : prim_val term := (primArray; primArrayModel a).
-
-Definition prim_model_val {term} (p : prim_val term) : prim_model_of term (prim_val_tag p) :=
-  match prim_val_model p in prim_model _ t return prim_model_of term t with
-  | primIntModel i => i
-  | primFloatModel f => f
-  | primArrayModel a => a
-  end.
-
-Lemma exist_irrel_eq {A} (P : A -> bool) (x y : sig P) :
-  proj1_sig x = proj1_sig y -> x = y.
-Proof.
-  destruct x as [x p], y as [y q]; simpl; intros ->.
-  now destruct (uip p q).
-Qed.
-
-#[global]
-Instance reflect_eq_Z : ReflectEq Z := EqDec_ReflectEq _.
-
-Import ReflectEq.
-
-Local Obligation Tactic := idtac.
-
-Definition eqb_array {term} {eqt : term -> term -> bool} (x y : array_model term) :=
-   forallb2 eqt x.(array_value) y.(array_value) &&
-   eqt x.(array_default) y.(array_default).
-
-#[program,global]
-Instance reflect_eq_array {term} {req : ReflectEq term}: ReflectEq (array_model term) :=
-  { eqb := eqb_array (eqt := eqb) }.
-Next Obligation.
-  intros term req [] []; cbn. unfold eqb_array. cbn.
-  change (forallb2 eqb) with (eqb (A := list term)).
-  case: eqb_spec => //=. intros ->.
-  case: eqb_spec => //=. intros ->. constructor; auto.
-  all:constructor; congruence.
-Qed.
-
-Equations eqb_prim_model {term} {req : term -> term -> bool} {t : prim_tag} (x y : prim_model term t) : bool :=
-  | primIntModel x, primIntModel y := ReflectEq.eqb x y
-  | primFloatModel x, primFloatModel y := ReflectEq.eqb x y
-  | primArrayModel x, primArrayModel y := eqb_array (eqt:=req) x y.
-
-#[global, program]
-Instance prim_model_reflecteq {term} {req : ReflectEq term} {p : prim_tag} : ReflectEq (prim_model term p) :=
-  {| ReflectEq.eqb := eqb_prim_model (req := eqb) |}.
-Next Obligation.
-  intros. depelim x; depelim y; simp eqb_prim_model.
-  case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
-  case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
-  change (eqb_array a a0) with (eqb a a0).
-  case: ReflectEq.eqb_spec; constructor; subst; auto. congruence.
-Qed.
-
-#[global]
-Instance prim_model_eqdec {term} {req : ReflectEq term} : forall p : prim_tag, EqDec (prim_model term p) := _.
-
-Equations eqb_prim_val {term} {req : term -> term -> bool} (x y : prim_val term) : bool :=
-  | (primInt; i), (primInt; i') := eqb_prim_model (req := req) i i'
-  | (primFloat; f), (primFloat; f') := eqb_prim_model (req := req) f f'
-  | (primArray; a), (primArray; a') := eqb_prim_model (req := req) a a'
-  | x, y := false.
-
-#[global, program]
-Instance prim_val_reflect_eq {term} {req : ReflectEq term} : ReflectEq (prim_val term) :=
-  {| ReflectEq.eqb := eqb_prim_val (req := eqb) |}.
-Next Obligation.
-  intros. funelim (eqb_prim_val x y); simp eqb_prim_val.
-  change (eqb_prim_model i i') with (eqb i i').
-  case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H. cbn in n. auto.
-  constructor. intros H; noconf H; auto.
-  constructor. intros H; noconf H; auto.
-  constructor. intros H; noconf H; auto.
-  change (eqb_prim_model f f') with (eqb f f').
-  case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H; auto.
-  constructor. intros H; noconf H; auto.
-  constructor. intros H; noconf H; auto.
-  constructor. intros H; noconf H; auto.
-  change (eqb_prim_model a a') with (eqb a a').
-  case: ReflectEq.eqb_spec; constructor; subst; auto. intros H; noconf H; auto.
-Qed.
-
-#[global]
-Instance prim_tag_model_eqdec term {req : ReflectEq term} : EqDec (prim_val term) := _.
-
-(** Printing *)
-
-Definition string_of_prim {term} (soft : term -> string) (p : prim_val term) : string :=
-  match p.π2 return string with
-  | primIntModel f => "(int: " ^ string_of_prim_int f ^ ")"
-  | primFloatModel f => "(float: " ^ string_of_float f ^ ")"
-  | primArrayModel a => "(array:" ^ soft a.(array_default) ^ " , " ^ string_of_list soft a.(array_value) ^ ")"
-  end.
-
-Definition map_array_model {term term'} (f : term -> term') (a : array_model term) : array_model term' :=
-  {| array_default := f a.(array_default);
-     array_value := map f a.(array_value) |}.
-
-Definition map_prim {term term'} (f : term -> term') (p : prim_val term) : prim_val term' :=
-  match p.π2 return prim_val term' with
-  | primIntModel f => (primInt; primIntModel f)
-  | primFloatModel f => (primFloat; primFloatModel f)
-  | primArrayModel a => (primArray; primArrayModel (map_array_model f a))
-  end.
-
-Definition test_array_model {term} (f : term -> bool) (a : array_model term) : bool :=
-  f a.(array_default) && forallb f a.(array_value).
-
-Definition test_prim {term} (f : term -> bool) (p : prim_val term) : bool :=
-  match p.π2 return bool with
-  | primIntModel f => true
-  | primFloatModel f => true
-  | primArrayModel a => test_array_model f a
-  end.
-
-Inductive primProp {term} P : prim_val term -> Type :=
-  | primPropInt i : primProp P (primInt; primIntModel i)
-  | primPropFloat f : primProp P (primFloat; primFloatModel f)
-  | primPropArray a : P a.(array_default) × All P a.(array_value) ->
-      primProp P (primArray; primArrayModel a).
-Derive Signature NoConfusion for primProp.
-
-Definition fold_prim {A term} (f : A -> term -> A) (p : prim_val term) (acc : A) : A :=
-  match p.π2 return A with
-  | primIntModel f => acc
-  | primFloatModel f => acc
-  | primArrayModel a => fold_left f a.(array_value) (f acc a.(array_default))
-  end.
+  Definition map_prim (f : term -> term') (p : prim_val term) : prim_val term' :=
+    match p.π2 return prim_val term' with
+    | primIntModel f => (primInt; primIntModel f)
+    | primFloatModel f => (primFloat; primFloatModel f)
+    | primArrayModel a => (primArray; primArrayModel (map_array_model f a))
+    end.
+End PrimOps.
 
 Section primtheory.
-  Context {term term' term''} (g : term' -> term'') (f : term -> term') (p : prim_val term).
+  Universes i j k.
+  Context {term : Type@{i}} {term' : Type@{j}} {term'' : Type@{k}} (g : term' -> term'') (f : term -> term') (p : prim_val term).
 
-  Lemma map_prim_compose  :
-    map_prim g (map_prim f p) = map_prim (g ∘ f) p.
-  Proof.
-    destruct p as [? []]; cbn; auto.
-    do 2 f_equal. destruct a; rewrite /map_array_model //= map_map_compose //.
-  Qed.
+    Lemma map_prim_compose  :
+      map_prim g (map_prim f p) = map_prim (g ∘ f) p.
+    Proof.
+      destruct p as [? []]; cbn; auto.
+      do 2 f_equal. destruct a; rewrite /map_array_model //= map_map_compose //.
+    Qed.
 End primtheory.
 #[global] Hint Rewrite @map_prim_compose : map all.
 
@@ -200,121 +210,122 @@ Proof.
 Qed.
 
 Section primtheory.
-  Context {term} {p : prim_val term}.
+  Universe i. Context {term : Type@{i}}.
+  Context {p : prim_val term}.
 
-  Lemma map_prim_id f :
-    (forall x, f x = x) ->
-    map_prim f p = p.
-  Proof.
-    destruct p as [? []]; cbn; auto.
-    intros hf. do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto.
-    rewrite map_id_f //.
-  Qed.
+    Lemma map_prim_id f :
+      (forall x, f x = x) ->
+      map_prim f p = p.
+    Proof.
+      destruct p as [? []]; cbn; auto.
+      intros hf. do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto.
+      rewrite map_id_f //.
+    Qed.
 
-  Lemma map_prim_id_prop f P :
-    primProp P p ->
-    (forall x, P x -> f x = x) ->
-    map_prim f p = p.
-  Proof.
-    destruct p as [? []]; cbn; auto.
-    intros hp hf. do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto; depelim hp.
-    * eapply hf; intuition eauto.
-    * eapply All_map_id. destruct p0 as [_ hp].
+    Lemma map_prim_id_prop f P :
+      primProp P p ->
+      (forall x, P x -> f x = x) ->
+      map_prim f p = p.
+    Proof.
+      destruct p as [? []]; cbn; auto.
+      intros hp hf. do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto; depelim hp.
+      * eapply hf; intuition eauto.
+      * eapply All_map_id. destruct p0 as [_ hp].
+        eapply All_impl; tea.
+    Qed.
+
+    Lemma map_prim_eq {term'} {f g : term -> term'} :
+      (forall x, f x = g x) ->
+      map_prim f p = map_prim g p.
+    Proof.
+      destruct p as [? []]; cbn; auto.
+      intros hf. do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto.
+      now eapply map_ext.
+    Qed.
+
+    Lemma map_prim_eq_prop {term' P} {f g : term -> term'} :
+      primProp P p ->
+      (forall x, P x -> f x = g x) ->
+      map_prim f p = map_prim g p.
+    Proof.
+      intros hp; depelim hp; subst; cbn; auto. intros hf.
+      do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto.
+      * eapply hf; intuition eauto.
+      * destruct p0 as [_ hp].
+        eapply All_map_eq.
+        eapply All_impl; tea.
+    Qed.
+
+    Lemma test_prim_primProp P pr :
+      (forall t, reflectT (P t) (pr t)) ->
+      reflectT (primProp P p) (test_prim pr p).
+    Proof.
+      intros hr.
+      destruct p as [? []]; cbn; repeat constructor => //.
+      destruct a as []; cbn.
+      rewrite /test_array_model /=.
+      case: (hr array_default0) => //= hd.
+      - case: (reflectT_forallb hr) => hv; repeat constructor; eauto.
+        intros hp; depelim hp; intuition eauto.
+      - constructor. intros hp; depelim hp; intuition eauto.
+    Qed.
+
+    Lemma test_prim_impl_primProp pr :
+      test_prim pr p -> primProp pr p.
+    Proof.
+      case: (test_prim_primProp (fun x => pr x) pr) => //.
+      intros t; destruct (pr t); constructor; eauto.
+    Qed.
+
+    Lemma primProp_impl_test_prim (pr : term -> bool) :
+      primProp pr p -> test_prim pr p.
+    Proof.
+      case: (test_prim_primProp (fun x => pr x) pr) => //.
+      intros t; destruct (pr t); constructor; eauto. eauto.
+    Qed.
+
+    Lemma primProp_conj {P Q} : primProp P p -> primProp Q p -> primProp (fun x => P x × Q x) p.
+    Proof.
+      destruct p as [? []]; cbn; repeat constructor; intuition eauto.
+      now depelim X. now depelim X0.
+      depelim X; depelim X0.
+      now eapply All_mix.
+    Qed.
+
+    Lemma primProp_impl {P Q} : primProp P p -> (forall x, P x -> Q x) -> primProp Q p.
+    Proof.
+      intros hp hpq; destruct p as [? []]; cbn in *; intuition eauto; constructor.
+      depelim hp; intuition eauto.
       eapply All_impl; tea.
-  Qed.
+    Qed.
 
-  Lemma map_prim_eq {term'} {f g : term -> term'} :
-    (forall x, f x = g x) ->
-    map_prim f p = map_prim g p.
-  Proof.
-    destruct p as [? []]; cbn; auto.
-    intros hf. do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto.
-    now eapply map_ext.
-  Qed.
+    Lemma primProp_map {term' P} {f : term -> term'} :
+      primProp (P ∘ f) p ->
+      primProp P (map_prim f p).
+    Proof.
+      destruct p as [? []]; cbn in *; intuition eauto; constructor.
+      depelim X; intuition eauto.
+      eapply All_map, All_impl; tea. cbn; eauto.
+    Qed.
 
-  Lemma map_prim_eq_prop {term' P} {f g : term -> term'} :
-    primProp P p ->
-    (forall x, P x -> f x = g x) ->
-    map_prim f p = map_prim g p.
-  Proof.
-    intros hp; depelim hp; subst; cbn; auto. intros hf.
-    do 2 f_equal. destruct a; rewrite /map_array_model //=; f_equal; eauto.
-    * eapply hf; intuition eauto.
-    * destruct p0 as [_ hp].
-      eapply All_map_eq.
-      eapply All_impl; tea.
-  Qed.
+    Lemma test_prim_map {term' pr} {f : term -> term'} :
+      test_prim pr (map_prim f p) = test_prim (pr ∘ f) p.
+    Proof.
+      destruct p as [? []]; cbn in *; intuition auto.
+      destruct a as []; rewrite /test_array_model //=. f_equal.
+      rewrite forallb_map //.
+    Qed.
 
-  Lemma test_prim_primProp P pr :
-    (forall t, reflectT (P t) (pr t)) ->
-    reflectT (primProp P p) (test_prim pr p).
-  Proof.
-    intros hr.
-    destruct p as [? []]; cbn; repeat constructor => //.
-    destruct a as []; cbn.
-    rewrite /test_array_model /=.
-    case: (hr array_default0) => //= hd.
-    - case: (reflectT_forallb hr) => hv; repeat constructor; eauto.
-      intros hp; depelim hp; intuition eauto.
-    - constructor. intros hp; depelim hp; intuition eauto.
-  Qed.
-
-  Lemma test_prim_impl_primProp pr :
-    test_prim pr p -> primProp pr p.
-  Proof.
-    case: (test_prim_primProp (fun x => pr x) pr) => //.
-    intros t; destruct (pr t); constructor; eauto.
-  Qed.
-
-  Lemma primProp_impl_test_prim (pr : term -> bool) :
-    primProp pr p -> test_prim pr p.
-  Proof.
-    case: (test_prim_primProp (fun x => pr x) pr) => //.
-    intros t; destruct (pr t); constructor; eauto.
-  Qed.
-
-  Lemma primProp_conj {P Q} : primProp P p -> primProp Q p -> primProp (fun x => P x × Q x) p.
-  Proof.
-    destruct p as [? []]; cbn; repeat constructor; intuition eauto.
-    now depelim X. now depelim X0.
-    depelim X; depelim X0.
-    now eapply All_mix.
-  Qed.
-
-  Lemma primProp_impl {P Q} : primProp P p -> (forall x, P x -> Q x) -> primProp Q p.
-  Proof.
-    intros hp hpq; destruct p as [? []]; cbn in *; intuition eauto; constructor.
-    depelim hp; intuition eauto.
-    eapply All_impl; tea.
-  Qed.
-
-  Lemma primProp_map {term' P} {f : term -> term'} :
-    primProp (P ∘ f) p ->
-    primProp P (map_prim f p).
-  Proof.
-    destruct p as [? []]; cbn in *; intuition eauto; constructor.
-    depelim X; intuition eauto.
-    eapply All_map, All_impl; tea. cbn; eauto.
-  Qed.
-
-  Lemma test_prim_map {term' pr} {f : term -> term'} :
-    test_prim pr (map_prim f p) = test_prim (pr ∘ f) p.
-  Proof.
-    destruct p as [? []]; cbn in *; intuition auto.
-    destruct a as []; rewrite /test_array_model //=. f_equal.
-    rewrite forallb_map //.
-  Qed.
-
-  Lemma test_prim_eq_prop P pr pr' :
-    primProp P p ->
-    (forall x, P x -> pr x = pr' x) ->
-    test_prim pr p = test_prim pr' p.
-  Proof.
-    destruct p as [? []]; cbn in *; intuition auto.
-    destruct a as []; rewrite /test_array_model //=.
-    depelim X; f_equal; intuition eauto.
-    eapply All_forallb_eq_forallb; tea.
-  Qed.
+    Lemma test_prim_eq_prop P pr pr' :
+      primProp P p ->
+      (forall x, P x -> pr x = pr' x) ->
+      test_prim pr p = test_prim pr' p.
+    Proof.
+      destruct p as [? []]; cbn in *; intuition auto.
+      destruct a as []; rewrite /test_array_model //=.
+      depelim X; f_equal; intuition eauto.
+      eapply All_forallb_eq_forallb; tea.
+    Qed.
 
 End primtheory.
 
@@ -327,7 +338,7 @@ End primtheory.
 Set Equations Transparent.
 
 Section PrimIn.
-  Context {term : Set}.
+  Universe i. Context {term : Type@{i}}.
 
   Equations InPrim (x : term) (p : prim_val term) : Prop :=
     | x | (primInt; primIntModel i) := False
@@ -365,7 +376,7 @@ Section PrimIn.
     | (primArray; primArrayModel a) | f :=
       (primArray; primArrayModel
         {| array_default := f a.(array_default) (or_introl eq_refl);
-           array_value := map_InP a.(array_value) (fun x H => f x (or_intror H)) |}).
+          array_value := map_InP a.(array_value) (fun x H => f x (or_intror H)) |}).
 
   Lemma map_primIn_spec p f :
     map_primIn p (fun x _ => f x) = map_prim f p.
@@ -378,6 +389,8 @@ Section PrimIn.
 End PrimIn.
 
 #[global] Hint Rewrite @map_primIn_spec : map.
+
+Unset Universe Polymorphism.
 
 Inductive All2_Set {A B : Set} (R : A -> B -> Set) : list A -> list B -> Set :=
   All2_nil : All2_Set R [] []
@@ -438,39 +451,43 @@ Section map_All2_dep.
 
 End map_All2_dep.
 
-Inductive onPrims {term term' : Set} (R : term -> term' -> Set) : prim_val term -> prim_val term' -> Set :=
-  | onPrimsInt i : onPrims R (primInt; primIntModel i) (primInt; primIntModel i)
-  | onPrimsFloat f : onPrims R (primFloat; primFloatModel f) (primFloat; primFloatModel f)
-  | onPrimsArray v def v' def' :
-    R def def' ->
-    All2_Set R v v' ->
+Section onPrims.
+  Inductive onPrims {term term' : Set} (R : term -> term' -> Set) : prim_val term -> prim_val term' -> Type :=
+    | onPrimsInt i : onPrims R (primInt; primIntModel i) (primInt; primIntModel i)
+    | onPrimsFloat f : onPrims R (primFloat; primFloatModel f) (primFloat; primFloatModel f)
+    | onPrimsArray v def v' def' :
+      R def def' ->
+      All2_Set R v v' ->
+      let a := {| array_default := def; array_value := v |} in
+      let a' := {| array_default := def'; array_value := v' |} in
+      onPrims R (primArray; primArrayModel a) (primArray; primArrayModel a').
+  Derive Signature for onPrims.
+
+  Variant onPrims_dep {term term' : Set} (R : term -> term' -> Set) (P : forall x y, R x y -> Type) : forall x y, onPrims R x y -> Type :=
+  | onPrimsIntDep i : onPrims_dep R P (prim_int i) (prim_int i) (onPrimsInt R i)
+  | onPrimsFloatDep f : onPrims_dep R P (prim_float f) (prim_float f) (onPrimsFloat R f)
+  | onPrimsArrayDep v def v' def'
+    (ed : R def def')
+    (ev : All2_Set R v v') :
+    P _ _ ed ->
+    All2_over ev P ->
     let a := {| array_default := def; array_value := v |} in
     let a' := {| array_default := def'; array_value := v' |} in
-    onPrims R (primArray; primArrayModel a) (primArray; primArrayModel a').
-Derive Signature for onPrims.
+    onPrims_dep R P (prim_array a) (prim_array a') (onPrimsArray R v def v' def' ed ev).
+  Derive Signature for onPrims_dep.
 
-Variant onPrims_dep {term term' : Set} (R : term -> term' -> Set) (P : forall x y, R x y -> Type) : forall x y, onPrims R x y -> Type :=
-| onPrimsIntDep i : onPrims_dep R P (prim_int i) (prim_int i) (onPrimsInt R i)
-| onPrimsFloatDep f : onPrims_dep R P (prim_float f) (prim_float f) (onPrimsFloat R f)
-| onPrimsArrayDep v def v' def'
-  (ed : R def def')
-  (ev : All2_Set R v v') :
-  P _ _ ed ->
-  All2_over ev P ->
-  let a := {| array_default := def; array_value := v |} in
-  let a' := {| array_default := def'; array_value := v' |} in
-  onPrims_dep R P (prim_array a) (prim_array a') (onPrimsArray R v def v' def' ed ev).
-Derive Signature for onPrims_dep.
+  Section map_onPrims.
+    Context {term term' : Set}.
+    Context {R : term -> term' -> Set}.
+    Context {P : forall x y, R x y -> Type}.
+    Context (F : forall x y (e : R x y), P x y e).
 
-Section map_onPrims.
-  Context {term term' : Set}.
-  Context {R : term -> term' -> Set}.
-  Context {P : forall x y, R x y -> Type}.
-  Context (F : forall x y (e : R x y), P x y e).
+    Equations map_onPrims {p : prim_val term} {p' : prim_val term'} (ev : onPrims R p p') : onPrims_dep R P p p' ev :=
+    | @onPrimsInt _ _ _ _ := onPrimsIntDep _ _ i;
+    | @onPrimsFloat _ _ _ _ := onPrimsFloatDep _ _ f;
+    | @onPrimsArray v def v' def' ed ev :=
+      onPrimsArrayDep _ _ v def v' def' ed ev (F _ _ ed) (map_All2_dep _ F ev).
+  End map_onPrims.
 
-  Equations map_onPrims {p : prim_val term} {p' : prim_val term'} (ev : onPrims R p p') : onPrims_dep R P p p' ev :=
-  | @onPrimsInt _ _ _ _ := onPrimsIntDep _ _ i;
-  | @onPrimsFloat _ _ _ _ := onPrimsFloatDep _ _ f;
-  | @onPrimsArray v def v' def' ed ev :=
-    onPrimsArrayDep _ _ v def v' def' ed ev (F _ _ ed) (map_All2_dep _ F ev).
-End map_onPrims.
+End onPrims.
+

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -79,7 +79,7 @@ Section strip.
   Qed.
   End Def.
 
-  Hint Rewrite @map_primIn_spec @map_InP_spec : strip.
+  #[universes(polymorphic)] Hint Rewrite @map_primIn_spec @map_InP_spec : strip.
 
   Lemma map_repeat {A B} (f : A -> B) x n : map f (repeat x n) = repeat (f x) n.
   Proof using Type.
@@ -358,7 +358,7 @@ Section strip.
 
 End strip.
 
-Global Hint Rewrite @map_primIn_spec @map_InP_spec : strip.
+#[universes(polymorphic)] Global Hint Rewrite @map_primIn_spec @map_InP_spec : strip.
 Tactic Notation "simp_eta" "in" hyp(H) := simp isEtaExp in H; rewrite -?isEtaExp_equation_1 in H.
 Ltac simp_eta := simp isEtaExp; rewrite -?isEtaExp_equation_1.
 Tactic Notation "simp_strip" "in" hyp(H) := simp strip in H; rewrite -?strip_equation_1 in H.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -1746,6 +1746,7 @@ Proof.
     intuition auto.
     depelim a => //.
   - depelim X; solve_all.
+  - depelim X; solve_all.
     eapply All2_over_undep in a. subst a0 a'; depelim Hc'; constructor; cbn in *; solve_all.
     solve_all.
 Qed.

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
@@ -42,7 +42,7 @@ Section OnSubterm.
   | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
   | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
   | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx)
-  | on_prim p : has_tPrim -> primProp (Q n) p -> on_subterms Q n (tPrim p).
+  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p).
   Derive Signature for on_subterms.
 End OnSubterm.
 

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
@@ -42,7 +42,7 @@ Section OnSubterm.
   | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
   | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
   | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx)
-  | on_prim p : has_tPrim -> primProp (Q n) p -> on_subterms Q n (tPrim p).
+  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p).
   Derive Signature for on_subterms.
 End OnSubterm.
 
@@ -307,6 +307,7 @@ Lemma eval_preserve_mkApps_ind :
     P' (tConstruct ind i args) (tConstruct ind i args')) →
 
     (forall p p' (ev : eval_primitive (eval Σ) p p'),
+    Q 0 (tPrim p) ->
     eval_primitive_ind _ (fun x y _ => P x y) _ _ ev ->
     P' (tPrim p) (tPrim p')) ->
 

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -42,7 +42,7 @@ Section OnSubterm.
   | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
   | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
   | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx)
-  | on_prim p : has_tPrim -> primProp (Q n) p -> on_subterms Q n (tPrim p).
+  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p).
   Derive Signature for on_subterms.
 End OnSubterm.
 
@@ -727,7 +727,7 @@ Definition term_flags :=
     has_tProj := false;
     has_tFix := true;
     has_tCoFix := false;
-    has_tPrim := true
+    has_tPrim := all_primitive_flags;
   |}.
 
 Definition env_flags :=

--- a/erasure/theories/EWcbvEvalNamed.v
+++ b/erasure/theories/EWcbvEvalNamed.v
@@ -917,7 +917,7 @@ Definition extraction_term_flags :=
   ; has_tProj := false
   ; has_tFix := true
   ; has_tCoFix := false
-  ; has_tPrim := true
+  ; has_tPrim := all_primitive_flags
   |}.
 
 Definition extraction_env_flags :=
@@ -962,7 +962,7 @@ Definition named_extraction_term_flags :=
   ; has_tProj := false
   ; has_tFix := true
   ; has_tCoFix := false
-  ; has_tPrim := true
+  ; has_tPrim := all_primitive_flags
   |}.
 
 Definition named_extraction_env_flags :=
@@ -1041,7 +1041,7 @@ Proof.
       - econstructor.
       - invs H1. cbn. destruct a; cbn. destruct dname; cbn; econstructor; eauto.
     }
-  - solve_all. eapply primProp_map. solve_all.
+  - repeat solve_all.
 Qed.
 
 Lemma wellformed_annotate Σ Γ s :
@@ -1093,7 +1093,7 @@ Proof.
       - econstructor.
       - cbn. destruct x; cbn. destruct dname; cbn; econstructor; eauto.
     }
-  - constructor; solve_all. depelim H; cbn; solve_all; try econstructor.
+  - constructor; solve_all. depelim H1; cbn; solve_all; try econstructor.
     destruct a; constructor; solve_all. eapply All2_All2_Set. solve_all.
 Qed.
 

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -1,7 +1,7 @@
 (* Distributed under the terms of the MIT license. *)
 From Coq Require Import Utf8 Program.
 From MetaCoq.Utils Require Import utils.
-From MetaCoq.Common Require Import config Kernames.
+From MetaCoq.Common Require Import config Kernames Primitive.
 From MetaCoq.Erasure Require Import EPrimitive EAst EAstUtils ELiftSubst ECSubst EGlobalEnv.
 From MetaCoq.PCUIC Require Import PCUICTactics.
 
@@ -20,6 +20,18 @@ Definition isSome {A} (o : option A) :=
   | Some _ => true
   end.
 
+Class EPrimitiveFlags :=
+  { has_primint : bool;
+    has_primfloat : bool;
+    has_primarray : bool }.
+
+Definition has_prim {epfl : EPrimitiveFlags} (p : prim_val term) :=
+  match p.π1 with
+  | primInt => has_primint
+  | primFloat => has_primfloat
+  | primArray => has_primarray
+  end.
+
 Class ETermFlags :=
   { has_tBox : bool
   ; has_tRel : bool
@@ -34,17 +46,24 @@ Class ETermFlags :=
   ; has_tProj : bool
   ; has_tFix : bool
   ; has_tCoFix : bool
-  ; has_tPrim : bool
+  ; has_tPrim :: EPrimitiveFlags
   }.
 
-Set Warnings "-future-coercion-class-field".
 Class EEnvFlags := {
   has_axioms : bool;
   has_cstr_params : bool;
-  term_switches :> ETermFlags ;
+  term_switches :: ETermFlags ;
   cstr_as_blocks : bool ;
   }.
-Set Warnings "+future-coercion-class-field".
+
+Definition all_primitive_flags :=
+  {| has_primint := true;
+     has_primfloat := true;
+     has_primarray := true |}.
+
+Lemma has_prim_all_primitive_flags p : @has_prim all_primitive_flags p.
+Proof. destruct p as [? []]; auto. Qed.
+#[global] Hint Resolve has_prim_all_primitive_flags : core.
 
 Definition all_term_flags :=
   {| has_tBox := true
@@ -60,7 +79,7 @@ Definition all_term_flags :=
     ; has_tProj := true
     ; has_tFix := true
     ; has_tCoFix := true
-    ; has_tPrim := true
+    ; has_tPrim := all_primitive_flags
   |}.
 
 Definition all_env_flags :=
@@ -119,10 +138,16 @@ Section wf.
         | _ => true end
         && forallb (wellformed k) block_args else is_nil block_args
     | tVar _ => has_tVar
-    | tPrim p => has_tPrim && test_prim (wellformed k) p
+    | tPrim p => has_prim p && test_prim (wellformed k) p
     end.
 
 End wf.
+
+Lemma has_prim_map_prim {efl : EEnvFlags} f p : has_prim (map_prim f p) = has_prim p.
+Proof.
+  destruct p as [? []]; cbn; auto.
+Qed.
+#[global] Hint Rewrite @has_prim_map_prim : map.
 
 Notation wf_fix Σ := (wf_fix_gen (wellformed Σ)).
 

--- a/erasure/theories/ErasureFunctionProperties.v
+++ b/erasure/theories/ErasureFunctionProperties.v
@@ -1456,7 +1456,7 @@ Proof.
     * move/andP: H6; PCUICAstUtils.solve_all.
   - cbn -[lookup_projection] in *. apply/andP; split; eauto.
     now rewrite (declared_projection_lookup H0).
-  - cbn in H, H0 |- *. solve_all_k 7.
+  - cbn in H, H0 |- *. rtoProp; intuition eauto. solve_all_k 7.
 Qed.
 
 Lemma erases_wf_fixpoints Σ Γ t t' : Σ;;; Γ |- t ⇝ℇ t' ->

--- a/erasure/theories/ErasureProperties.v
+++ b/erasure/theories/ErasureProperties.v
@@ -671,8 +671,6 @@ Proof.
     depelim X0; depelim X1; repeat constructor; cbn; intuition eauto. solve_all.
 Qed.
 
-
-
 Lemma eval_empty_brs {wfl : Ee.WcbvFlags} Σ ci p e : Σ ⊢ E.tCase ci p [] ⇓ e -> False.
 Proof.
   intros He.


### PR DESCRIPTION
Add a way to control the presence of primitive ints/floats or arrays in terms (useful for correctness statements about translations which do not yet support arrays, or any primitive types).