### PR TITLE
Improve evar_map handling in tmMkDefinition and friends 

### DIFF
--- a/template-coq/src/plugin_core.ml
+++ b/template-coq/src/plugin_core.ml
@@ -90,7 +90,7 @@ let tmDefinition (nm : ident) ?poly:(poly=false) ?opaque:(opaque=false) (typ : t
     let info = Declare.Info.make ~poly ~kind:(Decls.(IsDefinition Definition)) () in
     let n = Declare.declare_definition ~cinfo ~info ~opaque ~body:(EConstr.of_constr body) evm in
     let env = Global.env () in
-    let evm = Evd.from_env env in
+    let evm = Evd.update_sigma_univs (Environ.universes env) evm in
     success ~st env evm (Names.Constant.canonical (Globnames.destConstRef n))
 
 let tmAxiom (nm : ident) ?poly:(poly=false) (typ : term) : kername tm =
@@ -105,7 +105,9 @@ let tmAxiom (nm : ident) ?poly:(poly=false) (typ : term) : kername tm =
         ~kind:(Decls.IsDefinition Decls.Definition)
         param
     in
-    success ~st (Global.env ()) evm (Names.Constant.canonical n)
+    let env = Global.env () in
+    let evm = Evd.update_sigma_univs (Environ.universes env) evm in
+    success ~st env evm (Names.Constant.canonical n)
 
 (* this generates a lemma leaving a hole *)
 let tmLemma (nm : ident) ?poly:(poly=false)(ty : term) : kername tm =

--- a/test-suite/bug_mk_def.v
+++ b/test-suite/bug_mk_def.v
@@ -1,0 +1,15 @@
+From MetaCoq.Template Require Import All.
+From MetaCoq.Utils Require Import monad_utils.
+Import MCMonadNotation.
+
+Unset MetaCoq Strict Unquote Universe Mode.
+
+Definition test :=
+  mlet t1 <- tmUnquoteTyped Type (tSort (sType (Universe.make' fresh_level))) ;;
+  mlet t2 <- tmUnquoteTyped Type (tSort (sType (Universe.make' fresh_level))) ;;
+  tmPrint (t1, t2) ;;
+  tmDefinitionRed "t1"%bs None t1 ;;
+  tmDefinitionRed "t2"%bs None t2.
+
+MetaCoq Run test.
+  


### PR DESCRIPTION
Fixes (part of) https://github.com/MetaCoq/metacoq/issues/1108. 

This PR fixes a bug in the implementation of the template monad. When modifying the global environment (`tmDefinitionRed` and friends), we currently ditch the old evar map and create a fresh one using `Evd.from_env` (see e.g. `template-coq/run_template_monad.ml`, in the main loop, the `TmDefinition` case).  

This is a problem since the evar map can contain evars and universes which are still used afterwards, and we discard them, leading to `Undeclared universe` errors e.g. when calling `tmMkDefinition` multiple times.

The fix is to replace :
```Coq
let evm = Evd.from_env (Global.env ())
```
by :
```Coq
let evm = Evd.update_sigma_univs (Environ.universes env) evm
``` 
in the relevant places.