### PR TITLE
Implement tLazy and tForce in EAst

### DIFF
--- a/erasure/theories/EAst.v
+++ b/erasure/theories/EAst.v
@@ -40,7 +40,9 @@ Inductive term : Set :=
 | tProj (p : projection) (c : term)
 | tFix (mfix : mfixpoint term) (idx : nat)
 | tCoFix (mfix : mfixpoint term) (idx : nat)
-| tPrim (prim : prim_val term).
+| tPrim (prim : prim_val term)
+| tLazy (t : term)
+| tForce (t : term).
 
 Derive NoConfusion for term.
 

--- a/erasure/theories/EAstUtils.v
+++ b/erasure/theories/EAstUtils.v
@@ -374,6 +374,8 @@ Fixpoint string_of_term (t : term) : string :=
   | tFix l n => "Fix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tCoFix l n => "CoFix(" ^ (string_of_list (string_of_def string_of_term) l) ^ "," ^ string_of_nat n ^ ")"
   | tPrim p => "Prim(" ^ EPrimitive.string_of_prim string_of_term p ^ ")"
+  | tLazy t => "Lazy(" ^ string_of_term t ^ ")"
+  | tForce t => "Force(" ^ string_of_term t ^ ")"
   end.
 
 (** Compute all the global environment dependencies of the term *)
@@ -409,5 +411,7 @@ Fixpoint term_global_deps (t : term) :=
     KernameSet.union (KernameSet.singleton (inductive_mind p.(proj_ind)))
       (term_global_deps c)
   | tPrim p => prim_global_deps term_global_deps p
+  | tLazy t => term_global_deps t
+  | tForce t => term_global_deps t
   | _ => KernameSet.empty
   end.

--- a/erasure/theories/ECSubst.v
+++ b/erasure/theories/ECSubst.v
@@ -38,6 +38,8 @@ Fixpoint csubst t k u :=
     tCoFix mfix' idx
   | tConstruct ind n args => tConstruct ind n (map (csubst t k) args)
   | tPrim p => tPrim (map_prim (csubst t k) p)
+  | tLazy u => tLazy (csubst t k u)
+  | tForce u => tForce (csubst t k u)
   | x => x
   end.
 

--- a/erasure/theories/EConstructorsAsBlocks.v
+++ b/erasure/theories/EConstructorsAsBlocks.v
@@ -62,7 +62,9 @@ Section transform_blocks.
     | tVar n => EAst.tVar n
     | tConst n => EAst.tConst n
     | tConstruct ind i block_args => EAst.tConstruct ind i []
-    | tPrim p => EAst.tPrim (map_primIn p (fun x H => transform_blocks x)) }.
+    | tPrim p => EAst.tPrim (map_primIn p (fun x H => transform_blocks x))
+    | tLazy t => EAst.tLazy (transform_blocks t)
+    | tForce t => EAst.tForce (transform_blocks t) }.
   Proof.
     all:try lia.
     all:try apply (In_size); tea.

--- a/erasure/theories/EDeps.v
+++ b/erasure/theories/EDeps.v
@@ -86,6 +86,8 @@ Proof.
     now apply e.
   - depelim X; depelim er; constructor; cbn. solve_all.
     destruct p. solve_all.
+  - depelim er.
+  - depelim er.
 Qed.
 
 Lemma erases_deps_subst Σ Σ' s k t :
@@ -137,6 +139,8 @@ Proof.
     constructor; [|easy].
     now apply e.
   - depelim X; depelim er; constructor; cbn; intuition auto; solve_all.
+  - depelim er.
+  - depelim er.
 Qed.
 
 Lemma erases_deps_subst1 Σ Σ' t k u :
@@ -195,6 +199,8 @@ Proof.
     constructor; [|easy].
     now apply e.
   - depelim X; depelim er; constructor; cbn; intuition auto; solve_all.
+  - depelim er.
+  - depelim er.
 Qed.
 
 Lemma erases_deps_substl Σ Σ' s t :

--- a/erasure/theories/EEtaExpanded.v
+++ b/erasure/theories/EEtaExpanded.v
@@ -76,6 +76,8 @@ Section isEtaExp.
     | tVar _ => true
     | tConst _ => true
     | tPrim p => test_primIn p (fun x H => isEtaExp x)
+    | tLazy t => isEtaExp t
+    | tForce t => isEtaExp t
     | tConstruct ind i block_args => isEtaExp_app ind i 0 && is_nil block_args }.
   Proof.
     all:try lia.
