### PR TITLE
Correct noccur for Template

### DIFF
--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -537,7 +537,7 @@ Notation closed t := (closedn 0 t).
 
 Fixpoint noccur_between k n (t : term) : bool :=
   match t with
-  | tRel i => Nat.ltb i k && Nat.leb (k + n) i
+  | tRel i => Nat.ltb i k || Nat.leb (k + n) i
   | tEvar ev args => List.forallb (noccur_between k n) args
   | tLambda _ T M | tProd _ T M => noccur_between k n T && noccur_between (S k) n M
   | tApp u v => noccur_between k n u && List.forallb (noccur_between k n) v


### PR DESCRIPTION
One of the definitions of `noccur_between` is wrong, because the Template one uses an `&&` where the PCUIC one uses `||`. I *think* PCUIC's is the right one, since it's the one where we actually prove things. I guess we didn't catch the issue because we don't use the function from Template anywhere and so we don't prove any of its properties…

I'm working on the 8.19 branch locally (because that's the Coq version I have) so the PR it to that branch, I'll make another one for `main` :)