### PR TITLE
Point 'index' in CoqDocJS header to index.html

### DIFF
--- a/html/resources/header.html
+++ b/html/resources/header.html
@@ -19,7 +19,7 @@
 
     <span class="right">
       <a href="../">Project Page</a>
-      <a href="./indexpage.html"> Index </a>
+      <a href="./index.html"> Index </a>
       <a href="./toc.html"> Table of Contents </a>
     </span>
 </div>


### PR DESCRIPTION
The current link in the header, "Index", points to a non-existent page `indexpage.html` (https://metacoq.github.io/html/indexpage.html), while the index is actually generated in `index.html` (https://metacoq.github.io/html/index.html).

There are two ways to fix this:
we can either add the flag `--index indexpage` to the `html` target in `Makefile`, or make the changes proposed in this PR. I don't know which is the preferred method.