@@ -473,6 +475,8 @@ Inductive expanded : term -> Prop :=
     Forall expanded args ->
     expanded (mkApps (tConstruct ind idx []) args)
 | expanded_tPrim p : primProp expanded p -> expanded (tPrim p)
+| expanded_tLazy t : expanded t -> expanded (tLazy t)
+| expanded_tForce t : expanded t -> expanded (tForce t)
 | expanded_tBox : expanded tBox.
 
 End expanded.
@@ -512,19 +516,21 @@ forall (Σ : global_declarations) (P : term -> Prop),
  declared_constructor Σ (ind, idx) mind idecl cdecl ->
  #|args| >= cstr_arity mind cdecl -> Forall (expanded Σ) args -> Forall P args -> P (mkApps (tConstruct ind idx []) args)) ->
 (forall p, primProp (expanded Σ) p -> primProp P p -> P (tPrim p)) ->
+(forall t, expanded Σ t -> P t -> P (tLazy t)) ->
+(forall t, expanded Σ t -> P t -> P (tForce t)) ->
 (P tBox) ->
 forall t : term, expanded Σ t -> P t.
 Proof.
-  intros. revert t H13.
+  intros Σ P. intros hrel hvar hevar hlam hletin happ hconst hcase hproj hfix hcofix hcapp hprim hlazy hforce hbox.
   fix f 2.
   intros t Hexp. destruct Hexp; eauto.
-  - eapply H1; eauto. induction H13; econstructor; cbn in *; eauto.
-  - eapply H4; eauto. clear H14. induction H15; econstructor; cbn in *; eauto.
-  - eapply H6; eauto. induction H13; econstructor; cbn in *; eauto.
-  - eapply H8; eauto. induction H13; econstructor; cbn in *; intuition eauto.
-  - eapply H9; eauto. induction H13; econstructor; cbn in *; eauto.
-  - eapply H10; eauto. clear - H15 f. induction H15; econstructor; cbn in *; eauto.
-  - eapply H11; eauto.
+  - eapply hevar; eauto. induction H; econstructor; cbn in *; eauto.
+  - eapply happ; eauto. clear H0. induction H1; econstructor; cbn in *; eauto.
+  - eapply hcase; eauto. induction H; econstructor; cbn in *; eauto.
+  - eapply hfix; eauto. induction H; econstructor; cbn in *; intuition eauto.
+  - eapply hcofix; eauto. induction H; econstructor; cbn in *; eauto.
+  - eapply hcapp; eauto. clear - H1 f. induction H1; econstructor; cbn in *; eauto.
+  - eapply hprim; eauto.
     depelim X; constructor. destruct p; split; eauto.
     eapply (make_All_All f a0).
 Qed.

--- a/erasure/theories/EEtaExpandedFix.v
+++ b/erasure/theories/EEtaExpandedFix.v
@@ -61,6 +61,8 @@ Inductive expanded (Γ : list nat): term -> Prop :=
     Forall (expanded Γ) args ->
     expanded Γ (mkApps (tConstruct ind idx []) args)
 | expanded_tPrim p : primProp (expanded Γ) p -> expanded Γ (tPrim p)
+| expanded_tLazy t : expanded Γ t -> expanded Γ (tLazy t)
+| expanded_tForce t : expanded Γ t -> expanded Γ (tForce t)
 | expanded_tBox : expanded Γ tBox.
 
 End expanded.
@@ -139,10 +141,12 @@ Lemma expanded_ind :
         → Forall (P Γ) args
         → P Γ (mkApps (tConstruct ind idx []) args))
     → (∀ Γ p, primProp (expanded Σ Γ) p -> primProp (P Γ) p -> P Γ (tPrim p))
+    → (∀ Γ t, expanded Σ Γ t -> P Γ t -> P Γ (tLazy t))
+    → (∀ Γ t, expanded Σ Γ t -> P Γ t -> P Γ (tForce t))
     → (∀ Γ : list nat, P Γ tBox)
     → ∀ (Γ : list nat) (t : term), expanded Σ Γ t → P Γ t.
 Proof.
