### PR TITLE
Adapt to coq PR #18921 fixing bugs of the inference of the return clause for Program-style pattern-matching

### DIFF
--- a/safechecker/theories/PCUICSafeChecker.v
+++ b/safechecker/theories/PCUICSafeChecker.v
@@ -1946,7 +1946,9 @@ End monad_Alli_nth_forall.
     rename Heq_anonymous into eqp.
     sq. red. rewrite -eqp. exact I.
   Qed.
-  Next Obligation.  specialize_Σ H. sq. rewrite Heq_x. eauto. Qed.
+  (* Obligation automatically solved in the presence of Coq PR #18921
+  Next Obligation. specialize_Σ H. Show. sq. Show. rewrite Heq_x. eauto. Qed.
+  *)
   Next Obligation.
     specialize_Σ H. sq. red. intros. rewrite -Heq_x //.
     destruct ind_projs => //.


### PR DESCRIPTION
Coq PR coq/coq#18921 fixes two bugs in the inference of the return clause for Program-style pattern-matching and this has the apparent consequence of modifying the return clause of the `match` in the definition `PCUICSafeChecker.check_projections`, and that one more obligation is solved automatically.

We drop the now useless proof (with a comment to indicate that it depends on the Coq version).

To be merged synchronously (though maybe there is a way to make it compatible over different versions? ~~maybe with a `Fail`?~~)