### PR TITLE
Improve evar handling in tmUnquote/tmUnquoteTyped

### DIFF
--- a/test-suite/unquote_evars.v
+++ b/test-suite/unquote_evars.v
@@ -1,0 +1,20 @@
+From MetaCoq.Template Require Import All.
+Import MCMonadNotation.
+
+(* Unquoting evars. *)
+MetaCoq Run (mlet t <- tmUnquote (tEvar fresh_evar_id []) ;; tmPrint t).
+MetaCoq Run (mlet t <- tmUnquoteTyped nat (tEvar fresh_evar_id []) ;; tmPrint t).
+
+(* Unquoting evars, with typeclass resolution. *)
+Existing Class nat.
+Existing Instance O.
+
+MetaCoq Quote Definition quoted_nat := nat.
+MetaCoq Run (
+  mlet t <- tmUnquote (tCast (tEvar fresh_evar_id []) Cast quoted_nat) ;;
+  tmEval cbv t
+).
+MetaCoq Run (
+  mlet t <- tmUnquoteTyped nat (tEvar fresh_evar_id []) ;;
+  tmEval cbv t
+).


### PR DESCRIPTION
This PR enables unquoting terms which contain evars (e.g. `tEvar fresh_evar_id []`). Unquoting attempts to solve evars (using typing information and typeclass resolution). Evars which could not be solved are kept in the unquoted term.