-  intros Σ P HRel_app HVar HEvar HLamdba HLetIn HmkApps HConst HCase HProj HFix HCoFix HConstruct HPrim HBox.
+  intros Σ P HRel_app HVar HEvar HLamdba HLetIn HmkApps HConst HCase HProj HFix HCoFix HConstruct HPrim HLazy HForce HBox.
   fix f 3.
   intros Γ t Hexp.  destruct Hexp; eauto.
   - eapply HRel_app; eauto. clear - f H0. induction H0; econstructor; eauto.
@@ -297,6 +301,8 @@ Section isEtaExp.
     | tVar _ => true
     | tConst _ => true
     | tPrim p => test_primIn p (fun x H => isEtaExp Γ x)
+    | tLazy t => isEtaExp Γ t
+    | tForce t => isEtaExp Γ t
     | tConstruct ind i block_args => isEtaExp_app ind i 0 && is_nil block_args }.
   Proof using Σ.
     all:try lia.

--- a/erasure/theories/EImplementBox.v
+++ b/erasure/theories/EImplementBox.v
@@ -54,7 +54,9 @@ Section implement_box.
     | tVar n => EAst.tVar n
     | tConst n => EAst.tConst n
     | tConstruct ind i block_args => EAst.tConstruct ind i (map_InP block_args (fun d H => implement_box d))
-    | tPrim p => EAst.tPrim (map_primIn p (fun x H => implement_box x)).
+    | tPrim p => EAst.tPrim (map_primIn p (fun x H => implement_box x))
+    | tLazy t => EAst.tLazy (implement_box t)
+    | tForce t => EAst.tForce (implement_box t).
   Proof.
     all:try lia.
     all:try apply (In_size); tea.
@@ -445,6 +447,7 @@ Definition disable_box_term_flags (et : ETermFlags) :=
     ; has_tFix := true
     ; has_tCoFix := has_tCoFix
     ; has_tPrim := has_tPrim
+    ; has_tLazy_Force := has_tLazy_Force
   |}.
 
 Definition switch_off_box (efl : EEnvFlags) :=

--- a/erasure/theories/EInlineProjections.v
+++ b/erasure/theories/EInlineProjections.v
@@ -49,6 +49,7 @@ Definition disable_projections_term_flags (et : ETermFlags) :=
     ; has_tFix := has_tFix
     ; has_tCoFix := has_tCoFix
     ; has_tPrim := has_tPrim
+    ; has_tLazy_Force := has_tLazy_Force
   |}.
 
 Definition disable_projections_env_flag (efl : EEnvFlags) :=
@@ -124,6 +125,8 @@ Section optimize.
     | tConst _ => t
     | tConstruct ind n args => tConstruct ind n (map optimize args)
     | tPrim p => tPrim (map_prim optimize p)
+    | tLazy t => tLazy (optimize t)
+    | tForce t => tForce (optimize t)
     end.
 
   Lemma optimize_mkApps f l : optimize (mkApps f l) = mkApps (optimize f) (map optimize l).

--- a/erasure/theories/ELiftSubst.v
+++ b/erasure/theories/ELiftSubst.v
@@ -37,6 +37,8 @@ Fixpoint lift n k t : term :=
   | tConst _ => t
   | tConstruct ind i args => tConstruct ind i (map (lift n k) args)
   | tPrim p => tPrim (map_prim (lift n k) p)
+  | tLazy t => tLazy (lift n k t)
+  | tForce t => tForce (lift n k t)
   end.
 
 Notation lift0 n := (lift n 0).
@@ -72,7 +74,11 @@ Fixpoint subst s k u :=
     tCoFix mfix' idx
   | tConstruct ind i args => tConstruct ind i (map (subst s k) args)
   | tPrim p => tPrim (map_prim (subst s k) p)
-  | x => x
+  | tLazy t => tLazy (subst s k t)
+  | tForce t => tForce (subst s k t)
+  | tBox => tBox
+  | tVar n => tVar n
+  | tConst c => tConst c
   end.
 
 (** Substitutes [t1 ; .. ; tn] in u for [Rel 0; .. Rel (n-1)] *in parallel* *)
