### PR TITLE
Remove useless calls to Eval vm_compute.

### DIFF
--- a/test-suite/vs.v
+++ b/test-suite/vs.v
@@ -2317,13 +2317,11 @@ Definition example_myent := Entailment
   (Assertion nil nil)
   (Assertion [Equ a a] nil).
 Definition ce_example_myent := check_entailment example_myent.
-Eval vm_compute in ce_example_myent.
 
 Definition example1_myent := Entailment
   (Assertion [Equ a b] nil)
   (Assertion [Equ b a] nil).
 Definition ce_example1_myent := check_entailment example1_myent.
-Eval vm_compute in ce_example1_myent.
 
 Definition example2_myent := Entailment
   (Assertion [Equ a b; Equ b c] nil)


### PR DESCRIPTION
These evaluations do not produce anything interesting, since the called function is just a wrapper around a function created by `Function the_loop. Admitted.` and therefore opaque. This is related to coq/coq#18917.