### PR TITLE
Fix the translation of cofix to fix 

### DIFF
--- a/erasure-plugin/theories/Erasure.v
+++ b/erasure-plugin/theories/Erasure.v
@@ -128,11 +128,10 @@ Program Definition optional_unsafe_transforms econf :=
   let efl := EConstructorsAsBlocks.switch_cstr_as_blocks
   (EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags)) in
   ETransform.optional_self_transform passes.(cofix_to_lazy)
-    ((* Rebuild the efficient lookup table *)
-    rebuild_wf_env_transform (efl := efl) false false ▷
-    (* Coinductives & cofixpoints are translated to inductive types and thunked fixpoints *)
+    ((* Coinductives & cofixpoints are translated to inductive types and thunked fixpoints *)
     coinductive_to_inductive_transformation efl
-      (has_app := eq_refl) (has_box := eq_refl) (has_rel := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl)) ▷
+      (has_app := eq_refl) (has_box := eq_refl) (has_rel := eq_refl) (has_pars := eq_refl) (has_cstrblocks := eq_refl) ▷
+    project_wf_env_transform false false) ▷
   ETransform.optional_self_transform passes.(reorder_constructors)
     (reorder_cstrs_transformation efl final_wcbv_flags econf.(inductives_mapping)) ▷
   ETransform.optional_self_transform passes.(unboxing)

--- a/make-opam-files.sh
+++ b/make-opam-files.sh
@@ -6,15 +6,32 @@ then
     exit 0
 fi
 
+archive=`basename $3`
+tag=${archive/.tar.gz/}
+
 echo "Target directory: " $1
 echo "Target version: " $2
 echo "Releases package: " $3
+echo "Archive:" $archive
+echo "Tag:" $tag
+
+if [ -f $archive ]
+then
+    echo "Removing existing archive!"
+    rm $archive
+fi
 
 wget $3
-archive=`basename $3`
+
 hash=`shasum -a 512 $archive | cut -f 1 -d " "`
 
 echo "Shasum = " $hash
+
+echo "Uploading to release assets"
+
+gh release upload $tag $archive
+
+release=https://github.com/MetaCoq/metacoq/releases/download/$tag/$archive
 
 for f in *.opam;
 do
@@ -24,7 +41,7 @@ do
     mkdir -p $1/$opamf/$opamf.$2
     gsed -e "/^version:.*/d" $f > $target
     echo url { >> $target
-    echo "  src:" \"$3\" >> $target
+    echo "  src:" \"$release\" >> $target
     echo "  checksum:" \"sha512=$hash\" >> $target
     echo } >> $target
 done

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -372,12 +372,13 @@ Print P_provedCopyx.
 From Coq Require Import Streams.
 
 CoFixpoint ones : Stream nat := Cons 1 ones.
-
 MetaCoq Erase ones.
 MetaCoq Erase -unsafe ones.
-
 MetaCoq Erase -typed -time -unsafe (map S ones).
 
+CoFixpoint ones_broken : Stream nat := let t := ones_broken in Cons 1 t.
+MetaCoq Erase ones_broken.
+MetaCoq Erase -unsafe ones_broken.
 
 (* 0.2s purely in the bytecode VM *)
 (*Time Definition P_provedCopyxvm' := Eval vm_compute in (test p_provedCopyx). *)

--- a/test-suite/erasure_live_test.v
+++ b/test-suite/erasure_live_test.v
@@ -428,7 +428,7 @@ Import MCMonadNotation MCOption.
 Definition whnf : option EAst.term :=
   match decomp with
   | None => None
-  | Some deco => remove_head_lazy (whnf Σrepeat (snd deco))
+  | Some deco => Some (force_cofix_body (whnf Σrepeat (snd deco)))
   end.
 
 Eval lazy in whnf.
@@ -442,10 +442,7 @@ Module maybe_ones.
   MetaCoq Quote Recursively Definition maybe_onesq := maybe_ones.
   Eval lazy in (EPretty.print_program (testp_eprogram maybe_onesq)).
 
-
-
-EAst.program
-
+End maybe_ones.
 
 (* 0.2s purely in the bytecode VM *)
 (*Time Definition P_provedCopyxvm' := Eval vm_compute in (test p_provedCopyx). *)


### PR DESCRIPTION
This moves the head constructors's lazy of a cofixpoint definition to the toplevel of the fixpoint definition to avoid creating diverging functions in call-by-value semantics. See stedolan/malfunction#39 for an explanation of the problem with Coq's extraction which we mimicked.