@@ -100,6 +106,8 @@ Fixpoint closedn k (t : term) : bool :=
     List.forallb (test_def (closedn k')) mfix
   | tConstruct ind i args => forallb (closedn k) args
   | tPrim p => test_prim (closedn k) p
+  | tLazy t => closedn k t
+  | tForce t => closedn k t
   | _ => true
   end.
 
@@ -633,6 +641,8 @@ Proof.
   - eapply All_forallb_eq_forallb; tea. cbn.
     intros. specialize (H (#|m| + k')).
     now rewrite !Nat.add_assoc !(Nat.add_comm k) in H |- *.
+  - solve_all.
+  - solve_all.
   - solve_all.
 Qed.
 

--- a/erasure/theories/EOptimizePropDiscr.v
+++ b/erasure/theories/EOptimizePropDiscr.v
@@ -69,6 +69,8 @@ Section remove_match_on_box.
     | tConst _ => t
     | tConstruct ind i args => tConstruct ind i (map remove_match_on_box args)
     | tPrim p => tPrim (map_prim remove_match_on_box p)
+    | tLazy t => tLazy (remove_match_on_box t)
+    | tForce t => tForce (remove_match_on_box t)
     end.
 
   Lemma remove_match_on_box_mkApps f l : remove_match_on_box (mkApps f l) = mkApps (remove_match_on_box f) (map remove_match_on_box l).

--- a/erasure/theories/EPretty.v
+++ b/erasure/theories/EPretty.v
@@ -170,6 +170,8 @@ Module PrintTermTree.
       parens top ("let cofix " ^ print_defs print_term Γ l ^ nl ^
                                 " in " ^ List.nth_default (string_of_nat n) (map (string_of_name ∘ dname) l) n)
     | tPrim p => parens top (print_prim (print_term Γ false false) p)
+    | tLazy t => parens top ("lazy " ^ print_term Γ false false t)
+    | tForce t => parens top ("force " ^ print_term Γ false false t)
     end.
   End print_term.
 

--- a/erasure/theories/EReflect.v
+++ b/erasure/theories/EReflect.v
@@ -121,6 +121,8 @@ Proof.
       revert array_value; induction hv; intros []; eauto; nodec.
       destruct (p t); subst; nodec.
       destruct (IHhv l0); nodec. noconf e; eauto.
+  - destruct (IHx t); subst; nodec. now left.
+  - destruct (IHx t); subst; nodec. now left.
 Defined.
 
 #[global]

--- a/erasure/theories/ERemoveParams.v
+++ b/erasure/theories/ERemoveParams.v
@@ -59,7 +59,9 @@ Section strip.
     | tVar n => EAst.tVar n
     | tConst n => EAst.tConst n
     | tConstruct ind i block_args => EAst.tConstruct ind i block_args
-    | tPrim p => EAst.tPrim (map_primIn p (fun x H => strip x)) }.
+    | tPrim p => EAst.tPrim (map_primIn p (fun x H => strip x))
+    | tLazy t => EAst.tLazy (strip t)
+    | tForce t => EAst.tForce (strip t) }.
   Proof.
     all:try lia.
     all:try apply (In_size); tea.
@@ -569,6 +571,8 @@ Module Fast.
     | app, tPrim (primFloat; primFloatModel f) => mkApps (tPrim (primFloat; primFloatModel f)) app
     | app, tPrim (primArray; primArrayModel a) =>
       mkApps (tPrim (primArray; primArrayModel {| array_default := strip [] a.(array_default); array_value := strip_args a.(array_value) |})) app
+    | app, tLazy t => mkApps (tLazy (strip [] t)) app
+    | app, tForce t => mkApps (tForce (strip [] t)) app
     | app, x => mkApps x app }
 
     where strip_args (t : list term) : list term :=

--- a/erasure/theories/ESpineView.v
+++ b/erasure/theories/ESpineView.v
@@ -23,7 +23,9 @@ Inductive t : term -> Set :=
 | tProj p c : t (tProj p c)
 | tFix mfix idx : t (tFix mfix idx)
 | tCoFix mfix idx : t (tCoFix mfix idx)
-| tPrim p : t (tPrim p).
+| tPrim p : t (tPrim p)
+| tLazy p : t (tLazy p)
+| tForce p : t (tForce p).
 Derive Signature for t.
 
 Definition view : forall x : term, t x :=
@@ -39,7 +41,9 @@ Definition view : forall x : term, t x :=
     (fun p t => tProj p t)
     (fun mfix n => tFix mfix n)
     (fun mfix n => tCoFix mfix n)
-    (fun p => tPrim p).
+    (fun p => tPrim p)
+    tLazy
+    tForce.
 
 Lemma view_mkApps {f v} (vi : t (mkApps f v)) : ~~ isApp f -> v <> [] ->
   exists hf vn, vi = tApp f v hf vn.

--- a/erasure/theories/EWcbvEval.v
+++ b/erasure/theories/EWcbvEval.v
@@ -272,6 +272,12 @@ Section Wcbv.
     eval_primitive eval p p' ->
     eval (tPrim p) (tPrim p')
 
+  (*
+  | eval_lazy : eval (tLazy t) (tLazy t)
+  | eval_force t v v' : eval t (tLazy v) ->
+    eval v v' ->
+    eval (tForce t) v' *)
+
   (** Atoms are values (includes abstractions, cofixpoints and constructors) *)
   | eval_atom t : atom Σ t -> eval t t.
 

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksFixLambdaInd.v
@@ -42,7 +42,9 @@ Section OnSubterm.
   | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
   | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
   | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx)
-  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p).
+  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p)
+  | on_lazy t : has_tLazy_Force -> Q n t -> on_subterms Q n (tLazy t)
+  | on_force t : has_tLazy_Force -> Q n t -> on_subterms Q n (tForce t).
   Derive Signature for on_subterms.
 End OnSubterm.
 
@@ -593,6 +595,8 @@ Proof.
     rtoProp; intuition auto.
     eapply on_cofix => //. move/andP: H0 => [] _ ha. solve_all.
     move/andP: H => [] hp ha. eapply on_prim => //. solve_all.
+    eapply on_lazy; rtoProp; intuition auto.
+    eapply on_force; rtoProp; intuition auto.
  - red. intros kn decl.
     move/(lookup_env_wellformed clΣ).
     unfold wf_global_decl. destruct cst_body => //.

--- a/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
+++ b/erasure/theories/EWcbvEvalCstrsAsBlocksInd.v
@@ -42,7 +42,9 @@ Section OnSubterm.
   | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
   | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
   | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx)
-  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p).
+  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p)
+  | on_lazy t : has_tLazy_Force -> Q n t -> on_subterms Q n (tLazy t)
+  | on_force t : has_tLazy_Force -> Q n t -> on_subterms Q n (tForce t).
   Derive Signature for on_subterms.
 End OnSubterm.
 
@@ -492,6 +494,8 @@ Proof.
     rtoProp; intuition auto.
     eapply on_cofix => //. move/andP: H0 => [] _ ha. solve_all.
     move/andP: H => [] hasp ht. eapply on_prim => //. solve_all.
+    eapply on_lazy; rtoProp; intuition auto.
+    eapply on_force; rtoProp; intuition auto.
   - red. intros kn decl.
     move/(lookup_env_wellformed clΣ).
     unfold wf_global_decl. destruct cst_body => //.

--- a/erasure/theories/EWcbvEvalEtaInd.v
+++ b/erasure/theories/EWcbvEvalEtaInd.v
@@ -42,7 +42,9 @@ Section OnSubterm.
   | on_proj p c : has_tProj -> Q n c -> on_subterms Q n (tProj p c)
   | on_fix mfix idx : has_tFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tFix mfix idx)
   | on_cofix mfix idx : has_tCoFix -> All (fun d => Q (#|mfix| + n) d.(dbody)) mfix -> on_subterms Q n (tCoFix mfix idx)
-  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p).
+  | on_prim p : has_prim p -> primProp (Q n) p -> on_subterms Q n (tPrim p)
+  | on_lazy t : has_tLazy_Force -> Q n t -> on_subterms Q n (tLazy t)
+  | on_force t : has_tLazy_Force -> Q n t -> on_subterms Q n (tForce t).
   Derive Signature for on_subterms.
 End OnSubterm.
 
@@ -323,6 +325,12 @@ Lemma eval_preserve_mkApps_ind :
   (forall p p' (ev : eval_primitive (eval Σ) p p'),
     eval_primitive_ind _ (fun x y _ => P x y) _ _ ev ->
     P' (tPrim p) (tPrim p')) ->
+
+  (* (forall t t', eval Σ t t' -> Q 0 t -> Q 0 t' -> P t t' ->
+    P' (tLazy t) (tLazy t')) ->
+
+  (forall t t', eval Σ t t' -> Q 0 t -> Q 0 t' -> P t t' ->
+    P' (tForce t) (tForce t')) -> *)
 
   (∀ t : term, atom Σ t → Q 0 t -> isEtaExp Σ t -> P' t t) ->
   ∀ (t t0 : term), Q 0 t -> isEtaExp Σ t -> eval Σ t t0 → P' t t0.
@@ -712,30 +720,6 @@ Proof.
  - intros ise. split => //. eapply Qatom; tea.
 Qed.
 
-Definition term_flags :=
-  {|
-    has_tBox := true;
-    has_tRel := true;
-    has_tVar := false;
-    has_tEvar := false;
-    has_tLambda := true;
-    has_tLetIn := true;
-    has_tApp := true;
-    has_tConst := true;
-    has_tConstruct := true;
-    has_tCase := true;
-    has_tProj := false;
-    has_tFix := true;
-    has_tCoFix := false;
-    has_tPrim := all_primitive_flags;
-  |}.
-
-Definition env_flags :=
-    {| has_axioms := false;
-       has_cstr_params := false;
-       term_switches := term_flags ;
-       cstr_as_blocks := false
-    |}.
 
 From MetaCoq.Erasure Require Import ELiftSubst.
 Lemma Qpreserves_wellformed (efl : EEnvFlags) Σ :
@@ -759,6 +743,8 @@ Proof.
     eapply on_fix; eauto. move/andP: H0 => [] _ wf. solve_all.
     eapply on_cofix; eauto. move/andP: H0 => [] _ wf. solve_all.
     eapply on_prim; eauto. solve_all.
+    eapply on_lazy; eauto.
+    eapply on_force; eauto.
   - red. intros kn decl.
     move/(lookup_env_wellformed clΣ).
     unfold wf_global_decl. destruct cst_body => //.
@@ -781,6 +767,32 @@ Ltac destruct_nary_times :=
   | [ H : [× _, _, _ & _] |- _ ] => destruct H
   | [ H : [× _, _, _, _ & _] |- _ ] => destruct H
   end.
+
+Definition term_flags :=
+  {|
+    has_tBox := true;
+    has_tRel := true;
+    has_tVar := false;
+    has_tEvar := false;
+    has_tLambda := true;
+    has_tLetIn := true;
+    has_tApp := true;
+    has_tConst := true;
+    has_tConstruct := true;
+    has_tCase := true;
+    has_tProj := false;
+    has_tFix := true;
+    has_tCoFix := false;
+    has_tPrim := all_primitive_flags;
+    has_tLazy_Force := false;
+  |}.
+
+Definition env_flags :=
+    {| has_axioms := false;
+        has_cstr_params := false;
+        term_switches := term_flags ;
+        cstr_as_blocks := false
+  |}.
 
 Lemma eval_etaexp {fl : WcbvFlags} (efl := env_flags) {Σ a a'} :
   with_constructor_as_block = false ->

--- a/erasure/theories/EWellformed.v
+++ b/erasure/theories/EWellformed.v
@@ -47,6 +47,7 @@ Class ETermFlags :=
   ; has_tFix : bool
   ; has_tCoFix : bool
   ; has_tPrim :: EPrimitiveFlags
+  ; has_tLazy_Force : bool
   }.
 
 Class EEnvFlags := {
@@ -80,6 +81,7 @@ Definition all_term_flags :=
     ; has_tFix := true
     ; has_tCoFix := true
     ; has_tPrim := all_primitive_flags
+    ; has_tLazy_Force := true
   |}.
 
 Definition all_env_flags :=
@@ -139,6 +141,8 @@ Section wf.
         && forallb (wellformed k) block_args else is_nil block_args
     | tVar _ => has_tVar
     | tPrim p => has_prim p && test_prim (wellformed k) p
+    | tLazy t => has_tLazy_Force && wellformed k t
+    | tForce t => has_tLazy_Force && wellformed k t
     end.
 
 End wf.

--- a/erasure/theories/ErasureFunctionProperties.v
+++ b/erasure/theories/ErasureFunctionProperties.v
@@ -1433,6 +1433,8 @@ Section wffix.
     | tVar _ => true
     | tBox => true
     | tPrim p => test_prim wf_fixpoints p
+    | tLazy t => wf_fixpoints t
+    | tForce t => wf_fixpoints t
     end.
 
 End wffix.

--- a/erasure/theories/Typed/OptimizeCorrectness.v
+++ b/erasure/theories/Typed/OptimizeCorrectness.v
@@ -287,6 +287,8 @@ Proof.
     rewrite <- Nat.add_succ_r in *.
     now eapply IHX.
   - solve_all.
+  - solve_all.
+  - solve_all.
 Qed.
 
 Lemma is_dead_csubst k t u k' :
@@ -521,6 +523,8 @@ Proof.
       now f_equal.
     + rewrite <- !Nat.add_succ_r in *.
       now apply IHX.
+  - f_equal; solve_all.
+  - f_equal; solve_all.
   - f_equal; solve_all.
 Qed.
 
@@ -871,6 +875,8 @@ Proof.
     f_equal.
     now rewrite p.
   - rewrite lift_mkApps. f_equal. simpl lift. f_equal. solve_all.
+  - rewrite lift_mkApps. f_equal. simpl lift. f_equal. solve_all.
+  - rewrite lift_mkApps. f_equal. simpl lift. f_equal. solve_all.
 Qed.
 
 Lemma lift_dearg n k t :
@@ -921,6 +927,8 @@ Proof.
     f_equal.
     rewrite <- !Nat.add_succ_r.
     now apply IHX.
+  - solve_all.
+  - solve_all.
   - solve_all.
 Qed.
 
@@ -1486,6 +1494,8 @@ Proof.
     split; [easy|].
     now apply IHX.
   - solve_all. rtoProp; intuition solve_all.
+  - solve_all. rtoProp; intuition solve_all.
+  - solve_all. rtoProp; intuition solve_all.
 Qed.
 
 Lemma valid_dearg_mask_dearg mask t :
@@ -1645,6 +1655,10 @@ Proof.
   - rewrite subst_mkApps, map_map; cbn; f_equal. f_equal.
     solve_all. eapply map_prim_eq_prop; tea; cbn; intuition eauto.
     specialize (a s k []). eauto.
+  - rewrite subst_mkApps, map_map; cbn; f_equal.
+    f_equal. specialize (IHt s k []); cbn in IHt. eauto.
+  - rewrite subst_mkApps, map_map; cbn; f_equal.
+    f_equal. specialize (IHt s k []); cbn in IHt. eauto.
 Qed.
 
 Lemma dearg_subst s k t :
@@ -1761,6 +1775,8 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     now rewrite p, IHX.
   - solve_all_k 6.
+  - solve_all.
+  - solve_all.
 Qed.
 
 Lemma is_expanded_aux_subst s n t k :
@@ -1805,6 +1821,8 @@ Proof.
     rewrite <- !Nat.add_succ_r.
     now rewrite p, IHX.
   - solve_all_k 6.
+  - solve_all.
+  - solve_all.
 Qed.
 
 Lemma is_expanded_substl s n t :
@@ -2416,6 +2434,8 @@ Proof.
     rewrite <- !Nat.add_succ_r in *.
     now apply IHX.
   - rewrite closedn_mkApps; cbn; rtoProp; intuition solve_all. solve_all_k 6.
+  - rewrite closedn_mkApps; cbn; rtoProp; intuition solve_all.
+  - rewrite closedn_mkApps; cbn; rtoProp; intuition solve_all.
 Qed.
 
 Lemma Alli_map {A B P n} {f : A -> B} l :

--- a/erasure/theories/Typed/TypeAnnotations.v
+++ b/erasure/theories/Typed/TypeAnnotations.v
@@ -586,6 +586,8 @@ Proof.
     intros.
     exact (f _ All_nil _ X).
   - refine (annot_mkApps _ argsa). cbn. cbn in ta. exact ta.
+  - refine (annot_mkApps _ argsa). cbn. cbn in ta. exact ta.
+  - refine (annot_mkApps _ argsa). cbn. cbn in ta. exact ta.
 Defined.
 
 Definition annot_dearg im cm {t : term} (ta : annots box_type t) : annots box_type (dearg im cm t) :=

--- a/template-coq/Makefile.plugin.local-late
+++ b/template-coq/Makefile.plugin.local-late
@@ -1,0 +1,1 @@
+FINDLIBFILESTOINSTALL += gen-src/metacoq_template_plugin.a


### PR DESCRIPTION
This add new term constructors to map to lazy and force in ocaml/malfunction or more naive thunks in other targets. 
This is now used in the unverified ECoInductiveToInductive phase. In coq-malfunction we can compile this to ocaml's implementation for an efficient implementation of coinductives and cofixpoints.

As these constructors are not produced by erasure, and we do NOT add evaluation rules for lazy/force, the correctness proofs do not change for the rest of the pipeline. It should just be considered unsafe to use lazy and force.